### PR TITLE
fix: make Codex hooks compatible with the actual PreToolUse contract

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -182,7 +182,7 @@ lean-ctx init --global         # Install 23 shell aliases (.zshrc/.bashrc/.confi
 lean-ctx init --agent claude   # Install Claude Code PreToolUse hook
 lean-ctx init --agent cursor   # Install Cursor hooks.json
 lean-ctx init --agent gemini   # Install Gemini CLI BeforeTool hook
-lean-ctx init --agent codex    # Install Codex AGENTS.md
+lean-ctx init --agent codex    # Install Codex AGENTS.md + compatible hooks
 lean-ctx init --agent windsurf # Install .windsurfrules
 lean-ctx init --agent cline    # Install .clinerules
 lean-ctx init --agent crush    # Install Crush MCP config
@@ -514,6 +514,18 @@ args = []
 ```
 
 Or via CLI: `codex mcp add lean-ctx`
+
+Then run:
+
+```bash
+lean-ctx init --agent codex
+```
+
+This installs:
+
+- `~/.codex/AGENTS.md` + `~/.codex/LEAN-CTX.md`
+- a `SessionStart` hook that reminds Codex to prefer `lean-ctx -c "<command>"` for rewritable shell commands
+- a `PreToolUse` hook that blocks rewritable raw Bash commands and tells Codex exactly how to rerun them through `lean-ctx`
 
 ### Google Antigravity
 

--- a/rust/src/cli/dispatch.rs
+++ b/rust/src/cli/dispatch.rs
@@ -683,9 +683,11 @@ pub fn run() {
                     "rewrite" => hook_handlers::handle_rewrite(),
                     "redirect" => hook_handlers::handle_redirect(),
                     "copilot" => hook_handlers::handle_copilot(),
+                    "codex-pretooluse" => hook_handlers::handle_codex_pretooluse(),
+                    "codex-session-start" => hook_handlers::handle_codex_session_start(),
                     "rewrite-inline" => hook_handlers::handle_rewrite_inline(),
                     _ => {
-                        eprintln!("Usage: lean-ctx hook <rewrite|redirect|copilot|rewrite-inline>");
+                        eprintln!("Usage: lean-ctx hook <rewrite|redirect|copilot|codex-pretooluse|codex-session-start|rewrite-inline>");
                         eprintln!("  Internal commands used by agent hooks (Claude, Cursor, Copilot, etc.)");
                         std::process::exit(1);
                     }

--- a/rust/src/doctor.rs
+++ b/rust/src/doctor.rs
@@ -980,6 +980,9 @@ fn run_fix(opts: DoctorFixOptions) -> Result<i32, String> {
         doctor_report_path, PlatformInfo, SetupItem, SetupReport, SetupStepReport,
     };
 
+    let _quiet_guard = opts
+        .json
+        .then(|| crate::setup::EnvVarGuard::set("LEAN_CTX_QUIET", "1"));
     let started_at = Utc::now();
     let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
 

--- a/rust/src/hook_handlers.rs
+++ b/rust/src/hook_handlers.rs
@@ -19,17 +19,7 @@ pub fn handle_rewrite() {
         None => return,
     };
 
-    if cmd.starts_with("lean-ctx ") || cmd.starts_with(&format!("{binary} ")) {
-        return;
-    }
-
-    if let Some(rewritten) = build_rewrite_compound(&cmd, &binary) {
-        emit_rewrite(&rewritten);
-        return;
-    }
-
-    if is_rewritable(&cmd) {
-        let rewritten = wrap_single_command(&cmd, &binary);
+    if let Some(rewritten) = rewrite_candidate(&cmd, &binary) {
         emit_rewrite(&rewritten);
     }
 }
@@ -41,6 +31,22 @@ fn is_rewritable(cmd: &str) -> bool {
 fn wrap_single_command(cmd: &str, binary: &str) -> String {
     let shell_escaped = cmd.replace('\\', "\\\\").replace('"', "\\\"");
     format!("{binary} -c \"{shell_escaped}\"")
+}
+
+fn rewrite_candidate(cmd: &str, binary: &str) -> Option<String> {
+    if cmd.starts_with("lean-ctx ") || cmd.starts_with(&format!("{binary} ")) {
+        return None;
+    }
+
+    if let Some(rewritten) = build_rewrite_compound(cmd, binary) {
+        return Some(rewritten);
+    }
+
+    if is_rewritable(cmd) {
+        return Some(wrap_single_command(cmd, binary));
+    }
+
+    None
 }
 
 fn build_rewrite_compound(cmd: &str, binary: &str) -> Option<String> {
@@ -68,6 +74,41 @@ pub fn handle_redirect() {
     // Blocking them breaks Edit (which requires native Read) and causes
     // unnecessary friction. The MCP instructions already guide the AI
     // to prefer ctx_read/ctx_search/ctx_tree.
+}
+
+fn codex_reroute_message(rewritten: &str) -> String {
+    format!(
+        "Command should run via lean-ctx for compact output. Do not retry the original command. Re-run with: {rewritten}"
+    )
+}
+
+pub fn handle_codex_pretooluse() {
+    let binary = resolve_binary();
+    let mut input = String::new();
+    if std::io::stdin().read_to_string(&mut input).is_err() {
+        return;
+    }
+
+    let tool = extract_json_field(&input, "tool_name");
+    if !matches!(tool.as_deref(), Some("Bash" | "bash")) {
+        return;
+    }
+
+    let cmd = match extract_json_field(&input, "command") {
+        Some(c) => c,
+        None => return,
+    };
+
+    if let Some(rewritten) = rewrite_candidate(&cmd, &binary) {
+        eprintln!("{}", codex_reroute_message(&rewritten));
+        std::process::exit(2);
+    }
+}
+
+pub fn handle_codex_session_start() {
+    println!(
+        "For shell commands matched by lean-ctx compression rules, prefer `lean-ctx -c \"<command>\"`. If a Bash call is blocked, rerun it with the exact command suggested by the hook."
+    );
 }
 
 /// Copilot-specific PreToolUse handler.
@@ -99,17 +140,7 @@ pub fn handle_copilot() {
         None => return,
     };
 
-    if cmd.starts_with("lean-ctx ") || cmd.starts_with(&format!("{binary} ")) {
-        return;
-    }
-
-    if let Some(rewritten) = build_rewrite_compound(&cmd, &binary) {
-        emit_rewrite(&rewritten);
-        return;
-    }
-
-    if is_rewritable(&cmd) {
-        let rewritten = wrap_single_command(&cmd, &binary);
+    if let Some(rewritten) = rewrite_candidate(&cmd, &binary) {
         emit_rewrite(&rewritten);
     }
 }
@@ -126,19 +157,13 @@ pub fn handle_rewrite_inline() {
     }
     let cmd = args[3..].join(" ");
 
+    if let Some(rewritten) = rewrite_candidate(&cmd, &binary) {
+        print!("{rewritten}");
+        return;
+    }
+
     if cmd.starts_with("lean-ctx ") || cmd.starts_with(&format!("{binary} ")) {
         print!("{cmd}");
-        return;
-    }
-
-    if let Some(rewritten) = build_rewrite_compound(&cmd, &binary) {
-        print!("{rewritten}");
-        return;
-    }
-
-    if is_rewritable(&cmd) {
-        let rewritten = wrap_single_command(&cmd, &binary);
-        print!("{rewritten}");
         return;
     }
 
@@ -196,6 +221,31 @@ mod tests {
     fn wrap_with_quotes() {
         let r = wrap_single_command(r#"curl -H "Auth" https://api.com"#, "lean-ctx");
         assert_eq!(r, r#"lean-ctx -c "curl -H \"Auth\" https://api.com""#);
+    }
+
+    #[test]
+    fn rewrite_candidate_returns_none_for_existing_lean_ctx_command() {
+        assert_eq!(
+            rewrite_candidate("lean-ctx -c git status", "lean-ctx"),
+            None
+        );
+    }
+
+    #[test]
+    fn rewrite_candidate_wraps_single_command() {
+        assert_eq!(
+            rewrite_candidate("git status", "lean-ctx"),
+            Some(r#"lean-ctx -c "git status""#.to_string())
+        );
+    }
+
+    #[test]
+    fn codex_reroute_message_includes_exact_rewritten_command() {
+        let message = codex_reroute_message(r#"lean-ctx -c "git status""#);
+        assert_eq!(
+            message,
+            r#"Command should run via lean-ctx for compact output. Do not retry the original command. Re-run with: lean-ctx -c "git status""#
+        );
     }
 
     #[test]

--- a/rust/src/hooks/agents.rs
+++ b/rust/src/hooks/agents.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 
 use super::{
-    full_server_entry, generate_compact_rewrite_script, generate_rewrite_script,
-    install_mcp_json_agent, install_project_rules, is_inside_git_repo, make_executable,
-    mcp_server_quiet_mode, resolve_binary_path, resolve_binary_path_for_bash, write_file,
-    KIRO_STEERING_TEMPLATE, REDIRECT_SCRIPT_CLAUDE, REDIRECT_SCRIPT_GENERIC,
+    ensure_codex_hooks_enabled as shared_ensure_codex_hooks_enabled, full_server_entry,
+    generate_compact_rewrite_script, generate_rewrite_script, install_codex_instruction_docs,
+    install_mcp_json_agent, install_named_json_server, install_project_rules, is_inside_git_repo,
+    make_executable, mcp_server_quiet_mode, resolve_binary_path, resolve_binary_path_for_bash,
+    upsert_lean_ctx_codex_hook_entries, write_file, KIRO_STEERING_TEMPLATE, REDIRECT_SCRIPT_CLAUDE,
+    REDIRECT_SCRIPT_GENERIC,
 };
 
 pub(super) fn install_claude_hook(global: bool) {
@@ -334,18 +336,7 @@ pub fn install_cursor_hook(global: bool) {
 
 pub(super) fn install_cursor_hook_scripts(home: &std::path::Path) {
     let hooks_dir = home.join(".cursor").join("hooks");
-    let _ = std::fs::create_dir_all(&hooks_dir);
-
-    let binary = resolve_binary_path_for_bash();
-
-    let rewrite_path = hooks_dir.join("lean-ctx-rewrite.sh");
-    let rewrite_script = generate_compact_rewrite_script(&binary);
-    write_file(&rewrite_path, &rewrite_script);
-    make_executable(&rewrite_path);
-
-    let redirect_path = hooks_dir.join("lean-ctx-redirect.sh");
-    write_file(&redirect_path, REDIRECT_SCRIPT_GENERIC);
-    make_executable(&redirect_path);
+    install_standard_hook_scripts(&hooks_dir, "lean-ctx-rewrite.sh", "lean-ctx-redirect.sh");
 
     let native_binary = resolve_binary_path();
     let rewrite_native = hooks_dir.join("lean-ctx-rewrite-native");
@@ -442,20 +433,31 @@ pub(super) fn install_gemini_hook() {
     install_gemini_hook_config(&home);
 }
 
-pub(super) fn install_gemini_hook_scripts(home: &std::path::Path) {
-    let hooks_dir = home.join(".gemini").join("hooks");
-    let _ = std::fs::create_dir_all(&hooks_dir);
+fn install_standard_hook_scripts(
+    hooks_dir: &std::path::Path,
+    rewrite_name: &str,
+    redirect_name: &str,
+) {
+    let _ = std::fs::create_dir_all(hooks_dir);
 
     let binary = resolve_binary_path_for_bash();
-
-    let rewrite_path = hooks_dir.join("lean-ctx-rewrite-gemini.sh");
+    let rewrite_path = hooks_dir.join(rewrite_name);
     let rewrite_script = generate_compact_rewrite_script(&binary);
     write_file(&rewrite_path, &rewrite_script);
     make_executable(&rewrite_path);
 
-    let redirect_path = hooks_dir.join("lean-ctx-redirect-gemini.sh");
+    let redirect_path = hooks_dir.join(redirect_name);
     write_file(&redirect_path, REDIRECT_SCRIPT_GENERIC);
     make_executable(&redirect_path);
+}
+
+pub(super) fn install_gemini_hook_scripts(home: &std::path::Path) {
+    let hooks_dir = home.join(".gemini").join("hooks");
+    install_standard_hook_scripts(
+        &hooks_dir,
+        "lean-ctx-rewrite-gemini.sh",
+        "lean-ctx-redirect-gemini.sh",
+    );
 }
 
 pub(super) fn install_gemini_hook_config(home: &std::path::Path) {
@@ -537,162 +539,87 @@ pub fn install_codex_hook() {
     let codex_dir = home.join(".codex");
     let _ = std::fs::create_dir_all(&codex_dir);
 
-    install_codex_hook_scripts(&home);
-    install_codex_hook_config(&home);
+    let hook_config_changed = install_codex_hook_config(&home);
+    let installed_docs = install_codex_instruction_docs(&codex_dir);
 
-    let agents_path = codex_dir.join("AGENTS.md");
-    let agents_content = "# Global Agent Instructions\n\n@LEAN-CTX.md\n";
-
-    let lean_ctx_md = codex_dir.join("LEAN-CTX.md");
-    let binary = resolve_binary_path();
-    let lean_ctx_content = format!(
-        r#"# lean-ctx — Token Optimization
-
-Prefix all shell commands with `{binary} -c` for compressed output:
-
-```bash
-{binary} -c git status    # instead of: git status
-{binary} -c cargo test    # instead of: cargo test
-{binary} -c ls src/       # instead of: ls src/
-```
-
-This saves 60-90% tokens per command. Works with: git, cargo, npm, pnpm, docker, kubectl, pip, ruff, go, curl, grep, find, ls, aws, helm, and 90+ more commands.
-Use `{binary} -c --raw <cmd>` to skip compression and get full output.
-"#
-    );
-
-    if agents_path.exists() {
-        let content = std::fs::read_to_string(&agents_path).unwrap_or_default();
-        if content.contains("lean-ctx") || content.contains("LEAN-CTX") {
-            println!("Codex AGENTS.md already configured.");
-            return;
-        }
-    }
-
-    write_file(&agents_path, agents_content);
-    write_file(&lean_ctx_md, &lean_ctx_content);
-    println!("Installed Codex instructions at {}", codex_dir.display());
-}
-
-fn install_codex_hook_config(home: &std::path::Path) {
-    let binary = resolve_binary_path();
-    let rewrite_cmd = format!("{binary} hook rewrite");
-
-    let codex_dir = home.join(".codex");
-
-    let hooks_json_path = codex_dir.join("hooks.json");
-    let hook_config = serde_json::json!({
-        "hooks": {
-            "PreToolUse": [
-                {
-                    "matcher": "Bash",
-                    "hooks": [{
-                        "type": "command",
-                        "command": rewrite_cmd,
-                        "timeout": 15
-                    }]
-                }
-            ]
-        }
-    });
-
-    let needs_write = if hooks_json_path.exists() {
-        let content = std::fs::read_to_string(&hooks_json_path).unwrap_or_default();
-        !content.contains("hook rewrite")
-    } else {
-        true
-    };
-
-    if needs_write {
-        if hooks_json_path.exists() {
-            if let Ok(mut existing) = serde_json::from_str::<serde_json::Value>(
-                &std::fs::read_to_string(&hooks_json_path).unwrap_or_default(),
-            ) {
-                if let Some(obj) = existing.as_object_mut() {
-                    obj.insert("hooks".to_string(), hook_config["hooks"].clone());
-                    write_file(
-                        &hooks_json_path,
-                        &serde_json::to_string_pretty(&existing).unwrap(),
-                    );
-                    if !mcp_server_quiet_mode() {
-                        println!("Updated Codex hooks.json at {}", hooks_json_path.display());
-                    }
-                    return;
-                }
-            }
-        }
-        write_file(
-            &hooks_json_path,
-            &serde_json::to_string_pretty(&hook_config).unwrap(),
-        );
-        if !mcp_server_quiet_mode() {
-            println!(
-                "Installed Codex hooks.json at {}",
-                hooks_json_path.display()
+    if !mcp_server_quiet_mode() {
+        if hook_config_changed {
+            eprintln!(
+                "Installed Codex-compatible SessionStart/PreToolUse hooks at {}",
+                codex_dir.display()
             );
         }
+        if installed_docs {
+            eprintln!("Installed Codex instructions at {}", codex_dir.display());
+        } else {
+            eprintln!("Codex AGENTS.md already configured.");
+        }
+    }
+}
+
+fn install_codex_hook_config(home: &std::path::Path) -> bool {
+    let binary = resolve_binary_path();
+    let session_start_cmd = format!("{binary} hook codex-session-start");
+    let pre_tool_use_cmd = format!("{binary} hook codex-pretooluse");
+    let codex_dir = home.join(".codex");
+    let hooks_json_path = codex_dir.join("hooks.json");
+
+    let mut changed = false;
+    let mut root = if hooks_json_path.exists() {
+        match std::fs::read_to_string(&hooks_json_path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        {
+            Some(parsed) => parsed,
+            None => {
+                changed = true;
+                serde_json::json!({ "hooks": {} })
+            }
+        }
+    } else {
+        changed = true;
+        serde_json::json!({ "hooks": {} })
+    };
+
+    if upsert_lean_ctx_codex_hook_entries(&mut root, &session_start_cmd, &pre_tool_use_cmd) {
+        changed = true;
+    }
+    if changed {
+        write_file(
+            &hooks_json_path,
+            &serde_json::to_string_pretty(&root).unwrap(),
+        );
+    }
+
+    let rewrite_path = codex_dir.join("hooks").join("lean-ctx-rewrite-codex.sh");
+    if rewrite_path.exists() && std::fs::remove_file(&rewrite_path).is_ok() {
+        changed = true;
     }
 
     let config_toml_path = codex_dir.join("config.toml");
     let config_content = std::fs::read_to_string(&config_toml_path).unwrap_or_default();
-    if !config_content.contains("codex_hooks") {
-        let mut out = config_content;
-        if !out.is_empty() && !out.ends_with('\n') {
-            out.push('\n');
-        }
-        if !out.contains("[features]") {
-            out.push_str("\n[features]\ncodex_hooks = true\n");
-        } else {
-            out.push_str("codex_hooks = true\n");
-        }
-        write_file(&config_toml_path, &out);
+    if let Some(updated) = ensure_codex_hooks_enabled(&config_content) {
+        write_file(&config_toml_path, &updated);
+        changed = true;
         if !mcp_server_quiet_mode() {
-            println!(
+            eprintln!(
                 "Enabled codex_hooks feature in {}",
                 config_toml_path.display()
             );
         }
     }
+
+    changed
 }
 
-pub(super) fn install_codex_hook_scripts(home: &std::path::Path) {
-    let hooks_dir = home.join(".codex").join("hooks");
-    let _ = std::fs::create_dir_all(&hooks_dir);
-
-    let binary = resolve_binary_path_for_bash();
-    let rewrite_path = hooks_dir.join("lean-ctx-rewrite-codex.sh");
-    let rewrite_script = generate_compact_rewrite_script(&binary);
-    write_file(&rewrite_path, &rewrite_script);
-    make_executable(&rewrite_path);
-    if !mcp_server_quiet_mode() {
-        println!(
-            "  \x1b[32m✓\x1b[0m Installed Codex hook scripts at {}",
-            hooks_dir.display()
-        );
-    }
+fn ensure_codex_hooks_enabled(config_content: &str) -> Option<String> {
+    shared_ensure_codex_hooks_enabled(config_content)
 }
 
 pub(super) fn install_windsurf_rules(global: bool) {
-    let scope = crate::core::config::Config::load().rules_scope_effective();
-    if global || scope == crate::core::config::RulesScope::Global {
-        println!("Global mode: skipping project-local .windsurfrules (use without --global in a project).");
+    let Some(rules_path) = prepare_project_rules_path(global, ".windsurfrules") else {
         return;
-    }
-
-    let cwd = std::env::current_dir().unwrap_or_default();
-    if !is_inside_git_repo(&cwd) || cwd == dirs::home_dir().unwrap_or_default() {
-        eprintln!("  Skipping .windsurfrules: not inside a git repository or in home directory.");
-        return;
-    }
-
-    let rules_path = PathBuf::from(".windsurfrules");
-    if rules_path.exists() {
-        let content = std::fs::read_to_string(&rules_path).unwrap_or_default();
-        if content.contains("lean-ctx") {
-            println!(".windsurfrules already configured.");
-            return;
-        }
-    }
+    };
 
     let rules = include_str!("../templates/windsurfrules.txt");
     write_file(&rules_path, rules);
@@ -700,28 +627,9 @@ pub(super) fn install_windsurf_rules(global: bool) {
 }
 
 pub(super) fn install_cline_rules(global: bool) {
-    let scope = crate::core::config::Config::load().rules_scope_effective();
-    if global || scope == crate::core::config::RulesScope::Global {
-        println!(
-            "Global mode: skipping project-local .clinerules (use without --global in a project)."
-        );
+    let Some(rules_path) = prepare_project_rules_path(global, ".clinerules") else {
         return;
-    }
-
-    let cwd = std::env::current_dir().unwrap_or_default();
-    if !is_inside_git_repo(&cwd) || cwd == dirs::home_dir().unwrap_or_default() {
-        eprintln!("  Skipping .clinerules: not inside a git repository or in home directory.");
-        return;
-    }
-
-    let rules_path = PathBuf::from(".clinerules");
-    if rules_path.exists() {
-        let content = std::fs::read_to_string(&rules_path).unwrap_or_default();
-        if content.contains("lean-ctx") {
-            println!(".clinerules already configured.");
-            return;
-        }
-    }
+    };
 
     let binary = resolve_binary_path();
     let rules = format!(
@@ -739,6 +647,33 @@ Supported commands: git, cargo, npm, pnpm, docker, kubectl, pip, ruff, go, curl,
 
     write_file(&rules_path, &rules);
     println!("Installed .clinerules in current project.");
+}
+
+fn prepare_project_rules_path(global: bool, file_name: &str) -> Option<PathBuf> {
+    let scope = crate::core::config::Config::load().rules_scope_effective();
+    if global || scope == crate::core::config::RulesScope::Global {
+        println!(
+            "Global mode: skipping project-local {file_name} (use without --global in a project)."
+        );
+        return None;
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    if !is_inside_git_repo(&cwd) || cwd == dirs::home_dir().unwrap_or_default() {
+        eprintln!("  Skipping {file_name}: not inside a git repository or in home directory.");
+        return None;
+    }
+
+    let rules_path = PathBuf::from(file_name);
+    if rules_path.exists() {
+        let content = std::fs::read_to_string(&rules_path).unwrap_or_default();
+        if content.contains("lean-ctx") {
+            println!("{file_name} already configured.");
+            return None;
+        }
+    }
+
+    Some(rules_path)
 }
 
 pub(super) fn install_pi_hook(global: bool) {
@@ -868,7 +803,7 @@ pub(super) fn install_copilot_hook(global: bool) {
     let binary = resolve_binary_path();
 
     if global {
-        let mcp_path = copilot_global_mcp_path();
+        let mcp_path = crate::core::editor_registry::vscode_mcp_path();
         if mcp_path.as_os_str() == "/nonexistent" {
             println!("  \x1b[2mVS Code not found — skipping global Copilot config\x1b[0m");
             return;
@@ -957,29 +892,6 @@ fn install_copilot_pretooluse_hook(global: bool) {
     }
 }
 
-fn copilot_global_mcp_path() -> PathBuf {
-    if let Some(home) = dirs::home_dir() {
-        #[cfg(target_os = "macos")]
-        {
-            return home.join("Library/Application Support/Code/User/mcp.json");
-        }
-        #[cfg(target_os = "linux")]
-        {
-            return home.join(".config/Code/User/mcp.json");
-        }
-        #[cfg(target_os = "windows")]
-        {
-            if let Ok(appdata) = std::env::var("APPDATA") {
-                return PathBuf::from(appdata).join("Code/User/mcp.json");
-            }
-        }
-        #[allow(unreachable_code)]
-        home.join(".config/Code/User/mcp.json")
-    } else {
-        PathBuf::from("/nonexistent")
-    }
-}
-
 fn write_vscode_mcp_file(mcp_path: &PathBuf, binary: &str, label: &str) {
     let data_dir = crate::core::data_dir::lean_ctx_data_dir()
         .map(|d| d.to_string_lossy().to_string())
@@ -1061,38 +973,7 @@ pub(super) fn install_amp_hook() {
         "command": binary,
         "env": { "LEAN_CTX_DATA_DIR": data_dir }
     });
-
-    if config_path.exists() {
-        let content = std::fs::read_to_string(&config_path).unwrap_or_default();
-        if content.contains("lean-ctx") {
-            println!("Amp MCP already configured at {display_path}");
-            return;
-        }
-
-        if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(obj) = json.as_object_mut() {
-                let servers = obj
-                    .entry("amp.mcpServers")
-                    .or_insert_with(|| serde_json::json!({}));
-                if let Some(servers_obj) = servers.as_object_mut() {
-                    servers_obj.insert("lean-ctx".to_string(), entry.clone());
-                }
-                if let Ok(formatted) = serde_json::to_string_pretty(&json) {
-                    let _ = std::fs::write(&config_path, formatted);
-                    println!("  \x1b[32m✓\x1b[0m Amp MCP configured at {display_path}");
-                    return;
-                }
-            }
-        }
-    }
-
-    let config = serde_json::json!({ "amp.mcpServers": { "lean-ctx": entry } });
-    if let Ok(json_str) = serde_json::to_string_pretty(&config) {
-        let _ = std::fs::write(&config_path, json_str);
-        println!("  \x1b[32m✓\x1b[0m Amp MCP configured at {display_path}");
-    } else {
-        eprintln!("  \x1b[31m✗\x1b[0m Failed to configure Amp");
-    }
+    install_named_json_server("Amp", display_path, &config_path, "amp.mcpServers", entry);
 }
 
 pub(super) fn install_jetbrains_hook() {
@@ -1432,3 +1313,167 @@ Re-reads cost ~13 tokens (cached).
 Available tools: ctx_overview, ctx_preload, ctx_dedup, ctx_compress, ctx_session, ctx_knowledge, ctx_semantic_search.
 Multi-agent: ctx_agent(action=handoff|sync). Diary: ctx_agent(action=diary, category=discovery|decision|blocker|progress|insight).
 ";
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_codex_hooks_enabled, upsert_lean_ctx_codex_hook_entries};
+    use serde_json::json;
+
+    #[test]
+    fn upsert_replaces_legacy_codex_rewrite_but_keeps_custom_hooks() {
+        let mut input = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/opt/homebrew/bin/lean-ctx hook rewrite",
+                            "timeout": 15
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo keep-me",
+                            "timeout": 5
+                        }]
+                    }
+                ],
+                "SessionStart": [
+                    {
+                        "matcher": "startup|resume|clear",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "lean-ctx hook codex-session-start",
+                            "timeout": 15
+                        }]
+                    }
+                ],
+                "PostToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo keep-post",
+                            "timeout": 5
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let changed = upsert_lean_ctx_codex_hook_entries(
+            &mut input,
+            "lean-ctx hook codex-session-start",
+            "lean-ctx hook codex-pretooluse",
+        );
+        assert!(changed, "legacy hooks should be migrated");
+
+        let pre_tool_use = input["hooks"]["PreToolUse"]
+            .as_array()
+            .expect("PreToolUse array should remain");
+        assert_eq!(pre_tool_use.len(), 2, "custom hook should be preserved");
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"].as_str(),
+            Some("echo keep-me")
+        );
+        assert_eq!(
+            pre_tool_use[1]["hooks"][0]["command"].as_str(),
+            Some("lean-ctx hook codex-pretooluse")
+        );
+        assert_eq!(
+            input["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
+            Some("lean-ctx hook codex-session-start")
+        );
+        assert_eq!(
+            input["hooks"]["PostToolUse"][0]["hooks"][0]["command"].as_str(),
+            Some("echo keep-post")
+        );
+    }
+
+    #[test]
+    fn ignores_non_lean_ctx_codex_entries() {
+        let custom = json!({
+            "matcher": "Bash",
+            "hooks": [{
+                "type": "command",
+                "command": "echo keep-me",
+                "timeout": 5
+            }]
+        });
+        assert!(
+            !super::super::support::is_lean_ctx_codex_managed_entry("PreToolUse", &custom),
+            "custom Codex hooks must be preserved"
+        );
+    }
+
+    #[test]
+    fn detects_managed_codex_session_start_entry() {
+        let managed = json!({
+            "matcher": "startup|resume|clear",
+            "hooks": [{
+                "type": "command",
+                "command": "/opt/homebrew/bin/lean-ctx hook codex-session-start",
+                "timeout": 15
+            }]
+        });
+        assert!(super::super::support::is_lean_ctx_codex_managed_entry(
+            "SessionStart",
+            &managed
+        ));
+    }
+
+    #[test]
+    fn ensure_codex_hooks_enabled_updates_existing_features_flag() {
+        let input = "\
+[features]
+other = true
+codex_hooks = false
+
+[mcp_servers.other]
+command = \"other\"
+";
+
+        let output =
+            ensure_codex_hooks_enabled(input).expect("codex_hooks=false should be migrated");
+
+        assert!(output.contains("[features]\nother = true\ncodex_hooks = true\n"));
+        assert!(!output.contains("codex_hooks = false"));
+    }
+
+    #[test]
+    fn ensure_codex_hooks_enabled_moves_stray_assignment_into_features_section() {
+        let input = "\
+[features]
+other = true
+
+[mcp_servers.lean-ctx]
+command = \"lean-ctx\"
+codex_hooks = true
+";
+
+        let output = ensure_codex_hooks_enabled(input)
+            .expect("stray codex_hooks assignment should be normalized");
+
+        assert!(output.contains("[features]\nother = true\ncodex_hooks = true\n"));
+        assert_eq!(output.matches("codex_hooks = true").count(), 1);
+        assert!(
+            !output.contains("[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\ncodex_hooks = true")
+        );
+    }
+
+    #[test]
+    fn ensure_codex_hooks_enabled_adds_features_section_when_missing() {
+        let input = "\
+[mcp_servers.lean-ctx]
+command = \"lean-ctx\"
+";
+
+        let output =
+            ensure_codex_hooks_enabled(input).expect("missing features section should be added");
+
+        assert!(output.ends_with("\n[features]\ncodex_hooks = true\n"));
+    }
+}

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -1,10 +1,16 @@
 use std::path::PathBuf;
 
 pub mod agents;
+mod support;
 use agents::*;
+use support::{
+    ensure_codex_hooks_enabled, install_codex_instruction_docs, install_named_json_server,
+    upsert_lean_ctx_codex_hook_entries,
+};
 
 fn mcp_server_quiet_mode() -> bool {
     std::env::var_os("LEAN_CTX_MCP_SERVER").is_some()
+        || matches!(std::env::var("LEAN_CTX_QUIET"), Ok(value) if value.trim() == "1")
 }
 
 /// Silently refresh all hook scripts for agents that are already configured.
@@ -45,8 +51,14 @@ pub fn refresh_installed_hooks() {
         install_gemini_hook_config(&home);
     }
 
-    if home.join(".codex/hooks/lean-ctx-rewrite-codex.sh").exists() {
-        install_codex_hook_scripts(&home);
+    let codex_hooks = home.join(".codex/hooks/lean-ctx-rewrite-codex.sh").exists()
+        || home.join(".codex/hooks.json").exists()
+            && std::fs::read_to_string(home.join(".codex/hooks.json"))
+                .unwrap_or_default()
+                .contains("lean-ctx");
+
+    if codex_hooks {
+        install_codex_hook();
     }
 }
 
@@ -511,47 +523,7 @@ fn full_server_entry(binary: &str) -> serde_json::Value {
 fn install_mcp_json_agent(name: &str, display_path: &str, config_path: &std::path::Path) {
     let binary = resolve_binary_path();
     let entry = full_server_entry(&binary);
-
-    if let Some(parent) = config_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    if config_path.exists() {
-        let content = std::fs::read_to_string(config_path).unwrap_or_default();
-        if content.contains("lean-ctx") {
-            println!("{name} MCP already configured at {display_path}");
-            return;
-        }
-
-        if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(obj) = json.as_object_mut() {
-                let servers = obj
-                    .entry("mcpServers")
-                    .or_insert_with(|| serde_json::json!({}));
-                if let Some(servers_obj) = servers.as_object_mut() {
-                    servers_obj.insert("lean-ctx".to_string(), entry.clone());
-                }
-                if let Ok(formatted) = serde_json::to_string_pretty(&json) {
-                    let _ = std::fs::write(config_path, formatted);
-                    println!("  \x1b[32m✓\x1b[0m {name} MCP configured at {display_path}");
-                    return;
-                }
-            }
-        }
-    }
-
-    let content = serde_json::to_string_pretty(&serde_json::json!({
-        "mcpServers": {
-            "lean-ctx": entry
-        }
-    }));
-
-    if let Ok(json_str) = content {
-        let _ = std::fs::write(config_path, json_str);
-        println!("  \x1b[32m✓\x1b[0m {name} MCP configured at {display_path}");
-    } else {
-        eprintln!("  \x1b[31m✗\x1b[0m Failed to configure {name}");
-    }
+    install_named_json_server(name, display_path, config_path, "mcpServers", entry);
 }
 
 #[cfg(test)]

--- a/rust/src/hooks/support.rs
+++ b/rust/src/hooks/support.rs
@@ -1,0 +1,408 @@
+use std::path::Path;
+
+pub(super) fn install_named_json_server(
+    name: &str,
+    display_path: &str,
+    config_path: &std::path::Path,
+    root_key: &str,
+    entry: serde_json::Value,
+) {
+    if let Some(parent) = config_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    if config_path.exists() {
+        let content = std::fs::read_to_string(config_path).unwrap_or_default();
+        if content.contains("lean-ctx") {
+            println!("{name} MCP already configured at {display_path}");
+            return;
+        }
+        if update_named_json_server(config_path, &content, root_key, &entry) {
+            print_named_json_server_success(name, display_path);
+            return;
+        }
+    }
+
+    if write_named_json_server_root(config_path, root_key, entry) {
+        print_named_json_server_success(name, display_path);
+    } else {
+        eprintln!("  \x1b[31m✗\x1b[0m Failed to configure {name}");
+    }
+}
+
+fn update_named_json_server(
+    config_path: &std::path::Path,
+    content: &str,
+    root_key: &str,
+    entry: &serde_json::Value,
+) -> bool {
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(content) else {
+        return false;
+    };
+    let Some(obj) = json.as_object_mut() else {
+        return false;
+    };
+    let servers = obj
+        .entry(root_key.to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(servers_obj) = servers.as_object_mut() else {
+        return false;
+    };
+    servers_obj.insert("lean-ctx".to_string(), entry.clone());
+    write_json_config(config_path, &json)
+}
+
+fn write_named_json_server_root(
+    config_path: &std::path::Path,
+    root_key: &str,
+    entry: serde_json::Value,
+) -> bool {
+    let mut servers = serde_json::Map::new();
+    servers.insert("lean-ctx".to_string(), entry);
+
+    let mut root = serde_json::Map::new();
+    root.insert(root_key.to_string(), serde_json::Value::Object(servers));
+
+    write_json_config(config_path, &serde_json::Value::Object(root))
+}
+
+fn write_json_config(config_path: &std::path::Path, value: &serde_json::Value) -> bool {
+    let Ok(json_str) = serde_json::to_string_pretty(value) else {
+        return false;
+    };
+    std::fs::write(config_path, json_str).is_ok()
+}
+
+fn print_named_json_server_success(name: &str, display_path: &str) {
+    println!("  \x1b[32m✓\x1b[0m {name} MCP configured at {display_path}");
+}
+
+pub(super) fn install_codex_instruction_docs(codex_dir: &Path) -> bool {
+    let agents_path = codex_dir.join("AGENTS.md");
+    let agents_content = "# Global Agent Instructions\n\n@LEAN-CTX.md\n";
+    let lean_ctx_md = codex_dir.join("LEAN-CTX.md");
+    let lean_ctx_content = codex_instruction_doc_content();
+
+    match std::fs::read_to_string(&agents_path) {
+        Ok(content) if content.contains("lean-ctx") || content.contains("LEAN-CTX") => {
+            if lean_ctx_md.exists() {
+                false
+            } else {
+                super::write_file(&lean_ctx_md, &lean_ctx_content);
+                true
+            }
+        }
+        _ => {
+            super::write_file(&agents_path, agents_content);
+            super::write_file(&lean_ctx_md, &lean_ctx_content);
+            true
+        }
+    }
+}
+
+fn codex_instruction_doc_content() -> String {
+    let binary = super::resolve_binary_path();
+    format!(
+        r#"# lean-ctx — Token Optimization
+
+Prefix all shell commands with `{binary} -c` for compressed output:
+
+```bash
+{binary} -c git status    # instead of: git status
+{binary} -c cargo test    # instead of: cargo test
+{binary} -c ls src/       # instead of: ls src/
+```
+
+This saves 60-90% tokens per command. Works with: git, cargo, npm, pnpm, docker, kubectl, pip, ruff, go, curl, grep, find, ls, aws, helm, and 90+ more commands.
+Use `{binary} -c --raw <cmd>` to skip compression and get full output.
+"#
+    )
+}
+
+pub(super) fn ensure_codex_hooks_enabled(config_content: &str) -> Option<String> {
+    let newline = config_newline(config_content);
+    let mut lines = config_lines(config_content);
+    let layout = inspect_codex_hooks_layout(&lines);
+
+    let mut changed =
+        rewrite_existing_codex_hooks_assignment(&mut lines, layout.features_codex_index);
+    changed |= clear_stray_codex_hooks_assignments(&mut lines, &layout.stray_codex_indices);
+
+    if layout.features_codex_index.is_none() {
+        insert_codex_hooks_assignment(&mut lines, layout.features_insert_index);
+        changed = true;
+    }
+
+    changed.then(|| render_codex_hook_config(lines, newline))
+}
+
+struct CodexHooksLayout {
+    features_insert_index: Option<usize>,
+    features_codex_index: Option<usize>,
+    stray_codex_indices: Vec<usize>,
+}
+
+fn config_newline(config_content: &str) -> &'static str {
+    if config_content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+fn config_lines(config_content: &str) -> Vec<String> {
+    config_content
+        .lines()
+        .map(|line| line.to_string())
+        .collect()
+}
+
+fn inspect_codex_hooks_layout(lines: &[String]) -> CodexHooksLayout {
+    let mut features_codex_index = None;
+    let mut features_insert_index = None;
+    let mut stray_codex_indices = Vec::new();
+    let mut current_section: Option<&str> = None;
+
+    for (idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if let Some(section) = parse_toml_section_name(trimmed) {
+            current_section = Some(section);
+            if section == "features" {
+                features_insert_index = Some(idx + 1);
+            }
+            continue;
+        }
+
+        if current_section == Some("features") {
+            features_insert_index = Some(idx + 1);
+        }
+
+        if !is_codex_hooks_assignment(trimmed) {
+            continue;
+        }
+
+        if current_section == Some("features") && features_codex_index.is_none() {
+            features_codex_index = Some(idx);
+        } else {
+            stray_codex_indices.push(idx);
+        }
+    }
+
+    CodexHooksLayout {
+        features_insert_index,
+        features_codex_index,
+        stray_codex_indices,
+    }
+}
+
+fn rewrite_existing_codex_hooks_assignment(lines: &mut [String], index: Option<usize>) -> bool {
+    let Some(index) = index else {
+        return false;
+    };
+
+    let replacement = rewrite_codex_hooks_line(&lines[index]);
+    if lines[index] == replacement {
+        return false;
+    }
+
+    lines[index] = replacement;
+    true
+}
+
+fn clear_stray_codex_hooks_assignments(lines: &mut [String], indices: &[usize]) -> bool {
+    let mut changed = false;
+    for &idx in indices {
+        if !lines[idx].is_empty() {
+            lines[idx].clear();
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn insert_codex_hooks_assignment(lines: &mut Vec<String>, insert_index: Option<usize>) {
+    if let Some(insert_index) = insert_index {
+        let insert_at = trim_blank_lines_before(lines, insert_index);
+        lines.insert(insert_at, "codex_hooks = true".to_string());
+        return;
+    }
+
+    if !lines.is_empty() && !lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.push(String::new());
+    }
+    lines.push("[features]".to_string());
+    lines.push("codex_hooks = true".to_string());
+}
+
+fn trim_blank_lines_before(lines: &[String], mut index: usize) -> usize {
+    while index > 0 && lines[index - 1].trim().is_empty() {
+        index -= 1;
+    }
+    index
+}
+
+fn render_codex_hook_config(lines: Vec<String>, newline: &str) -> String {
+    let mut output = compact_blank_lines(lines).join(newline);
+    output.push_str(newline);
+    output
+}
+
+fn compact_blank_lines(lines: Vec<String>) -> Vec<String> {
+    let mut compacted = Vec::with_capacity(lines.len());
+    let mut previous_blank = false;
+    for line in lines {
+        let is_blank = line.trim().is_empty();
+        if is_blank && previous_blank {
+            continue;
+        }
+        previous_blank = is_blank;
+        compacted.push(line);
+    }
+    while compacted.last().is_some_and(|line| line.trim().is_empty()) {
+        compacted.pop();
+    }
+    compacted
+}
+
+fn parse_toml_section_name(trimmed_line: &str) -> Option<&str> {
+    if trimmed_line.starts_with('[') && trimmed_line.ends_with(']') {
+        Some(
+            trimmed_line
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .trim(),
+        )
+    } else {
+        None
+    }
+}
+
+fn is_codex_hooks_assignment(trimmed_line: &str) -> bool {
+    let without_comment = trimmed_line.split('#').next().unwrap_or("").trim();
+    without_comment
+        .strip_prefix("codex_hooks")
+        .is_some_and(|rest| rest.trim_start().starts_with('='))
+}
+
+fn rewrite_codex_hooks_line(line: &str) -> String {
+    let indent_len = line.chars().take_while(|c| c.is_whitespace()).count();
+    let indent = &line[..indent_len];
+    let comment = line
+        .find('#')
+        .map(|index| line[index..].trim_end())
+        .filter(|comment| !comment.is_empty());
+
+    match comment {
+        Some(comment) => format!("{indent}codex_hooks = true  {comment}"),
+        None => format!("{indent}codex_hooks = true"),
+    }
+}
+
+pub(super) fn upsert_lean_ctx_codex_hook_entries(
+    root: &mut serde_json::Value,
+    session_start_cmd: &str,
+    pre_tool_use_cmd: &str,
+) -> bool {
+    let original = root.clone();
+    if !root.is_object() {
+        *root = serde_json::json!({});
+    }
+    let root_obj = root.as_object_mut().expect("root should be object");
+    let hooks_value = root_obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if !hooks_value.is_object() {
+        *hooks_value = serde_json::json!({});
+    }
+    let hooks_obj = hooks_value
+        .as_object_mut()
+        .expect("hooks should be object after normalization");
+
+    remove_lean_ctx_codex_managed_entries(hooks_obj, "PreToolUse");
+    remove_lean_ctx_codex_managed_entries(hooks_obj, "SessionStart");
+
+    push_codex_hook_entry(hooks_obj, "PreToolUse", "Bash", pre_tool_use_cmd);
+    push_codex_hook_entry(
+        hooks_obj,
+        "SessionStart",
+        "startup|resume|clear",
+        session_start_cmd,
+    );
+
+    *root != original
+}
+
+fn push_codex_hook_entry(
+    hooks_obj: &mut serde_json::Map<String, serde_json::Value>,
+    event_name: &str,
+    matcher: &str,
+    command: &str,
+) {
+    codex_hook_entries_mut(hooks_obj, event_name).push(serde_json::json!({
+        "matcher": matcher,
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "timeout": 15
+        }]
+    }));
+}
+
+fn codex_hook_entries_mut<'a>(
+    hooks_obj: &'a mut serde_json::Map<String, serde_json::Value>,
+    event_name: &str,
+) -> &'a mut Vec<serde_json::Value> {
+    let value = hooks_obj
+        .entry(event_name.to_string())
+        .or_insert_with(|| serde_json::json!([]));
+    if !value.is_array() {
+        *value = serde_json::json!([]);
+    }
+    value
+        .as_array_mut()
+        .unwrap_or_else(|| panic!("{event_name} should be an array"))
+}
+
+pub(super) fn remove_lean_ctx_codex_managed_entries(
+    hooks_obj: &mut serde_json::Map<String, serde_json::Value>,
+    event_name: &str,
+) {
+    let Some(entries) = hooks_obj
+        .get_mut(event_name)
+        .and_then(|value| value.as_array_mut())
+    else {
+        return;
+    };
+    entries.retain(|entry| !is_lean_ctx_codex_managed_entry(event_name, entry));
+    if entries.is_empty() {
+        hooks_obj.remove(event_name);
+    }
+}
+
+pub(super) fn is_lean_ctx_codex_managed_entry(event_name: &str, entry: &serde_json::Value) -> bool {
+    let Some(entry_obj) = entry.as_object() else {
+        return false;
+    };
+
+    let Some(hooks) = entry_obj.get("hooks").and_then(|value| value.as_array()) else {
+        return false;
+    };
+
+    hooks.iter().any(|hook| {
+        let Some(command) = hook.get("command").and_then(|value| value.as_str()) else {
+            return false;
+        };
+        match event_name {
+            "PreToolUse" => {
+                entry_obj.get("matcher").and_then(|value| value.as_str()) == Some("Bash")
+                    && command.contains("lean-ctx")
+                    && (command.contains("hook rewrite")
+                        || command.contains("hook codex-pretooluse"))
+            }
+            "SessionStart" => {
+                command.contains("lean-ctx") && command.contains("hook codex-session-start")
+            }
+            _ => false,
+        }
+    })
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -681,9 +681,11 @@ fn main() {
                     "rewrite" => hook_handlers::handle_rewrite(),
                     "redirect" => hook_handlers::handle_redirect(),
                     "copilot" => hook_handlers::handle_copilot(),
+                    "codex-pretooluse" => hook_handlers::handle_codex_pretooluse(),
+                    "codex-session-start" => hook_handlers::handle_codex_session_start(),
                     "rewrite-inline" => hook_handlers::handle_rewrite_inline(),
                     _ => {
-                        eprintln!("Usage: lean-ctx hook <rewrite|redirect|copilot|rewrite-inline>");
+                        eprintln!("Usage: lean-ctx hook <rewrite|redirect|copilot|codex-pretooluse|codex-session-start|rewrite-inline>");
                         eprintln!("  Internal commands used by agent hooks (Claude, Cursor, Copilot, etc.)");
                         std::process::exit(1);
                     }

--- a/rust/src/setup.rs
+++ b/rust/src/setup.rs
@@ -4,6 +4,7 @@ use crate::core::editor_registry::{ConfigType, EditorTarget, WriteAction, WriteO
 use crate::core::portable_binary::resolve_portable_binary;
 use crate::core::setup_report::{PlatformInfo, SetupItem, SetupReport, SetupStepReport};
 use chrono::Utc;
+use std::ffi::OsString;
 
 pub fn claude_config_json_path(home: &std::path::Path) -> PathBuf {
     crate::core::editor_registry::claude_mcp_json_path(home)
@@ -11,6 +12,29 @@ pub fn claude_config_json_path(home: &std::path::Path) -> PathBuf {
 
 pub fn claude_config_dir(home: &std::path::Path) -> PathBuf {
     crate::core::editor_registry::claude_state_dir(home)
+}
+
+pub(crate) struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    pub(crate) fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
 }
 
 pub fn run_setup() {
@@ -292,6 +316,7 @@ pub struct SetupOptions {
 }
 
 pub fn run_setup_with_options(opts: SetupOptions) -> Result<SetupReport, String> {
+    let _quiet_guard = opts.json.then(|| EnvVarGuard::set("LEAN_CTX_QUIET", "1"));
     let started_at = Utc::now();
     let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
     let binary = resolve_portable_binary();
@@ -450,10 +475,13 @@ pub fn run_setup_with_options(opts: SetupOptions) -> Result<SetupReport, String>
             "codex" => {
                 crate::hooks::agents::install_codex_hook();
                 hooks_step.items.push(SetupItem {
-                    name: "Codex hooks".to_string(),
+                    name: "Codex integration".to_string(),
                     status: "installed".to_string(),
-                    path: Some("~/.codex/hooks/".to_string()),
-                    note: None,
+                    path: Some("~/.codex/".to_string()),
+                    note: Some(
+                        "Installs AGENTS/MCP guidance and Codex-compatible SessionStart/PreToolUse hooks."
+                            .to_string(),
+                    ),
                 });
             }
             "cursor" => {

--- a/rust/tests/shell_and_agent_tests.rs
+++ b/rust/tests/shell_and_agent_tests.rs
@@ -219,6 +219,170 @@ fn agent_init_unknown_agent_fails() {
 }
 
 #[test]
+fn codex_pretooluse_blocks_rewritable_bash_with_reroute_message() {
+    let input =
+        r#"{"tool_name":"Bash","tool_input":{"command":"git status"},"command":"git status"}"#;
+    let (stdout, stderr, code) = run_with_env(&["hook", "codex-pretooluse"], &[], Some(input));
+    assert_eq!(code, 2, "hook should block and reroute: {stderr}");
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout should stay empty: {stdout}"
+    );
+    assert!(
+        stderr.contains("Re-run with:")
+            && stderr.contains("lean-ctx -c")
+            && stderr.contains(r#""git status""#),
+        "stderr should contain reroute command: {stderr}"
+    );
+}
+
+#[test]
+fn agent_init_codex_installs_compatible_hooks_and_instructions() {
+    let tmpdir = tempfile::tempdir().expect("create tempdir");
+    let home = tmpdir.path();
+    let codex_dir = home.join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+
+    let home_str = home.to_string_lossy().to_string();
+    #[cfg(not(windows))]
+    let envs = vec![("HOME", home_str.as_str())];
+    #[cfg(windows)]
+    let envs = vec![
+        ("HOME", home_str.as_str()),
+        ("USERPROFILE", home_str.as_str()),
+    ];
+
+    let (_stdout, stderr, code) =
+        run_with_env(&["init", "--agent", "codex", "--global"], &envs, None);
+    assert_eq!(code, 0, "codex init should succeed: {stderr}");
+
+    assert!(
+        codex_dir.join("AGENTS.md").exists(),
+        "AGENTS.md should exist"
+    );
+    assert!(
+        codex_dir.join("LEAN-CTX.md").exists(),
+        "LEAN-CTX.md should exist"
+    );
+
+    let hooks: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(codex_dir.join("hooks.json")).unwrap())
+            .expect("hooks.json should be valid");
+    assert_eq!(
+        hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"].as_str(),
+        Some("lean-ctx hook codex-pretooluse")
+    );
+    assert_eq!(
+        hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
+        Some("lean-ctx hook codex-session-start")
+    );
+
+    let config = std::fs::read_to_string(codex_dir.join("config.toml")).unwrap_or_default();
+    assert!(
+        config.contains("codex_hooks = true"),
+        "init should enable Codex hook support"
+    );
+}
+
+#[test]
+fn agent_init_codex_migrates_legacy_lean_ctx_hook_but_keeps_other_hooks() {
+    let tmpdir = tempfile::tempdir().expect("create tempdir");
+    let home = tmpdir.path();
+    let codex_dir = home.join(".codex");
+    let hooks_dir = codex_dir.join("hooks");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+
+    std::fs::write(
+        hooks_dir.join("lean-ctx-rewrite-codex.sh"),
+        "#!/bin/sh\nexit 0\n",
+    )
+    .unwrap();
+    std::fs::write(
+        codex_dir.join("hooks.json"),
+        serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "lean-ctx hook rewrite",
+                            "timeout": 15
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo keep-me",
+                            "timeout": 5
+                        }]
+                    }
+                ],
+                "PostToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo keep-post",
+                            "timeout": 5
+                        }]
+                    }
+                ]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let home_str = home.to_string_lossy().to_string();
+    #[cfg(not(windows))]
+    let envs = vec![("HOME", home_str.as_str())];
+    #[cfg(windows)]
+    let envs = vec![
+        ("HOME", home_str.as_str()),
+        ("USERPROFILE", home_str.as_str()),
+    ];
+
+    let (_stdout, stderr, code) =
+        run_with_env(&["init", "--agent", "codex", "--global"], &envs, None);
+    assert_eq!(code, 0, "codex init should succeed: {stderr}");
+
+    assert!(
+        !hooks_dir.join("lean-ctx-rewrite-codex.sh").exists(),
+        "legacy Codex hook script should be removed"
+    );
+
+    let hooks: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(codex_dir.join("hooks.json")).unwrap())
+            .expect("hooks.json should stay valid");
+    let pre_tool_use = hooks["hooks"]["PreToolUse"]
+        .as_array()
+        .expect("PreToolUse should remain");
+    assert_eq!(
+        pre_tool_use.len(),
+        2,
+        "legacy hook should be replaced and custom hook preserved"
+    );
+    assert_eq!(
+        pre_tool_use[0]["hooks"][0]["command"].as_str(),
+        Some("echo keep-me")
+    );
+    assert_eq!(
+        pre_tool_use[1]["hooks"][0]["command"].as_str(),
+        Some("lean-ctx hook codex-pretooluse")
+    );
+    assert_eq!(
+        hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
+        Some("lean-ctx hook codex-session-start")
+    );
+    assert_eq!(
+        hooks["hooks"]["PostToolUse"][0]["hooks"][0]["command"].as_str(),
+        Some("echo keep-post")
+    );
+}
+
+#[test]
 fn agent_init_lists_antigravity_in_supported() {
     let (_stdout, stderr, _code) =
         run_with_env(&["init", "--agent", "nonexistent_agent"], &[], None);

--- a/rust/tests/shell_and_agent_tests.rs
+++ b/rust/tests/shell_and_agent_tests.rs
@@ -47,6 +47,18 @@ fn run_with_env(
     (stdout, stderr, code)
 }
 
+fn assert_hook_command_suffix(actual: Option<&str>, expected_suffix: &str) {
+    let actual = actual.expect("hook command should exist");
+    assert!(
+        actual.contains("lean-ctx"),
+        "expected hook command to reference lean-ctx, got {actual:?}"
+    );
+    assert!(
+        actual.ends_with(expected_suffix),
+        "expected hook command to end with {expected_suffix:?}, got {actual:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // LEAN_CTX_SHELL override tests (via `lean-ctx -c`)
 // ---------------------------------------------------------------------------
@@ -268,13 +280,13 @@ fn agent_init_codex_installs_compatible_hooks_and_instructions() {
     let hooks: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(codex_dir.join("hooks.json")).unwrap())
             .expect("hooks.json should be valid");
-    assert_eq!(
+    assert_hook_command_suffix(
         hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"].as_str(),
-        Some("lean-ctx hook codex-pretooluse")
+        "hook codex-pretooluse",
     );
-    assert_eq!(
+    assert_hook_command_suffix(
         hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
-        Some("lean-ctx hook codex-session-start")
+        "hook codex-session-start",
     );
 
     let config = std::fs::read_to_string(codex_dir.join("config.toml")).unwrap_or_default();
@@ -368,13 +380,13 @@ fn agent_init_codex_migrates_legacy_lean_ctx_hook_but_keeps_other_hooks() {
         pre_tool_use[0]["hooks"][0]["command"].as_str(),
         Some("echo keep-me")
     );
-    assert_eq!(
+    assert_hook_command_suffix(
         pre_tool_use[1]["hooks"][0]["command"].as_str(),
-        Some("lean-ctx hook codex-pretooluse")
+        "hook codex-pretooluse",
     );
-    assert_eq!(
+    assert_hook_command_suffix(
         hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"].as_str(),
-        Some("lean-ctx hook codex-session-start")
+        "hook codex-session-start",
     );
     assert_eq!(
         hooks["hooks"]["PostToolUse"][0]["hooks"][0]["command"].as_str(),


### PR DESCRIPTION
Fixes #135.

## Summary

The Codex integration currently installs a `PreToolUse` hook that returns `updatedInput`.
Codex rejects that payload with `PreToolUse hook returned unsupported updatedInput`, so the installed rewrite flow cannot work as intended.

This change keeps the useful Codex hook behavior, but switches it to a Codex-compatible model:

- `SessionStart` gives guidance to prefer `lean-ctx -c "<command>"`
- `PreToolUse` blocks rewritable raw Bash commands and returns a deterministic reroute message
- existing lean-ctx-managed Codex hook config is migrated instead of silently left in a broken state

## What Changed

- added dedicated `codex-pretooluse` and `codex-session-start` hook handlers
- replaced the unsupported Codex `updatedInput` rewrite path with block-and-reroute behavior for rewritable Bash commands
- updated Codex hook installation to manage both `PreToolUse` and `SessionStart` entries in `~/.codex/hooks.json`
- normalized `~/.codex/config.toml` so `codex_hooks = true` is present under `[features]`
- migrated legacy lean-ctx-managed Codex entries and removed the obsolete `lean-ctx-rewrite-codex.sh` script
- preserved unrelated user-defined Codex hooks during migration
- extracted shared Codex/MCP JSON config helpers into `rust/src/hooks/support.rs`
- updated setup, doctor, CLI help, and README text to describe the compatible Codex integration
- added regression coverage for reroute behavior, install flow, and migration behavior

## Why This Approach

We did not want to remove the feature entirely, and we did not want to depend on a Codex-side fix.

The new flow preserves the original product value while matching Codex's supported hook behavior:

- guidance at session start
- enforcement at tool time
- safe migration for existing users

## Testing

- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
