### PR TITLE
fix(pi-lean-ctx): await bridge startup so MCP tools register before session_start

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -259,7 +259,7 @@ async function execLeanCtx(pi: ExtensionAPI, args: string[]) {
   return result.stdout;
 }
 
-export default function (pi: ExtensionAPI) {
+export default async function (pi: ExtensionAPI) {
   const baseBashTool = createBashToolDefinition(process.cwd(), {
     spawnHook: ({ command, cwd, env }) => {
       const bin = resolveBinary();
@@ -493,9 +493,11 @@ export default function (pi: ExtensionAPI) {
   const mcpBridge = new McpBridge(resolveBinary());
 
   if (!isMcpAdapterConfigured()) {
-    mcpBridge.start(pi).catch((err) => {
+    try {
+      await mcpBridge.start(pi);
+    } catch (err) {
       console.error(`[pi-lean-ctx] MCP bridge startup failed: ${err}`);
-    });
+    }
   }
 
   pi.registerCommand("lean-ctx", {


### PR DESCRIPTION
## Problem

The extension factory called `mcpBridge.start()` as a fire-and-forget async call:

```ts
// Before
if (!isMcpAdapterConfigured()) {
  mcpBridge.start(pi).catch((err) => {
    console.error(`[pi-lean-ctx] MCP bridge startup failed: ${err}`);
  });
}
```

`mcpBridge.start()` is the critical path that connects to the lean-ctx binary via stdio, performs the MCP initialize handshake, calls `tools/list`, and registers each discovered tool via `pi.registerTool()`. All of this is async and takes real time.

`ExtensionFactory` is typed as `(pi: ExtensionAPI) => void | Promise<void>`. The host awaits the returned promise before proceeding with session setup — specifically, before emitting the `session_start` lifecycle hook. Because the factory returned `void` (synchronously), the host moved forward immediately — before the bridge had a chance to connect or register any tools.

This means the tools registered inside `mcpBridge.start()` via `pi.registerTool()` were not guaranteed to be present by the time `session_start` fired. The MCP bridge was effectively a no-op from the perspective of tool availability.

## Fix

Make the factory `async` and `await` the bridge start:

```ts
// After
export default async function (pi: ExtensionAPI) {
  // ...
  if (!isMcpAdapterConfigured()) {
    try {
      await mcpBridge.start(pi);
    } catch (err) {
      console.error(`[pi-lean-ctx] MCP bridge startup failed: ${err}`);
    }
  }
}
```

The bridge now fully connects, discovers tools, and calls `pi.registerTool()` for each **before** the factory resolves. The host receives a fully-initialized extension with all lean-ctx MCP tools ready at `session_start`.

## Impact

- `ctx_session`, `ctx_knowledge`, `ctx_edit`, `ctx_discover_tools` are now reliably available at `session_start`
- No change to CLI override tools (`bash`/`read`/`grep`/`find`/`ls`) — those register synchronously and are unaffected
- Error handling is preserved: bridge failure is caught and logged, the session continues without MCP tools