### PR TITLE
Support configurable proxy upstreams

### DIFF
--- a/rust/src/cli/config_cmd.rs
+++ b/rust/src/cli/config_cmd.rs
@@ -80,6 +80,15 @@ pub fn cmd_config(args: &[String]) {
                         std::process::exit(1);
                     }
                 },
+                "proxy.anthropic_upstream" => {
+                    cfg.proxy.anthropic_upstream = normalize_optional_url(val);
+                }
+                "proxy.openai_upstream" => {
+                    cfg.proxy.openai_upstream = normalize_optional_url(val);
+                }
+                "proxy.gemini_upstream" => {
+                    cfg.proxy.gemini_upstream = normalize_optional_url(val);
+                }
                 _ => {
                     eprintln!("Unknown config key: {key}");
                     std::process::exit(1);
@@ -94,6 +103,15 @@ pub fn cmd_config(args: &[String]) {
             eprintln!("Usage: lean-ctx config [init|set <key> <value>]");
             std::process::exit(1);
         }
+    }
+}
+
+fn normalize_optional_url(value: &str) -> Option<String> {
+    let trimmed = value.trim().trim_end_matches('/');
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("default") {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
 }
 

--- a/rust/src/core/config.rs
+++ b/rust/src/core/config.rs
@@ -128,6 +128,8 @@ pub struct Config {
     pub cloud: CloudConfig,
     #[serde(default)]
     pub autonomy: AutonomyConfig,
+    #[serde(default)]
+    pub proxy: ProxyConfig,
     #[serde(default = "default_buddy_enabled")]
     pub buddy_enabled: bool,
     #[serde(default)]
@@ -201,6 +203,15 @@ impl Default for ArchiveConfig {
             max_disk_mb: 500,
         }
     }
+}
+
+/// API proxy upstreams. Empty values use provider defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProxyConfig {
+    pub anthropic_upstream: Option<String>,
+    pub openai_upstream: Option<String>,
+    pub gemini_upstream: Option<String>,
 }
 
 fn default_buddy_enabled() -> bool {
@@ -390,6 +401,7 @@ impl Default for Config {
             theme: default_theme(),
             cloud: CloudConfig::default(),
             autonomy: AutonomyConfig::default(),
+            proxy: ProxyConfig::default(),
             buddy_enabled: default_buddy_enabled(),
             redirect_exclude: Vec::new(),
             disabled_tools: Vec::new(),
@@ -693,6 +705,45 @@ mod loop_detection_config_tests {
     }
 }
 
+#[cfg(test)]
+mod proxy_config_tests {
+    use super::*;
+
+    #[test]
+    fn proxy_config_defaults_to_no_custom_upstreams() {
+        let cfg = Config::default();
+        assert!(cfg.proxy.anthropic_upstream.is_none());
+        assert!(cfg.proxy.openai_upstream.is_none());
+        assert!(cfg.proxy.gemini_upstream.is_none());
+    }
+
+    #[test]
+    fn proxy_config_deserializes_from_toml() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [proxy]
+            anthropic_upstream = "https://gateway.example.test/anthropic"
+            openai_upstream = "https://gateway.example.test/openai"
+            gemini_upstream = "https://gateway.example.test/gemini"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            cfg.proxy.anthropic_upstream.as_deref(),
+            Some("https://gateway.example.test/anthropic")
+        );
+        assert_eq!(
+            cfg.proxy.openai_upstream.as_deref(),
+            Some("https://gateway.example.test/openai")
+        );
+        assert_eq!(
+            cfg.proxy.gemini_upstream.as_deref(),
+            Some("https://gateway.example.test/gemini")
+        );
+    }
+}
+
 impl Config {
     /// Returns the path to the global config file (`~/.lean-ctx/config.toml`).
     pub fn path() -> Option<PathBuf> {
@@ -795,6 +846,18 @@ impl Config {
         cfg
     }
 
+    /// Loads only the global config file, without merging project-local overrides.
+    pub fn load_global() -> Self {
+        let Some(path) = Self::path() else {
+            return Self::default();
+        };
+
+        match std::fs::read_to_string(&path) {
+            Ok(content) => toml::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
     fn merge_local(&mut self, local_toml: &str) {
         let local: Config = match toml::from_str(local_toml) {
             Ok(c) => c,
@@ -842,6 +905,15 @@ impl Config {
         }
         if local.rules_scope.is_some() {
             self.rules_scope = local.rules_scope;
+        }
+        if local.proxy.anthropic_upstream.is_some() {
+            self.proxy.anthropic_upstream = local.proxy.anthropic_upstream;
+        }
+        if local.proxy.openai_upstream.is_some() {
+            self.proxy.openai_upstream = local.proxy.openai_upstream;
+        }
+        if local.proxy.gemini_upstream.is_some() {
+            self.proxy.gemini_upstream = local.proxy.gemini_upstream;
         }
         if !local.autonomy.enabled {
             self.autonomy.enabled = false;
@@ -987,6 +1059,31 @@ impl Config {
         );
         let content = toml::to_string_pretty(self).unwrap_or_default();
         let mut out = format!("Global config: {global_path}\n\n{content}");
+        out.push_str("\nEffective proxy upstreams:\n");
+        out.push_str(&format!(
+            "  anthropic: {}\n",
+            proxy_upstream_display(
+                "LEAN_CTX_ANTHROPIC_UPSTREAM",
+                self.proxy.anthropic_upstream.as_deref(),
+                "https://api.anthropic.com",
+            )
+        ));
+        out.push_str(&format!(
+            "  openai: {}\n",
+            proxy_upstream_display(
+                "LEAN_CTX_OPENAI_UPSTREAM",
+                self.proxy.openai_upstream.as_deref(),
+                "https://api.openai.com",
+            )
+        ));
+        out.push_str(&format!(
+            "  gemini: {}\n",
+            proxy_upstream_display(
+                "LEAN_CTX_GEMINI_UPSTREAM",
+                self.proxy.gemini_upstream.as_deref(),
+                "https://generativelanguage.googleapis.com",
+            )
+        ));
 
         if let Some(root) = Self::find_project_root() {
             let local = Self::local_path(&root);
@@ -1001,4 +1098,20 @@ impl Config {
         }
         out
     }
+}
+
+fn proxy_upstream_display(env_name: &str, config_value: Option<&str>, default: &str) -> String {
+    if let Ok(value) = std::env::var(env_name) {
+        let trimmed = value.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return format!("{trimmed} (env)");
+        }
+    }
+    if let Some(value) = config_value {
+        let trimmed = value.trim().trim_end_matches('/');
+        if !trimmed.is_empty() {
+            return format!("{trimmed} (config)");
+        }
+    }
+    format!("{default} (default)")
 }

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -655,7 +655,7 @@ fn docker_env_outcomes() -> Vec<Outcome> {
 /// Run diagnostic checks and print colored results to stdout.
 pub fn run() {
     let mut passed = 0u32;
-    let total = 9u32;
+    let total = 11u32;
 
     println!("{BOLD}{WHITE}lean-ctx doctor{RST}  {DIM}diagnostics{RST}\n");
 
@@ -807,14 +807,21 @@ pub fn run() {
     };
     print_check(&config_outcome);
 
-    // 6) Shell aliases
+    // 6) API proxy upstream
+    let proxy_upstream = proxy_upstream_outcome();
+    if proxy_upstream.ok {
+        passed += 1;
+    }
+    print_check(&proxy_upstream);
+
+    // 7) Shell aliases
     let aliases = shell_aliases_outcome();
     if aliases.ok {
         passed += 1;
     }
     print_check(&aliases);
 
-    // 7) MCP
+    // 8) MCP
     let mcp = mcp_config_outcome();
     if mcp.ok {
         passed += 1;
@@ -865,14 +872,14 @@ pub fn run() {
     }
     print_check(&daemon_outcome);
 
-    // 9) Session state (project_root + shell_cwd)
+    // Session state (project_root + shell_cwd)
     let session_outcome = session_state_outcome();
     if session_outcome.ok {
         passed += 1;
     }
     print_check(&session_outcome);
 
-    // 10) Docker env vars (optional, only in containers)
+    // Docker env vars (optional, only in containers)
     let docker_outcomes = docker_env_outcomes();
     for docker_check in &docker_outcomes {
         if docker_check.ok {
@@ -881,7 +888,7 @@ pub fn run() {
         print_check(docker_check);
     }
 
-    // 11) Pi Coding Agent (optional)
+    // Pi Coding Agent (optional)
     let pi = pi_outcome();
     if let Some(ref pi_check) = pi {
         if pi_check.ok {
@@ -890,7 +897,7 @@ pub fn run() {
         print_check(pi_check);
     }
 
-    // 12) Build integrity (canary / origin check)
+    // Build integrity (canary / origin check)
     let integrity = crate::core::integrity::check();
     let integrity_ok = integrity.seed_ok && integrity.origin_ok;
     if integrity_ok {
@@ -912,14 +919,14 @@ pub fn run() {
         line: integrity_line,
     });
 
-    // 13) Cache safety
+    // Cache safety
     let cache_safety = cache_safety_outcome();
     if cache_safety.ok {
         passed += 1;
     }
     print_check(&cache_safety);
 
-    // 14) Claude Code instruction truncation guard
+    // Claude Code instruction truncation guard
     let claude_truncation = claude_truncation_outcome();
     if let Some(ref ct) = claude_truncation {
         if ct.ok {
@@ -982,6 +989,271 @@ fn skill_files_outcome() -> Outcome {
             ),
         }
     }
+}
+
+fn proxy_upstream_outcome() -> Outcome {
+    let cfg = crate::core::config::Config::load();
+    let local_proxy_clients = local_proxy_clients_using_provider_defaults(&cfg);
+    proxy_upstream_outcome_with_clients(&cfg, &local_proxy_clients)
+}
+
+#[derive(Clone, Copy)]
+struct LocalProxyClient {
+    client: &'static str,
+    provider: &'static str,
+}
+
+#[cfg(test)]
+fn proxy_upstream_outcome_for_config(cfg: &crate::core::config::Config) -> Outcome {
+    proxy_upstream_outcome_with_clients(cfg, &[])
+}
+
+fn proxy_upstream_outcome_with_clients(
+    cfg: &crate::core::config::Config,
+    local_default_clients: &[LocalProxyClient],
+) -> Outcome {
+    let providers = [
+        (
+            "Anthropic",
+            "proxy.anthropic_upstream",
+            cfg.proxy.anthropic_upstream.as_deref(),
+        ),
+        (
+            "OpenAI",
+            "proxy.openai_upstream",
+            cfg.proxy.openai_upstream.as_deref(),
+        ),
+        (
+            "Gemini",
+            "proxy.gemini_upstream",
+            cfg.proxy.gemini_upstream.as_deref(),
+        ),
+    ];
+
+    let mut configured = Vec::new();
+    for (label, key, value) in providers {
+        let Some(value) = value else {
+            continue;
+        };
+        if value.trim().is_empty() {
+            continue;
+        }
+        let normalized = normalize_doctor_url(value);
+        if !is_http_url(&normalized) {
+            return Outcome {
+                ok: false,
+                line: format!(
+                    "{BOLD}Proxy upstream{RST}  {RED}invalid {label} upstream{RST}  {YELLOW}set {key} to an http(s) URL{RST}"
+                ),
+            };
+        }
+        if is_local_proxy_url(&normalized) {
+            return Outcome {
+                ok: false,
+                line: format!(
+                    "{BOLD}Proxy upstream{RST}  {RED}{label} upstream points back to local proxy{RST}  {YELLOW}run: lean-ctx config set {key} <url>{RST}"
+                ),
+            };
+        }
+        configured.push(format!("{label}={normalized}"));
+    }
+
+    let default_clients = local_default_clients
+        .iter()
+        .map(|client| format!("{}/{}", client.client, client.provider))
+        .collect::<Vec<_>>();
+
+    if !configured.is_empty() {
+        let mut details = vec![format!("configured: {}", configured.join(", "))];
+        if !default_clients.is_empty() {
+            details.push(format!("provider defaults: {}", default_clients.join(", ")));
+        }
+
+        return Outcome {
+            ok: true,
+            line: format!(
+                "{BOLD}Proxy upstream{RST}  {GREEN}custom upstream configured{RST}  {DIM}{}{RST}",
+                details.join("; ")
+            ),
+        };
+    }
+
+    if !default_clients.is_empty() {
+        let clients = default_clients.join(", ");
+
+        return Outcome {
+            ok: true,
+            line: format!(
+                "{BOLD}Proxy upstream{RST}  {GREEN}provider defaults{RST}  {DIM}active local proxy clients: {clients}{RST}"
+            ),
+        };
+    }
+
+    Outcome {
+        ok: true,
+        line: format!(
+            "{BOLD}Proxy upstream{RST}  {GREEN}provider defaults{RST}  {DIM}(override keys: proxy.anthropic_upstream, proxy.openai_upstream, proxy.gemini_upstream){RST}"
+        ),
+    }
+}
+
+fn local_proxy_clients_using_provider_defaults(
+    cfg: &crate::core::config::Config,
+) -> Vec<LocalProxyClient> {
+    let mut clients = Vec::new();
+
+    if !proxy_upstream_override_present(
+        "LEAN_CTX_ANTHROPIC_UPSTREAM",
+        cfg.proxy.anthropic_upstream.as_deref(),
+    ) && url_is_local_proxy(claude_code_anthropic_base().as_deref())
+    {
+        clients.push(LocalProxyClient {
+            client: "Claude Code",
+            provider: "Anthropic",
+        });
+    }
+
+    if !proxy_upstream_override_present(
+        "LEAN_CTX_OPENAI_UPSTREAM",
+        cfg.proxy.openai_upstream.as_deref(),
+    ) && url_is_local_proxy(codex_openai_base().as_deref())
+    {
+        clients.push(LocalProxyClient {
+            client: "Codex",
+            provider: "OpenAI",
+        });
+    }
+
+    if !proxy_upstream_override_present(
+        "LEAN_CTX_GEMINI_UPSTREAM",
+        cfg.proxy.gemini_upstream.as_deref(),
+    ) && url_is_local_proxy(gemini_api_base().as_deref())
+    {
+        clients.push(LocalProxyClient {
+            client: "Gemini",
+            provider: "Gemini",
+        });
+    }
+
+    clients
+}
+
+fn proxy_upstream_override_present(env_name: &str, config_value: Option<&str>) -> bool {
+    nonempty_env_var(env_name).is_some()
+        || config_value.is_some_and(|value| !normalize_doctor_url(value).is_empty())
+}
+
+fn claude_code_anthropic_base() -> Option<String> {
+    nonempty_env_var("ANTHROPIC_BASE_URL").or_else(claude_settings_anthropic_base)
+}
+
+fn codex_openai_base() -> Option<String> {
+    nonempty_env_var("OPENAI_BASE_URL").or_else(codex_config_openai_base)
+}
+
+fn gemini_api_base() -> Option<String> {
+    nonempty_env_var("GEMINI_API_BASE_URL").or_else(shell_gemini_api_base)
+}
+
+fn nonempty_env_var(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| normalize_doctor_url(&value))
+        .filter(|value| !value.is_empty())
+}
+
+fn claude_settings_anthropic_base() -> Option<String> {
+    let home = dirs::home_dir()?;
+    let settings_path = crate::core::editor_registry::claude_state_dir(&home).join("settings.json");
+    let content = std::fs::read_to_string(settings_path).ok()?;
+    let doc: serde_json::Value = serde_json::from_str(&content).ok()?;
+    doc.get("env")?
+        .get("ANTHROPIC_BASE_URL")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn codex_config_openai_base() -> Option<String> {
+    let home = dirs::home_dir()?;
+    let content = std::fs::read_to_string(home.join(".codex").join("config.toml")).ok()?;
+    let doc: toml::Value = toml::from_str(&content).ok()?;
+    doc.get("env")?
+        .get("OPENAI_BASE_URL")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn shell_gemini_api_base() -> Option<String> {
+    let home = dirs::home_dir()?;
+    for rc in [home.join(".zshrc"), home.join(".bashrc")] {
+        let Ok(content) = std::fs::read_to_string(rc) else {
+            continue;
+        };
+        if let Some(value) = extract_shell_assignment(&content, "GEMINI_API_BASE_URL") {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn extract_shell_assignment(content: &str, key: &str) -> Option<String> {
+    for line in content.lines() {
+        let mut trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("export ") {
+            trimmed = rest.trim_start();
+        }
+        let Some(rest) = trimmed.strip_prefix(key) else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(value) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let value = strip_matching_shell_quotes(value.trim());
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn strip_matching_shell_quotes(value: &str) -> &str {
+    if let Some(inner) = value
+        .strip_prefix('"')
+        .and_then(|unquoted| unquoted.strip_suffix('"'))
+    {
+        return inner;
+    }
+    if let Some(inner) = value
+        .strip_prefix('\'')
+        .and_then(|unquoted| unquoted.strip_suffix('\''))
+    {
+        return inner;
+    }
+    value
+}
+
+fn normalize_doctor_url(value: &str) -> String {
+    value.trim().trim_end_matches('/').to_string()
+}
+
+fn is_http_url(value: &str) -> bool {
+    value.starts_with("http://") || value.starts_with("https://")
+}
+
+fn is_local_proxy_url(value: &str) -> bool {
+    value.starts_with("http://127.0.0.1:")
+        || value.starts_with("http://localhost:")
+        || value.starts_with("http://[::1]:")
+}
+
+fn url_is_local_proxy(value: Option<&str>) -> bool {
+    value
+        .map(normalize_doctor_url)
+        .is_some_and(|url| is_local_proxy_url(&url))
 }
 
 fn cache_safety_outcome() -> Outcome {
@@ -1167,4 +1439,66 @@ pub(super) fn print_compact_status(passed: u32, total: u32) {
         format!("{YELLOW}{passed}/{total} passed{RST} — run {BOLD}lean-ctx doctor{RST} for details")
     };
     println!("  {status}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_upstream_outcome_accepts_custom_anthropic_upstream() {
+        let mut cfg = crate::core::config::Config::default();
+        cfg.proxy.anthropic_upstream = Some("https://gateway.example.test/api/code".to_string());
+
+        let outcome = proxy_upstream_outcome_for_config(&cfg);
+        assert!(outcome.ok);
+        assert!(outcome.line.contains("custom upstream configured"));
+        assert!(outcome
+            .line
+            .contains("Anthropic=https://gateway.example.test/api/code"));
+    }
+
+    #[test]
+    fn proxy_upstream_outcome_rejects_local_proxy_loop() {
+        let mut cfg = crate::core::config::Config::default();
+        cfg.proxy.anthropic_upstream = Some("http://127.0.0.1:4444".to_string());
+
+        let outcome = proxy_upstream_outcome_for_config(&cfg);
+        assert!(!outcome.ok);
+        assert!(outcome.line.contains("points back to local proxy"));
+    }
+
+    #[test]
+    fn proxy_upstream_outcome_rejects_invalid_openai_upstream() {
+        let mut cfg = crate::core::config::Config::default();
+        cfg.proxy.openai_upstream = Some("not-a-url".to_string());
+
+        let outcome = proxy_upstream_outcome_for_config(&cfg);
+        assert!(!outcome.ok);
+        assert!(outcome.line.contains("invalid OpenAI upstream"));
+    }
+
+    #[test]
+    fn proxy_upstream_outcome_accepts_multiple_custom_upstreams() {
+        let mut cfg = crate::core::config::Config::default();
+        cfg.proxy.openai_upstream = Some("https://openai.example.test".to_string());
+        cfg.proxy.gemini_upstream = Some("https://gemini.example.test".to_string());
+
+        let outcome = proxy_upstream_outcome_for_config(&cfg);
+        assert!(outcome.ok);
+        assert!(outcome.line.contains("OpenAI=https://openai.example.test"));
+        assert!(outcome.line.contains("Gemini=https://gemini.example.test"));
+    }
+
+    #[test]
+    fn extract_shell_assignment_reads_exported_gemini_base() {
+        let content = r#"
+export OTHER=value
+export GEMINI_API_BASE_URL="http://127.0.0.1:4444"
+"#;
+
+        let value = extract_shell_assignment(content, "GEMINI_API_BASE_URL");
+
+        assert_eq!(value.as_deref(), Some("http://127.0.0.1:4444"));
+    }
 }

--- a/rust/src/proxy/anthropic.rs
+++ b/rust/src/proxy/anthropic.rs
@@ -10,13 +10,20 @@ use super::compress::compress_tool_result;
 use super::forward;
 use super::ProxyState;
 
-const UPSTREAM: &str = "https://api.anthropic.com";
+const DEFAULT_UPSTREAM: &str = "https://api.anthropic.com";
+const UPSTREAM_ENV: &str = "LEAN_CTX_ANTHROPIC_UPSTREAM";
 
 pub async fn handler(state: State<ProxyState>, req: Request<Body>) -> Result<Response, StatusCode> {
+    let config = crate::core::config::Config::load();
+    let upstream = forward::upstream_from_env_or_config(
+        UPSTREAM_ENV,
+        config.proxy.anthropic_upstream.as_deref(),
+        DEFAULT_UPSTREAM,
+    );
     forward::forward_request(
         state,
         req,
-        UPSTREAM,
+        &upstream,
         "/v1/messages",
         compress_request_body,
         "Anthropic",

--- a/rust/src/proxy/forward.rs
+++ b/rust/src/proxy/forward.rs
@@ -11,6 +11,26 @@ const MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
 
 pub type CompressFn = fn(&[u8]) -> (Vec<u8>, usize, usize);
 
+pub(crate) fn upstream_from_env_or_config(
+    var_name: &str,
+    config_value: Option<&str>,
+    default: &str,
+) -> String {
+    std::env::var(var_name)
+        .ok()
+        .and_then(|value| normalize_upstream(&value))
+        .or_else(|| config_value.and_then(normalize_upstream))
+        .unwrap_or_else(|| default.trim_end_matches('/').to_string())
+}
+
+fn normalize_upstream(value: &str) -> Option<String> {
+    let trimmed = value.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
 pub async fn forward_request(
     State(state): State<ProxyState>,
     req: Request<Body>,
@@ -122,4 +142,77 @@ async fn build_response(
     }
     resp.body(Body::from(resp_bytes))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_upstream, upstream_from_env_or_config};
+
+    #[test]
+    fn normalizes_configured_upstream() {
+        assert_eq!(
+            normalize_upstream(" https://example.test/api/code/ "),
+            Some("https://example.test/api/code".to_string())
+        );
+        assert_eq!(normalize_upstream("   "), None);
+    }
+
+    #[test]
+    fn upstream_from_env_or_config_uses_default_when_unset_or_empty() {
+        let var_name = "LEAN_CTX_TEST_UPSTREAM_FROM_ENV";
+        std::env::remove_var(var_name);
+        assert_eq!(
+            upstream_from_env_or_config(var_name, None, "https://api.example.test/"),
+            "https://api.example.test"
+        );
+
+        std::env::set_var(var_name, "   ");
+        assert_eq!(
+            upstream_from_env_or_config(var_name, None, "https://api.example.test/"),
+            "https://api.example.test"
+        );
+        std::env::remove_var(var_name);
+    }
+
+    #[test]
+    fn upstream_from_env_prefers_configured_value() {
+        let var_name = "LEAN_CTX_TEST_CONFIGURED_UPSTREAM";
+        std::env::set_var(var_name, "https://gateway.example.test/api/code/");
+        assert_eq!(
+            upstream_from_env_or_config(var_name, None, "https://api.example.test"),
+            "https://gateway.example.test/api/code"
+        );
+        std::env::remove_var(var_name);
+    }
+
+    #[test]
+    fn upstream_from_env_or_config_prefers_env_then_config_then_default() {
+        let _guard = crate::core::data_dir::test_env_lock();
+        let var_name = "LEAN_CTX_TEST_CONFIG_PRECEDENCE_UPSTREAM";
+
+        std::env::set_var(var_name, "https://env.example.test/");
+        assert_eq!(
+            upstream_from_env_or_config(
+                var_name,
+                Some("https://config.example.test/"),
+                "https://default.example.test/"
+            ),
+            "https://env.example.test"
+        );
+
+        std::env::remove_var(var_name);
+        assert_eq!(
+            upstream_from_env_or_config(
+                var_name,
+                Some("https://config.example.test/"),
+                "https://default.example.test/"
+            ),
+            "https://config.example.test"
+        );
+
+        assert_eq!(
+            upstream_from_env_or_config(var_name, Some("   "), "https://default.example.test/"),
+            "https://default.example.test"
+        );
+    }
 }

--- a/rust/src/proxy/google.rs
+++ b/rust/src/proxy/google.rs
@@ -10,13 +10,20 @@ use super::compress::compress_tool_result;
 use super::forward;
 use super::ProxyState;
 
-const UPSTREAM: &str = "https://generativelanguage.googleapis.com";
+const DEFAULT_UPSTREAM: &str = "https://generativelanguage.googleapis.com";
+const UPSTREAM_ENV: &str = "LEAN_CTX_GEMINI_UPSTREAM";
 
 pub async fn handler(state: State<ProxyState>, req: Request<Body>) -> Result<Response, StatusCode> {
+    let config = crate::core::config::Config::load();
+    let upstream = forward::upstream_from_env_or_config(
+        UPSTREAM_ENV,
+        config.proxy.gemini_upstream.as_deref(),
+        DEFAULT_UPSTREAM,
+    );
     forward::forward_request(
         state,
         req,
-        UPSTREAM,
+        &upstream,
         "/",
         compress_request_body,
         "Gemini",

--- a/rust/src/proxy/openai.rs
+++ b/rust/src/proxy/openai.rs
@@ -10,13 +10,20 @@ use super::compress::compress_tool_result;
 use super::forward;
 use super::ProxyState;
 
-const UPSTREAM: &str = "https://api.openai.com";
+const DEFAULT_UPSTREAM: &str = "https://api.openai.com";
+const UPSTREAM_ENV: &str = "LEAN_CTX_OPENAI_UPSTREAM";
 
 pub async fn handler(state: State<ProxyState>, req: Request<Body>) -> Result<Response, StatusCode> {
+    let config = crate::core::config::Config::load();
+    let upstream = forward::upstream_from_env_or_config(
+        UPSTREAM_ENV,
+        config.proxy.openai_upstream.as_deref(),
+        DEFAULT_UPSTREAM,
+    );
     forward::forward_request(
         state,
         req,
-        UPSTREAM,
+        &upstream,
         "/v1/chat/completions",
         compress_request_body,
         "OpenAI",

--- a/rust/src/proxy_setup.rs
+++ b/rust/src/proxy_setup.rs
@@ -52,6 +52,15 @@ export GEMINI_API_BASE_URL="{base}"
 
 fn install_claude_env(home: &Path, port: u16, quiet: bool) {
     let base = format!("http://127.0.0.1:{port}");
+    let mut cfg = crate::core::config::Config::load_global();
+    let capture = capture_claude_upstream_from_settings(home, &base, quiet, &mut cfg);
+    if capture.captured {
+        let _ = cfg.save();
+    }
+
+    if capture.already_local_proxy {
+        return;
+    }
 
     if !is_proxy_reachable(port) {
         if !quiet {
@@ -60,9 +69,69 @@ fn install_claude_env(home: &Path, port: u16, quiet: bool) {
         return;
     }
 
+    write_claude_proxy_env(home, &base, quiet);
+}
+
+#[derive(Default)]
+struct ClaudeUpstreamCapture {
+    captured: bool,
+    already_local_proxy: bool,
+}
+
+fn capture_claude_upstream_from_settings(
+    home: &Path,
+    proxy_base: &str,
+    quiet: bool,
+    cfg: &mut crate::core::config::Config,
+) -> ClaudeUpstreamCapture {
     let settings_dir = crate::core::editor_registry::claude_state_dir(home);
     let settings_path = settings_dir.join("settings.json");
+    let existing = std::fs::read_to_string(&settings_path).unwrap_or_default();
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(&existing) else {
+        return ClaudeUpstreamCapture::default();
+    };
 
+    let current = doc
+        .get("env")
+        .and_then(|e| e.get("ANTHROPIC_BASE_URL"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if current == proxy_base {
+        if !quiet {
+            println!("  Claude Code proxy env already configured");
+            if !has_custom_anthropic_upstream(cfg) {
+                println!(
+                    "  Anthropic upstream not configured; run: lean-ctx config set proxy.anthropic_upstream <url>"
+                );
+            }
+        }
+        return ClaudeUpstreamCapture {
+            captured: false,
+            already_local_proxy: true,
+        };
+    }
+
+    let captured = capture_claude_upstream_in_config(current, proxy_base, cfg);
+    if captured && !quiet {
+        let path = crate::core::config::Config::path().map_or_else(
+            || "~/.lean-ctx/config.toml".to_string(),
+            |p| p.to_string_lossy().to_string(),
+        );
+        println!("  Saved Claude Code upstream to {path}");
+        println!("    proxy.anthropic_upstream = {current}");
+        println!("    Change later with: lean-ctx config set proxy.anthropic_upstream <url>");
+    }
+
+    ClaudeUpstreamCapture {
+        captured,
+        already_local_proxy: false,
+    }
+}
+
+fn write_claude_proxy_env(home: &Path, base: &str, quiet: bool) {
+    let settings_dir = crate::core::editor_registry::claude_state_dir(home);
+    let settings_path = settings_dir.join("settings.json");
     let existing = std::fs::read_to_string(&settings_path).unwrap_or_default();
 
     let mut doc: serde_json::Value = if existing.trim().is_empty() {
@@ -74,7 +143,7 @@ fn install_claude_env(home: &Path, port: u16, quiet: bool) {
         }
     };
 
-    let env = doc
+    if doc
         .as_object_mut()
         .and_then(|o| {
             o.entry("env")
@@ -82,25 +151,16 @@ fn install_claude_env(home: &Path, port: u16, quiet: bool) {
                 .as_object_mut()
                 .map(|_| ())
         })
-        .is_some();
+        .is_none()
+    {
+        return;
+    }
 
-    if env {
-        if let Some(env_obj) = doc.get_mut("env").and_then(|e| e.as_object_mut()) {
-            let current = env_obj
-                .get("ANTHROPIC_BASE_URL")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            if current == base {
-                if !quiet {
-                    println!("  Claude Code proxy env already configured");
-                }
-                return;
-            }
-            env_obj.insert(
-                "ANTHROPIC_BASE_URL".to_string(),
-                serde_json::Value::String(base),
-            );
-        }
+    if let Some(env_obj) = doc.get_mut("env").and_then(|e| e.as_object_mut()) {
+        env_obj.insert(
+            "ANTHROPIC_BASE_URL".to_string(),
+            serde_json::Value::String(base.to_string()),
+        );
     }
 
     let _ = std::fs::create_dir_all(&settings_dir);
@@ -109,6 +169,59 @@ fn install_claude_env(home: &Path, port: u16, quiet: bool) {
     if !quiet {
         println!("  Configured ANTHROPIC_BASE_URL in Claude Code settings");
     }
+}
+
+fn has_custom_anthropic_upstream(cfg: &crate::core::config::Config) -> bool {
+    cfg.proxy
+        .anthropic_upstream
+        .as_deref()
+        .is_some_and(|v| normalize_captured_upstream(v).is_some_and(|u| !is_local_proxy_url(&u)))
+}
+
+fn capture_claude_upstream_in_config(
+    current: &str,
+    proxy_base: &str,
+    cfg: &mut crate::core::config::Config,
+) -> bool {
+    let Some(upstream) = normalize_captured_upstream(current) else {
+        return false;
+    };
+    if upstream == normalize_url(proxy_base) || is_local_proxy_url(&upstream) {
+        return false;
+    }
+
+    if cfg
+        .proxy
+        .anthropic_upstream
+        .as_deref()
+        .is_some_and(|v| normalize_captured_upstream(v).is_some())
+    {
+        return false;
+    }
+
+    cfg.proxy.anthropic_upstream = Some(upstream);
+    true
+}
+
+fn normalize_captured_upstream(value: &str) -> Option<String> {
+    let trimmed = normalize_url(value);
+    if trimmed.is_empty() {
+        return None;
+    }
+    if !(trimmed.starts_with("http://") || trimmed.starts_with("https://")) {
+        return None;
+    }
+    Some(trimmed)
+}
+
+fn normalize_url(value: &str) -> String {
+    value.trim().trim_end_matches('/').to_string()
+}
+
+fn is_local_proxy_url(value: &str) -> bool {
+    value.starts_with("http://127.0.0.1:")
+        || value.starts_with("http://localhost:")
+        || value.starts_with("http://[::1]:")
 }
 
 fn is_proxy_reachable(port: u16) -> bool {
@@ -170,4 +283,88 @@ fn install_codex_env(home: &Path, port: u16, quiet: bool) {
 
 pub fn default_port() -> u16 {
     DEFAULT_PROXY_PORT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captures_existing_claude_upstream_into_proxy_config() {
+        let mut cfg = crate::core::config::Config::default();
+
+        let captured = capture_claude_upstream_in_config(
+            "https://gateway.example.test/api/code",
+            "http://127.0.0.1:4444",
+            &mut cfg,
+        );
+
+        assert!(captured);
+        assert_eq!(
+            cfg.proxy.anthropic_upstream.as_deref(),
+            Some("https://gateway.example.test/api/code")
+        );
+    }
+
+    #[test]
+    fn captures_existing_claude_upstream_even_when_proxy_is_not_running() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let settings_dir = crate::core::editor_registry::claude_state_dir(&home);
+        std::fs::create_dir_all(&settings_dir).unwrap();
+        std::fs::write(
+            settings_dir.join("settings.json"),
+            r#"{"env":{"ANTHROPIC_BASE_URL":"https://gateway.example.test/api/code"}}"#,
+        )
+        .unwrap();
+        let mut cfg = crate::core::config::Config::default();
+
+        let capture =
+            capture_claude_upstream_from_settings(&home, "http://127.0.0.1:9", true, &mut cfg);
+
+        assert!(capture.captured);
+        assert!(!capture.already_local_proxy);
+        assert_eq!(
+            cfg.proxy.anthropic_upstream.as_deref(),
+            Some("https://gateway.example.test/api/code")
+        );
+        let settings = std::fs::read_to_string(settings_dir.join("settings.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&settings).unwrap();
+        assert_eq!(
+            doc["env"]["ANTHROPIC_BASE_URL"].as_str(),
+            Some("https://gateway.example.test/api/code")
+        );
+    }
+
+    #[test]
+    fn preserves_existing_custom_upstream() {
+        let mut cfg = crate::core::config::Config::default();
+        cfg.proxy.anthropic_upstream = Some("https://existing.example.test".to_string());
+
+        let captured = capture_claude_upstream_in_config(
+            "https://gateway.example.test/api/code",
+            "http://127.0.0.1:4444",
+            &mut cfg,
+        );
+
+        assert!(!captured);
+        assert_eq!(
+            cfg.proxy.anthropic_upstream.as_deref(),
+            Some("https://existing.example.test")
+        );
+    }
+
+    #[test]
+    fn ignores_local_proxy_when_capturing_claude_upstream() {
+        let mut cfg = crate::core::config::Config::default();
+
+        let captured = capture_claude_upstream_in_config(
+            "http://127.0.0.1:4444",
+            "http://127.0.0.1:4444",
+            &mut cfg,
+        );
+
+        assert!(!captured);
+        assert!(cfg.proxy.anthropic_upstream.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- Add configurable upstream base URLs for Anthropic, OpenAI, and Gemini proxy handlers.
- Keep default behavior unchanged when no custom upstream is configured.
- Preserve existing Claude Code `ANTHROPIC_BASE_URL` by storing it as `proxy.anthropic_upstream` before installing the local proxy.
- Show effective proxy upstreams in `lean-ctx config` and validate invalid or self-referential upstreams in `lean-ctx doctor`.

## Why

Claude Code, Codex, and Gemini CLI all support model or provider selection. Users who route them through custom endpoints, gateways, or model-router services need lean-ctx's local proxy to forward to that existing upstream instead of always falling back to provider defaults.

## Validation

- `git diff --check upstream/main...HEAD`
- `cargo fmt --check`
- `cargo test proxy -- --nocapture`
- `cargo check`