### PR TITLE
feat: improve Kotlin graph analysis

### DIFF
--- a/rust/src/core/deep_queries.rs
+++ b/rust/src/core/deep_queries.rs
@@ -119,6 +119,7 @@ fn get_language(ext: &str) -> Option<Language> {
         "py" => Some(tree_sitter_python::LANGUAGE.into()),
         "go" => Some(tree_sitter_go::LANGUAGE.into()),
         "java" => Some(tree_sitter_java::LANGUAGE.into()),
+        "kt" | "kts" => Some(tree_sitter_kotlin_ng::LANGUAGE.into()),
         _ => None,
     }
 }
@@ -135,6 +136,7 @@ fn extract_imports(root: Node, src: &str, ext: &str) -> Vec<ImportInfo> {
         "py" => extract_imports_python(root, src),
         "go" => extract_imports_go(root, src),
         "java" => extract_imports_java(root, src),
+        "kt" | "kts" => extract_imports_kotlin(root, src),
         _ => Vec::new(),
     }
 }
@@ -543,6 +545,54 @@ fn extract_imports_java(root: Node, src: &str) -> Vec<ImportInfo> {
     imports
 }
 
+#[cfg(feature = "tree-sitter")]
+fn extract_imports_kotlin(root: Node, src: &str) -> Vec<ImportInfo> {
+    let mut imports = Vec::new();
+    let mut cursor = root.walk();
+
+    for node in root.children(&mut cursor) {
+        if node.kind() != "import" {
+            continue;
+        }
+
+        let Some(path_node) = find_child_by_kind(node, "qualified_identifier") else {
+            continue;
+        };
+        let source = node_text(path_node, src).to_string();
+        let text = node_text(node, src);
+        let alias = node
+            .children(&mut node.walk())
+            .filter(|child| {
+                child.kind() == "identifier" && child.start_byte() > path_node.end_byte()
+            })
+            .next()
+            .map(|child| node_text(child, src).to_string());
+        let is_star = text.contains(".*");
+
+        let names = if is_star {
+            vec!["*".to_string()]
+        } else if let Some(alias) = alias {
+            vec![alias]
+        } else {
+            vec![source.rsplit('.').next().unwrap_or(&source).to_string()]
+        };
+
+        imports.push(ImportInfo {
+            source,
+            names,
+            kind: if is_star {
+                ImportKind::Star
+            } else {
+                ImportKind::Named
+            },
+            line: node.start_position().row + 1,
+            is_type_only: false,
+        });
+    }
+
+    imports
+}
+
 // ---------------------------------------------------------------------------
 // Call Sites
 // ---------------------------------------------------------------------------
@@ -576,6 +626,7 @@ fn parse_call(node: Node, src: &str, ext: &str) -> Option<CallSite> {
         "py" => parse_call_python(node, src),
         "go" => parse_call_go(node, src),
         "java" => parse_call_java(node, src),
+        "kt" | "kts" => parse_call_kotlin(node, src),
         _ => None,
     }
 }
@@ -726,6 +777,60 @@ fn parse_call_java(node: Node, src: &str) -> Option<CallSite> {
     })
 }
 
+#[cfg(feature = "tree-sitter")]
+fn parse_call_kotlin(node: Node, src: &str) -> Option<CallSite> {
+    let callee = node.child(0)?;
+
+    match callee.kind() {
+        "identifier" => Some(CallSite {
+            callee: node_text(callee, src).to_string(),
+            line: node.start_position().row + 1,
+            col: node.start_position().column,
+            receiver: None,
+            is_method: false,
+        }),
+        "navigation_expression" => {
+            let mut cursor = callee.walk();
+            let children: Vec<Node> = callee.children(&mut cursor).collect();
+            let callee_name = children
+                .iter()
+                .rev()
+                .find(|child| child.kind() == "identifier")
+                .map(|child| node_text(*child, src).to_string())?;
+            let receiver = children
+                .iter()
+                .find(|child| {
+                    matches!(
+                        child.kind(),
+                        "expression"
+                            | "primary_expression"
+                            | "identifier"
+                            | "navigation_expression"
+                            | "this_expression"
+                            | "super_expression"
+                    )
+                })
+                .map(|child| node_text(*child, src).to_string())
+                .filter(|text| text != &callee_name);
+
+            Some(CallSite {
+                callee: callee_name,
+                line: node.start_position().row + 1,
+                col: node.start_position().column,
+                receiver,
+                is_method: true,
+            })
+        }
+        _ => find_descendant_by_kind(callee, "identifier").map(|name| CallSite {
+            callee: node_text(name, src).to_string(),
+            line: node.start_position().row + 1,
+            col: node.start_position().column,
+            receiver: None,
+            is_method: false,
+        }),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Type Definitions
 // ---------------------------------------------------------------------------
@@ -759,6 +864,7 @@ fn match_type_def(node: Node, src: &str, ext: &str, parent_exported: bool) -> Op
         "py" => match_type_def_python(node, src)?,
         "go" => match_type_def_go(node, src)?,
         "java" => match_type_def_java(node, src)?,
+        "kt" | "kts" => match_type_def_kotlin(node, src)?,
         _ => return None,
     };
 
@@ -892,6 +998,39 @@ fn match_type_def_java(node: Node, src: &str) -> Option<(String, TypeDefKind)> {
     }
 }
 
+#[cfg(feature = "tree-sitter")]
+fn match_type_def_kotlin(node: Node, src: &str) -> Option<(String, TypeDefKind)> {
+    match node.kind() {
+        "class_declaration" => {
+            let name = node
+                .child_by_field_name("name")
+                .or_else(|| find_child_by_kind(node, "identifier"))?;
+            let text = node_text(node, src);
+            let kind = if text.contains("interface") {
+                TypeDefKind::Interface
+            } else if text.contains("enum class") {
+                TypeDefKind::Enum
+            } else {
+                TypeDefKind::Class
+            };
+            Some((node_text(name, src).to_string(), kind))
+        }
+        "object_declaration" => {
+            let name = node
+                .child_by_field_name("name")
+                .or_else(|| find_child_by_kind(node, "identifier"))?;
+            Some((node_text(name, src).to_string(), TypeDefKind::Class))
+        }
+        "type_alias" => {
+            let name = node
+                .child_by_field_name("type")
+                .or_else(|| find_child_by_kind(node, "identifier"))?;
+            Some((node_text(name, src).to_string(), TypeDefKind::TypeAlias))
+        }
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
@@ -934,6 +1073,7 @@ fn is_exported_node(node: Node, src: &str, ext: &str) -> bool {
             }
         }
         "java" => node_text(node, src).trim_start().starts_with("public "),
+        "kt" | "kts" => kotlin_declaration_exported(node, src),
         "py" => {
             if let Some(name) = get_declaration_name(node, src) {
                 !name.starts_with('_')
@@ -958,6 +1098,15 @@ fn get_declaration_name(node: Node, src: &str) -> Option<String> {
         }
     }
     None
+}
+
+#[cfg(feature = "tree-sitter")]
+fn kotlin_declaration_exported(node: Node, src: &str) -> bool {
+    if let Some(modifiers) = find_child_by_kind(node, "modifiers") {
+        !node_text(modifiers, src).contains("private")
+    } else {
+        !node_text(node, src).contains("private")
+    }
 }
 
 #[cfg(feature = "tree-sitter")]
@@ -1280,6 +1429,65 @@ public record Point(int x, int y) {}
         assert!(kinds.contains(&&TypeDefKind::Class));
         assert!(kinds.contains(&&TypeDefKind::Interface));
         assert!(kinds.contains(&&TypeDefKind::Enum));
+    }
+
+    #[test]
+    fn kotlin_imports_and_aliases() {
+        let src = r#"
+package com.example.app
+
+import com.example.services.UserService
+import com.example.factories.WidgetFactory as Factory
+import com.example.shared.*
+"#;
+        let analysis = analyze(src, "kt");
+        assert_eq!(analysis.imports.len(), 3);
+        assert_eq!(
+            analysis.imports[0].source,
+            "com.example.services.UserService"
+        );
+        assert_eq!(analysis.imports[1].names, vec!["Factory"]);
+        assert_eq!(analysis.imports[2].kind, ImportKind::Star);
+    }
+
+    #[test]
+    fn kotlin_call_sites() {
+        let src = r#"
+class UserService {
+    fun run() {
+        prepare()
+        repository.save(user)
+        Factory.create()
+    }
+}
+"#;
+        let analysis = analyze(src, "kt");
+        let callees: Vec<&str> = analysis.calls.iter().map(|c| c.callee.as_str()).collect();
+        assert!(callees.contains(&"prepare"));
+        assert!(callees.contains(&"save"));
+        assert!(callees.contains(&"create"));
+    }
+
+    #[test]
+    fn kotlin_types_and_visibility() {
+        let src = r#"
+sealed interface Handler
+data class User(val id: String)
+enum class Status { ACTIVE, INACTIVE }
+object Registry
+private typealias UserId = String
+"#;
+        let analysis = analyze(src, "kt");
+        let names: Vec<&str> = analysis.types.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"Handler"));
+        assert!(names.contains(&"User"));
+        assert!(names.contains(&"Status"));
+        assert!(names.contains(&"Registry"));
+        assert!(names.contains(&"UserId"));
+        let handler = analysis.types.iter().find(|t| t.name == "Handler").unwrap();
+        assert_eq!(handler.kind, TypeDefKind::Interface);
+        let alias = analysis.types.iter().find(|t| t.name == "UserId").unwrap();
+        assert!(!alias.is_exported);
     }
 
     #[test]

--- a/rust/src/core/deps.rs
+++ b/rust/src/core/deps.rs
@@ -2,6 +2,9 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::sync::OnceLock;
 
+#[cfg(feature = "tree-sitter")]
+use super::deep_queries::{self, ImportKind};
+
 static IMPORT_RE: OnceLock<Regex> = OnceLock::new();
 static REQUIRE_RE: OnceLock<Regex> = OnceLock::new();
 static RUST_USE_RE: OnceLock<Regex> = OnceLock::new();
@@ -38,6 +41,7 @@ pub fn extract_deps(content: &str, ext: &str) -> DepInfo {
         "rs" => extract_rust_deps(content),
         "py" => extract_python_deps(content),
         "go" => extract_go_deps(content),
+        "kt" | "kts" => extract_kotlin_deps(content),
         _ => DepInfo {
             imports: Vec::new(),
             exports: Vec::new(),
@@ -198,6 +202,32 @@ fn extract_go_deps(content: &str) -> DepInfo {
     }
 }
 
+#[cfg(feature = "tree-sitter")]
+fn extract_kotlin_deps(content: &str) -> DepInfo {
+    let analysis = deep_queries::analyze(content, "kt");
+    let imports = analysis
+        .imports
+        .into_iter()
+        .map(|import| match import.kind {
+            ImportKind::Star => format!("{}.*", import.source),
+            _ => import.source,
+        })
+        .collect();
+
+    DepInfo {
+        imports,
+        exports: analysis.exports,
+    }
+}
+
+#[cfg(not(feature = "tree-sitter"))]
+fn extract_kotlin_deps(_content: &str) -> DepInfo {
+    DepInfo {
+        imports: Vec::new(),
+        exports: Vec::new(),
+    }
+}
+
 fn clean_import_path(path: &str) -> String {
     path.trim_start_matches("./")
         .trim_end_matches(".js")
@@ -234,4 +264,29 @@ fn extract_export_name(line: &str) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kotlin_deps_are_extracted_from_ast() {
+        let content = r#"
+package com.example.app
+
+import com.example.services.UserService
+import com.example.shared.*
+
+class Feature
+fun build(): Feature = Feature()
+"#;
+        let deps = extract_deps(content, "kt");
+        assert!(deps
+            .imports
+            .contains(&"com.example.services.UserService".to_string()));
+        assert!(deps.imports.contains(&"com.example.shared.*".to_string()));
+        assert!(deps.exports.contains(&"Feature".to_string()));
+        assert!(deps.exports.contains(&"build".to_string()));
+    }
 }

--- a/rust/src/core/graph_index.rs
+++ b/rust/src/core/graph_index.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::deps;
 use crate::core::signatures;
 
-const INDEX_VERSION: u32 = 1;
+const INDEX_VERSION: u32 = 2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProjectIndex {
@@ -67,7 +67,11 @@ impl ProjectIndex {
         let dir = Self::index_dir(project_root)?;
         let path = dir.join("index.json");
         let content = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&content).ok()
+        let index: Self = serde_json::from_str(&content).ok()?;
+        if index.version != INDEX_VERSION {
+            return None;
+        }
+        Some(index)
     }
 
     pub fn save(&self) -> Result<(), String> {
@@ -292,7 +296,10 @@ pub fn scan(project_root: &str) -> ProjectIndex {
         );
 
         for sig in &sigs {
-            let (start, end) = find_symbol_range(&content, sig);
+            let (start, end) = sig
+                .start_line
+                .zip(sig.end_line)
+                .unwrap_or_else(|| find_symbol_range(&content, sig));
             let key = format!("{}::{}", rel_path, sig.name);
             index.symbols.insert(
                 key,
@@ -601,10 +608,42 @@ class UserService {
             is_async: false,
             is_exported: true,
             indent: 2,
+            ..signatures::Signature::no_span()
         };
         let (start, end) = find_symbol_range(content, &sig);
         assert_eq!(start, 5);
         assert!(end >= start);
+    }
+
+    #[test]
+    fn test_signature_spans_override_fallback_range() {
+        let sig = signatures::Signature {
+            kind: "method",
+            name: "release".to_string(),
+            params: "id:String".to_string(),
+            return_type: "Boolean".to_string(),
+            is_async: true,
+            is_exported: true,
+            indent: 2,
+            start_line: Some(42),
+            end_line: Some(43),
+        };
+
+        let (start, end) = sig
+            .start_line
+            .zip(sig.end_line)
+            .unwrap_or_else(|| find_symbol_range("ignored", &sig));
+        assert_eq!((start, end), (42, 43));
+    }
+
+    #[test]
+    fn test_parse_stale_index_version() {
+        let json = format!(
+            r#"{{"version":{},"project_root":"/test","last_scan":"now","files":{{}},"edges":[],"symbols":{{}}}}"#,
+            INDEX_VERSION - 1
+        );
+        let parsed: ProjectIndex = serde_json::from_str(&json).unwrap();
+        assert_ne!(parsed.version, INDEX_VERSION);
     }
 
     #[test]

--- a/rust/src/core/graph_index.rs
+++ b/rust/src/core/graph_index.rs
@@ -371,7 +371,21 @@ fn find_symbol_range(content: &str, sig: &signatures::Signature) -> (usize, usiz
                 || trimmed.starts_with("type ")
                 || trimmed.starts_with("export type ")
                 || trimmed.starts_with("const ")
-                || trimmed.starts_with("export const ");
+                || trimmed.starts_with("export const ")
+                || trimmed.starts_with("fun ")
+                || trimmed.starts_with("private fun ")
+                || trimmed.starts_with("public fun ")
+                || trimmed.starts_with("internal fun ")
+                || trimmed.starts_with("class ")
+                || trimmed.starts_with("data class ")
+                || trimmed.starts_with("sealed class ")
+                || trimmed.starts_with("sealed interface ")
+                || trimmed.starts_with("enum class ")
+                || trimmed.starts_with("object ")
+                || trimmed.starts_with("private object ")
+                || trimmed.starts_with("interface ")
+                || trimmed.starts_with("typealias ")
+                || trimmed.starts_with("private typealias ");
             if is_def {
                 start = i + 1;
                 break;
@@ -497,6 +511,14 @@ fn is_indexable_ext(ext: &str) -> bool {
 }
 
 #[cfg(test)]
+fn kotlin_package_name(content: &str) -> Option<String> {
+    content.lines().map(str::trim).find_map(|line| {
+        line.strip_prefix("package ")
+            .map(|rest| rest.trim().trim_end_matches(';').to_string())
+    })
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -558,5 +580,39 @@ mod tests {
         assert_eq!(deps.len(), 2);
         assert!(deps.contains(&"a.rs".to_string()));
         assert!(deps.contains(&"c.rs".to_string()));
+    }
+
+    #[test]
+    fn test_find_symbol_range_kotlin_function() {
+        let content = r#"
+package com.example
+
+class UserService {
+    fun greet(name: String): String {
+        return "hi $name"
+    }
+}
+"#;
+        let sig = signatures::Signature {
+            kind: "method",
+            name: "greet".to_string(),
+            params: "name:String".to_string(),
+            return_type: "String".to_string(),
+            is_async: false,
+            is_exported: true,
+            indent: 2,
+        };
+        let (start, end) = find_symbol_range(content, &sig);
+        assert_eq!(start, 5);
+        assert!(end >= start);
+    }
+
+    #[test]
+    fn test_kotlin_package_name() {
+        let content = "package com.example.feature\n\nclass UserService";
+        assert_eq!(
+            kotlin_package_name(content).as_deref(),
+            Some("com.example.feature")
+        );
     }
 }

--- a/rust/src/core/signatures.rs
+++ b/rust/src/core/signatures.rs
@@ -10,9 +10,25 @@ pub struct Signature {
     pub is_async: bool,
     pub is_exported: bool,
     pub indent: usize,
+    pub start_line: Option<usize>,
+    pub end_line: Option<usize>,
 }
 
 impl Signature {
+    pub fn no_span() -> Self {
+        Self {
+            kind: "",
+            name: String::new(),
+            params: String::new(),
+            return_type: String::new(),
+            is_async: false,
+            is_exported: false,
+            indent: 0,
+            start_line: None,
+            end_line: None,
+        }
+    }
+
     pub fn to_compact(&self) -> String {
         let export = if self.is_exported { "⊛ " } else { "" };
         let async_prefix = if self.is_async { "async " } else { "" };
@@ -201,6 +217,7 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: caps.get(3).is_some(),
                 is_exported: caps.get(2).is_some(),
                 indent: if indent > 0 { 2 } else { 0 },
+                ..Signature::no_span()
             });
         } else if let Some(caps) = class_re().captures(line) {
             sigs.push(Signature {
@@ -211,6 +228,7 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = iface_re().captures(line) {
             sigs.push(Signature {
@@ -221,6 +239,7 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = type_re().captures(line) {
             sigs.push(Signature {
@@ -231,6 +250,7 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = const_re().captures(line) {
             if caps.get(2).is_some() {
@@ -244,6 +264,7 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                     is_async: false,
                     is_exported: true,
                     indent: 0,
+                    ..Signature::no_span()
                 });
             }
         }
@@ -273,6 +294,7 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: caps.get(3).is_some(),
                 is_exported: caps.get(2).is_some(),
                 indent: if indent > 0 { 2 } else { 0 },
+                ..Signature::no_span()
             });
         } else if let Some(caps) = rust_struct_re().captures(line) {
             sigs.push(Signature {
@@ -283,6 +305,7 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = rust_enum_re().captures(line) {
             sigs.push(Signature {
@@ -293,6 +316,7 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = rust_trait_re().captures(line) {
             sigs.push(Signature {
@@ -303,6 +327,7 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = rust_impl_re().captures(line) {
             let trait_name = caps.get(2).map(|m| m.as_str());
@@ -320,6 +345,7 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: false,
                 indent: 0,
+                ..Signature::no_span()
             });
         }
     }
@@ -351,6 +377,7 @@ fn extract_python_signatures(content: &str) -> Vec<Signature> {
                 is_async: caps.get(2).is_some(),
                 is_exported: !caps[3].starts_with('_'),
                 indent: if indent > 0 { 2 } else { 0 },
+                ..Signature::no_span()
             });
         } else if let Some(caps) = py_class.captures(line) {
             sigs.push(Signature {
@@ -361,6 +388,7 @@ fn extract_python_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: !caps[2].starts_with('_'),
                 indent: 0,
+                ..Signature::no_span()
             });
         }
     }
@@ -392,6 +420,7 @@ fn extract_go_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps[3].starts_with(char::is_uppercase),
                 indent: if is_method { 2 } else { 0 },
+                ..Signature::no_span()
             });
         } else if let Some(caps) = go_type.captures(line) {
             sigs.push(Signature {
@@ -406,6 +435,7 @@ fn extract_go_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps[1].starts_with(char::is_uppercase),
                 indent: 0,
+                ..Signature::no_span()
             });
         }
     }
@@ -527,6 +557,7 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: true,
                 indent: 0,
+                ..Signature::no_span()
             });
         } else if let Some(caps) = re_func.captures(trimmed) {
             sigs.push(Signature {
@@ -537,6 +568,7 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
                 is_async: trimmed.contains("async"),
                 is_exported: true,
                 indent: 0,
+                ..Signature::no_span()
             });
         }
     }

--- a/rust/src/core/signatures_ts.rs
+++ b/rust/src/core/signatures_ts.rs
@@ -262,7 +262,7 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
     let kind_str = node.kind();
     let start_col = node.start_position().column;
 
-    match kind_str {
+    let mut sig = match kind_str {
         "function_item" => rust_function(node, name, source),
         "struct_item" => rust_struct_like(node, name, "struct"),
         "enum_item" => rust_struct_like(node, name, "enum"),
@@ -308,6 +308,7 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
             is_async: false,
             is_exported: !name.starts_with('_'),
             indent: 0,
+            ..Signature::no_span()
         }),
         "class" | "module" => Some(Signature {
             kind: "class",
@@ -317,6 +318,7 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
             is_async: false,
             is_exported: true,
             indent: 0,
+            ..Signature::no_span()
         }),
 
         "struct_specifier" => simple_def(name, "struct"),
@@ -329,6 +331,7 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
             is_async: false,
             is_exported: is_in_export(node),
             indent: 0,
+            ..Signature::no_span()
         }),
         "type_definition" => simple_def(name, "type"),
         "namespace_definition" => simple_def(name, "class"),
@@ -347,6 +350,7 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
                 is_async: false,
                 is_exported: exported,
                 indent: 0,
+                ..Signature::no_span()
             })
         }
 
@@ -367,7 +371,14 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
         "call" if ext == "ex" || ext == "exs" => elixir_call(node, name, source),
 
         _ => None,
+    }?;
+
+    if matches!(ext, "kt" | "kts") {
+        sig.start_line = Some(node.start_position().row + 1);
+        sig.end_line = Some(node.end_position().row + 1);
     }
+
+    Some(sig)
 }
 
 // ---------------------------------------------------------------------------
@@ -390,6 +401,7 @@ fn rust_function(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async,
         is_exported: exported,
         indent: if is_method { 2 } else { 0 },
+        ..Signature::no_span()
     })
 }
 
@@ -402,6 +414,7 @@ fn rust_struct_like(node: &Node, name: &str, kind: &'static str) -> Option<Signa
         is_async: false,
         is_exported: has_named_child(node, "visibility_modifier"),
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -422,6 +435,7 @@ fn rust_impl(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async: false,
         is_exported: false,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -435,6 +449,7 @@ fn rust_const(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async: false,
         is_exported: has_named_child(node, "visibility_modifier"),
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -465,6 +480,7 @@ fn ts_or_go_function(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
         is_async,
         is_exported: exported,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -480,6 +496,7 @@ fn ts_method(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async: has_keyword_child(node, "async"),
         is_exported: false,
         indent: 2,
+        ..Signature::no_span()
     })
 }
 
@@ -501,6 +518,7 @@ fn ts_arrow_function(node: &Node, name: &str, source: &[u8]) -> Option<Signature
         is_async: has_keyword_child(&arrow, "async"),
         is_exported: exported,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -528,6 +546,7 @@ fn py_or_c_function(
                 is_async: has_keyword_child(node, "async"),
                 is_exported: !name.starts_with('_'),
                 indent: if is_method { 2 } else { 0 },
+                ..Signature::no_span()
             })
         }
         _ => {
@@ -546,6 +565,7 @@ fn py_or_c_function(
                 is_async: false,
                 is_exported: true,
                 indent: 0,
+                ..Signature::no_span()
             })
         }
     }
@@ -568,6 +588,7 @@ fn go_or_java_method(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
                 is_async: false,
                 is_exported: name.starts_with(|c: char| c.is_uppercase()),
                 indent: 2,
+                ..Signature::no_span()
             })
         }
         "java" => {
@@ -582,6 +603,7 @@ fn go_or_java_method(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
                 is_async: false,
                 is_exported: has_modifier(node, "public", source),
                 indent: if is_method { 2 } else { 0 },
+                ..Signature::no_span()
             })
         }
         "cs" => {
@@ -596,6 +618,7 @@ fn go_or_java_method(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
                 is_async: false,
                 is_exported: csharp_has_modifier_text(node, "public", source),
                 indent: if is_method { 2 } else { 0 },
+                ..Signature::no_span()
             })
         }
         "php" => {
@@ -610,6 +633,7 @@ fn go_or_java_method(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
                 is_async: false,
                 is_exported: true,
                 indent: if is_method { 2 } else { 0 },
+                ..Signature::no_span()
             })
         }
         _ => None,
@@ -634,6 +658,7 @@ fn go_type_spec(node: &Node, name: &str, _source: &[u8]) -> Option<Signature> {
         is_async: false,
         is_exported: name.starts_with(|c: char| c.is_uppercase()),
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -647,6 +672,7 @@ fn java_constructor(node: &Node, name: &str, source: &[u8]) -> Option<Signature>
         is_async: false,
         is_exported: has_modifier(node, "public", source),
         indent: 2,
+        ..Signature::no_span()
     })
 }
 
@@ -664,6 +690,7 @@ fn ruby_method(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async: false,
         is_exported: true,
         indent: 2,
+        ..Signature::no_span()
     })
 }
 
@@ -698,6 +725,7 @@ fn kotlin_function(node: &Node, name: &str, source: &[u8]) -> Option<Signature> 
         is_async: false,
         is_exported: exported,
         indent: if is_method { 2 } else { 0 },
+        ..Signature::no_span()
     })
 }
 
@@ -730,6 +758,7 @@ fn swift_function(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async,
         is_exported: true,
         indent: if is_method { 2 } else { 0 },
+        ..Signature::no_span()
     })
 }
 
@@ -743,6 +772,7 @@ fn swift_protocol_function(node: &Node, name: &str, source: &[u8]) -> Option<Sig
         is_async: has_named_child(node, "async"),
         is_exported: true,
         indent: 2,
+        ..Signature::no_span()
     })
 }
 
@@ -764,6 +794,7 @@ fn swift_class_declaration(node: &Node, name: &str, source: &[u8]) -> Option<Sig
         is_async: false,
         is_exported: true,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -827,6 +858,7 @@ fn scala_function(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async: false,
         is_exported: !name.starts_with('_'),
         indent: if is_method { 2 } else { 0 },
+        ..Signature::no_span()
     })
 }
 
@@ -848,6 +880,7 @@ fn elixir_call(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
             is_async: false,
             is_exported: true,
             indent: 0,
+            ..Signature::no_span()
         }),
         "def" | "defmacro" | "defdelegate" | "defguard" => Some(Signature {
             kind: "fn",
@@ -857,6 +890,7 @@ fn elixir_call(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
             is_async: false,
             is_exported: true,
             indent: 2,
+            ..Signature::no_span()
         }),
         "defp" | "defmacrop" | "defguardp" => Some(Signature {
             kind: "fn",
@@ -866,6 +900,7 @@ fn elixir_call(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
             is_async: false,
             is_exported: false,
             indent: 2,
+            ..Signature::no_span()
         }),
         _ => None,
     }
@@ -887,6 +922,7 @@ fn zig_function(node: &Node, name: &str, source: &[u8]) -> Option<Signature> {
         is_async: false,
         is_exported: exported,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -940,6 +976,7 @@ fn class_like(
         is_async: false,
         is_exported: exported,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -952,6 +989,7 @@ fn simple_def(name: &str, kind: &'static str) -> Option<Signature> {
         is_async: false,
         is_exported: true,
         indent: 0,
+        ..Signature::no_span()
     })
 }
 
@@ -1336,6 +1374,29 @@ interface Handler {
         assert!(names.contains(&"greet"));
         assert!(names.contains(&"build"));
         assert!(names.contains(&"handle"));
+    }
+
+    #[test]
+    fn test_kotlin_signature_spans() {
+        let src = r#"
+class Service {
+    suspend fun release(id: String): Boolean =
+        repository.release(id)
+
+    fun block_body(name: String): String {
+        return "ok $name"
+    }
+}
+"#;
+        let sigs = extract_signatures_ts(src, "kt").unwrap();
+
+        let release = sigs.iter().find(|s| s.name == "release").unwrap();
+        assert_eq!(release.start_line, Some(3));
+        assert_eq!(release.end_line, Some(4));
+
+        let block_body = sigs.iter().find(|s| s.name == "block_body").unwrap();
+        assert_eq!(block_body.start_line, Some(6));
+        assert_eq!(block_body.end_line, Some(8));
     }
 
     #[test]

--- a/rust/src/tools/ctx_graph.rs
+++ b/rust/src/tools/ctx_graph.rs
@@ -209,13 +209,19 @@ fn handle_symbol(
     format!("{result}[ctx_graph symbol: {tokens} tok (full file: {full_tokens} tok, -{pct}%)]")
 }
 
-fn file_path_to_module_prefixes(rel_path: &str, project_root: &str) -> Vec<String> {
+fn file_path_to_module_prefixes(
+    rel_path: &str,
+    project_root: &str,
+    index: &ProjectIndex,
+) -> Vec<String> {
     let without_ext = rel_path
         .strip_suffix(".rs")
         .or_else(|| rel_path.strip_suffix(".ts"))
         .or_else(|| rel_path.strip_suffix(".tsx"))
         .or_else(|| rel_path.strip_suffix(".js"))
         .or_else(|| rel_path.strip_suffix(".py"))
+        .or_else(|| rel_path.strip_suffix(".kt"))
+        .or_else(|| rel_path.strip_suffix(".kts"))
         .unwrap_or(rel_path);
 
     let module_path = without_ext
@@ -251,6 +257,33 @@ fn file_path_to_module_prefixes(rel_path: &str, project_root: &str) -> Vec<Strin
     if !crate_name.is_empty() {
         prefixes.insert(0, format!("{crate_name}::{module_path}"));
     }
+
+    let ext = Path::new(rel_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    if matches!(ext, "kt" | "kts") {
+        let abs_path = Path::new(project_root).join(rel_path);
+        if let Ok(content) = std::fs::read_to_string(abs_path) {
+            if let Some(package_name) = content.lines().map(str::trim).find_map(|line| {
+                line.strip_prefix("package ")
+                    .map(|rest| rest.trim().trim_end_matches(';').to_string())
+            }) {
+                prefixes.push(package_name.clone());
+                if let Some(entry) = index.files.get(rel_path) {
+                    for export in &entry.exports {
+                        prefixes.push(format!("{package_name}.{export}"));
+                    }
+                }
+                if let Some(file_stem) = Path::new(rel_path).file_stem().and_then(|s| s.to_str()) {
+                    prefixes.push(format!("{package_name}.{file_stem}"));
+                }
+            }
+        }
+    }
+
+    prefixes.sort();
+    prefixes.dedup();
     prefixes
 }
 
@@ -280,7 +313,7 @@ fn handle_impact(path: Option<&str>, root: &str) -> String {
         .unwrap_or(target)
         .trim_start_matches('/');
 
-    let module_prefixes = file_path_to_module_prefixes(rel_target, root);
+    let module_prefixes = file_path_to_module_prefixes(rel_target, root, &index);
 
     let direct: Vec<&str> = index
         .edges
@@ -398,14 +431,16 @@ mod tests {
 
     #[test]
     fn test_file_path_to_module_prefixes_rust() {
-        let prefixes = file_path_to_module_prefixes("src/core/cache.rs", "/nonexistent");
+        let index = ProjectIndex::new("/nonexistent");
+        let prefixes = file_path_to_module_prefixes("src/core/cache.rs", "/nonexistent", &index);
         assert!(prefixes.contains(&"crate::core::cache".to_string()));
         assert!(prefixes.contains(&"core::cache".to_string()));
     }
 
     #[test]
     fn test_file_path_to_module_prefixes_mod_rs() {
-        let prefixes = file_path_to_module_prefixes("src/core/mod.rs", "/nonexistent");
+        let index = ProjectIndex::new("/nonexistent");
+        let prefixes = file_path_to_module_prefixes("src/core/mod.rs", "/nonexistent", &index);
         assert!(prefixes.contains(&"crate::core".to_string()));
         assert!(!prefixes.iter().any(|p| p.contains("mod")));
     }


### PR DESCRIPTION
## Summary

Improve Kotlin support in the graph-analysis pipeline used by:
- `ctx_graph`
- `ctx_callers`
- `ctx_callees`

## What changed

- added Kotlin support to AST-backed deep analysis for imports, call sites, type definitions, and visibility/export detection
- wired Kotlin imports into the dependency graph pipeline used by `ctx_graph`
- improved Kotlin module-prefix handling for graph `related` / `impact` queries
- replaced Kotlin symbol range guessing with AST-derived source spans during signature extraction
- made `graph_index` prefer signature spans over heuristic text rescanning when spans are available
- bumped the graph index version so stale cached symbol ranges are invalidated automatically
- added Kotlin-focused tests for graph behavior and signature spans

## Why

Kotlin support already existed for top-level signature extraction, but graph and caller/callee behavior was still much weaker than for other AST-backed languages. In particular, symbol ranges could be wrong when the line-matching heuristic failed on Kotlin declarations. This change improves Kotlin dependency and call exploration while also making symbol boundaries reliable.

## Validation

Ran:
- `cargo fmt`
- `cargo test`

## Related issue

Link the feature request issue here once created.