### PR TITLE
[codex] fix stale session root across checkouts

### DIFF
--- a/rust/src/core/session.rs
+++ b/rust/src/core/session.rs
@@ -657,56 +657,49 @@ impl SessionState {
         Self::load_by_id(&pointer.id)
     }
 
+    pub fn load_latest_for_project_root(project_root: &str) -> Option<Self> {
+        let dir = sessions_dir()?;
+        let target_root =
+            crate::core::pathutil::safe_canonicalize_or_self(std::path::Path::new(project_root));
+        let mut latest_match: Option<Self> = None;
+
+        for entry in std::fs::read_dir(&dir).ok()?.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if path.file_name().and_then(|n| n.to_str()) == Some("latest.json") {
+                continue;
+            }
+
+            let Some(id) = path.file_stem().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Some(session) = Self::load_by_id(id) else {
+                continue;
+            };
+
+            if !session_matches_project_root(&session, &target_root) {
+                continue;
+            }
+
+            if latest_match
+                .as_ref()
+                .is_none_or(|existing| session.updated_at > existing.updated_at)
+            {
+                latest_match = Some(session);
+            }
+        }
+
+        latest_match
+    }
+
     pub fn load_by_id(id: &str) -> Option<Self> {
         let dir = sessions_dir()?;
         let path = dir.join(format!("{id}.json"));
         let json = std::fs::read_to_string(&path).ok()?;
-        let mut session: Self = serde_json::from_str(&json).ok()?;
-        // Legacy/malformed sessions may serialize empty strings instead of null.
-        if matches!(session.project_root.as_deref(), Some(r) if r.trim().is_empty()) {
-            session.project_root = None;
-        }
-        if matches!(session.shell_cwd.as_deref(), Some(c) if c.trim().is_empty()) {
-            session.shell_cwd = None;
-        }
-
-        // Heal stale project_root caused by agent/temp working directories.
-        // If project_root doesn't look like a real project root but shell_cwd does, prefer shell_cwd.
-        if let (Some(ref root), Some(ref cwd)) = (&session.project_root, &session.shell_cwd) {
-            fn has_marker(dir: &std::path::Path) -> bool {
-                const MARKERS: &[&str] = &[
-                    ".git",
-                    ".lean-ctx.toml",
-                    "Cargo.toml",
-                    "package.json",
-                    "go.mod",
-                    "pyproject.toml",
-                    ".planning",
-                ];
-                MARKERS.iter().any(|m| dir.join(m).exists())
-            }
-            fn is_agent_or_temp_dir(dir: &std::path::Path) -> bool {
-                let s = dir.to_string_lossy();
-                s.contains("/.claude")
-                    || s.contains("/.codex")
-                    || s.contains("/var/folders/")
-                    || s.contains("/tmp/")
-                    || s.contains("\\.claude")
-                    || s.contains("\\.codex")
-                    || s.contains("\\AppData\\Local\\Temp")
-                    || s.contains("\\Temp\\")
-            }
-
-            let root_p = std::path::Path::new(root);
-            let cwd_p = std::path::Path::new(cwd);
-            let root_looks_real = has_marker(root_p);
-            let cwd_looks_real = has_marker(cwd_p);
-
-            if !root_looks_real && cwd_looks_real && is_agent_or_temp_dir(root_p) {
-                session.project_root = Some(cwd.clone());
-            }
-        }
-        Some(session)
+        let session: Self = serde_json::from_str(&json).ok()?;
+        Some(normalize_loaded_session(session))
     }
 
     pub fn list_sessions() -> Vec<SessionSummary> {
@@ -850,6 +843,75 @@ fn shorten_path(path: &str) -> String {
     }
     let last_two: Vec<&str> = parts.iter().rev().take(2).copied().collect();
     format!("…/{}/{}", last_two[1], last_two[0])
+}
+
+fn normalize_loaded_session(mut session: SessionState) -> SessionState {
+    if matches!(session.project_root.as_deref(), Some(r) if r.trim().is_empty()) {
+        session.project_root = None;
+    }
+    if matches!(session.shell_cwd.as_deref(), Some(c) if c.trim().is_empty()) {
+        session.shell_cwd = None;
+    }
+
+    // Heal stale project_root caused by agent/temp working directories.
+    // If project_root doesn't look like a real project root but shell_cwd does, prefer shell_cwd.
+    if let (Some(ref root), Some(ref cwd)) = (&session.project_root, &session.shell_cwd) {
+        let root_p = std::path::Path::new(root);
+        let cwd_p = std::path::Path::new(cwd);
+        let root_looks_real = has_project_marker(root_p);
+        let cwd_looks_real = has_project_marker(cwd_p);
+
+        if !root_looks_real && cwd_looks_real && is_agent_or_temp_dir(root_p) {
+            session.project_root = Some(cwd.clone());
+        }
+    }
+
+    session
+}
+
+fn session_matches_project_root(session: &SessionState, target_root: &std::path::Path) -> bool {
+    if let Some(root) = session.project_root.as_deref() {
+        let root_path =
+            crate::core::pathutil::safe_canonicalize_or_self(std::path::Path::new(root));
+        if root_path == target_root {
+            return true;
+        }
+        if has_project_marker(&root_path) {
+            return false;
+        }
+    }
+
+    if let Some(cwd) = session.shell_cwd.as_deref() {
+        let cwd_path = crate::core::pathutil::safe_canonicalize_or_self(std::path::Path::new(cwd));
+        return cwd_path == target_root || cwd_path.starts_with(target_root);
+    }
+
+    false
+}
+
+fn has_project_marker(dir: &std::path::Path) -> bool {
+    const MARKERS: &[&str] = &[
+        ".git",
+        ".lean-ctx.toml",
+        "Cargo.toml",
+        "package.json",
+        "go.mod",
+        "pyproject.toml",
+        ".planning",
+    ];
+    MARKERS.iter().any(|m| dir.join(m).exists())
+}
+
+fn is_agent_or_temp_dir(dir: &std::path::Path) -> bool {
+    let s = dir.to_string_lossy();
+    s.contains("/.claude")
+        || s.contains("/.codex")
+        || s.contains("/var/folders/")
+        || s.contains("/tmp/")
+        || s.contains("\\.claude")
+        || s.contains("\\.codex")
+        || s.contains("\\AppData\\Local\\Temp")
+        || s.contains("\\Temp\\")
 }
 
 #[cfg(test)]

--- a/rust/src/tools/mod.rs
+++ b/rust/src/tools/mod.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -114,6 +115,8 @@ pub struct LeanCtxServer {
     pub workflow: Arc<RwLock<Option<crate::core::workflow::WorkflowRun>>>,
     pub ledger: Arc<RwLock<crate::core::context_ledger::ContextLedger>>,
     pub pipeline_stats: Arc<RwLock<crate::core::pipeline::PipelineStats>>,
+    startup_project_root: Option<String>,
+    startup_shell_cwd: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -138,6 +141,10 @@ impl LeanCtxServer {
     }
 
     pub fn new_with_project_root(project_root: Option<String>) -> Self {
+        Self::new_with_startup(project_root, std::env::current_dir().ok())
+    }
+
+    fn new_with_startup(project_root: Option<String>, startup_cwd: Option<PathBuf>) -> Self {
         let config = crate::core::config::Config::load();
 
         let interval = std::env::var("LEAN_CTX_CHECKPOINT_INTERVAL")
@@ -152,10 +159,20 @@ impl LeanCtxServer {
 
         let crp_mode = CrpMode::from_env();
 
-        let mut session = SessionState::load_latest().unwrap_or_default();
-        if project_root.is_some() {
-            session.project_root = project_root;
+        let startup = detect_startup_context(project_root.as_deref(), startup_cwd.as_deref());
+        let mut session = if let Some(ref root) = startup.project_root {
+            SessionState::load_latest_for_project_root(root).unwrap_or_default()
+        } else {
+            SessionState::load_latest().unwrap_or_default()
+        };
+
+        if let Some(ref root) = startup.project_root {
+            session.project_root = Some(root.clone());
         }
+        if let Some(ref cwd) = startup.shell_cwd {
+            session.shell_cwd = Some(cwd.clone());
+        }
+
         Self {
             cache: Arc::new(RwLock::new(SessionCache::new())),
             session: Arc::new(RwLock::new(session)),
@@ -180,6 +197,8 @@ impl LeanCtxServer {
                 crate::core::context_ledger::ContextLedger::new(),
             )),
             pipeline_stats: Arc::new(RwLock::new(crate::core::pipeline::PipelineStats::new())),
+            startup_project_root: startup.project_root,
+            startup_shell_cwd: startup.shell_cwd,
         }
     }
 
@@ -228,17 +247,28 @@ impl LeanCtxServer {
             Err(e) => {
                 if p.is_absolute() {
                     if let Some(new_root) = maybe_derive_project_root_from_absolute(&resolved) {
-                        let jail_has_marker = has_project_marker(jail_root_path);
                         let candidate_under_jail = resolved.starts_with(jail_root_path);
-
-                        if !candidate_under_jail
-                            && (!jail_has_marker || is_suspicious_root(jail_root_path))
-                        {
-                            let mut session = self.session.write().await;
-                            session.project_root = Some(new_root.to_string_lossy().to_string());
-                            if session.shell_cwd.is_none() {
-                                session.shell_cwd = Some(new_root.to_string_lossy().to_string());
+                        let allow_reroot = if !candidate_under_jail {
+                            if let Some(ref trusted_root) = self.startup_project_root {
+                                std::path::Path::new(trusted_root) == new_root.as_path()
+                            } else {
+                                !has_project_marker(jail_root_path)
+                                    || is_suspicious_root(jail_root_path)
                             }
+                        } else {
+                            false
+                        };
+
+                        if allow_reroot {
+                            let mut session = self.session.write().await;
+                            let new_root_str = new_root.to_string_lossy().to_string();
+                            session.project_root = Some(new_root_str.clone());
+                            session.shell_cwd = self
+                                .startup_shell_cwd
+                                .as_ref()
+                                .filter(|cwd| std::path::Path::new(cwd).starts_with(&new_root))
+                                .cloned()
+                                .or_else(|| Some(new_root_str.clone()));
                             let _ = session.save();
 
                             crate::core::pathjail::jail_path(&resolved, &new_root)?
@@ -610,6 +640,12 @@ impl LeanCtxServer {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct StartupContext {
+    project_root: Option<String>,
+    shell_cwd: Option<String>,
+}
+
 pub fn create_server() -> LeanCtxServer {
     LeanCtxServer::new()
 }
@@ -637,6 +673,43 @@ fn is_suspicious_root(dir: &std::path::Path) -> bool {
         || s.contains("/.codex")
         || s.contains("\\.claude")
         || s.contains("\\.codex")
+}
+
+fn canonicalize_path(path: &std::path::Path) -> String {
+    crate::core::pathutil::safe_canonicalize_or_self(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+fn detect_startup_context(
+    explicit_project_root: Option<&str>,
+    startup_cwd: Option<&std::path::Path>,
+) -> StartupContext {
+    let shell_cwd = startup_cwd.map(canonicalize_path);
+    let project_root = explicit_project_root
+        .map(|root| canonicalize_path(std::path::Path::new(root)))
+        .or_else(|| {
+            startup_cwd
+                .and_then(maybe_derive_project_root_from_absolute)
+                .map(|p| canonicalize_path(&p))
+        });
+
+    let shell_cwd = match (shell_cwd, project_root.as_ref()) {
+        (Some(cwd), Some(root))
+            if std::path::Path::new(&cwd).starts_with(std::path::Path::new(root)) =>
+        {
+            Some(cwd)
+        }
+        (Some(_), Some(root)) => Some(root.clone()),
+        (Some(cwd), None) => Some(cwd),
+        (None, Some(root)) => Some(root.clone()),
+        (None, None) => None,
+    };
+
+    StartupContext {
+        project_root,
+        shell_cwd,
+    }
 }
 
 fn maybe_derive_project_root_from_absolute(abs: &std::path::Path) -> Option<std::path::PathBuf> {
@@ -716,18 +789,26 @@ fn auto_consolidate_knowledge(project_root: &str) {
 mod resolve_path_tests {
     use super::*;
 
+    fn create_git_root(path: &std::path::Path) -> String {
+        std::fs::create_dir_all(path.join(".git")).unwrap();
+        canonicalize_path(path)
+    }
+
     #[tokio::test]
-    async fn resolve_path_can_auto_update_stale_root_from_absolute_project_path() {
+    async fn resolve_path_can_reroot_to_trusted_startup_root_when_session_root_is_stale() {
         let tmp = tempfile::tempdir().unwrap();
         let stale = tmp.path().join("stale");
         let real = tmp.path().join("real");
         std::fs::create_dir_all(&stale).unwrap();
-        std::fs::create_dir_all(&real).unwrap();
-        std::fs::create_dir_all(real.join(".git")).unwrap();
+        let real_root = create_git_root(&real);
         std::fs::write(real.join("a.txt"), "ok").unwrap();
 
-        let server =
-            LeanCtxServer::new_with_project_root(Some(stale.to_string_lossy().to_string()));
+        let server = LeanCtxServer::new_with_startup(None, Some(real.clone()));
+        {
+            let mut session = server.session.write().await;
+            session.project_root = Some(stale.to_string_lossy().to_string());
+            session.shell_cwd = Some(stale.to_string_lossy().to_string());
+        }
 
         let out = server
             .resolve_path(&real.join("a.txt").to_string_lossy())
@@ -737,10 +818,112 @@ mod resolve_path_tests {
         assert!(out.ends_with("/a.txt"));
 
         let session = server.session.read().await;
-        let expected = crate::core::pathutil::safe_canonicalize_or_self(&real)
-            .to_string_lossy()
-            .to_string();
-        assert_eq!(session.project_root.as_deref(), Some(expected.as_str()));
+        assert_eq!(session.project_root.as_deref(), Some(real_root.as_str()));
+        assert_eq!(session.shell_cwd.as_deref(), Some(real_root.as_str()));
+    }
+
+    #[tokio::test]
+    async fn resolve_path_rejects_absolute_path_outside_trusted_startup_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stale = tmp.path().join("stale");
+        let root = tmp.path().join("root");
+        let other = tmp.path().join("other");
+        std::fs::create_dir_all(&stale).unwrap();
+        create_git_root(&root);
+        let _other_value = create_git_root(&other);
+        std::fs::write(other.join("b.txt"), "no").unwrap();
+
+        let server = LeanCtxServer::new_with_startup(None, Some(root.clone()));
+        {
+            let mut session = server.session.write().await;
+            session.project_root = Some(stale.to_string_lossy().to_string());
+            session.shell_cwd = Some(stale.to_string_lossy().to_string());
+        }
+
+        let err = server
+            .resolve_path(&other.join("b.txt").to_string_lossy())
+            .await
+            .unwrap_err();
+        assert!(err.contains("path escapes project root"));
+
+        let session = server.session.read().await;
+        assert_eq!(
+            session.project_root.as_deref(),
+            Some(stale.to_string_lossy().as_ref())
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_prefers_workspace_scoped_session_over_global_latest() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let data = tempfile::tempdir().unwrap();
+        std::env::set_var("LEAN_CTX_DATA_DIR", data.path());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_a = tmp.path().join("repo-a");
+        let repo_b = tmp.path().join("repo-b");
+        let root_a = create_git_root(&repo_a);
+        let root_b = create_git_root(&repo_b);
+
+        let mut session_b = SessionState::new();
+        session_b.project_root = Some(root_b.clone());
+        session_b.shell_cwd = Some(root_b.clone());
+        session_b.set_task("repo-b task", None);
+        session_b.save().unwrap();
+
+        let mut session_a = SessionState::new();
+        session_a.project_root = Some(root_a.clone());
+        session_a.shell_cwd = Some(root_a.clone());
+        session_a.set_task("repo-a latest task", None);
+        session_a.save().unwrap();
+
+        let server = LeanCtxServer::new_with_startup(None, Some(repo_b.clone()));
+        let session = server.session.read().await;
+
+        assert_eq!(session.project_root.as_deref(), Some(root_b.as_str()));
+        assert_eq!(session.shell_cwd.as_deref(), Some(root_b.as_str()));
+        assert_eq!(
+            session.task.as_ref().map(|t| t.description.as_str()),
+            Some("repo-b task")
+        );
+
+        std::env::remove_var("LEAN_CTX_DATA_DIR");
+    }
+
+    #[tokio::test]
+    async fn startup_creates_fresh_session_for_new_workspace_and_preserves_subdir_cwd() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let data = tempfile::tempdir().unwrap();
+        std::env::set_var("LEAN_CTX_DATA_DIR", data.path());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_a = tmp.path().join("repo-a");
+        let repo_b = tmp.path().join("repo-b");
+        let repo_b_src = repo_b.join("src");
+        let root_a = create_git_root(&repo_a);
+        let root_b = create_git_root(&repo_b);
+        std::fs::create_dir_all(&repo_b_src).unwrap();
+        let repo_b_src_value = canonicalize_path(&repo_b_src);
+
+        let mut session_a = SessionState::new();
+        session_a.project_root = Some(root_a.clone());
+        session_a.shell_cwd = Some(root_a.clone());
+        session_a.set_task("repo-a latest task", None);
+        let old_id = session_a.id.clone();
+        session_a.save().unwrap();
+
+        let server = LeanCtxServer::new_with_startup(None, Some(repo_b_src.clone()));
+        let session = server.session.read().await;
+
+        assert_eq!(session.project_root.as_deref(), Some(root_b.as_str()));
+        assert_eq!(
+            session.shell_cwd.as_deref(),
+            Some(repo_b_src_value.as_str())
+        );
+        assert!(session.task.is_none());
+        assert_ne!(session.id, old_id);
+
+        std::env::remove_var("LEAN_CTX_DATA_DIR");
     }
 
     #[tokio::test]
@@ -748,10 +931,8 @@ mod resolve_path_tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().join("root");
         let other = tmp.path().join("other");
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::create_dir_all(&other).unwrap();
-        std::fs::create_dir_all(root.join(".git")).unwrap();
-        std::fs::create_dir_all(other.join(".git")).unwrap();
+        let root_value = create_git_root(&root);
+        create_git_root(&other);
         std::fs::write(other.join("b.txt"), "no").unwrap();
 
         let server = LeanCtxServer::new_with_project_root(Some(root.to_string_lossy().to_string()));
@@ -761,5 +942,8 @@ mod resolve_path_tests {
             .await
             .unwrap_err();
         assert!(err.contains("path escapes project root"));
+
+        let session = server.session.read().await;
+        assert_eq!(session.project_root.as_deref(), Some(root_value.as_str()));
     }
 }


### PR DESCRIPTION
## Summary

Fix stale `project_root` reuse when `lean-ctx` starts in a different checkout or worktree.

The stdio server was restoring the global latest session during startup. In practice that meant a new MCP server opened from checkout B could inherit checkout A as its active `project_root`, and a later absolute-path tool call in B would fail with `path escapes project root` against A.

Refs #137.

## Root Cause

`LeanCtxServer::new_with_project_root(None)` reused `SessionState::load_latest()` without first scoping the startup state to the current checkout.

That left the server in this state:
- startup cwd: checkout B
- restored session root: checkout A
- absolute path tool call in B
- path jail still enforced against A

## What Changed

- scope startup session restore to the current checkout/worktree when a real startup root can be derived
- initialize both `project_root` and `shell_cwd` from the current workspace instead of inheriting a foreign checkout
- keep the path jail intact, but only allow automatic re-rooting to the trusted startup workspace
- add regression coverage for:
  - preferring the workspace-scoped session over the global latest session
  - creating a fresh session for a brand-new workspace
  - preserving a startup subdirectory as `shell_cwd`
  - allowing reroot only to the trusted startup root
  - continuing to reject absolute paths outside that trusted root

## Validation

- `cargo fmt --check --manifest-path rust/Cargo.toml`
- `cargo clippy --all-features --manifest-path rust/Cargo.toml -- -D warnings`
- `cargo test --all-features --manifest-path rust/Cargo.toml`
- `cargo test --manifest-path rust/Cargo.toml --test adversarial_compression -- --nocapture`
- local SonarQube scan with Rust plugin: `QUALITY GATE STATUS: PASSED`

## Notes

The issue report in #137 includes a client-agnostic reproduction script that talks directly to the installed `lean-ctx` MCP stdio server.
