### PR TITLE
Fix/pi lean ctx environment

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -251,7 +251,7 @@ function isMcpAdapterConfigured(): boolean {
 
 async function execLeanCtx(pi: ExtensionAPI, args: string[]) {
   const bin = resolveBinary();
-  const result = await pi.exec(bin, args, { env: { LEAN_CTX_COMPRESS: "1" } });
+  const result = await pi.exec(bin, args, { env: { ...process.env, LEAN_CTX_COMPRESS: "1" } });
   if (result.code !== 0) {
     const msg = (result.stderr || result.stdout || `lean-ctx failed: ${args.join(" ")}`).trim();
     throw new Error(msg);

--- a/packages/pi-lean-ctx/extensions/mcp-bridge.ts
+++ b/packages/pi-lean-ctx/extensions/mcp-bridge.ts
@@ -78,6 +78,7 @@ export class McpBridge {
     this.transport = new StdioClientTransport({
       command: this.binary,
       args: [],
+      env: { ...process.env, LEAN_CTX_COMPRESS: "1" },
       stderr: "pipe",
     });
 


### PR DESCRIPTION
 - Forward parent process environment to `lean-ctx` to support [Environment Variables](https://leanctx.com/docs/configuration/#environment-variables)