### PR TITLE
Adding disabled_tools field to config for token reduction

### DIFF
--- a/rust/src/core/attention_model.rs
+++ b/rust/src/core/attention_model.rs
@@ -155,11 +155,9 @@ pub fn attention_optimize(lines: &[&str], _alpha: f64, _beta: f64, _gamma: f64) 
         } else if i % 3 == 1 && end_idx > 2 * n / 3 {
             result[end_idx] = lines[*orig_idx].to_string();
             end_idx -= 1;
-        } else {
-            if mid_idx < 2 * n / 3 {
-                result[mid_idx] = lines[*orig_idx].to_string();
-                mid_idx += 1;
-            }
+        } else if mid_idx < 2 * n / 3 {
+            result[mid_idx] = lines[*orig_idx].to_string();
+            mid_idx += 1;
         }
     }
 

--- a/rust/src/core/config.rs
+++ b/rust/src/core/config.rs
@@ -35,6 +35,11 @@ pub struct Config {
     pub buddy_enabled: bool,
     #[serde(default)]
     pub redirect_exclude: Vec<String>,
+    /// Tools to exclude from the MCP tool list returned by list_tools.
+    /// Accepts exact tool names (e.g. ["ctx_graph", "ctx_agent"]).
+    /// Empty by default — all tools listed, no behaviour change.
+    #[serde(default)]
+    pub disabled_tools: Vec<String>,
 }
 
 fn default_buddy_enabled() -> bool {
@@ -175,7 +180,84 @@ impl Default for Config {
             autonomy: AutonomyConfig::default(),
             buddy_enabled: default_buddy_enabled(),
             redirect_exclude: Vec::new(),
+            disabled_tools: Vec::new(),
         }
+    }
+}
+
+impl Config {
+    fn parse_disabled_tools_env(val: &str) -> Vec<String> {
+        val.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    pub fn disabled_tools_effective(&self) -> Vec<String> {
+        if let Ok(val) = std::env::var("LEAN_CTX_DISABLED_TOOLS") {
+            Self::parse_disabled_tools_env(&val)
+        } else {
+            self.disabled_tools.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod disabled_tools_tests {
+    use super::*;
+
+    #[test]
+    fn config_field_default_is_empty() {
+        let cfg = Config::default();
+        assert!(cfg.disabled_tools.is_empty());
+    }
+
+    #[test]
+    fn effective_returns_config_field_when_no_env_var() {
+        // Only meaningful when LEAN_CTX_DISABLED_TOOLS is unset; skip otherwise.
+        if std::env::var("LEAN_CTX_DISABLED_TOOLS").is_ok() {
+            return;
+        }
+        let mut cfg = Config::default();
+        cfg.disabled_tools = vec!["ctx_graph".to_string(), "ctx_agent".to_string()];
+        assert_eq!(cfg.disabled_tools_effective(), vec!["ctx_graph", "ctx_agent"]);
+    }
+
+    #[test]
+    fn parse_env_basic() {
+        let result = Config::parse_disabled_tools_env("ctx_graph,ctx_agent");
+        assert_eq!(result, vec!["ctx_graph", "ctx_agent"]);
+    }
+
+    #[test]
+    fn parse_env_trims_whitespace_and_skips_empty() {
+        let result = Config::parse_disabled_tools_env(" ctx_graph , , ctx_agent ");
+        assert_eq!(result, vec!["ctx_graph", "ctx_agent"]);
+    }
+
+    #[test]
+    fn parse_env_single_entry() {
+        let result = Config::parse_disabled_tools_env("ctx_graph");
+        assert_eq!(result, vec!["ctx_graph"]);
+    }
+
+    #[test]
+    fn parse_env_empty_string_returns_empty() {
+        let result = Config::parse_disabled_tools_env("");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn disabled_tools_deserialization_defaults_to_empty() {
+        let cfg: Config = toml::from_str("").unwrap();
+        assert!(cfg.disabled_tools.is_empty());
+    }
+
+    #[test]
+    fn disabled_tools_deserialization_from_toml() {
+        let cfg: Config =
+            toml::from_str(r#"disabled_tools = ["ctx_graph", "ctx_agent"]"#).unwrap();
+        assert_eq!(cfg.disabled_tools, vec!["ctx_graph", "ctx_agent"]);
     }
 }
 

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -48,17 +48,26 @@ impl ServerHandler for LeanCtxServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        if std::env::var("LEAN_CTX_UNIFIED").is_ok()
+        let all_tools = if std::env::var("LEAN_CTX_UNIFIED").is_ok()
             && std::env::var("LEAN_CTX_FULL_TOOLS").is_err()
         {
-            return Ok(ListToolsResult {
-                tools: crate::tool_defs::unified_tool_defs(),
-                ..Default::default()
-            });
-        }
+            crate::tool_defs::unified_tool_defs()
+        } else {
+            crate::tool_defs::granular_tool_defs()
+        };
+
+        let disabled = crate::core::config::Config::load().disabled_tools_effective();
+        let tools = if disabled.is_empty() {
+            all_tools
+        } else {
+            all_tools
+                .into_iter()
+                .filter(|t| !disabled.iter().any(|d| t.name.as_ref() == d.as_str()))
+                .collect()
+        };
 
         Ok(ListToolsResult {
-            tools: crate::tool_defs::granular_tool_defs(),
+            tools,
             ..Default::default()
         })
     }
@@ -1178,5 +1187,43 @@ mod tests {
     fn test_granular_tool_count() {
         let tools = crate::tool_defs::granular_tool_defs();
         assert!(tools.len() >= 25, "Expected at least 25 granular tools");
+    }
+
+    #[test]
+    fn disabled_tools_filters_list() {
+        let all = crate::tool_defs::granular_tool_defs();
+        let total = all.len();
+        let disabled = vec!["ctx_graph".to_string(), "ctx_agent".to_string()];
+        let filtered: Vec<_> = all
+            .into_iter()
+            .filter(|t| !disabled.iter().any(|d| t.name.as_ref() == d.as_str()))
+            .collect();
+        assert_eq!(filtered.len(), total - 2);
+        assert!(!filtered.iter().any(|t| t.name.as_ref() == "ctx_graph"));
+        assert!(!filtered.iter().any(|t| t.name.as_ref() == "ctx_agent"));
+    }
+
+    #[test]
+    fn empty_disabled_tools_returns_all() {
+        let all = crate::tool_defs::granular_tool_defs();
+        let total = all.len();
+        let disabled: Vec<String> = vec![];
+        let filtered: Vec<_> = all
+            .into_iter()
+            .filter(|t| !disabled.iter().any(|d| t.name.as_ref() == d.as_str()))
+            .collect();
+        assert_eq!(filtered.len(), total);
+    }
+
+    #[test]
+    fn misspelled_disabled_tool_is_silently_ignored() {
+        let all = crate::tool_defs::granular_tool_defs();
+        let total = all.len();
+        let disabled = vec!["ctx_nonexistent_tool".to_string()];
+        let filtered: Vec<_> = all
+            .into_iter()
+            .filter(|t| !disabled.iter().any(|d| t.name.as_ref() == d.as_str()))
+            .collect();
+        assert_eq!(filtered.len(), total);
     }
 }


### PR DESCRIPTION
Hello!

Thank you for your great work with lean-ctx!  I dug into my context usage and found that there was no way to disable tools that I never used before, or needed to use.  This change adds this functionality to the config to further optimize token reductions.

Example:
disabled_tools = [
    "ctx_benchmark", "ctx_metrics", "ctx_analyze", "ctx_cache", "ctx_discover",
    "ctx_dedup", "ctx_session", "ctx_context",
    "ctx_graph", "ctx_semantic_search", "ctx_agent", "ctx_response", "ctx_wrapped",
]

Summary

* Adds disabled_tools field to Config struct (TOML-deserializable, defaults to empty)
* Adds disabled_tools_effective() method — returns env var LEAN_CTX_DISABLED_TOOLS (comma-separated) when set, otherwise falls back to config field
* Filters list_tools response in MCP server to exclude any tools in the effective disabled list

Test plan

* cargo test disabled_tools — 10 unit tests covering parsing, whitespace trimming, TOML deserialization, and effective fallback path
* Manually verified: with ctx_tree added to ~/.lean-ctx/config.toml, restarting Claude Code drops tool count from 16→15; restoring it brings count back to 16
