### PR TITLE
fix(dashboard): add routes api route

### DIFF
--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -347,6 +347,15 @@ fn route_response(
             });
             ("200 OK", "application/json", json)
         }
+        "/api/routes" => {
+            let root = detect_project_root_for_dashboard();
+            let index = crate::core::graph_index::load_or_build(&root);
+            let routes =
+                crate::core::route_extractor::extract_routes_from_project(&root, &index.files);
+            let json = serde_json::to_string(&routes)
+                .unwrap_or_else(|_| "{\"error\":\"failed to serialize routes\"}".to_string());
+            ("200 OK", "application/json", json)
+        }
         "/api/compression-demo" => {
             let body = match extract_query_param(query_str, "path") {
                 None => r#"{"error":"missing path query parameter"}"#.to_string(),


### PR DESCRIPTION
## Summary

Adds the missing `/api/routes` backend route used by the dashboard Route Map view.

## Changes

- Add `/api/routes` route in the dashboard server
- Reuse the existing graph index
- Reuse the existing route extractor to return route entries for the dashboard

## Why

The dashboard frontend includes a Route Map view, but the backend route was not implemented.

## Scope

- Dashboard backend only
- Reuses existing route extraction logic
- No frontend changes

## Testing

Not run locally.

This environment cannot build Rust locally because the MSVC linker/toolchain is unavailable on this machine, so this was validated as a narrow source-level fix.
