### PR TITLE
fix(install.sh): rewrite as POSIX sh to fix `curl | sh` on dash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,35 +7,19 @@
 #   ./install.sh --build-only   # build only, don't install
 #
 # One-liner (no Rust required):
+#   curl -fsSL https://leanctx.com/install.sh | sh
 #   curl -fsSL https://leanctx.com/install.sh | bash
-#   curl -fsSL https://leanctx.com/install.sh | sh   (auto-detects bash)
 
-# POSIX preamble: re-exec under bash if needed.
-# Supports both:
-#   curl ... | sh      (stdin; dash on Ubuntu/WSL)
-#   sh ./install.sh    (file)
-if [ -z "${BASH_VERSION:-}" ]; then
-  if command -v bash >/dev/null 2>&1; then
-    if [ -t 0 ]; then
-      exec bash "$0" "$@"
-    else
-      exec bash -s -- "$@"
-    fi
-  else
-    echo "Error: lean-ctx installer requires bash."
-    echo ""
-    echo "Install bash first, or run:"
-    echo "  curl -fsSL https://leanctx.com/install.sh | bash"
-    exit 1
-  fi
-fi
-
-set -euo pipefail
+set -eu
 
 REPO="yvgude/lean-ctx"
 INSTALL_DIR="${LEAN_CTX_INSTALL_DIR:-$HOME/.local/bin}"
+# Resolve the script's directory when invoked as a file. When piped via
+# `curl ... | sh`, $0 is "sh" (or similar) — the [ -f "$0" ] guard then
+# falls back to pwd, which is what the bottom-of-file dispatcher expects:
+# RUST_DIR check fails outside the repo, so we route to install_download.
 SCRIPT_DIR="$(
-  src="${BASH_SOURCE[0]:-}"
+  src="$0"
   if [ -n "$src" ] && [ -f "$src" ]; then
     cd "$(dirname "$src")" 2>/dev/null && pwd
   else
@@ -48,33 +32,34 @@ echo "lean-ctx installer"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 finish() {
-  if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-    echo ""
-    echo "Warning: $INSTALL_DIR is not in your PATH."
-    local shell_name
-    shell_name="$(basename "${SHELL:-bash}" 2>/dev/null || echo bash)"
-    local rc="$HOME/.bashrc"
-    case "$shell_name" in
-      zsh)  rc="$HOME/.zshrc" ;;
-      fish) rc="$HOME/.config/fish/config.fish" ;;
-    esac
-    if [[ "$shell_name" == "fish" ]]; then
-      echo "  fish_add_path $INSTALL_DIR"
-    else
-      echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> $rc && source $rc"
-    fi
-  fi
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+      echo ""
+      echo "Warning: $INSTALL_DIR is not in your PATH."
+      shell_name="$(basename "${SHELL:-bash}" 2>/dev/null || echo bash)"
+      rc="$HOME/.bashrc"
+      case "$shell_name" in
+        zsh)  rc="$HOME/.zshrc" ;;
+        fish) rc="$HOME/.config/fish/config.fish" ;;
+      esac
+      if [ "$shell_name" = "fish" ]; then
+        echo "  fish_add_path $INSTALL_DIR"
+      else
+        echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> $rc && source $rc"
+      fi
+      ;;
+  esac
   echo ""
   echo "Done! Verify with: lean-ctx --version"
 }
 
 detect_target() {
-  local os arch libc
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   arch="$(uname -m)"
 
   case "$arch" in
-    x86_64)       arch="x86_64" ;;
+    x86_64)        arch="x86_64" ;;
     arm64|aarch64) arch="aarch64" ;;
     *)
       echo "Error: unsupported architecture '$arch'"
@@ -85,14 +70,12 @@ detect_target() {
   case "$os" in
     linux)
       libc="musl"
-      if command -v ldd &>/dev/null; then
-        local glibc_ver
+      if command -v ldd >/dev/null 2>&1; then
         glibc_ver="$(ldd --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+$' || true)"
-        if [[ -n "$glibc_ver" ]]; then
-          local major minor
+        if [ -n "$glibc_ver" ]; then
           major="${glibc_ver%%.*}"
           minor="${glibc_ver##*.}"
-          if [[ "$major" -gt 2 ]] || { [[ "$major" -eq 2 ]] && [[ "$minor" -ge 35 ]]; }; then
+          if [ "$major" -gt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -ge 35 ]; }; then
             libc="gnu"
           fi
         fi
@@ -108,18 +91,18 @@ detect_target() {
 }
 
 verify_checksum() {
-  local file="$1" expected="$2"
-  local actual
-  if command -v sha256sum &>/dev/null; then
+  file="$1"
+  expected="$2"
+  if command -v sha256sum >/dev/null 2>&1; then
     actual="$(sha256sum "$file" | cut -d' ' -f1)"
-  elif command -v shasum &>/dev/null; then
+  elif command -v shasum >/dev/null 2>&1; then
     actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
   else
     echo "Warning: no sha256sum/shasum found, skipping checksum verification"
     return 0
   fi
 
-  if [[ "$actual" != "$expected" ]]; then
+  if [ "$actual" != "$expected" ]; then
     echo "Error: checksum mismatch!"
     echo "  Expected: $expected"
     echo "  Got:      $actual"
@@ -129,27 +112,24 @@ verify_checksum() {
 }
 
 install_download() {
-  local target
   target="$(detect_target)"
   echo "Mode: download pre-built binary"
   echo "Platform: $target"
   echo ""
 
   echo "Fetching latest release..."
-  local latest
   latest="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
     | grep '"tag_name"' | head -1 | cut -d'"' -f4)"
 
-  if [[ -z "$latest" ]]; then
+  if [ -z "$latest" ]; then
     echo "Error: could not determine latest release."
     exit 1
   fi
   echo "Latest: $latest"
 
-  local asset_url="https://github.com/${REPO}/releases/download/${latest}/lean-ctx-${target}.tar.gz"
-  local sums_url="https://github.com/${REPO}/releases/download/${latest}/SHA256SUMS"
+  asset_url="https://github.com/${REPO}/releases/download/${latest}/lean-ctx-${target}.tar.gz"
+  sums_url="https://github.com/${REPO}/releases/download/${latest}/SHA256SUMS"
 
-  local tmpdir
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "${tmpdir:-}"' EXIT
 
@@ -161,9 +141,8 @@ install_download() {
 
   echo "Downloading checksums..."
   if curl -fsSL "$sums_url" -o "$tmpdir/SHA256SUMS" 2>/dev/null; then
-    local expected
     expected="$(grep "lean-ctx-${target}.tar.gz" "$tmpdir/SHA256SUMS" | cut -d' ' -f1)"
-    if [[ -n "$expected" ]]; then
+    if [ -n "$expected" ]; then
       verify_checksum "$tmpdir/lean-ctx.tar.gz" "$expected"
     fi
   else
@@ -175,7 +154,7 @@ install_download() {
   mkdir -p "$INSTALL_DIR"
   install -m755 "$tmpdir/lean-ctx" "$INSTALL_DIR/lean-ctx"
 
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if [ "$(uname -s)" = "Darwin" ]; then
     xattr -cr "$INSTALL_DIR/lean-ctx" 2>/dev/null || true
     codesign --force --sign - "$INSTALL_DIR/lean-ctx" 2>/dev/null || true
   fi
@@ -186,21 +165,21 @@ install_download() {
 }
 
 install_from_source() {
-  if ! command -v cargo &>/dev/null; then
+  if ! command -v cargo >/dev/null 2>&1; then
     echo "Error: cargo not found. Install Rust: https://rustup.rs"
     echo "Or download a pre-built binary: $0 --download"
     exit 1
   fi
 
-  local build_only="${1:-}"
+  build_only="${1:-}"
 
   echo "Mode: build from source"
   echo ""
   echo "Building lean-ctx (release)..."
 
-  if [[ -d "$RUST_DIR" ]]; then
+  if [ -d "$RUST_DIR" ]; then
     (cd "$RUST_DIR" && cargo build --release)
-    local binary="$RUST_DIR/target/release/lean-ctx"
+    binary="$RUST_DIR/target/release/lean-ctx"
   else
     cargo install lean-ctx
     echo ""
@@ -208,13 +187,13 @@ install_from_source() {
     return
   fi
 
-  if [[ ! -x "$binary" ]]; then
+  if [ ! -x "$binary" ]; then
     echo "Error: build failed — binary not found"
     exit 1
   fi
   echo "Built: $binary"
 
-  if [[ "$build_only" == "--build-only" ]]; then
+  if [ "$build_only" = "--build-only" ]; then
     echo "Done (build only)."
     return
   fi
@@ -240,7 +219,7 @@ case "${1:-}" in
     echo "  LEAN_CTX_INSTALL_DIR  Custom install directory (default: ~/.local/bin)"
     ;;
   *)
-    if [[ -d "$RUST_DIR" ]]; then
+    if [ -d "$RUST_DIR" ]; then
       install_from_source
     else
       install_download


### PR DESCRIPTION
## Summary

`curl -fsSL https://leanctx.com/install.sh | sh` fails on Ubuntu/WSL with:

```
bash: line 53: syntax error near unexpected token `('
bash: line 53: `  echo "Building lean-ctx (release)..."'
```

This is a regression from the 3.2.6 POSIX preamble (commit 6fe67d40, "install.sh fails on WSL2/Ubuntu (POSIX preamble, auto-detects bash)"). The preamble re-execs `bash -s --` when stdin is non-tty. That's broken because dash reads stdin in ~4 KiB chunks: by the time it parses the 984-byte preamble, it has already buffered ~4096 bytes (lines 1–146). `exec bash -s --` discards that buffer with the dash process. Bash inherits the FD at offset ~4096, lands mid-string at line 147 (`echo "Latest: $latest"`), and the leading `"` of line 199's string is lost — so `(release)` looks unquoted.

Byte math (script is 6889 bytes, ~4 KiB ≈ one dash read chunk):
- through preamble (line 31): 984 bytes
- through line 146: 4003 bytes
- bash's "line 53" = original line 147 + 52 = line 199 ✓

There is no portable way to recover a buffered stdin script in a child shell after `exec`. The fix is to drop the re-exec and convert the body to POSIX sh so dash can run it directly.

## Changes

- Remove the bash re-exec preamble entirely
- `set -euo pipefail` → `set -eu` (`pipefail` not in older dash; explicit `[ -z … ]` guards already catch pipeline failures)
- `${BASH_SOURCE[0]:-}` → `$0` (dash can't parse `VAR[0]`; the `[ -f "$0" ]` fallback to `pwd` preserves the in-repo detection used by the bottom-of-file dispatcher)
- All `[[ … ]]` → `[ … ]`; the line-51 glob match becomes a `case` statement
- All `&>/dev/null` → `>/dev/null 2>&1`
- Drop `local` keyword (no recursion or nested-call conflicts in this script; POSIX-portable)

Net: `+46 / −67` lines. Behavior under bash is unchanged — POSIX is a strict subset.

## Test plan

- [x] `dash install.sh --help`
- [x] `bash install.sh --help`
- [x] `./install.sh --help`
- [x] `cat install.sh | dash -s -- --help`  *(reproduces the original failing scenario; now passes)*
- [x] `cat install.sh | sh -s -- --help`  *(`/bin/sh` → dash on Ubuntu)*
- [x] `dash -n install.sh && bash -n install.sh`  *(parse-only)*
- [x] `./install.sh` end-to-end on Ubuntu — `cargo build --release` succeeds, `~/.local/bin/lean-ctx` symlink created, `lean-ctx --version` reports 3.4.7

## Suggested follow-up (not in this PR)

`.github/workflows/ci.yml` currently has zero coverage for `install.sh`. Adding a job that runs `dash install.sh --help`, `bash install.sh --help`, and `checkbashisms install.sh` on Ubuntu would have caught commit 6fe67d40 before merge. Happy to follow up with a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)