### PR TITLE
fix(dashboard): add call graph api route

### DIFF
--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -324,6 +324,16 @@ fn route_response(
             });
             ("200 OK", "application/json", json)
         }
+        "/api/call-graph" => {
+            let root = detect_project_root_for_dashboard();
+            let index = crate::core::graph_index::load_or_build(&root);
+            let call_graph = crate::core::call_graph::CallGraph::load_or_build(&root, &index);
+            let _ = call_graph.save();
+            let json = serde_json::to_string(&call_graph).unwrap_or_else(|_| {
+                "{\"error\":\"failed to serialize call graph\"}".to_string()
+            });
+            ("200 OK", "application/json", json)
+        }
         "/api/feedback" => {
             let store = crate::core::feedback::FeedbackStore::load();
             let json = serde_json::to_string(&store).unwrap_or_else(|_| {

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -329,9 +329,8 @@ fn route_response(
             let index = crate::core::graph_index::load_or_build(&root);
             let call_graph = crate::core::call_graph::CallGraph::load_or_build(&root, &index);
             let _ = call_graph.save();
-            let json = serde_json::to_string(&call_graph).unwrap_or_else(|_| {
-                "{\"error\":\"failed to serialize call graph\"}".to_string()
-            });
+            let json = serde_json::to_string(&call_graph)
+                .unwrap_or_else(|_| "{\"error\":\"failed to serialize call graph\"}".to_string());
             ("200 OK", "application/json", json)
         }
         "/api/feedback" => {


### PR DESCRIPTION
## Summary

Adds the missing `/api/call-graph` backend route used by the dashboard Call Graph view.

## Changes

- Add `/api/call-graph` route in the dashboard server
- Reuse the existing graph index
- Build/load the existing call graph through `core::call_graph`
- Return the serialized call graph payload expected by the frontend

## Why

The dashboard frontend includes a Call Graph view, but the backend route was missing.

## Scope

- Dashboard backend only
- Reuses existing call graph infrastructure
- No frontend changes

## Testing

Not run locally.

This environment cannot build Rust locally because the MSVC linker/toolchain is unavailable on this machine, so this was validated as a narrow source-level fix.
