### PR TITLE
fix: recover from tool handler panics instead of crashing MCP server

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -181,7 +181,7 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 strip = true
-panic = "abort"
+panic = "unwind"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/rust/src/cli/dispatch.rs
+++ b/rust/src/cli/dispatch.rs
@@ -838,7 +838,22 @@ fn run_mcp_server() -> Result<()> {
                 return Err(e.into());
             }
         };
-        service.waiting().await?;
+        match service.waiting().await {
+            Ok(reason) => {
+                tracing::info!("MCP server stopped: {reason:?}");
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("broken pipe")
+                    || msg.contains("connection reset")
+                    || msg.contains("context canceled")
+                {
+                    tracing::info!("MCP server: transport closed ({msg})");
+                } else {
+                    tracing::error!("MCP server error: {msg}");
+                }
+            }
+        }
 
         core::stats::flush();
         core::mode_predictor::ModePredictor::flush();

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -290,9 +290,29 @@ impl ServerHandler for LeanCtxServer {
         let minimal = config.minimal_overhead_effective();
 
         let tool_start = std::time::Instant::now();
-        let result_text = self.dispatch_tool(name, args, minimal).await?;
-
-        let mut result_text = result_text;
+        let mut result_text = {
+            use std::panic::AssertUnwindSafe;
+            use futures::FutureExt;
+            match AssertUnwindSafe(self.dispatch_tool(name, args, minimal))
+                .catch_unwind()
+                .await
+            {
+                Ok(Ok(text)) => text,
+                Ok(Err(e)) => return Err(e),
+                Err(panic_payload) => {
+                    let detail = if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                        (*s).to_string()
+                    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "unknown".to_string()
+                    };
+                    tracing::error!("Tool '{name}' panicked: {detail}");
+                    format!("ERROR: lean-ctx internal error in tool '{name}': {detail}\n\
+                             The MCP server is still running. Please retry or use a different approach.")
+                }
+            }
+        };
 
         let archive_hint = if minimal {
             None

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -291,8 +291,8 @@ impl ServerHandler for LeanCtxServer {
 
         let tool_start = std::time::Instant::now();
         let mut result_text = {
-            use std::panic::AssertUnwindSafe;
             use futures::FutureExt;
+            use std::panic::AssertUnwindSafe;
             match AssertUnwindSafe(self.dispatch_tool(name, args, minimal))
                 .catch_unwind()
                 .await


### PR DESCRIPTION
## Summary

- **`panic = "abort"` in the release profile** causes any tool handler panic to instantly kill the MCP server process (SIGABRT). Clients see `No such tool available` on subsequent calls.
- `coredumpctl` confirms SIGABRT crashes, and Claude Code session history shows **21 disconnections across 6 sessions** in one project.

### Changes

| File | Change |
|------|--------|
| `Cargo.toml` | `panic = "abort"` → `"unwind"` (enables `catch_unwind`) |
| `server/mod.rs` | Wrap `dispatch_tool` in `catch_unwind` — panics return an error message instead of killing the server |
| `cli/dispatch.rs` | Handle `service.waiting()` errors with logging instead of silent `?` propagation |

## Test plan

- [x] Inserted deliberate `panic!()` in `ctx_shell` handler, verified server catches it and returns error
- [x] Verified next tool call after panic succeeds (server stays alive)
- [x] `cargo test --release` passes (21/21)
- [x] Clean MCP stdio integration test (initialize → panic call → follow-up call)
- [ ] Soak test in real Claude Code sessions to confirm no more random disconnects