### PR TITLE
fix: clarify telemetry claims, add version check opt-out (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://discord.gg/pTHkG9Hew9"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://x.com/leanctx"><img src="https://img.shields.io/badge/𝕏-Follow-000000?logo=x&logoColor=white" alt="X/Twitter"></a>
-  <img src="https://img.shields.io/badge/Telemetry-Zero-brightgreen?logo=shield&logoColor=white" alt="Zero Telemetry">
+  <img src="https://img.shields.io/badge/Telemetry-Opt--in%20Only-brightgreen?logo=shield&logoColor=white" alt="Opt-in Telemetry">
 </p>
 
 <p align="center">
@@ -837,7 +837,7 @@ When running inside Codex CLI (`CODEX_CLI_SESSION` set), `~/.codex` is automatic
 | Full output recovery | `tee` | ✓ (`tee_mode: always/failures/never`) |
 | Truncation warnings | ✗ | ✓ (transparent markers) |
 | ANSI auto-strip | ✗ | ✓ (pre-compression) |
-| Telemetry | **Default ON (PII)** | **Zero. None. Ever.** |
+| Telemetry | **Default ON (PII)** | **Opt-in only, no PII, no tracking** |
 | Editor support | 3 editors | **24 editors/tools** |
 
 <br>
@@ -846,9 +846,9 @@ When running inside Codex CLI (`CODEX_CLI_SESSION` set), `~/.codex` is automatic
 
 lean-ctx is **privacy-first by design**:
 
-- **Zero telemetry** — no data collection, no analytics, no phone-home, ever
-- **Zero network requests** — everything runs locally on your machine
-- **No PII exposure** — no hostnames, usernames, or project paths leave your system
+- **No tracking, no analytics** — no PII, no hostnames, no project paths leave your system
+- **Opt-in data sharing** — anonymous compression stats are only sent if you explicitly enable it during setup (default: off)
+- **Update check** — a lightweight daily version check against `leanctx.com/version.txt` runs in the background (disable with `update_check_disabled = true` in config or `LEAN_CTX_NO_UPDATE_CHECK=1`)
 - **Fully auditable** — Apache 2.0 licensed, single Rust binary, no hidden dependencies
 
 See [SECURITY.md](SECURITY.md).
@@ -893,14 +893,14 @@ No. lean-ctx adds <1ms overhead per operation. The MCP server runs as a persiste
 <details>
 <summary><strong>Is it safe? Does it send data anywhere?</strong></summary>
 
-lean-ctx has **zero telemetry** — no data collection, no analytics, no network requests, ever. Everything runs 100% locally. The code is Apache 2.0 licensed and fully auditable. See [SECURITY.md](SECURITY.md).
+lean-ctx has **no tracking and no analytics**. All compression runs 100% locally. The only network activity is an optional daily version check (disable with `LEAN_CTX_NO_UPDATE_CHECK=1`) and opt-in anonymous compression stats sharing (off by default). No PII, hostnames, or project paths are ever transmitted. The code is Apache 2.0 licensed and fully auditable. See [SECURITY.md](SECURITY.md).
 
 </details>
 
 <details>
 <summary><strong>What's the difference between lean-ctx and Rust Token Killer (RTK)?</strong></summary>
 
-lean-ctx is a hybrid architecture (shell hook + MCP server) while Rust Token Killer is shell-hook only. lean-ctx offers 46 tools vs RTK's basic compression, supports 24 editors vs 3, has tree-sitter AST parsing for 18 languages, cross-session memory, multi-agent coordination, and — critically — zero telemetry (RTK has default-on telemetry with PII).
+lean-ctx is a hybrid architecture (shell hook + MCP server) while Rust Token Killer is shell-hook only. lean-ctx offers 46 tools vs RTK's basic compression, supports 24 editors vs 3, has tree-sitter AST parsing for 18 languages, cross-session memory, multi-agent coordination, and no tracking or analytics (RTK has default-on telemetry with PII). lean-ctx's optional data sharing is fully opt-in and anonymized.
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,9 +26,12 @@ lean-ctx is a **local-only CLI tool and MCP server**. Understanding its scope he
 - Store statistics in `~/.lean-ctx/stats.json` (command counts, token savings)
 - Store session state in `~/.lean-ctx/sessions/` (task context, findings)
 
+**Optional network activity (fully disableable):**
+- **Update check**: a lightweight daily GET to `leanctx.com/version.txt` to notify you of new versions. Sends only the current version as User-Agent. Disable with `update_check_disabled = true` in `~/.lean-ctx/config.toml` or `LEAN_CTX_NO_UPDATE_CHECK=1`.
+- **Anonymous stats sharing** (opt-in, off by default): if you enable `contribute_enabled` in setup, anonymized compression statistics (token counts, compression ratios — no file names, no code, no PII) are periodically sent to `api.leanctx.com`.
+
 **Does NOT:**
-- Make any network requests or phone home
-- Collect telemetry or usage analytics
+- Collect tracking analytics, fingerprints, or PII
 - Access files outside of requested paths
 - Store or transmit credentials, API keys, or secrets
 - Require elevated privileges (runs as your user)
@@ -73,7 +76,7 @@ All dependencies in `Cargo.toml` meet these criteria:
 - **Established crates**: All 29 dependencies are well-known, widely-used Rust crates
 - **License**: MIT or Apache-2.0 compatible
 - **Active maintenance**: Recent commits within 6 months
-- **No network crates**: lean-ctx has zero HTTP/networking dependencies
+- **Minimal network**: `ureq` (lightweight HTTP client) used only for version check and opt-in cloud sync
 
 Key dependencies and their purpose:
 
@@ -150,4 +153,4 @@ Critical vulnerabilities (RCE, data exfiltration) are fast-tracked.
 
 ---
 
-**Last updated**: 2026-03-25
+**Last updated**: 2026-04-27

--- a/rust/README.md
+++ b/rust/README.md
@@ -735,7 +735,7 @@ Contributions welcome! Please open an issue or PR on [GitHub](https://github.com
 
 ## Security
 
-lean-ctx is a **local-only** tool — zero network requests, zero telemetry. See [SECURITY.md](SECURITY.md) for:
+lean-ctx is a **privacy-first** tool — no tracking, no analytics, no PII collection. Optional network activity (daily version check, opt-in anonymous stats) is fully disableable. See [SECURITY.md](SECURITY.md) for:
 
 - Vulnerability reporting process
 - Automated CI security checks (cargo audit, clippy, dangerous pattern scans)

--- a/rust/src/core/config.rs
+++ b/rust/src/core/config.rs
@@ -151,6 +151,10 @@ pub struct Config {
     /// Override via LEAN_CTX_NO_HOOK env var.
     #[serde(default)]
     pub shell_hook_disabled: bool,
+    /// Disable the daily version check against leanctx.com/version.txt.
+    /// Override via LEAN_CTX_NO_UPDATE_CHECK env var.
+    #[serde(default)]
+    pub update_check_disabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -364,6 +368,7 @@ impl Default for Config {
             content_defined_chunking: false,
             minimal_overhead: false,
             shell_hook_disabled: false,
+            update_check_disabled: false,
         }
     }
 }
@@ -409,6 +414,10 @@ impl Config {
 
     pub fn shell_hook_disabled_effective(&self) -> bool {
         std::env::var("LEAN_CTX_NO_HOOK").is_ok() || self.shell_hook_disabled
+    }
+
+    pub fn update_check_disabled_effective(&self) -> bool {
+        std::env::var("LEAN_CTX_NO_UPDATE_CHECK").is_ok() || self.update_check_disabled
     }
 }
 

--- a/rust/src/core/version_check.rs
+++ b/rust/src/core/version_check.rs
@@ -78,7 +78,13 @@ fn is_newer(latest: &str, current: &str) -> bool {
 /// Spawn a background thread to fetch latest version from leanctx.com/version.txt
 /// and write the result to ~/.lean-ctx/latest-version.json.
 /// Non-blocking, fire-and-forget. Skips if cache is fresh (<24h).
+/// Respects `update_check_disabled` config and `LEAN_CTX_NO_UPDATE_CHECK` env var.
 pub fn check_background() {
+    let cfg = super::config::Config::load();
+    if cfg.update_check_disabled_effective() {
+        return;
+    }
+
     let cache = read_cache();
     if let Some(ref c) = cache {
         if !is_cache_stale(c) {

--- a/rust/src/setup.rs
+++ b/rust/src/setup.rs
@@ -198,14 +198,14 @@ pub fn run_setup() {
     println!("  Share anonymous compression stats to make lean-ctx better.");
     println!("  \x1b[1mNo code, no file names, no personal data — ever.\x1b[0m");
     println!();
-    print!("  Enable anonymous data sharing? \x1b[1m[Y/n]\x1b[0m ");
+    print!("  Enable anonymous data sharing? \x1b[1m[y/N]\x1b[0m ");
     use std::io::Write;
     std::io::stdout().flush().ok();
 
     let mut input = String::new();
     let contribute = if std::io::stdin().read_line(&mut input).is_ok() {
         let answer = input.trim().to_lowercase();
-        answer.is_empty() || answer == "y" || answer == "yes"
+        answer == "y" || answer == "yes"
     } else {
         false
     };


### PR DESCRIPTION
## Summary

Addresses all three requests from #160:

1. **README updated** — replaced "Zero telemetry / Zero network requests" with accurate descriptions of what network activity exists and how to control it
2. **Version check opt-out added** — new `update_check_disabled = true` config option and `LEAN_CTX_NO_UPDATE_CHECK=1` env var to completely disable the daily version check
3. **Data sharing default flipped** — `lean-ctx setup` now asks `[y/N]` (opt-in) instead of `[Y/n]` (opt-out)

### Changes

| File | Change |
|------|--------|
| `README.md` | Badge updated, privacy section rewritten, FAQ corrected, comparison table fixed |
| `SECURITY.md` | "Does NOT make network requests" replaced with accurate documentation of optional network activity |
| `rust/README.md` | Security section updated |
| `rust/src/core/config.rs` | Added `update_check_disabled` field + `update_check_disabled_effective()` accessor |
| `rust/src/core/version_check.rs` | `check_background()` now respects config/env before pinging |
| `rust/src/setup.rs` | Default flipped from `[Y/n]` to `[y/N]` |

### Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] All 1430+ tests pass
- [x] `LEAN_CTX_NO_UPDATE_CHECK=1` prevents version check
- [x] Setup default now requires explicit `y` to enable data sharing

Closes #160

Made with [Cursor](https://cursor.com)