### PR TITLE
feat(cloud): support LEAN_CTX_DATA_DIR env var for cloud config directory

### DIFF
--- a/rust/src/cloud_client.rs
+++ b/rust/src/cloud_client.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
 fn config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("LEAN_CTX_DATA_DIR") {
+        return PathBuf::from(dir).join("cloud");
+    }
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     home.join(".lean-ctx").join("cloud")
 }


### PR DESCRIPTION
 - Support `LEAN_CTX_DATA_DIR`  as per [Environment documentation](https://leanctx.com/docs/configuration/env-vars/) variable for the `cloud` configuration (keep files in a `cloud` subfolder)