### PR TITLE
fix(dashboard): improve route and graph empty states

### DIFF
--- a/rust/src/dashboard/dashboard.html
+++ b/rust/src/dashboard/dashboard.html
@@ -633,6 +633,15 @@ function howItWorks(title, content) {
 function showLoading(container) { container.innerHTML = '<div class="loading-state">Loading...</div>'; }
 function showEmpty(container, msg) { container.innerHTML = `<div class="empty-state"><h2>No data yet</h2><p>${msg}</p></div>`; }
 function showError(container, msg) { container.innerHTML = `<div class="empty-state"><h2>Connection Error</h2><p>${esc(msg)}</p></div>`; }
+function showGuidedEmpty(container, title, msg, hints, actionLabel, actionJs) {
+  const hintList = (hints || []).length
+    ? `<ul style="margin:14px auto 0;max-width:560px;text-align:left;color:var(--muted);font-size:12px;line-height:1.7;padding-left:18px">${hints.map(h => `<li>${esc(h)}</li>`).join('')}</ul>`
+    : '';
+  const action = actionLabel && actionJs
+    ? `<div style="margin-top:16px"><button class="btn" onclick="${actionJs}">${esc(actionLabel)}</button></div>`
+    : '';
+  container.innerHTML = `<div class="empty-state"><h2>${esc(title)}</h2><p>${esc(msg)}</p>${hintList}${action}</div>`;
+}
 
 const retryTimers = new Map();
 const retryDelays = new Map();
@@ -1742,18 +1751,37 @@ async function loadCallGraph() {
       return;
     }
     resetRetry('callgraph');
-    if (!data || !data.edges || !data.edges.length) {
-      container.innerHTML = '<div style="color:var(--dim);padding:24px;text-align:center">No call graph data available yet. LeanCTX builds it automatically once indexing finishes.</div>';
+    const edges = Array.isArray(data?.edges) ? data.edges : [];
+    if (!edges.length) {
+      const indexedFiles = data?.indexed_file_count ?? 0;
+      const indexedSymbols = data?.indexed_symbol_count ?? 0;
+      const analyzedFiles = data?.analyzed_file_count ?? 0;
+      showGuidedEmpty(
+        container,
+        'No call graph data yet',
+        data?.hint || 'LeanCTX has not produced any call edges for this project yet.',
+        [
+          `Indexed files: ${indexedFiles}`,
+          `Indexed symbols: ${indexedSymbols}`,
+          `Files analyzed for calls: ${analyzedFiles}`,
+          indexedFiles === 0
+            ? 'Open the project root in LeanCTX so indexing can discover source files first.'
+            : 'If this project is large, let indexing finish and then refresh this view.',
+          'If the graph still stays empty, refresh the dashboard or re-run LeanCTX from the project root to rebuild indexes.',
+        ],
+        'Refresh call graph',
+        'loadCallGraph()',
+      );
       return;
     }
     const nodes = new Map();
-    data.edges.forEach(e => {
+    edges.forEach(e => {
       nodes.set(e.caller_symbol, (nodes.get(e.caller_symbol) || 0) + 1);
       nodes.set(e.callee_name, (nodes.get(e.callee_name) || 0) + 1);
     });
     const topNodes = [...nodes.entries()].sort((a,b) => b[1]-a[1]).slice(0, 40).map(n => n[0]);
     const topSet = new Set(topNodes);
-    const filteredEdges = data.edges.filter(e => topSet.has(e.caller_symbol) || topSet.has(e.callee_name));
+    const filteredEdges = edges.filter(e => topSet.has(e.caller_symbol) || topSet.has(e.callee_name));
     const uniqueEdges = new Map();
     filteredEdges.forEach(e => {
       const key = e.caller_symbol + '→' + e.callee_name;
@@ -1761,7 +1789,7 @@ async function loadCallGraph() {
       else uniqueEdges.get(key).count++;
     });
     const graphNodes = [...new Set([...uniqueEdges.values()].flatMap(e => [e.source, e.target]))].map(n => ({ id: n, count: nodes.get(n) || 0 }));
-    container.innerHTML = `<div style="margin-bottom:8px;font-size:12px;color:var(--dim)">${data.edges.length} call edges, showing top ${graphNodes.length} symbols</div><div id="cgViz" style="width:100%;height:500px;background:var(--surface);border-radius:12px;border:1px solid var(--border)"></div>`;
+    container.innerHTML = `<div style="margin-bottom:8px;font-size:12px;color:var(--dim)">${edges.length} call edges, showing top ${graphNodes.length} symbols</div><div id="cgViz" style="width:100%;height:500px;background:var(--surface);border-radius:12px;border:1px solid var(--border)"></div>`;
     const width = container.clientWidth, height = 500;
     const svg = d3.select('#cgViz').append('svg').attr('width', width).attr('height', height);
     const sim = d3.forceSimulation(graphNodes)
@@ -1797,14 +1825,33 @@ async function loadRoutes() {
       return;
     }
     resetRetry('routes');
-    if (!data || !data.length) {
-      container.innerHTML = '<div style="color:var(--dim);padding:24px;text-align:center">No HTTP routes found in this project.</div>';
+    const routes = Array.isArray(data) ? data : (Array.isArray(data?.routes) ? data.routes : []);
+    if (!routes.length) {
+      const indexedFiles = data?.indexed_file_count ?? 0;
+      const routeCandidates = data?.route_candidate_count ?? 0;
+      const frameworks = Array.isArray(data?.supported_frameworks) ? data.supported_frameworks.join(', ') : 'Express, Flask, FastAPI, Actix, Spring, Rails, Next.js';
+      showGuidedEmpty(
+        container,
+        'No HTTP routes found',
+        data?.hint || 'LeanCTX did not detect any supported HTTP route declarations in this project.',
+        [
+          `Indexed files: ${indexedFiles}`,
+          `Likely route candidates scanned: ${routeCandidates}`,
+          `Supported frameworks: ${frameworks}`,
+          routeCandidates === 0
+            ? 'This project may not contain server route files, or LeanCTX may be pointed at the wrong project root.'
+            : 'This project may use a framework or routing style that LeanCTX does not extract yet.',
+          'If this looks wrong, refresh the dashboard after indexing completes or re-run LeanCTX from the project root to rebuild the project index.',
+        ],
+        'Refresh routes',
+        'loadRoutes()',
+      );
       return;
     }
     const methodColors = { GET: '#34d399', POST: '#60a5fa', PUT: '#fbbf24', PATCH: '#c084fc', DELETE: '#f87171', HEAD: '#94a3b8', OPTIONS: '#94a3b8' };
-    container.innerHTML = `<div style="margin-bottom:12px;font-size:12px;color:var(--dim)">${data.length} route(s) found</div>
+    container.innerHTML = `<div style="margin-bottom:12px;font-size:12px;color:var(--dim)">${routes.length} route(s) found</div>
       <table style="width:100%;border-collapse:collapse"><thead><tr style="text-align:left;font-size:11px;color:var(--dim)"><th style="padding:6px">Method</th><th style="padding:6px">Path</th><th style="padding:6px">Handler</th><th style="padding:6px">File</th><th style="padding:6px">Line</th></tr></thead><tbody>`
-      + data.map(r => `<tr style="border-top:1px solid var(--border)"><td style="padding:6px"><span style="background:${methodColors[r.method] || '#6b6b88'};color:#000;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:700">${esc(r.method)}</span></td><td style="padding:6px;font-family:var(--mono);font-size:13px">${esc(r.path)}</td><td style="padding:6px;font-size:12px;color:var(--green)">${esc(r.handler || '—')}</td><td style="padding:6px;font-size:12px;color:var(--dim)">${esc(r.file)}</td><td style="padding:6px;font-size:12px">${r.line}</td></tr>`).join('')
+      + routes.map(r => `<tr style="border-top:1px solid var(--border)"><td style="padding:6px"><span style="background:${methodColors[r.method] || '#6b6b88'};color:#000;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:700">${esc(r.method)}</span></td><td style="padding:6px;font-family:var(--mono);font-size:13px">${esc(r.path)}</td><td style="padding:6px;font-size:12px;color:var(--green)">${esc(r.handler || '—')}</td><td style="padding:6px;font-size:12px;color:var(--dim)">${esc(r.file)}</td><td style="padding:6px;font-size:12px">${r.line}</td></tr>`).join('')
       + '</tbody></table>';
   } catch (e) { showError(container, 'Could not load routes.'); }
 }

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -329,8 +329,37 @@ fn route_response(
             let index = crate::core::graph_index::load_or_build(&root);
             let call_graph = crate::core::call_graph::CallGraph::load_or_build(&root, &index);
             let _ = call_graph.save();
-            let json = serde_json::to_string(&call_graph)
-                .unwrap_or_else(|_| "{\"error\":\"failed to serialize call graph\"}".to_string());
+            let unique_callers = call_graph
+                .edges
+                .iter()
+                .map(|edge| edge.caller_symbol.as_str())
+                .collect::<std::collections::HashSet<_>>()
+                .len();
+            let unique_callees = call_graph
+                .edges
+                .iter()
+                .map(|edge| edge.callee_name.as_str())
+                .collect::<std::collections::HashSet<_>>()
+                .len();
+            let payload = serde_json::json!({
+                "status": if call_graph.edges.is_empty() { "empty" } else { "ready" },
+                "project_root": call_graph.project_root,
+                "edges": call_graph.edges,
+                "indexed_file_count": index.files.len(),
+                "indexed_symbol_count": index.symbols.len(),
+                "analyzed_file_count": call_graph.file_hashes.len(),
+                "edge_count": call_graph.edges.len(),
+                "unique_caller_count": unique_callers,
+                "unique_callee_count": unique_callees,
+                "hint": if unique_callers == 0 && unique_callees == 0 {
+                    "LeanCTX has indexed files, but it has not found call edges yet."
+                } else {
+                    "Call graph data is ready."
+                }
+            });
+            let json = serde_json::to_string(&payload).unwrap_or_else(|_| {
+                "{\"error\":\"failed to serialize call graph payload\"}".to_string()
+            });
             ("200 OK", "application/json", json)
         }
         "/api/feedback" => {
@@ -353,7 +382,33 @@ fn route_response(
             let index = crate::core::graph_index::load_or_build(&root);
             let routes =
                 crate::core::route_extractor::extract_routes_from_project(&root, &index.files);
-            let json = serde_json::to_string(&routes).unwrap_or_else(|_| "[]".to_string());
+            let route_candidate_count = index
+                .files
+                .keys()
+                .filter(|path| is_dashboard_route_candidate(path))
+                .count();
+            let payload = serde_json::json!({
+                "status": if routes.is_empty() { "empty" } else { "ready" },
+                "routes": routes,
+                "indexed_file_count": index.files.len(),
+                "route_candidate_count": route_candidate_count,
+                "supported_frameworks": [
+                    "Express",
+                    "Flask",
+                    "FastAPI",
+                    "Actix",
+                    "Spring",
+                    "Rails",
+                    "Next.js"
+                ],
+                "hint": if route_candidate_count == 0 {
+                    "No route-like source files were detected in the indexed project."
+                } else {
+                    "LeanCTX scanned likely route files but did not find supported HTTP route patterns."
+                }
+            });
+            let json =
+                serde_json::to_string(&payload).unwrap_or_else(|_| "{\"routes\":[]}".to_string());
             ("200 OK", "application/json", json)
         }
         "/api/session" => {
@@ -539,6 +594,17 @@ fn percent_decode_query_component(s: &str) -> String {
         }
     }
     String::from_utf8_lossy(&out).into_owned()
+}
+
+fn is_dashboard_route_candidate(path: &str) -> bool {
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    matches!(
+        ext,
+        "js" | "ts" | "jsx" | "tsx" | "py" | "rs" | "java" | "rb" | "go" | "kt"
+    )
 }
 
 fn normalize_dashboard_demo_path(path: &str) -> String {


### PR DESCRIPTION
## Summary
Improve the dashboard empty-state UX for `Route Map` and `Call Graph` so users get actionable guidance instead of a generic “nothing found” message.

## What changed
- Added richer empty-state messaging for `Route Map`
- Added richer empty-state messaging for `Call Graph`
- Added lightweight backend metadata to both endpoints so the UI can explain:
  - how many files were indexed
  - how many route-candidate files were scanned
  - how many files/symbols were analyzed for the call graph
- Added refresh/rebuild guidance directly in the UI

## Why
The previous UI made it hard to tell whether:
- the endpoint was missing
- indexing had not finished
- the project truly had no route/call graph data
- LeanCTX was pointed at the wrong project root

This change makes those empty states self-explanatory.

## Scope
- `rust/src/dashboard/dashboard.html`
- `rust/src/dashboard/mod.rs`

## Behavior
### Route Map
When no routes are found, the UI now explains:
- indexed file count
- route-candidate file count
- supported frameworks currently recognized by LeanCTX
- whether no route-like files were found at all vs. route patterns were not recognized
- that the user can refresh or rebuild by re-running LeanCTX from the project root

### Call Graph
When no call graph data is available, the UI now explains:
- indexed file count
- indexed symbol count
- files analyzed for call edges
- whether LeanCTX found source files but no call edges yet
- that the user can refresh or rebuild by re-running LeanCTX from the project root

## Testing
- `cargo fmt --check`

## Notes
This PR does not change the extraction logic itself.
It only improves the explanation and guidance shown when extracted data is empty.
