### PR TITLE
fix(pi-lean-ctx): lower code read thresholds for practical compression

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -31,6 +31,8 @@ const FULL_READ_EXTENSIONS = new Set([
 ]);
 
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+const CODE_FULL_READ_MAX_BYTES = 8 * 1024;
+const CODE_SIGNATURES_MIN_BYTES = 96 * 1024;
 
 const readSchema = Type.Object({
   path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
@@ -101,8 +103,8 @@ async function chooseReadMode(path: string): Promise<"full" | "map" | "signature
   const size = fileStat.size;
 
   if (!CODE_EXTENSIONS.has(ext)) return size > 48 * 1024 ? "map" : "full";
-  if (size >= 160 * 1024) return "signatures";
-  if (size >= 24 * 1024) return "map";
+  if (size >= CODE_SIGNATURES_MIN_BYTES) return "signatures";
+  if (size >= CODE_FULL_READ_MAX_BYTES) return "map";
   return "full";
 }
 


### PR DESCRIPTION
I've been seeing a lot of real-world code files still come through with "Compressed X → X (0%)" even after the .vue/.svelte support fix landed. The issue was no longer file type detection — it was the size heuristic.

In my day-to-day projects, a lot of normal application files sit below the old 24 KB map threshold, so the wrapper kept forcing them into full mode. That made the Pi integration return near-raw output for files that lean-ctx can actually compress very well in map mode.

A concrete example was MyRequestsPage.vue in my local project. It is about 23 KB, so it still fell into full mode and showed 0% compression through the Pi wrapper. Reading the same file directly with lean-ctx in map mode compressed it dramatically, which made it clear the wrapper threshold was too conservative for practical use.

This changes the code-file thresholds to:
- full below 8 KB
- map from 8 KB up to 96 KB
- signatures at 96 KB and above

That keeps very small files easy to inspect in full, but moves medium-sized code files into map mode much earlier, which matches how I actually use Pi with Vue, TS, PHP, and other app code.