### PR TITLE
Fix/pi agent promptguidelines

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -408,9 +408,6 @@ export default function (pi: ExtensionAPI) {
     label: "ls",
     description: "List directory contents. Use `limit` to reduce output size.",
     promptSnippet: "List directory contents",
-    promptGuidelines: [
-      "Use `ls` to explore directory structure and list files.",
-    ],
     parameters: lsSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path || ".");

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -276,7 +276,7 @@ export default function (pi: ExtensionAPI) {
     description: "Execute a bash command. Use `timeout` (seconds) to prevent hanging commands.",
     promptSnippet: "Run shell commands",
     promptGuidelines: [
-      "Use `bash` to run shell commands, scripts, or system tasks.",
+      "Use bash to run shell commands, scripts, or system tasks.",
     ],
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       try {
@@ -306,7 +306,7 @@ export default function (pi: ExtensionAPI) {
     description: "Read file contents. Use `offset` and `limit` to read specific line ranges",
     promptSnippet: "Read file contents",
     promptGuidelines: [
-      "Use `read` to inspect file contents instead of cat or less.",
+      "Use read to inspect file contents instead of cat or less.",
     ],
     parameters: readSchema,
     renderCall(args, theme, context) {

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -273,11 +273,10 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerTool({
     ...baseBashTool,
-    description:
-      "Execute a bash command through lean-ctx compression.",
-    promptSnippet: "Run shell commands (compressed output)",
+    description: "Execute a bash command.",
+    promptSnippet: "Run shell commands",
     promptGuidelines: [
-      "Avoid interactive prompts with bash; it cannot handle interactive input.",
+      "Tool: `bash`. Args: `command` (required), `timeout` (optional, seconds). No interactive prompts.",
     ],
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       try {
@@ -304,12 +303,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "read",
     label: "Read",
-    description:
-      "Read file contents through lean-ctx with automatic mode selection (full/map/signatures) based on file type and size.",
+    description: "Read file contents with automatic mode selection.",
     promptSnippet: "Smart file read",
     promptGuidelines: [
-      "Auto-selects mode: full (<8KB), map (8-96KB), signatures (>96KB) for code.",
-      "Text/configs always full-read; images passthrough.",
+      "Tool: `read`. Args: `path` (required), `offset` (optional, 1-indexed line), `limit` (optional max lines). Auto-selects mode by file size/type.",
     ],
     parameters: readSchema,
     renderCall(args, theme, context) {
@@ -409,10 +406,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "ls",
     label: "ls",
-    description: "List directory contents through lean-ctx compression.",
-    promptSnippet: "Directory listing (Compressed)",
+    description: "List directory contents.",
+    promptSnippet: "Directory listing",
     promptGuidelines: [
-      "Use ls with limit param to truncate long directory listings.",
+      "Tool: `ls`. Args: `path` (optional, default: cwd), `limit` (optional, default: 500).",
     ],
     parameters: lsSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -430,10 +427,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "find",
     label: "find",
-    description: "Find files by glob pattern through lean-ctx compression.",
-    promptSnippet: "File search (Compressed)",
+    description: "Find files by glob pattern.",
+    promptSnippet: "File search",
     promptGuidelines: [
-      "Use find with limit param to cap large result sets.",
+      "Tool: `find`. Args: `pattern` (required, glob), `path` (optional, default: cwd), `limit` (optional, default: 1000).",
     ],
     parameters: findSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -451,10 +448,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "grep",
     label: "grep",
-    description: "Search file contents through ripgrep + lean-ctx compression.",
-    promptSnippet: "Compressed code search (grouped results)",
+    description: "Search file contents using regex or literal patterns.",
+    promptSnippet: "Code search",
     promptGuidelines: [
-      "Use grep with ripgrep flags: -i, -F, -C, -m, --glob. Output includes line numbers.",
+      "Tool: `grep`. Args: `pattern` (required). Optional: `path`, `glob`, `ignoreCase`, `literal`, `context` (lines), `limit` (max matches). Returns line numbers.",
     ],
     parameters: grepSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -273,10 +273,10 @@ export default function (pi: ExtensionAPI) {
 
   pi.registerTool({
     ...baseBashTool,
-    description: "Execute a bash command.",
+    description: "Execute a bash command. Use `timeout` (seconds) to prevent hanging commands.",
     promptSnippet: "Run shell commands",
     promptGuidelines: [
-      "Tool: `bash`. Args: `command` (required), `timeout` (optional, seconds). No interactive prompts.",
+      "Use `bash` to run shell commands, scripts, or system tasks.",
     ],
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       try {
@@ -303,10 +303,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "read",
     label: "Read",
-    description: "Read file contents with automatic mode selection.",
-    promptSnippet: "Smart file read",
+    description: "Read file contents. Use `offset` and `limit` to read specific line ranges",
+    promptSnippet: "Read file contents",
     promptGuidelines: [
-      "Tool: `read`. Args: `path` (required), `offset` (optional, 1-indexed line), `limit` (optional max lines). Auto-selects mode by file size/type.",
+      "Use `read` to inspect file contents instead of cat or less.",
     ],
     parameters: readSchema,
     renderCall(args, theme, context) {
@@ -406,10 +406,10 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "ls",
     label: "ls",
-    description: "List directory contents.",
-    promptSnippet: "Directory listing",
+    description: "List directory contents. Use `limit` to reduce output size.",
+    promptSnippet: "List directory contents",
     promptGuidelines: [
-      "Tool: `ls`. Args: `path` (optional, default: cwd), `limit` (optional, default: 500).",
+      "Use `ls` to explore directory structure and list files.",
     ],
     parameters: lsSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -427,11 +427,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "find",
     label: "find",
-    description: "Find files by glob pattern.",
-    promptSnippet: "File search",
-    promptGuidelines: [
-      "Tool: `find`. Args: `pattern` (required, glob), `path` (optional, default: cwd), `limit` (optional, default: 1000).",
-    ],
+    description: "Find files by glob pattern. Use `limit` to reduce output size.",
+    promptSnippet: "Find files by glob pattern (respects .gitignore)",
     parameters: findSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path || ".");
@@ -448,11 +445,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "grep",
     label: "grep",
-    description: "Search file contents using regex or literal patterns.",
-    promptSnippet: "Code search",
-    promptGuidelines: [
-      "Tool: `grep`. Args: `pattern` (required). Optional: `path`, `glob`, `ignoreCase`, `literal`, `context` (lines), `limit` (max matches). Returns line numbers.",
-    ],
+    description: "Search file contents. Use `limit` to cap matches and `context` for surrounding lines to reduce token usage.",
+    promptSnippet: "Search file contents for patterns (respects .gitignore)",
     parameters: grepSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path || ".");

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -277,8 +277,7 @@ export default function (pi: ExtensionAPI) {
       "Execute a bash command through lean-ctx compression.",
     promptSnippet: "Run shell commands (compressed output)",
     promptGuidelines: [
-      "Use for any shell command—output (auto-compressed)",
-      "Avoid for interactive prompts; lean-ctx buffers output.",
+      "Avoid interactive prompts with bash; it cannot handle interactive input.",
     ],
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       try {
@@ -413,8 +412,7 @@ export default function (pi: ExtensionAPI) {
     description: "List directory contents through lean-ctx compression.",
     promptSnippet: "Directory listing (Compressed)",
     promptGuidelines: [
-      "ls → compressed output (respects .gitignore).",
-      "Use limit param to truncate long lists.",
+      "Use ls with limit param to truncate long directory listings.",
     ],
     parameters: lsSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -435,8 +433,7 @@ export default function (pi: ExtensionAPI) {
     description: "Find files by glob pattern through lean-ctx compression.",
     promptSnippet: "File search (Compressed)",
     promptGuidelines: [
-      "find [pattern] → lean-ctx compressed results.",
-      "Combines with .gitignore; use limit to cap results.",
+      "Use find with limit param to cap large result sets.",
     ],
     parameters: findSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -457,8 +454,7 @@ export default function (pi: ExtensionAPI) {
     description: "Search file contents through ripgrep + lean-ctx compression.",
     promptSnippet: "Compressed code search (grouped results)",
     promptGuidelines: [
-      "rg → lean-ctx compressed output (line numbers, no color).",
-      "Supports standard rg flags: -i, -F, -C, -m, --glob.",
+      "Use grep with ripgrep flags: -i, -F, -C, -m, --glob. Output includes line numbers.",
     ],
     parameters: grepSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {


### PR DESCRIPTION
Digging a bit further into the context-window when using Pi agent, reveals our `promptGuidelines`  and `description`  for the tools we register in `packages/pi-lean-ctx/index.ts -> pi.registerTool()` is not accurate enough.

As per [Pi Agent documentation ](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md#extensionapi-methods), we need to consider this important note:

> Important: promptGuidelines bullets are appended flat to the Guidelines section with no tool name prefix

So, in our case  - if we _need_ to use a `promptGuidelines`, we must ensure the tool name is part of it.

Further mode, digging through the source-code of [Pi agent system-prompt](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/system-prompt.ts#L115) reveals the tools `grep`+ `find` and `ls` are already covered by the auto-injected system prompt (If the tools exist) - thus no need to inject the guidelines twice.

The existing structure in Pi agent system-prompt, is to have the `description`  as the most informative place (Where we can give tool specific instructions). This will be linked to the directly to the "available tools" section in Pi Agent.
Example of [built-in read](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/tools/read.ts#L121)
