### PR TITLE
fix: hook handlers respect LEAN_CTX_DISABLED env var

### DIFF
--- a/rust/src/hook_handlers.rs
+++ b/rust/src/hook_handlers.rs
@@ -2,7 +2,14 @@ use crate::compound_lexer;
 use crate::rewrite_registry;
 use std::io::Read;
 
+fn is_disabled() -> bool {
+    std::env::var("LEAN_CTX_DISABLED").is_ok()
+}
+
 pub fn handle_rewrite() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -76,6 +83,11 @@ fn emit_rewrite(rewritten: &str) {
 }
 
 pub fn handle_redirect() {
+    // Already a no-op, but guard for consistency so the process exits
+    // before any future logic is added.
+    if is_disabled() {
+        return;
+    }
     // Allow all native tools (Read, Grep, ListFiles) to pass through.
     // Blocking them breaks Edit (which requires native Read) and causes
     // unnecessary friction. The MCP instructions already guide the AI
@@ -89,6 +101,9 @@ fn codex_reroute_message(rewritten: &str) -> String {
 }
 
 pub fn handle_codex_pretooluse() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -121,6 +136,9 @@ pub fn handle_codex_session_start() {
 /// VS Code Copilot Chat uses the same hook format as Claude Code.
 /// Tool names differ: "runInTerminal" / "editFile" instead of "Bash" / "Read".
 pub fn handle_copilot() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -155,6 +173,9 @@ pub fn handle_copilot() {
 /// Used by the OpenCode TS plugin where the command is passed as an argument,
 /// not via stdin JSON.
 pub fn handle_rewrite_inline() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let args: Vec<String> = std::env::args().collect();
     // args: [binary, "hook", "rewrite-inline", ...command parts]


### PR DESCRIPTION
## Summary

- All 5 hook entry points in `hook_handlers.rs` now early-exit when `LEAN_CTX_DISABLED=1` is set
- Adds a shared `is_disabled()` helper, consistent with the same check in `shell.rs` and `main.rs`
- Zero behavioral change when the env var is not set

## Problem

`LEAN_CTX_DISABLED` is documented as "Bypass ALL compression + prevent shell hook from loading" and is checked in `shell.rs` and `main.rs`, but was missing from the PreToolUse hook handlers.

This causes a real-world freeze in **Claude Code's conversation rewind**. When rewinding, Claude Code replays every historical tool call — each fires the PreToolUse hook, which spawns a blocking `lean-ctx hook rewrite` process. With 20-50 tool calls in a conversation, the serial process spawning locks up the terminal.

## Changes

One new shared helper + one guard per handler:

```rust
fn is_disabled() -> bool {
    std::env::var("LEAN_CTX_DISABLED").is_ok()
}
```

Added to: `handle_rewrite`, `handle_redirect`, `handle_copilot`, `handle_codex_pretooluse`, `handle_rewrite_inline`.

## Test plan

- [ ] Existing `cargo test hook_handlers` tests pass (no behavior change when env var is unset)
- [ ] With `LEAN_CTX_DISABLED=1`, `echo '{"tool_name":"Bash","command":"git status"}' | lean-ctx hook rewrite` produces no output (early exit)
- [ ] Without the env var, same command produces rewritten output as before

Fixes #162