### PR TITLE
feat: Add support for excluded_commands using cli arguments

### DIFF
--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -656,7 +656,14 @@ pub fn cmd_config(args: &[String]) {
                 }
                 "passthrough_urls" => {
                     cfg.passthrough_urls = val.split(',').map(|s| s.trim().to_string()).collect();
-                }
+                },
+                "excluded_commands" => {
+                    cfg.excluded_commands = val
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                },
                 "rules_scope" => match val.as_str() {
                     "global" | "project" | "both" => {
                         cfg.rules_scope = Some(val.to_string());


### PR DESCRIPTION
Add support for settings `excluded_commands` using CLI arguments.

Example usage:

 ```bash                                                                                                                                                                                                          
   lean-ctx config set excluded_commands "make,go build"                                                                                                                                                          
 ```                                                                                                                                                                                                              