### PR TITLE
fix: Pi compression loop + hook handlers respect LEAN_CTX_DISABLED

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -271,19 +271,37 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  const rawBash = createBashToolDefinition(process.cwd());
+
+  const bashSchemaWithRaw = Type.Object({
+    command: Type.String({ description: "Bash command to execute" }),
+    timeout: Type.Optional(Type.Number({ description: "Timeout in seconds to prevent hanging commands" })),
+    raw: Type.Optional(Type.Boolean({ description: "Skip compression, return full uncompressed output" })),
+  });
+
   pi.registerTool({
     ...baseBashTool,
+    parameters: bashSchemaWithRaw,
     description:
-      "Execute a bash command through lean-ctx compression.",
-    promptSnippet: "Run shell commands (compressed output)",
+      "Execute a bash command. Output is auto-compressed by lean-ctx. "
+      + "IMPORTANT: Do NOT use bash to read files (cat/head/tail) — use the read tool instead. "
+      + "Do NOT use bash for grep/find/ls — use the dedicated tools. "
+      + "Set raw=true to skip compression when exact output matters. "
+      + "Use timeout (seconds) to prevent hanging commands.",
+    promptSnippet: "Run shell commands (not for file reading — use read tool)",
     promptGuidelines: [
-      "Use for any shell command—output (auto-compressed)",
-      "Avoid for interactive prompts; lean-ctx buffers output.",
+      "Use bash only for commands with side effects: build, test, install, git, run scripts.",
     ],
     async execute(toolCallId, params, signal, onUpdate, ctx) {
+      const isRaw = !!params.raw;
+      const toolParams = { command: params.command, timeout: params.timeout };
+      const tool = isRaw ? rawBash : baseBashTool;
       try {
-        const result = await baseBashTool.execute(toolCallId, params, signal, onUpdate, ctx);
+        const result = await tool.execute(toolCallId, toolParams, signal, onUpdate, ctx);
         const text = result.content?.[0]?.type === "text" ? result.content[0].text : "";
+        if (isRaw) {
+          return { ...result, content: [{ type: "text", text }], details: { raw: true } };
+        }
         const decorated = withFooter(text, { always: true });
         return {
           ...result,
@@ -292,6 +310,7 @@ export default function (pi: ExtensionAPI) {
         };
       } catch (error) {
         if (error instanceof Error) {
+          if (isRaw) throw error;
           const decorated = withFooter(error.message, { always: true });
           throw new Error(decorated.text);
         }
@@ -306,11 +325,13 @@ export default function (pi: ExtensionAPI) {
     name: "read",
     label: "Read",
     description:
-      "Read file contents through lean-ctx with automatic mode selection (full/map/signatures) based on file type and size.",
-    promptSnippet: "Smart file read",
+      "Read file contents. ALWAYS use this instead of cat/head/tail via bash. "
+      + "Auto-selects mode: configs (.yaml/.json/.toml/.env) are always full-read. "
+      + "Code files: full (<8KB), map (8-96KB), signatures (>96KB). "
+      + "Use offset and limit to read specific line ranges.",
+    promptSnippet: "Read file contents (always use instead of cat)",
     promptGuidelines: [
-      "Auto-selects mode: full (<8KB), map (8-96KB), signatures (>96KB) for code.",
-      "Text/configs always full-read; images passthrough.",
+      "Use read to inspect file contents instead of cat or less.",
     ],
     parameters: readSchema,
     renderCall(args, theme, context) {
@@ -410,12 +431,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "ls",
     label: "ls",
-    description: "List directory contents through lean-ctx compression.",
-    promptSnippet: "Directory listing (Compressed)",
-    promptGuidelines: [
-      "ls → compressed output (respects .gitignore).",
-      "Use limit param to truncate long lists.",
-    ],
+    description: "List directory contents. Use limit to reduce output size.",
+    promptSnippet: "List directory contents",
     parameters: lsSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path || ".");
@@ -432,12 +449,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "find",
     label: "find",
-    description: "Find files by glob pattern through lean-ctx compression.",
-    promptSnippet: "File search (Compressed)",
-    promptGuidelines: [
-      "find [pattern] → lean-ctx compressed results.",
-      "Combines with .gitignore; use limit to cap results.",
-    ],
+    description: "Find files by glob pattern (respects .gitignore). Use limit to reduce output size.",
+    promptSnippet: "Find files by glob pattern",
     parameters: findSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path || ".");
@@ -454,12 +467,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "grep",
     label: "grep",
-    description: "Search file contents through ripgrep + lean-ctx compression.",
-    promptSnippet: "Compressed code search (grouped results)",
-    promptGuidelines: [
-      "rg → lean-ctx compressed output (line numbers, no color).",
-      "Supports standard rg flags: -i, -F, -C, -m, --glob.",
-    ],
+    description: "Search file contents with ripgrep. Use limit to cap matches and context for surrounding lines.",
+    promptSnippet: "Search file contents for patterns",
     parameters: grepSchema,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path || ".");

--- a/packages/pi-lean-ctx/package.json
+++ b/packages/pi-lean-ctx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-lean-ctx",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Pi Coding Agent extension with first-class MCP support \u2014 routes bash, read, grep, find, and ls through lean-ctx CLI, and exposes all 46 lean-ctx MCP tools (ctx_session, ctx_knowledge, ctx_semantic_search, ctx_impact, ctx_architecture, ctx_workflow, ctx_gain, etc.) natively in Pi",
   "keywords": [
     "pi-package",

--- a/rust/src/hook_handlers.rs
+++ b/rust/src/hook_handlers.rs
@@ -2,7 +2,14 @@ use crate::compound_lexer;
 use crate::rewrite_registry;
 use std::io::Read;
 
+fn is_disabled() -> bool {
+    std::env::var("LEAN_CTX_DISABLED").is_ok()
+}
+
 pub fn handle_rewrite() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -89,6 +96,9 @@ fn codex_reroute_message(rewritten: &str) -> String {
 }
 
 pub fn handle_codex_pretooluse() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -121,6 +131,9 @@ pub fn handle_codex_session_start() {
 /// VS Code Copilot Chat uses the same hook format as Claude Code.
 /// Tool names differ: "runInTerminal" / "editFile" instead of "Bash" / "Read".
 pub fn handle_copilot() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
@@ -155,6 +168,9 @@ pub fn handle_copilot() {
 /// Used by the OpenCode TS plugin where the command is passed as an argument,
 /// not via stdin JSON.
 pub fn handle_rewrite_inline() {
+    if is_disabled() {
+        return;
+    }
     let binary = resolve_binary();
     let args: Vec<String> = std::env::args().collect();
     // args: [binary, "hook", "rewrite-inline", ...command parts]

--- a/rust/tests/pre_release_check.sh
+++ b/rust/tests/pre_release_check.sh
@@ -44,7 +44,7 @@ step "6/6  Live hook JSON validation"
 validate_rewrite() {
     local label="$1" input="$2" expect="$3"
     local result
-    result=$(echo "$input" | LEAN_CTX_DISABLED=1 "$BIN" hook rewrite 2>/dev/null)
+    result=$(echo "$input" | "$BIN" hook rewrite 2>/dev/null)
 
     if [ "$expect" = "passthrough" ]; then
         if [ -z "$result" ]; then ok "$label"; else fail "$label (expected passthrough)"; fi

--- a/rust/tests/shell_and_agent_tests.rs
+++ b/rust/tests/shell_and_agent_tests.rs
@@ -47,6 +47,40 @@ fn run_with_env(
     (stdout, stderr, code)
 }
 
+fn run_hook_test(
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+    stdin_data: Option<&str>,
+) -> (String, String, i32) {
+    let mut cmd = Command::new(lean_ctx_bin());
+    cmd.args(args)
+        .env_remove("LEAN_CTX_DISABLED")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    for (k, v) in env_vars {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().expect("failed to spawn lean-ctx");
+
+    if let Some(data) = stdin_data {
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(data.as_bytes())
+            .unwrap();
+    }
+
+    let output = child.wait_with_output().expect("failed to wait");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let code = output.status.code().unwrap_or(1);
+    (stdout, stderr, code)
+}
+
 fn assert_hook_command_suffix(actual: Option<&str>, expected_suffix: &str) {
     let actual = actual.expect("hook command should exist");
     assert!(
@@ -234,7 +268,7 @@ fn agent_init_unknown_agent_fails() {
 fn codex_pretooluse_blocks_rewritable_bash_with_reroute_message() {
     let input =
         r#"{"tool_name":"Bash","tool_input":{"command":"git status"},"command":"git status"}"#;
-    let (stdout, stderr, code) = run_with_env(&["hook", "codex-pretooluse"], &[], Some(input));
+    let (stdout, stderr, code) = run_hook_test(&["hook", "codex-pretooluse"], &[], Some(input));
     assert_eq!(code, 2, "hook should block and reroute: {stderr}");
     assert!(
         stdout.trim().is_empty(),
@@ -411,7 +445,7 @@ fn agent_init_lists_antigravity_in_supported() {
 #[test]
 fn hook_rewrite_works_with_shell_override() {
     let input = r#"{"tool_name":"Bash","command":"git status"}"#;
-    let (stdout, _stderr, _code) = run_with_env(
+    let (stdout, _stderr, _code) = run_hook_test(
         &["hook", "rewrite"],
         &[("LEAN_CTX_SHELL", "/bin/sh")],
         Some(input),
@@ -426,6 +460,37 @@ fn hook_rewrite_works_with_shell_override() {
             "should have command field"
         );
     }
+}
+
+#[test]
+fn hook_rewrite_disabled_produces_no_output() {
+    let input = r#"{"tool_name":"Bash","command":"git status"}"#;
+    let (stdout, _stderr, code) = run_hook_test(
+        &["hook", "rewrite"],
+        &[("LEAN_CTX_DISABLED", "1")],
+        Some(input),
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "disabled hook should produce no output, got: {stdout}"
+    );
+    assert_eq!(code, 0, "disabled hook should exit cleanly");
+}
+
+#[test]
+fn codex_pretooluse_disabled_exits_cleanly() {
+    let input =
+        r#"{"tool_name":"Bash","tool_input":{"command":"git status"},"command":"git status"}"#;
+    let (stdout, _stderr, code) = run_hook_test(
+        &["hook", "codex-pretooluse"],
+        &[("LEAN_CTX_DISABLED", "1")],
+        Some(input),
+    );
+    assert_eq!(code, 0, "disabled codex hook should not exit(2)");
+    assert!(
+        stdout.trim().is_empty(),
+        "disabled codex hook should produce no output"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Comprehensive fix addressing three reported issues:

### Pi Extension — fixes #159 (Compression prevents work being done)

**Root cause**: The Pi agent used `cat`/`head`/`tail` via the `bash` tool to read files, but all output was compressed with no escape hatch. The agent entered infinite loops trying different approaches to read files.

**Three-layer fix (matching parity with other IDEs):**

1. **`raw=true` parameter on bash tool** — escape hatch to skip compression when exact output is critical. Uses a second `createBashToolDefinition` without `spawnHook` for raw execution.

2. **Reworked all tool descriptions** — following Pi Agent's prompt architecture (credit: @glemsom's research in #161):
   - `description` is the primary guidance surface (linked to "available tools")
   - `promptGuidelines` are flattened without tool name prefix, so kept minimal
   - bash: explicitly says "Do NOT use bash for cat/head/tail — use the read tool"
   - read: "ALWAYS use this instead of cat/head/tail via bash"
   - Removed redundant `promptGuidelines` for `ls`/`find`/`grep` (auto-injected by Pi)

3. **Dedicated tools** as the primary path — `read` for files, `grep` for search, etc.

### Hook Handlers — fixes #162 (PreToolUse hooks don't respect LEAN_CTX_DISABLED)

**Root cause**: `LEAN_CTX_DISABLED` was checked in `shell.rs` and `main.rs` but not in hook handlers. This caused terminal freezes during Claude Code conversation rewind (each replayed tool call spawned a blocking `lean-ctx hook rewrite` process).

**Fix**: Added `is_disabled()` guard to `handle_rewrite`, `handle_codex_pretooluse`, `handle_copilot`, and `handle_rewrite_inline`. Skipped `handle_redirect` (already a no-op).

This also helps with Claude Code subagents that don't have MCP access — setting `LEAN_CTX_DISABLED=1` in the subagent environment bypasses the hooks entirely.

### Tests

- Added `run_hook_test` helper that explicitly clears `LEAN_CTX_DISABLED` (the standard `run_with_env` sets it, which would conflict with the new guards)
- Added `hook_rewrite_disabled_produces_no_output` test
- Added `codex_pretooluse_disabled_exits_cleanly` test
- Fixed `pre_release_check.sh` to not set `LEAN_CTX_DISABLED` during hook validation

### Version bump

- `pi-lean-ctx` bumped to 3.4.3

## Test plan

- [x] All 1429 existing tests pass
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] New tests verify disabled hooks produce no output / exit cleanly
- [x] Hook rewrite and codex-pretooluse work correctly when NOT disabled

## Credits

Incorporates insights from:
- @glemsom (#161) — Pi Agent prompt architecture research
- @johnwhoyou (#162, #163) — LEAN_CTX_DISABLED guard pattern


Made with [Cursor](https://cursor.com)