### PR TITLE
fix(dashboard): normalize compression demo paths on Windows

### DIFF
--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -354,6 +354,7 @@ fn route_response(
                     let task = extract_query_param(query_str, "task");
                     let root = detect_project_root_for_dashboard();
                     let root_pb = std::path::Path::new(&root);
+                    let rel = normalize_dashboard_demo_path(&rel);
                     let candidate = std::path::Path::new(&rel);
                     let full = if candidate.is_absolute() {
                         candidate.to_path_buf()
@@ -479,6 +480,22 @@ fn percent_decode_query_component(s: &str) -> String {
         }
     }
     String::from_utf8_lossy(&out).into_owned()
+}
+
+fn normalize_dashboard_demo_path(path: &str) -> String {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let candidate = Path::new(trimmed);
+    if candidate.is_absolute() {
+        return trimmed.to_string();
+    }
+
+    trimmed
+        .trim_start_matches(['\\', '/'])
+        .replace('\\', std::path::MAIN_SEPARATOR_STR)
 }
 
 fn compression_mode_json(output: &str, original_tokens: usize) -> serde_json::Value {
@@ -749,5 +766,20 @@ mod tests {
         assert!(!"/".starts_with("/api/"));
         assert!(!"/index.html".starts_with("/api/"));
         assert!(!"/favicon.ico".starts_with("/api/"));
+    }
+
+    #[test]
+    fn normalize_dashboard_demo_path_strips_rooted_relative_windows_path() {
+        let normalized = normalize_dashboard_demo_path(r"\backend\list_tables.js");
+        assert_eq!(
+            normalized,
+            format!("backend{}list_tables.js", std::path::MAIN_SEPARATOR)
+        );
+    }
+
+    #[test]
+    fn normalize_dashboard_demo_path_preserves_absolute_windows_path() {
+        let input = r"C:\repo\backend\list_tables.js";
+        assert_eq!(normalize_dashboard_demo_path(input), input);
     }
 }

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -489,13 +489,26 @@ fn normalize_dashboard_demo_path(path: &str) -> String {
     }
 
     let candidate = Path::new(trimmed);
-    if candidate.is_absolute() {
+    if candidate.is_absolute() || is_windows_absolute_path(trimmed) {
         return trimmed.to_string();
     }
 
     trimmed
         .trim_start_matches(['\\', '/'])
         .replace('\\', std::path::MAIN_SEPARATOR_STR)
+}
+
+fn is_windows_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
+    {
+        return true;
+    }
+
+    path.starts_with("\\\\") || path.starts_with("//")
 }
 
 fn compression_mode_json(output: &str, original_tokens: usize) -> serde_json::Value {
@@ -780,6 +793,12 @@ mod tests {
     #[test]
     fn normalize_dashboard_demo_path_preserves_absolute_windows_path() {
         let input = r"C:\repo\backend\list_tables.js";
+        assert_eq!(normalize_dashboard_demo_path(input), input);
+    }
+
+    #[test]
+    fn normalize_dashboard_demo_path_preserves_unc_path() {
+        let input = r"\\server\share\backend\list_tables.js";
         assert_eq!(normalize_dashboard_demo_path(input), input);
     }
 }


### PR DESCRIPTION
## Summary

Fixes Compression Lab file selection when the dashboard sends Windows-style relative paths like `\backend\...`.

## Changes

- Normalize incoming `/api/compression-demo` `path` values before resolving them
- Strip leading `/` or `\` from non-absolute paths
- Preserve true absolute paths
- Add focused tests for rooted-relative Windows paths and absolute Windows paths

## Why

Compression Lab was returning:

```json
{"error":"failed to read file"}
