### PR TITLE
fix: use explicit extension entry point ./extensions/index.ts in pi-lean-ctx

### DIFF
--- a/packages/pi-lean-ctx/package.json
+++ b/packages/pi-lean-ctx/package.json
@@ -1,8 +1,14 @@
 {
   "name": "pi-lean-ctx",
   "version": "3.4.2",
-  "description": "Pi Coding Agent extension with first-class MCP support — routes bash, read, grep, find, and ls through lean-ctx CLI, and exposes all 46 lean-ctx MCP tools (ctx_session, ctx_knowledge, ctx_semantic_search, ctx_impact, ctx_architecture, ctx_workflow, ctx_gain, etc.) natively in Pi",
-  "keywords": ["pi-package", "lean-ctx", "token-optimization", "compression", "mcp"],
+  "description": "Pi Coding Agent extension with first-class MCP support \u2014 routes bash, read, grep, find, and ls through lean-ctx CLI, and exposes all 46 lean-ctx MCP tools (ctx_session, ctx_knowledge, ctx_semantic_search, ctx_impact, ctx_architecture, ctx_workflow, ctx_gain, etc.) natively in Pi",
+  "keywords": [
+    "pi-package",
+    "lean-ctx",
+    "token-optimization",
+    "compression",
+    "mcp"
+  ],
   "license": "Apache-2.0",
   "author": "Yves Gugger",
   "repository": {
@@ -22,7 +28,9 @@
     "@mariozechner/pi-tui": "*"
   },
   "pi": {
-    "extensions": ["./extensions"]
+    "extensions": [
+      "./extensions/index.ts"
+    ]
   },
   "files": [
     "extensions/",


### PR DESCRIPTION
## Problem

`packages/pi-lean-ctx/package.json` declares `"pi": { "extensions": ["./extensions"] }`. The pi extension loader resolves this entry against the package root, yielding the **`extensions/` directory** path. While `collectAutoExtensionEntries` can eventually discover `index.ts` inside that directory, this relies on implicit multi-step discovery logic that can fail silently — the error is caught in `loadExtension()` with no user-visible output, causing tools to disappear from the registry without explanation.

## Root Cause

The [pi extension loader](https://github.com/mariozechner/pi-coding-agent) calls `jiti.import(path)` on the resolved entry. When `path` is a directory, jiti follows standard Node.js directory resolution (`index.js` first), which can fail silently for TypeScript-only directories.

## Fix

Point directly to the extension entry file:

```diff
-"extensions": ["./extensions"]
+"extensions": ["./extensions/index.ts"]
```

No behaviour change — same file is loaded, just via an unambiguous path.