### PR TITLE
fix(dashboard): rename streak label

### DIFF
--- a/rust/src/dashboard/dashboard.html
+++ b/rust/src/dashboard/dashboard.html
@@ -765,7 +765,7 @@ function buildOverview(container) {
         <div class="buddy-sprite" id="buddySpriteWrap"><pre id="buddyAscii"></pre></div>
         <div class="buddy-info">
           <div class="buddy-name"><span id="buddyName"></span><span class="rarity-badge" id="buddyRarityBadge"></span></div>
-          <div class="buddy-meta"><span id="buddySpecies"></span> &middot; Lv.<span id="buddyLevel"></span> &middot; <span class="mood-dot" id="buddyMoodDot"></span> <span id="buddyMood"></span> &middot; <span id="buddyStreak"></span>d streak</div>
+          <div class="buddy-meta"><span id="buddySpecies"></span> &middot; Lv.<span id="buddyLevel"></span> &middot; <span class="mood-dot" id="buddyMoodDot"></span> <span id="buddyMood"></span> &middot; <span id="buddyStreak"></span> days streak</div>
           <div class="xp-wrap"><div class="xp-label"><span>XP <span id="buddyXp">0</span></span><span>Next Lv. <span id="buddyXpNext">0</span></span></div><div class="xp-track"><div class="xp-fill" id="buddyXpBar" style="width:0%"></div></div></div>
           <div class="buddy-stats-grid">
             <div class="stat-cell"><div class="stat-label">CMP</div><div class="stat-gauge"><svg viewBox="0 0 36 36"><circle class="bg" cx="18" cy="18" r="15.9"/><circle class="fg" id="sgComp" cx="18" cy="18" r="15.9" stroke="var(--green)" stroke-dasharray="100" stroke-dashoffset="100"/></svg></div><div class="stat-val" style="color:var(--green)" id="bsComp">0</div></div>


### PR DESCRIPTION
## Summary

Renames the buddy streak label in the dashboard from `d streak` to `days streak`.

## Changes

- Update the buddy meta label in `rust/src/dashboard/dashboard.html`

## Why

The previous label looked incomplete in the UI and read like a formatting bug.

## Scope

- UI text only
- No logic changes
- No backend changes

## Testing

Not run locally.

This environment cannot build Rust locally because the MSVC linker/toolchain is unavailable on this machine, so this was validated as a small isolated text fix.
