### PR TITLE
fix(windows): correct shell flag for Git Bash / POSIX shells (fix #7)

### DIFF
--- a/rust/src/shell.rs
+++ b/rust/src/shell.rs
@@ -176,6 +176,21 @@ fn compress_if_beneficial(command: &str, output: &str) -> String {
     output.to_string()
 }
 
+/// Windows only: argument that passes one command string to the shell binary.
+/// `exe_basename` must already be ASCII-lowercase (e.g. `bash.exe`, `cmd.exe`).
+fn windows_shell_flag_for_exe_basename(exe_basename: &str) -> &'static str {
+    if exe_basename.contains("powershell") || exe_basename.contains("pwsh") {
+        "-Command"
+    } else if exe_basename == "cmd.exe" || exe_basename == "cmd" {
+        "/C"
+    } else {
+        // POSIX-style shells: Git Bash / MSYS (`bash`, `sh`, `zsh`, `fish`, …).
+        // `/C` is only valid for `cmd.exe`; using it with bash produced
+        // `/C: Is a directory` and exit 126 (see github.com/yvgude/lean-ctx/issues/7).
+        "-c"
+    }
+}
+
 pub fn shell_and_flag() -> (String, String) {
     let shell = detect_shell();
     let flag = if cfg!(windows) {
@@ -184,11 +199,7 @@ pub fn shell_and_flag() -> (String, String) {
             .and_then(|n| n.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        if name.contains("powershell") || name.contains("pwsh") {
-            "-Command".to_string()
-        } else {
-            "/C".to_string()
-        }
+        windows_shell_flag_for_exe_basename(&name).to_string()
     } else {
         "-c".to_string()
     };
@@ -305,5 +316,34 @@ fn cleanup_old_tee_logs(tee_dir: &std::path::Path) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod windows_shell_flag_tests {
+    use super::windows_shell_flag_for_exe_basename;
+
+    #[test]
+    fn cmd_uses_slash_c() {
+        assert_eq!(windows_shell_flag_for_exe_basename("cmd.exe"), "/C");
+        assert_eq!(windows_shell_flag_for_exe_basename("cmd"), "/C");
+    }
+
+    #[test]
+    fn powershell_uses_command() {
+        assert_eq!(
+            windows_shell_flag_for_exe_basename("powershell.exe"),
+            "-Command"
+        );
+        assert_eq!(windows_shell_flag_for_exe_basename("pwsh.exe"), "-Command");
+    }
+
+    #[test]
+    fn posix_shells_use_dash_c() {
+        assert_eq!(windows_shell_flag_for_exe_basename("bash.exe"), "-c");
+        assert_eq!(windows_shell_flag_for_exe_basename("bash"), "-c");
+        assert_eq!(windows_shell_flag_for_exe_basename("sh.exe"), "-c");
+        assert_eq!(windows_shell_flag_for_exe_basename("zsh.exe"), "-c");
+        assert_eq!(windows_shell_flag_for_exe_basename("fish.exe"), "-c");
     }
 }


### PR DESCRIPTION
Closes #7.

Full reproduction and environment details: #7.

### Problem

On Windows, `lean-ctx -c <command>` failed with output like **`/C: Is a directory`** and exit code **126** in **Git Bash** and when **`SHELL`** points at a POSIX shell (e.g. `bash.exe`). Global shell hooks (`alias git='lean-ctx -c git'`, etc.) were unusable in those environments.

### Root cause

[`detect_shell()`](https://github.com/yvgude/lean-ctx/blob/main/rust/src/shell.rs) returns **`SHELL`** when set (e.g. Git for Windows sets it to `bash.exe`). [`shell_and_flag()`](https://github.com/yvgude/lean-ctx/blob/main/rust/src/shell.rs) treated every non–PowerShell executable on Windows as **`cmd.exe`**, passing **`/C`**. That switch is **only** valid for **`cmd.exe`**; **`bash`** expects **`-c`**. Invoking bash with `/C` leads to the MSYS-style error and **126**.

### Solution

| Shell executable (basename) | Flag |
|-----------------------------|------|
| `powershell` / `pwsh` | `-Command` |
| `cmd.exe` / `cmd` | `/C` |
| `bash`, `sh`, `zsh`, `fish`, … (default) | `-c` |

Implemented in `windows_shell_flag_for_exe_basename()` and wired through `shell_and_flag()` so **`exec`**, **`-c` passthrough**, and **`ctx_shell`**-style spawn paths stay consistent.

### Testing

- [x] Unit tests for `windows_shell_flag_for_exe_basename` (`cmd`, PowerShell, `bash`, etc.) in `rust/src/shell.rs`
- [x] **`cargo test`:** all tests passed in Docker `rust:1.88-bookworm` (contributor host lacked MSVC `link.exe`; CI should confirm)
- [ ] **Manual (Windows + Git Bash):** `lean-ctx -c "git --version"` and `lean-ctx -c "echo ok"` should succeed after build

### Checklist

- [x] Targeted change (`shell.rs` only); no unrelated refactors
- [x] Linux/macOS: behavior unchanged (`-c` only branch)
