### PR TITLE
Add Qoder and QoderWork support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For first-class integration, run:
 lean-ctx init --agent <tool>
 ```
 
-Supported `<tool>` values (24):
+Supported `<tool>` values (26):
 
 <details>
 <summary><strong>Show full list</strong></summary>
@@ -152,6 +152,8 @@ Supported `<tool>` values (24):
 - AWS Kiro (`kiro`)
 - Antigravity (`antigravity`)
 - Hermes (`hermes`)
+- Qoder (`qoder`)
+- QoderWork (`qoderwork`, `qoderworks`; MCP only)
 - Qwen (`qwen`)
 - Trae (`trae`)
 - Verdent (`verdent`)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1742,7 +1742,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lean-ctx"
-version = "3.4.6"
+version = "3.4.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/rust/src/cli/init_cmd.rs
+++ b/rust/src/cli/init_cmd.rs
@@ -131,7 +131,7 @@ pub fn cmd_init(args: &[String]) {
     qprintln!("For AI tool integration: lean-ctx init --agent <tool>");
     qprintln!("  Supported: aider, amazonq, amp, antigravity, claude, cline, codex, copilot,");
     qprintln!("    crush, cursor, emacs, gemini, hermes, jetbrains, kiro, neovim, opencode,");
-    qprintln!("    pi, qwen, roo, sublime, trae, verdent, windsurf");
+    qprintln!("    pi, qoder, qoderwork, qwen, roo, sublime, trae, verdent, windsurf");
 }
 
 pub fn cmd_init_quiet(args: &[String]) {

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use super::paths::{
-    claude_mcp_json_path, cline_mcp_path, roo_mcp_path, vscode_mcp_path, zed_config_dir,
-    zed_settings_path,
+    claude_mcp_json_path, cline_mcp_path, qoder_mcp_path, qoderwork_mcp_path, roo_mcp_path,
+    vscode_mcp_path, zed_config_dir, zed_settings_path,
 };
 use super::types::{ConfigType, EditorTarget};
 
@@ -21,8 +21,7 @@ pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
     #[cfg(windows)]
     let opencode_detect = opencode_cfg
         .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| home.join(".config/opencode"));
+        .map_or_else(|| home.join(".config/opencode"), Path::to_path_buf);
     #[cfg(not(windows))]
     let opencode_detect = home.join(".config/opencode");
 
@@ -96,6 +95,20 @@ pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
             config_path: home.join(".qwen/mcp.json"),
             detect_path: home.join(".qwen"),
             config_type: ConfigType::McpJson,
+        },
+        EditorTarget {
+            name: "Qoder",
+            agent_key: "qoder".to_string(),
+            config_path: qoder_mcp_path(home),
+            detect_path: detect_qoder_path(home),
+            config_type: ConfigType::QoderMcp,
+        },
+        EditorTarget {
+            name: "QoderWork",
+            agent_key: "qoderwork".to_string(),
+            config_path: qoderwork_mcp_path(home),
+            detect_path: detect_qoderwork_path(home),
+            config_type: ConfigType::QoderMcp,
         },
         EditorTarget {
             name: "Trae",
@@ -182,6 +195,40 @@ pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
             config_type: ConfigType::HermesYaml,
         },
     ]
+}
+
+pub fn detect_qoder_path(home: &Path) -> PathBuf {
+    let qoder_dir = home.join(".qoder");
+    if qoder_dir.exists() {
+        return qoder_dir;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            let app_dir = PathBuf::from(appdata).join("Qoder");
+            if app_dir.exists() {
+                return app_dir;
+            }
+        }
+    }
+    PathBuf::from("/nonexistent")
+}
+
+pub fn detect_qoderwork_path(home: &Path) -> PathBuf {
+    let qoderwork_dir = home.join(".qoderwork");
+    if qoderwork_dir.exists() {
+        return qoderwork_dir;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            let app_dir = PathBuf::from(appdata).join("QoderWork");
+            if app_dir.exists() {
+                return app_dir;
+            }
+        }
+    }
+    PathBuf::from("/nonexistent")
 }
 
 pub fn detect_claude_path() -> PathBuf {

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -39,6 +39,23 @@ pub fn vscode_mcp_path() -> PathBuf {
     }
 }
 
+pub fn qoder_mcp_path(home: &Path) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            return PathBuf::from(appdata)
+                .join("Qoder")
+                .join("SharedClientCache")
+                .join("mcp.json");
+        }
+    }
+    home.join(".qoder").join("mcp.json")
+}
+
+pub fn qoderwork_mcp_path(home: &Path) -> PathBuf {
+    home.join(".qoderwork").join("mcp.json")
+}
+
 #[allow(unreachable_code)]
 pub fn cline_mcp_path() -> PathBuf {
     #[cfg(target_os = "windows")]

--- a/rust/src/core/editor_registry/types.rs
+++ b/rust/src/core/editor_registry/types.rs
@@ -21,4 +21,5 @@ pub enum ConfigType {
     Amp,
     HermesYaml,
     GeminiSettings,
+    QoderMcp,
 }

--- a/rust/src/core/editor_registry/writers.rs
+++ b/rust/src/core/editor_registry/writers.rs
@@ -52,6 +52,7 @@ pub fn write_config_with_options(
         ConfigType::Amp => write_amp_config(target, binary, opts),
         ConfigType::HermesYaml => write_hermes_yaml(target, binary, opts),
         ConfigType::GeminiSettings => write_gemini_settings(target, binary, opts),
+        ConfigType::QoderMcp => write_qoder_mcp_config(target, binary, opts),
     }
 }
 
@@ -440,6 +441,86 @@ fn write_vscode_mcp_fresh(
         .unwrap_or_default();
     let content = serde_json::to_string_pretty(&serde_json::json!({
         "servers": { "lean-ctx": { "type": "stdio", "command": binary, "args": [], "env": { "LEAN_CTX_DATA_DIR": data_dir } } }
+    }))
+    .map_err(|e| e.to_string())?;
+    crate::config_io::write_atomic_with_backup(path, &content)?;
+    Ok(WriteResult {
+        action: if note.is_some() {
+            WriteAction::Updated
+        } else {
+            WriteAction::Created
+        },
+        note,
+    })
+}
+
+fn write_qoder_mcp_config(
+    target: &EditorTarget,
+    binary: &str,
+    opts: WriteOptions,
+) -> Result<WriteResult, String> {
+    let data_dir = default_data_dir()?;
+    let desired = serde_json::json!({
+        "command": binary,
+        "args": [],
+        "env": {
+            "LEAN_CTX_DATA_DIR": data_dir
+        }
+    });
+
+    if target.config_path.exists() {
+        let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
+        let mut json = match crate::core::jsonc::parse_jsonc(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                if !opts.overwrite_invalid {
+                    return Err(e.to_string());
+                }
+                backup_invalid_file(&target.config_path)?;
+                return write_qoder_mcp_fresh(
+                    &target.config_path,
+                    &desired,
+                    Some("overwrote invalid JSON".to_string()),
+                );
+            }
+        };
+        let obj = json
+            .as_object_mut()
+            .ok_or_else(|| "root JSON must be an object".to_string())?;
+        let servers = obj
+            .entry("mcpServers")
+            .or_insert_with(|| serde_json::json!({}));
+        let servers_obj = servers
+            .as_object_mut()
+            .ok_or_else(|| "\"mcpServers\" must be an object".to_string())?;
+
+        let existing = servers_obj.get("lean-ctx").cloned();
+        if existing.as_ref() == Some(&desired) {
+            return Ok(WriteResult {
+                action: WriteAction::Already,
+                note: None,
+            });
+        }
+        servers_obj.insert("lean-ctx".to_string(), desired);
+
+        let formatted = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+        crate::config_io::write_atomic_with_backup(&target.config_path, &formatted)?;
+        return Ok(WriteResult {
+            action: WriteAction::Updated,
+            note: None,
+        });
+    }
+
+    write_qoder_mcp_fresh(&target.config_path, &desired, None)
+}
+
+fn write_qoder_mcp_fresh(
+    path: &std::path::Path,
+    desired: &Value,
+    note: Option<String>,
+) -> Result<WriteResult, String> {
+    let content = serde_json::to_string_pretty(&serde_json::json!({
+        "mcpServers": { "lean-ctx": desired }
     }))
     .map_err(|e| e.to_string())?;
     crate::config_io::write_atomic_with_backup(path, &content)?;
@@ -1118,6 +1199,48 @@ args = ["x"]
         assert!(tools.contains(&"ctx_search"));
         assert!(tools.contains(&"ctx_workflow"));
         assert!(tools.contains(&"ctx_cost"));
+    }
+
+    #[test]
+    fn qoder_mcp_config_preserves_probe_and_upserts_lean_ctx() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{ "mcpServers": { "lean-ctx-probe": { "command": "cmd", "args": ["/C", "echo", "lean-ctx-probe"] } } }"#,
+        )
+        .unwrap();
+
+        let t = target(path.clone(), ConfigType::QoderMcp);
+        let res = write_qoder_mcp_config(&t, "lean-ctx", WriteOptions::default()).unwrap();
+        assert_eq!(res.action, WriteAction::Updated);
+
+        let json: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(json["mcpServers"]["lean-ctx-probe"]["command"], "cmd");
+        assert_eq!(json["mcpServers"]["lean-ctx"]["command"], "lean-ctx");
+        assert_eq!(
+            json["mcpServers"]["lean-ctx"]["args"],
+            serde_json::json!([])
+        );
+        assert!(json["mcpServers"]["lean-ctx"]["env"]["LEAN_CTX_DATA_DIR"]
+            .as_str()
+            .is_some_and(|s| !s.trim().is_empty()));
+        assert!(json["mcpServers"]["lean-ctx"]["identifier"].is_null());
+        assert!(json["mcpServers"]["lean-ctx"]["source"].is_null());
+        assert!(json["mcpServers"]["lean-ctx"]["version"].is_null());
+    }
+
+    #[test]
+    fn qoder_mcp_config_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        let t = target(path.clone(), ConfigType::QoderMcp);
+
+        let first = write_qoder_mcp_config(&t, "lean-ctx", WriteOptions::default()).unwrap();
+        let second = write_qoder_mcp_config(&t, "lean-ctx", WriteOptions::default()).unwrap();
+
+        assert_eq!(first.action, WriteAction::Created);
+        assert_eq!(second.action, WriteAction::Already);
     }
 
     #[test]

--- a/rust/src/hooks/agents/mod.rs
+++ b/rust/src/hooks/agents/mod.rs
@@ -11,6 +11,7 @@ mod jetbrains;
 mod kiro;
 mod opencode;
 mod pi;
+mod qoder;
 mod shared;
 mod windsurf;
 
@@ -33,4 +34,5 @@ pub(super) use jetbrains::install_jetbrains_hook;
 pub(super) use kiro::install_kiro_hook;
 pub(super) use opencode::install_opencode_hook;
 pub(super) use pi::install_pi_hook;
+pub use qoder::install_qoder_hook;
 pub(super) use windsurf::install_windsurf_rules;

--- a/rust/src/hooks/agents/qoder.rs
+++ b/rust/src/hooks/agents/qoder.rs
@@ -1,0 +1,168 @@
+use std::path::Path;
+
+use super::super::{mcp_server_quiet_mode, resolve_binary_path, write_file};
+
+pub fn install_qoder_hook() {
+    let Some(home) = crate::core::home::resolve_home_dir() else {
+        tracing::error!("Cannot resolve home directory");
+        return;
+    };
+    let settings_path = home.join(".qoder").join("settings.json");
+    install_qoder_hook_config_at("Qoder", &settings_path);
+}
+
+fn install_qoder_hook_config_at(name: &str, settings_path: &Path) -> bool {
+    let command = format!("{} hook rewrite", resolve_binary_path());
+    let mut changed = false;
+    let mut root = if settings_path.exists() {
+        if let Some(parsed) = std::fs::read_to_string(settings_path)
+            .ok()
+            .and_then(|content| crate::core::jsonc::parse_jsonc(&content).ok())
+        {
+            parsed
+        } else {
+            changed = true;
+            serde_json::json!({})
+        }
+    } else {
+        changed = true;
+        serde_json::json!({})
+    };
+
+    if upsert_qoder_hook_config(&mut root, &command) {
+        changed = true;
+    }
+
+    if changed {
+        write_file(
+            settings_path,
+            &serde_json::to_string_pretty(&root).unwrap_or_default(),
+        );
+        if !mcp_server_quiet_mode() {
+            println!("Installed {name} hooks at {}", settings_path.display());
+        }
+    }
+
+    changed
+}
+
+fn upsert_qoder_hook_config(root: &mut serde_json::Value, rewrite_cmd: &str) -> bool {
+    let original = root.clone();
+    if !root.is_object() {
+        *root = serde_json::json!({});
+    }
+    let root_obj = root.as_object_mut().expect("root should be object");
+    let hooks_value = root_obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if !hooks_value.is_object() {
+        *hooks_value = serde_json::json!({});
+    }
+    let hooks_obj = hooks_value
+        .as_object_mut()
+        .expect("hooks should be object after normalization");
+
+    let pre_tool_use = hooks_obj
+        .entry("PreToolUse".to_string())
+        .or_insert_with(|| serde_json::json!([]));
+    if !pre_tool_use.is_array() {
+        *pre_tool_use = serde_json::json!([]);
+    }
+    let entries = pre_tool_use
+        .as_array_mut()
+        .expect("PreToolUse should be array after normalization");
+
+    entries.retain(|entry| !is_lean_ctx_qoder_managed_entry(entry));
+    entries.push(serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": rewrite_cmd,
+            "timeout": 60
+        }]
+    }));
+
+    *root != original
+}
+
+fn is_lean_ctx_qoder_managed_entry(entry: &serde_json::Value) -> bool {
+    let Some(entry_obj) = entry.as_object() else {
+        return false;
+    };
+    let matcher = entry_obj
+        .get("matcher")
+        .and_then(|value| value.as_str())
+        .unwrap_or("*");
+    let is_shell_matcher = matcher
+        .split('|')
+        .map(str::trim)
+        .any(|part| matches!(part, "Bash" | "run_in_terminal"));
+    if !is_shell_matcher {
+        return false;
+    }
+    entry_obj
+        .get("hooks")
+        .and_then(|value| value.as_array())
+        .is_some_and(|hooks| {
+            hooks.iter().any(|hook| {
+                hook.get("command")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|command| {
+                        command.contains("lean-ctx") && command.contains("hook rewrite")
+                    })
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn qoder_hook_config_preserves_custom_hooks_and_upserts_rewrite() {
+        let mut root = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{ "type": "command", "command": "echo keep-me", "timeout": 5 }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{ "type": "command", "command": "lean-ctx hook rewrite", "timeout": 60 }]
+                    }
+                ],
+                "Stop": [
+                    {
+                        "hooks": [{ "type": "command", "command": "echo stop", "timeout": 5 }]
+                    }
+                ]
+            }
+        });
+
+        let changed = super::upsert_qoder_hook_config(&mut root, "/c/bin/lean-ctx hook rewrite");
+        assert!(changed);
+
+        let pre_tool_use = root["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 2);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "echo keep-me");
+        assert_eq!(
+            pre_tool_use[1]["hooks"][0]["command"],
+            "/c/bin/lean-ctx hook rewrite"
+        );
+        assert_eq!(root["hooks"]["Stop"][0]["hooks"][0]["command"], "echo stop");
+    }
+
+    #[test]
+    fn qoder_hook_config_creates_fresh_pretooluse_group() {
+        let mut root = json!({});
+        let changed = super::upsert_qoder_hook_config(&mut root, "lean-ctx hook rewrite");
+        assert!(changed);
+
+        assert_eq!(root["hooks"]["PreToolUse"][0]["matcher"], "Bash");
+        assert_eq!(
+            root["hooks"]["PreToolUse"][0]["hooks"][0],
+            json!({ "type": "command", "command": "lean-ctx hook rewrite", "timeout": 60 })
+        );
+    }
+}

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -8,7 +8,7 @@ use agents::{
     install_crush_hook, install_cursor_hook, install_cursor_hook_config,
     install_cursor_hook_scripts, install_gemini_hook, install_gemini_hook_config,
     install_gemini_hook_scripts, install_hermes_hook, install_jetbrains_hook, install_kiro_hook,
-    install_opencode_hook, install_pi_hook, install_windsurf_rules,
+    install_opencode_hook, install_pi_hook, install_qoder_hook, install_windsurf_rules,
 };
 use support::{
     ensure_codex_hooks_enabled, install_codex_instruction_docs, install_named_json_server,
@@ -443,6 +443,8 @@ pub fn install_agent_hook(agent: &str, global: bool) {
         "cline" | "roo" => install_cline_rules(global),
         "copilot" => install_copilot_hook(global),
         "pi" => install_pi_hook(global),
+        "qoder" => install_qoder_hook(),
+        "qoderwork" | "qoderworks" => {}
         "qwen" => install_mcp_json_agent(
             "Qwen Code",
             "~/.qwen/mcp.json",
@@ -470,7 +472,7 @@ pub fn install_agent_hook(agent: &str, global: bool) {
         "hermes" => install_hermes_hook(global),
         _ => {
             eprintln!("Unknown agent: {agent}");
-            eprintln!("  Supported: claude, cursor, gemini, codex, windsurf, cline, roo, copilot, pi, qwen, trae, amazonq, jetbrains, kiro, verdent, opencode, aider, amp, crush, antigravity, hermes");
+            eprintln!("  Supported: claude, cursor, gemini, codex, windsurf, cline, roo, copilot, pi, qoder, qoderwork, qwen, trae, amazonq, jetbrains, kiro, verdent, opencode, aider, amp, crush, antigravity, hermes");
             std::process::exit(1);
         }
     }

--- a/rust/src/setup.rs
+++ b/rust/src/setup.rs
@@ -462,7 +462,7 @@ pub fn run_setup_with_options(opts: SetupOptions) -> Result<SetupReport, String>
     }
     steps.push(rules_step);
 
-    // Step: Agent-specific hooks (Codex, Cursor)
+    // Step: Agent-specific hooks
     let mut hooks_step = SetupStepReport {
         name: "agent_hooks".to_string(),
         ok: true,
@@ -498,6 +498,15 @@ pub fn run_setup_with_options(opts: SetupOptions) -> Result<SetupReport, String>
                         note: None,
                     });
                 }
+            }
+            "qoder" => {
+                crate::hooks::agents::install_qoder_hook();
+                hooks_step.items.push(SetupItem {
+                    name: "Qoder hooks".to_string(),
+                    status: "installed".to_string(),
+                    path: Some("~/.qoder/settings.json".to_string()),
+                    note: Some("Installs PreToolUse shell rewrite hooks.".to_string()),
+                });
             }
             _ => {}
         }
@@ -651,6 +660,18 @@ pub fn configure_agent_mcp(agent: &str) -> Result<(), String> {
             "Pi Coding Agent",
             home.join(".pi/agent/mcp.json"),
             ConfigType::McpJson,
+        ),
+        "qoder" => push(
+            &mut targets,
+            "Qoder",
+            crate::core::editor_registry::qoder_mcp_path(&home),
+            ConfigType::QoderMcp,
+        ),
+        "qoderwork" | "qoderworks" => push(
+            &mut targets,
+            "QoderWork",
+            crate::core::editor_registry::qoderwork_mcp_path(&home),
+            ConfigType::QoderMcp,
         ),
         "cline" => push(
             &mut targets,


### PR DESCRIPTION
## Summary

- add Qoder and QoderWork as supported agents
- configure Qoder MCP at the Qoder source config path and QoderWork MCP at ~/.qoderwork/mcp.json
- add Qoder hook installation for ~/.qoder/settings.json
- keep QoderWork MCP-only and avoid writing Qoder runtime cache fields

## Validation

- cargo fmt --check
- cargo test qoder

## Notes

QoderWork is configured through MCP only. Qoder receives both MCP configuration and a hook installer matching the existing agent hook installer pattern.