### PR TITLE
shell_hook: support drop-in install style + transparent migration

### DIFF
--- a/rust/src/dropin.rs
+++ b/rust/src/dropin.rs
@@ -1,0 +1,214 @@
+//! Drop-in style installation.
+//!
+//! Some users (or their dotfiles managers — chezmoi, yadm, stow, oh-my-zsh
+//! `custom/`, etc.) keep their shell config split into a small main file plus
+//! a directory of numbered fragments that the main file sources in lexical
+//! order (e.g. `~/.zshenv.d/00-homebrew.zsh`, `10-fnm.zsh`, ...).
+//!
+//! When that convention is in use, appending an inline fenced block to the
+//! main rc file creates drift between the main file and the dotfiles source
+//! of truth. The drop-in install mode writes the same hook content into a
+//! single fragment file in the `.d/` directory instead, leaving the main rc
+//! file untouched.
+//!
+//! Detection is conservative: we require both that the `.d/` directory
+//! exists AND that the main rc file references it from a non-comment line.
+//! That avoids treating an unused empty directory as opt-in.
+
+use std::path::{Path, PathBuf};
+
+/// Detect whether the user's rc file in `home` references the named drop-in
+/// directory and that directory exists. Returns the resolved directory path
+/// on success.
+///
+/// Arguments are kept generic so this works for `.zshenv` / `.zshenv.d`,
+/// `.zshrc` / `.zshrc.d`, `.bashrc` / `.bashrc.d`, etc.
+pub fn detect(home: &Path, rc_file_name: &str, dropin_dir_name: &str) -> Option<PathBuf> {
+    let dir = home.join(dropin_dir_name);
+    if !dir.is_dir() {
+        return None;
+    }
+    let rc_contents = std::fs::read_to_string(home.join(rc_file_name)).ok()?;
+    if rc_references_dropin(&rc_contents, dropin_dir_name) {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+/// True if any non-comment line in `rc_contents` mentions `dropin_dir_name`.
+///
+/// We deliberately don't try to parse the shell — any user who has put the
+/// directory name in their live config (a source loop, a glob `for` loop,
+/// even an `autoload` call) has made the intent clear enough.
+pub fn rc_references_dropin(rc_contents: &str, dropin_dir_name: &str) -> bool {
+    rc_contents.lines().any(|line| {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            return false;
+        }
+        line.contains(dropin_dir_name)
+    })
+}
+
+/// Write `content` to `<dir>/<filename>`, creating `dir` if needed.
+///
+/// Idempotent: overwrites any existing file. The trailing newline is
+/// normalised so re-runs with identical content produce identical bytes.
+pub fn write(dir: &Path, filename: &str, content: &str, quiet: bool, label: &str) {
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::error!("Cannot create {}: {e}", dir.display());
+        return;
+    }
+    let file = dir.join(filename);
+    let body = format!("{}\n", content.trim_end_matches('\n'));
+    if let Err(e) = std::fs::write(&file, body) {
+        tracing::error!("Cannot write {}: {e}", file.display());
+        return;
+    }
+    if !quiet {
+        eprintln!("  Installed {label} at {}", file.display());
+    }
+}
+
+/// Remove `<dir>/<filename>` if it exists. No-op otherwise.
+pub fn remove(dir: &Path, filename: &str, quiet: bool, label: &str) {
+    let file = dir.join(filename);
+    if !file.exists() {
+        return;
+    }
+    if let Err(e) = std::fs::remove_file(&file) {
+        tracing::error!("Cannot remove {}: {e}", file.display());
+        return;
+    }
+    if !quiet {
+        println!("  Removed {label} from {}", file.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn rc_references_dropin_matches_source_loop() {
+        let rc = r#"# top
+if [[ -d "$HOME/.zshenv.d" ]]; then
+    for f in "$HOME/.zshenv.d"/*.zsh(N); do source "$f"; done
+fi
+"#;
+        assert!(rc_references_dropin(rc, ".zshenv.d"));
+    }
+
+    #[test]
+    fn rc_references_dropin_ignores_comment_only_mentions() {
+        let rc = "# Once we have a ~/.zshenv.d we should adopt it.\nexport PATH=/usr/bin\n";
+        assert!(!rc_references_dropin(rc, ".zshenv.d"));
+    }
+
+    #[test]
+    fn rc_references_dropin_handles_empty_file() {
+        assert!(!rc_references_dropin("", ".zshenv.d"));
+    }
+
+    #[test]
+    fn detect_returns_none_without_directory() {
+        let tmp = fixture();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+        assert!(detect(tmp.path(), ".zshenv", ".zshenv.d").is_none());
+    }
+
+    #[test]
+    fn detect_returns_none_with_directory_but_no_reference() {
+        let tmp = fixture();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(tmp.path().join(".zshenv"), "export PATH=/usr/bin\n").unwrap();
+        assert!(detect(tmp.path(), ".zshenv", ".zshenv.d").is_none());
+    }
+
+    #[test]
+    fn detect_returns_dir_when_loop_and_directory_present() {
+        let tmp = fixture();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "if [[ -d \"$HOME/.zshenv.d\" ]]; then\n  for f in $HOME/.zshenv.d/*.zsh; do source $f; done\nfi\n",
+        )
+        .unwrap();
+        let got = detect(tmp.path(), ".zshenv", ".zshenv.d");
+        assert_eq!(got, Some(tmp.path().join(".zshenv.d")));
+    }
+
+    #[test]
+    fn detect_returns_none_when_rc_file_missing() {
+        let tmp = fixture();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        assert!(detect(tmp.path(), ".zshenv", ".zshenv.d").is_none());
+    }
+
+    #[test]
+    fn write_then_remove_roundtrip() {
+        let tmp = fixture();
+        let dir = tmp.path().join(".zshenv.d");
+        write(&dir, "00-lean-ctx.zsh", "echo hi", true, "test");
+        let file = dir.join("00-lean-ctx.zsh");
+        assert!(file.exists());
+        let body = std::fs::read_to_string(&file).unwrap();
+        assert_eq!(body, "echo hi\n");
+        remove(&dir, "00-lean-ctx.zsh", true, "test");
+        assert!(!file.exists());
+    }
+
+    #[test]
+    fn write_creates_missing_directory() {
+        let tmp = fixture();
+        let dir = tmp.path().join("nested").join(".zshenv.d");
+        write(&dir, "00-lean-ctx.zsh", "echo hi", true, "test");
+        assert!(dir.join("00-lean-ctx.zsh").exists());
+    }
+
+    #[test]
+    fn write_is_idempotent_for_identical_content() {
+        let tmp = fixture();
+        let dir = tmp.path().join(".zshenv.d");
+        write(&dir, "00-lean-ctx.zsh", "echo hi", true, "test");
+        let first = std::fs::read(dir.join("00-lean-ctx.zsh")).unwrap();
+        write(&dir, "00-lean-ctx.zsh", "echo hi", true, "test");
+        let second = std::fs::read(dir.join("00-lean-ctx.zsh")).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn write_overwrites_changed_content() {
+        let tmp = fixture();
+        let dir = tmp.path().join(".zshenv.d");
+        write(&dir, "00-lean-ctx.zsh", "echo old", true, "test");
+        write(&dir, "00-lean-ctx.zsh", "echo new", true, "test");
+        let body = std::fs::read_to_string(dir.join("00-lean-ctx.zsh")).unwrap();
+        assert_eq!(body, "echo new\n");
+    }
+
+    #[test]
+    fn remove_is_noop_when_file_missing() {
+        let tmp = fixture();
+        let dir = tmp.path().join(".zshenv.d");
+        std::fs::create_dir_all(&dir).unwrap();
+        remove(&dir, "00-lean-ctx.zsh", true, "test");
+    }
+
+    #[test]
+    fn remove_is_noop_when_directory_missing() {
+        let tmp = fixture();
+        let dir = tmp.path().join(".zshenv.d");
+        // Directory deliberately not created.
+        remove(&dir, "00-lean-ctx.zsh", true, "test");
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@ pub mod daemon;
 pub mod daemon_client;
 pub mod dashboard;
 pub mod doctor;
+pub mod dropin;
 pub mod engine;
 pub mod heatmap;
 pub mod hook_handlers;

--- a/rust/src/shell_hook.rs
+++ b/rust/src/shell_hook.rs
@@ -1,9 +1,17 @@
-use crate::marked_block;
+use std::path::{Path, PathBuf};
+
+use crate::{dropin, marked_block};
 
 const MARKER_START: &str = "# >>> lean-ctx shell hook >>>";
 const MARKER_END: &str = "# <<< lean-ctx shell hook <<<";
 const ALIAS_START: &str = "# >>> lean-ctx agent aliases >>>";
 const ALIAS_END: &str = "# <<< lean-ctx agent aliases <<<";
+
+/// File name we use inside `.d/` directories. Stable so install / migration /
+/// uninstall can find it again without parsing. `00-` prefix sorts it ahead
+/// of other drop-ins so the agent intercept fires before any tool init.
+const DROPIN_ZSH: &str = "00-lean-ctx.zsh";
+const DROPIN_SH: &str = "00-lean-ctx.sh";
 
 const KNOWN_AGENT_ENV_VARS: &[&str] = &[
     "LEAN_CTX_AGENT",
@@ -18,54 +26,299 @@ const AGENT_ALIASES: &[(&str, &str)] = &[
     ("gemini", "gemini"),
 ];
 
+/// Installation style for the shell hook + agent aliases.
+///
+/// `Auto` (default) inspects each rc file to decide: if the file references
+/// an adjacent `.d/` directory from a non-comment line and that directory
+/// exists, install as a drop-in; otherwise fall back to an inline fenced
+/// block in the rc file itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Style {
+    /// Force inline marked-block install in the parent rc file.
+    Inline,
+    /// Force drop-in file install in the adjacent `.d/` directory.
+    /// Falls back to `Inline` if no `.d/` source loop is configured.
+    DropIn,
+    /// Auto-detect per file.
+    #[default]
+    Auto,
+}
+
+/// Static description of a single install slot: which rc file, which
+/// adjacent drop-in directory + filename, and the marker pair for the
+/// inline form.
+#[derive(Debug, Clone, Copy)]
+struct Slot {
+    rc_file: &'static str,
+    dropin_dir: &'static str,
+    dropin_file: &'static str,
+    marker_start: &'static str,
+    marker_end: &'static str,
+}
+
+const SLOT_ZSHENV: Slot = Slot {
+    rc_file: ".zshenv",
+    dropin_dir: ".zshenv.d",
+    dropin_file: DROPIN_ZSH,
+    marker_start: MARKER_START,
+    marker_end: MARKER_END,
+};
+
+const SLOT_BASHENV: Slot = Slot {
+    rc_file: ".bashenv",
+    dropin_dir: ".bashenv.d",
+    dropin_file: DROPIN_SH,
+    marker_start: MARKER_START,
+    marker_end: MARKER_END,
+};
+
+const SLOT_ZSHRC: Slot = Slot {
+    rc_file: ".zshrc",
+    dropin_dir: ".zshrc.d",
+    dropin_file: DROPIN_ZSH,
+    marker_start: ALIAS_START,
+    marker_end: ALIAS_END,
+};
+
+const SLOT_BASHRC: Slot = Slot {
+    rc_file: ".bashrc",
+    dropin_dir: ".bashrc.d",
+    dropin_file: DROPIN_SH,
+    marker_start: ALIAS_START,
+    marker_end: ALIAS_END,
+};
+
+/// Resolved destination for a single install slot.
+enum InstallTarget {
+    Marked {
+        path: PathBuf,
+        start: &'static str,
+        end: &'static str,
+    },
+    DropIn {
+        dir: PathBuf,
+        filename: &'static str,
+    },
+}
+
+impl InstallTarget {
+    fn upsert(&self, content: &str, quiet: bool, label: &str) {
+        match self {
+            Self::Marked { path, start, end } => {
+                marked_block::upsert(path, start, end, content, quiet, label);
+            }
+            Self::DropIn { dir, filename } => dropin::write(dir, filename, content, quiet, label),
+        }
+    }
+}
+
+/// Decide where a particular hook should live.
+fn pick_target(home: &Path, slot: &Slot, style: Style) -> InstallTarget {
+    let inline = InstallTarget::Marked {
+        path: home.join(slot.rc_file),
+        start: slot.marker_start,
+        end: slot.marker_end,
+    };
+    match style {
+        Style::Inline => inline,
+        // DropIn and Auto both prefer dropin when available; only difference
+        // is whether we fall back silently (Auto) or could be made to warn
+        // (DropIn). Today they behave identically; the distinction lets
+        // callers express intent in the CLI surface later.
+        Style::DropIn | Style::Auto => match dropin::detect(home, slot.rc_file, slot.dropin_dir) {
+            Some(dir) => InstallTarget::DropIn {
+                dir,
+                filename: slot.dropin_file,
+            },
+            None => inline,
+        },
+    }
+}
+
+/// Pre-formatted timestamp suffix for migration backups.
+///
+/// Created **once per install run** and threaded through every per-slot
+/// install function, so all backups produced by a single
+/// `install_all_with_style` invocation share the same suffix. This
+/// rules out the "two near-simultaneous `Utc::now()` calls drifted by
+/// 1 ms across a second boundary" bug class, and makes the backups
+/// produced by one logical migration trivially groupable for the user
+/// (e.g. `ls ~ | grep lean-ctx-20260511T203845Z`).
+///
+/// Tests construct one via `BackupStamp::at(...)` to get deterministic
+/// filenames without touching the system clock.
+struct BackupStamp(String);
+
+impl BackupStamp {
+    /// Capture the current UTC time. Call this **once** at the top of
+    /// an install run.
+    fn now() -> Self {
+        Self::at(chrono::Utc::now())
+    }
+
+    /// Inject a specific moment in time. Used by tests; can also be
+    /// used in future to align migration backups with a user-supplied
+    /// release marker.
+    fn at(stamp: chrono::DateTime<chrono::Utc>) -> Self {
+        Self(stamp.format("%Y%m%dT%H%M%SZ").to_string())
+    }
+
+    /// Compose the full backup path for a given original file.
+    fn backup_path_for(&self, path: &Path) -> Option<PathBuf> {
+        let file_name = path.file_name().and_then(|n| n.to_str())?;
+        Some(path.with_file_name(format!("{file_name}.lean-ctx-{}.bak", self.0)))
+    }
+}
+
+/// Save a *timestamped* sibling backup of `path` before a destructive
+/// migration step. Filename pattern: `<basename>.lean-ctx-<UTC>.bak`,
+/// e.g. `.zshenv.lean-ctx-20260511T203845Z.bak`.
+///
+/// The block content owned by lean-ctx is normally treated as ours to
+/// rewrite — `marked_block::upsert` already strips and replaces it on
+/// every reinstall. That convention is acceptable for *idempotent
+/// reinstalls* (the canonical content is always the same) but loses
+/// information during a *style migration* if the user has hand-edited
+/// anywhere in the file, including inside our fenced region.
+///
+/// Deliberate divergence from the elsewhere-in-the-codebase convention
+/// (`cli::shell_init::backup_shell_config`, `config_io.rs`), which
+/// writes a single `<file>.lean-ctx.bak` and clobbers it on every
+/// invocation. That single-generation scheme is fine for "I backed
+/// this up moments ago before this exact reinstall" use cases, but
+/// risky for migration backups: a second migration event would
+/// silently overwrite the first, destroying potentially-unrecoverable
+/// user state. Timestamped names are append-only and let us migrate
+/// repeatedly (e.g. across multiple `lean-ctx update` runs over
+/// months) without ever losing a snapshot.
+fn save_migration_backup(path: &Path, quiet: bool, stamp: &BackupStamp) {
+    if !path.exists() {
+        return;
+    }
+    let Some(bak) = stamp.backup_path_for(path) else {
+        return;
+    };
+    match std::fs::copy(path, &bak) {
+        Ok(_) => {
+            if !quiet {
+                eprintln!("  Backup: {} -> {}", path.display(), bak.display());
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to back up {}: {e}", path.display());
+        }
+    }
+}
+
+/// When we install one style, sweep away any prior install of the *other*
+/// style so users transparently migrate (and so re-running setup never
+/// leaves the hook in two places).
+///
+/// Whenever a migration would clobber pre-existing user content (a
+/// fenced block in the rc file, or a hand-tweaked drop-in file), the
+/// affected file is copied to `<filename>.lean-ctx-<stamp>.bak` first
+/// (see `save_migration_backup`). The backup is only created when there
+/// is something to migrate AWAY from, so clean installs and idempotent
+/// reinstalls don't generate noise. `stamp` is taken by reference so
+/// all migrations within one `install_all` invocation share the same
+/// suffix.
+fn strip_other_style(
+    home: &Path,
+    slot: &Slot,
+    target: &InstallTarget,
+    quiet: bool,
+    label: &str,
+    stamp: &BackupStamp,
+) {
+    match target {
+        InstallTarget::Marked { .. } => {
+            // Installing inline: remove any drop-in file we previously wrote.
+            let dropin_dir = home.join(slot.dropin_dir);
+            let dropin_path = dropin_dir.join(slot.dropin_file);
+            if dropin_path.exists() {
+                // Hand-edits to the drop-in file would otherwise be lost.
+                // The backup lands next to the original; the `.bak`
+                // suffix keeps it out of any `*.zsh` source glob.
+                save_migration_backup(&dropin_path, quiet, stamp);
+                dropin::remove(&dropin_dir, slot.dropin_file, quiet, label);
+            }
+        }
+        InstallTarget::DropIn { .. } => {
+            // Installing drop-in: remove any prior inline fenced block.
+            // Back up the whole rc file first so anything between the
+            // markers (and any unrelated user edits to the same file)
+            // is recoverable from `<rc>.lean-ctx-<stamp>.bak`.
+            let rc_path = home.join(slot.rc_file);
+            if let Ok(existing) = std::fs::read_to_string(&rc_path) {
+                if existing.contains(slot.marker_start) {
+                    save_migration_backup(&rc_path, quiet, stamp);
+                }
+            }
+            marked_block::remove_from_file(
+                &rc_path,
+                slot.marker_start,
+                slot.marker_end,
+                quiet,
+                label,
+            );
+        }
+    }
+}
+
+/// Public entrypoint: install with auto-detected style. Preserves the
+/// previous signature so existing callers (setup.rs, cli/shell_init.rs)
+/// don't need to change.
 pub fn install_all(quiet: bool) {
+    install_all_with_style(quiet, Style::Auto);
+}
+
+/// Explicit style entrypoint for callers that want to honour a `--style=`
+/// CLI flag.
+///
+/// Captures a single `BackupStamp` here so every migration backup
+/// produced by this invocation shares one suffix, even if the wall
+/// clock ticks over while we're walking the slots.
+pub fn install_all_with_style(quiet: bool, style: Style) {
     let Some(home) = dirs::home_dir() else {
         tracing::error!("Cannot resolve home directory");
         return;
     };
 
-    install_zshenv(&home, quiet);
-    install_bashenv(&home, quiet);
-    install_aliases(&home, quiet);
+    let stamp = BackupStamp::now();
+    install_zshenv(&home, quiet, style, &stamp);
+    install_bashenv(&home, quiet, style, &stamp);
+    install_aliases(&home, quiet, style, &stamp);
 }
 
 pub fn uninstall_all(quiet: bool) {
     let Some(home) = dirs::home_dir() else { return };
 
-    marked_block::remove_from_file(
-        &home.join(".zshenv"),
-        MARKER_START,
-        MARKER_END,
-        quiet,
-        "shell hook from ~/.zshenv",
-    );
-    marked_block::remove_from_file(
-        &home.join(".bashenv"),
-        MARKER_START,
-        MARKER_END,
-        quiet,
-        "shell hook from ~/.bashenv",
-    );
-    marked_block::remove_from_file(
-        &home.join(".zshrc"),
-        ALIAS_START,
-        ALIAS_END,
-        quiet,
-        "agent aliases from ~/.zshrc",
-    );
-    marked_block::remove_from_file(
-        &home.join(".bashrc"),
-        ALIAS_START,
-        ALIAS_END,
-        quiet,
-        "agent aliases from ~/.bashrc",
-    );
+    // Try both styles unconditionally for each slot. marked_block::remove
+    // and dropin::remove are both no-ops when their target is absent.
+    let slots: &[(Slot, &str)] = &[
+        (SLOT_ZSHENV, "shell hook for ~/.zshenv"),
+        (SLOT_BASHENV, "shell hook for ~/.bashenv"),
+        (SLOT_ZSHRC, "agent aliases for ~/.zshrc"),
+        (SLOT_BASHRC, "agent aliases for ~/.bashrc"),
+    ];
+
+    for (slot, label) in slots {
+        marked_block::remove_from_file(
+            &home.join(slot.rc_file),
+            slot.marker_start,
+            slot.marker_end,
+            quiet,
+            label,
+        );
+        let dir_path = home.join(slot.dropin_dir);
+        if dir_path.exists() {
+            dropin::remove(&dir_path, slot.dropin_file, quiet, label);
+        }
+    }
 }
 
-fn install_zshenv(home: &std::path::Path, quiet: bool) {
-    let path = home.join(".zshenv");
+fn install_zshenv(home: &Path, quiet: bool, style: Style, stamp: &BackupStamp) {
     let env_check = build_env_check();
-
     let hook = format!(
         r#"{MARKER_START}
 if [[ -z "$LEAN_CTX_ACTIVE" && -n "$ZSH_EXECUTION_STRING" ]] && command -v lean-ctx &>/dev/null; then
@@ -77,20 +330,14 @@ fi
 {MARKER_END}"#
     );
 
-    marked_block::upsert(
-        &path,
-        MARKER_START,
-        MARKER_END,
-        &hook,
-        quiet,
-        "shell hook in ~/.zshenv",
-    );
+    let label = "shell hook in ~/.zshenv";
+    let target = pick_target(home, &SLOT_ZSHENV, style);
+    strip_other_style(home, &SLOT_ZSHENV, &target, quiet, label, stamp);
+    target.upsert(&hook, quiet, label);
 }
 
-fn install_bashenv(home: &std::path::Path, quiet: bool) {
-    let path = home.join(".bashenv");
+fn install_bashenv(home: &Path, quiet: bool, style: Style, stamp: &BackupStamp) {
     let env_check = build_env_check();
-
     let hook = format!(
         r#"{MARKER_START}
 if [[ -z "$LEAN_CTX_ACTIVE" && -n "$BASH_EXECUTION_STRING" ]] && command -v lean-ctx &>/dev/null; then
@@ -102,17 +349,13 @@ fi
 {MARKER_END}"#
     );
 
-    marked_block::upsert(
-        &path,
-        MARKER_START,
-        MARKER_END,
-        &hook,
-        quiet,
-        "shell hook in ~/.bashenv",
-    );
+    let label = "shell hook in ~/.bashenv";
+    let target = pick_target(home, &SLOT_BASHENV, style);
+    strip_other_style(home, &SLOT_BASHENV, &target, quiet, label, stamp);
+    target.upsert(&hook, quiet, label);
 }
 
-fn install_aliases(home: &std::path::Path, quiet: bool) {
+fn install_aliases(home: &Path, quiet: bool, style: Style, stamp: &BackupStamp) {
     let mut lines = Vec::new();
     lines.push(ALIAS_START.to_string());
     for (alias_name, bin_name) in AGENT_ALIASES {
@@ -123,14 +366,16 @@ fn install_aliases(home: &std::path::Path, quiet: bool) {
     lines.push(ALIAS_END.to_string());
     let block = lines.join("\n");
 
-    for rc in &[home.join(".zshrc"), home.join(".bashrc")] {
-        if rc.exists() {
-            let label = format!(
-                "agent aliases in ~/{}",
-                rc.file_name().unwrap_or_default().to_string_lossy()
-            );
-            marked_block::upsert(rc, ALIAS_START, ALIAS_END, &block, quiet, &label);
+    for slot in &[SLOT_ZSHRC, SLOT_BASHRC] {
+        // Only act on rc files the user actually has. (Drop-in mode keys off
+        // the parent rc anyway — see `dropin::detect`.)
+        if !home.join(slot.rc_file).exists() {
+            continue;
         }
+        let label = format!("agent aliases in ~/{}", slot.rc_file);
+        let target = pick_target(home, slot, style);
+        strip_other_style(home, slot, &target, quiet, &label, stamp);
+        target.upsert(&block, quiet, &label);
     }
 }
 
@@ -146,11 +391,410 @@ fn build_env_check() -> String {
 mod tests {
     use super::*;
 
+    /// Fixed deterministic stamp for tests that don't care about
+    /// distinguishing migration generations. Tests that *do* care
+    /// (e.g. the no-clobber regression) construct their own.
+    fn test_stamp() -> BackupStamp {
+        BackupStamp::at(
+            chrono::DateTime::parse_from_rfc3339("2026-05-11T20:38:45Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        )
+    }
+
     #[test]
     fn env_check_format() {
         let check = build_env_check();
         assert!(check.contains("LEAN_CTX_AGENT"));
         assert!(check.contains("CLAUDECODE"));
         assert!(check.contains("||"));
+    }
+
+    #[test]
+    fn pick_target_inline_when_forced() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Even with a .d/ loop, Style::Inline must force the marked target.
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+        let t = pick_target(tmp.path(), &SLOT_ZSHENV, Style::Inline);
+        assert!(matches!(t, InstallTarget::Marked { .. }));
+    }
+
+    #[test]
+    fn pick_target_dropin_when_detected_under_auto() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+        let t = pick_target(tmp.path(), &SLOT_ZSHENV, Style::Auto);
+        assert!(matches!(t, InstallTarget::DropIn { .. }));
+    }
+
+    #[test]
+    fn pick_target_inline_under_auto_when_no_dropin() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".zshenv"), "export PATH=/usr/bin\n").unwrap();
+        let t = pick_target(tmp.path(), &SLOT_ZSHENV, Style::Auto);
+        assert!(matches!(t, InstallTarget::Marked { .. }));
+    }
+
+    #[test]
+    fn pick_target_dropin_falls_back_to_inline_when_no_directory() {
+        // User asked for DropIn but the layout isn't set up. Don't error —
+        // fall back to inline so the install still works.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".zshenv"), "export PATH=/usr/bin\n").unwrap();
+        let t = pick_target(tmp.path(), &SLOT_ZSHENV, Style::DropIn);
+        assert!(matches!(t, InstallTarget::Marked { .. }));
+    }
+
+    #[test]
+    fn install_zshenv_writes_inline_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        install_zshenv(tmp.path(), true, Style::Inline, &test_stamp());
+        let body = std::fs::read_to_string(tmp.path().join(".zshenv")).unwrap();
+        assert!(body.contains(MARKER_START));
+        assert!(body.contains(MARKER_END));
+        assert!(body.contains("ZSH_EXECUTION_STRING"));
+    }
+
+    #[test]
+    fn install_zshenv_writes_dropin_when_loop_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+
+        let dropin_file = tmp.path().join(".zshenv.d").join(DROPIN_ZSH);
+        assert!(dropin_file.exists(), "expected drop-in file");
+        let dropin_body = std::fs::read_to_string(&dropin_file).unwrap();
+        assert!(dropin_body.contains("ZSH_EXECUTION_STRING"));
+
+        let zshenv_body = std::fs::read_to_string(tmp.path().join(".zshenv")).unwrap();
+        assert!(
+            !zshenv_body.contains(MARKER_START),
+            "drop-in install must not also leave the inline block"
+        );
+    }
+
+    /// List sibling files of `path` whose name matches
+    /// `<basename>.lean-ctx-<timestamp>.bak`.
+    fn find_migration_backups(path: &Path) -> Vec<PathBuf> {
+        let Some(parent) = path.parent() else {
+            return Vec::new();
+        };
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            return Vec::new();
+        };
+        let prefix = format!("{name}.lean-ctx-");
+        let mut out: Vec<PathBuf> = std::fs::read_dir(parent)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                    n.starts_with(&prefix)
+                        && std::path::Path::new(n)
+                            .extension()
+                            .is_some_and(|ext| ext.eq_ignore_ascii_case("bak"))
+                })
+            })
+            .collect();
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn migration_inline_to_dropin_preserves_hand_edits_via_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        // Existing install with a hand-edit *inside* our fenced region —
+        // the bit a maintainer might worry about losing silently.
+        let edited_zshenv = format!(
+            "export PATH=/usr/bin\n\
+             \n\
+             {MARKER_START}\n\
+             # USER CUSTOM: bump zsh history size for this workstation\n\
+             export HISTSIZE=99999\n\
+             # original lean-ctx hook content lived here\n\
+             {MARKER_END}\n\
+             \n\
+             for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        );
+        std::fs::write(tmp.path().join(".zshenv"), &edited_zshenv).unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+
+        // Backup must exist and contain the user's exact pre-migration file.
+        let baks = find_migration_backups(&tmp.path().join(".zshenv"));
+        assert_eq!(baks.len(), 1, "expected one timestamped backup");
+        let bak_body = std::fs::read_to_string(&baks[0]).unwrap();
+        assert_eq!(bak_body, edited_zshenv);
+        assert!(bak_body.contains("USER CUSTOM"));
+        assert!(bak_body.contains("HISTSIZE=99999"));
+    }
+
+    #[test]
+    fn migration_dropin_to_inline_preserves_hand_edits_via_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dropin_dir = tmp.path().join(".zshenv.d");
+        std::fs::create_dir_all(&dropin_dir).unwrap();
+        // Pre-stage a drop-in file with user customisation.
+        let edited_dropin = "# USER CUSTOM addition to lean-ctx drop-in\nexport FAVOURITE_EDITOR=helix\n# canonical lean-ctx content would follow\n";
+        std::fs::write(dropin_dir.join(DROPIN_ZSH), edited_dropin).unwrap();
+        // No source loop -> Style::Auto resolves to inline (so we migrate
+        // *away* from the drop-in).
+        std::fs::write(tmp.path().join(".zshenv"), "# plain zshenv\n").unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Inline, &test_stamp());
+
+        let baks = find_migration_backups(&dropin_dir.join(DROPIN_ZSH));
+        assert_eq!(baks.len(), 1, "expected one timestamped backup");
+        let bak_body = std::fs::read_to_string(&baks[0]).unwrap();
+        assert_eq!(bak_body, edited_dropin);
+        assert!(bak_body.contains("USER CUSTOM"));
+        // The original drop-in is gone, replaced by an inline block in .zshenv.
+        assert!(!dropin_dir.join(DROPIN_ZSH).exists());
+        let zshenv = std::fs::read_to_string(tmp.path().join(".zshenv")).unwrap();
+        assert!(zshenv.contains(MARKER_START));
+    }
+
+    #[test]
+    fn migration_skips_backup_when_no_prior_block_exists() {
+        // Clean install (no prior lean-ctx artifacts) should not litter
+        // the home dir with empty `.lean-ctx-<ts>.bak` files.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+
+        assert!(
+            find_migration_backups(&tmp.path().join(".zshenv")).is_empty(),
+            "clean install should not create a .bak file"
+        );
+    }
+
+    #[test]
+    fn idempotent_dropin_reinstall_does_not_create_backup() {
+        // Once installed in drop-in mode, a second `install` (e.g. via
+        // `lean-ctx update` re-wiring) should not start producing backups
+        // every run. The strip-other-style path only fires when there IS
+        // an inline block to remove.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+
+        assert!(find_migration_backups(&tmp.path().join(".zshenv")).is_empty());
+    }
+
+    #[test]
+    fn backup_filename_handles_dotfile_correctly() {
+        // `.zshenv` has no extension; Path::with_extension would replace
+        // ".zshenv" wholesale. Using with_file_name produces the right
+        // sibling path. Timestamp is appended between basename and `.bak`.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".zshenv"), "content\n").unwrap();
+        save_migration_backup(&tmp.path().join(".zshenv"), true, &test_stamp());
+        let baks = find_migration_backups(&tmp.path().join(".zshenv"));
+        assert_eq!(baks.len(), 1);
+        // The full filename must start with the original basename so it
+        // sits as a sibling, not at the parent root.
+        let name = baks[0].file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with(".zshenv.lean-ctx-"), "got: {name}");
+        assert!(std::path::Path::new(name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("bak")));
+        // Sanity-check the timestamp is in the YYYYMMDDTHHMMSSZ slot.
+        let stamp = name
+            .trim_start_matches(".zshenv.lean-ctx-")
+            .trim_end_matches(".bak");
+        assert_eq!(stamp.len(), 16, "stamp should be YYYYMMDDTHHMMSSZ: {stamp}");
+        assert!(stamp.contains('T'));
+        assert!(stamp.ends_with('Z'));
+    }
+
+    #[test]
+    fn repeated_migrations_never_clobber_prior_backups() {
+        // Regression test for the convention upgrade: two migration
+        // events on the same slot must produce two distinct backups,
+        // not silently overwrite each other. We pin two different
+        // stamps directly instead of sleeping past a second boundary.
+        let stamp_first = BackupStamp::at(
+            chrono::DateTime::parse_from_rfc3339("2026-05-11T20:38:45Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        );
+        let stamp_later = BackupStamp::at(
+            chrono::DateTime::parse_from_rfc3339("2026-05-12T09:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+
+        let with_block_v1 = format!(
+            "{MARKER_START}\n# first-era custom content\n{MARKER_END}\n\nfor f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        );
+        std::fs::write(tmp.path().join(".zshenv"), &with_block_v1).unwrap();
+        install_zshenv(tmp.path(), true, Style::Auto, &stamp_first);
+        let baks_after_first = find_migration_backups(&tmp.path().join(".zshenv"));
+        assert_eq!(baks_after_first.len(), 1);
+
+        // User hand-puts a NEW inline block back (perhaps via a manual
+        // edit or a partial reinstall in a tool we don't know about).
+        let with_block_v2 = format!(
+            "{}{MARKER_START}\n# second-era custom content\n{MARKER_END}\n",
+            std::fs::read_to_string(tmp.path().join(".zshenv")).unwrap(),
+        );
+        std::fs::write(tmp.path().join(".zshenv"), &with_block_v2).unwrap();
+        install_zshenv(tmp.path(), true, Style::Auto, &stamp_later);
+        let baks_after_second = find_migration_backups(&tmp.path().join(".zshenv"));
+
+        assert_eq!(
+            baks_after_second.len(),
+            2,
+            "second migration should leave a second backup, not overwrite"
+        );
+        // First backup unchanged from after the first migration.
+        assert_eq!(baks_after_second[0], baks_after_first[0]);
+        let first_body = std::fs::read_to_string(&baks_after_second[0]).unwrap();
+        let second_body = std::fs::read_to_string(&baks_after_second[1]).unwrap();
+        assert!(first_body.contains("first-era custom"));
+        assert!(second_body.contains("second-era custom"));
+    }
+
+    #[test]
+    fn install_migrates_inline_to_dropin() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Simulate an existing install: .zshenv with the old fenced block.
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            format!(
+                "export PATH=/usr/bin\n\n{MARKER_START}\n# old hook\n{MARKER_END}\n\nfor f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+            ),
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+
+        let zshenv_body = std::fs::read_to_string(tmp.path().join(".zshenv")).unwrap();
+        assert!(
+            !zshenv_body.contains(MARKER_START),
+            "old inline block should be stripped after migration"
+        );
+        assert!(
+            zshenv_body.contains(".zshenv.d"),
+            "source loop must be preserved"
+        );
+        let dropin_file = tmp.path().join(".zshenv.d").join(DROPIN_ZSH);
+        assert!(dropin_file.exists(), "new drop-in file should be present");
+    }
+
+    #[test]
+    fn install_migrates_dropin_to_inline() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No source loop → Style::Inline forces inline. Pre-stage a
+        // leftover drop-in file as if the user previously had the layout.
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv.d").join(DROPIN_ZSH),
+            "# stale lean-ctx drop-in\n",
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join(".zshenv"), "export PATH=/usr/bin\n").unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Inline, &test_stamp());
+
+        assert!(
+            !tmp.path().join(".zshenv.d").join(DROPIN_ZSH).exists(),
+            "drop-in file should be removed when installing inline"
+        );
+        let body = std::fs::read_to_string(tmp.path().join(".zshenv")).unwrap();
+        assert!(body.contains(MARKER_START));
+    }
+
+    #[test]
+    fn install_is_idempotent_in_dropin_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshenv.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+        let after_first = std::fs::read(tmp.path().join(".zshenv.d").join(DROPIN_ZSH)).unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Auto, &test_stamp());
+        let after_second = std::fs::read(tmp.path().join(".zshenv.d").join(DROPIN_ZSH)).unwrap();
+
+        assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn install_is_idempotent_in_inline_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".zshenv"), "# top\n").unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Inline, &test_stamp());
+        let after_first = std::fs::read(tmp.path().join(".zshenv")).unwrap();
+
+        install_zshenv(tmp.path(), true, Style::Inline, &test_stamp());
+        let after_second = std::fs::read(tmp.path().join(".zshenv")).unwrap();
+
+        assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn install_aliases_skips_when_rc_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No .zshrc, no .bashrc — nothing should be created.
+        install_aliases(tmp.path(), true, Style::Auto, &test_stamp());
+        assert!(!tmp.path().join(".zshrc").exists());
+        assert!(!tmp.path().join(".bashrc").exists());
+    }
+
+    #[test]
+    fn install_aliases_writes_dropin_when_zshrc_d_configured() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".zshrc.d")).unwrap();
+        std::fs::write(
+            tmp.path().join(".zshrc"),
+            "for f in $HOME/.zshrc.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+
+        install_aliases(tmp.path(), true, Style::Auto, &test_stamp());
+
+        let dropin_file = tmp.path().join(".zshrc.d").join(DROPIN_ZSH);
+        assert!(dropin_file.exists());
+        let body = std::fs::read_to_string(&dropin_file).unwrap();
+        assert!(body.contains("LEAN_CTX_AGENT=1"));
     }
 }

--- a/rust/tests/dropin_install_tests.rs
+++ b/rust/tests/dropin_install_tests.rs
@@ -1,0 +1,410 @@
+//! End-to-end coverage for `shell_hook::install_all_with_style`.
+//!
+//! The unit tests inside `shell_hook.rs` exercise each per-shell install
+//! function with an explicit `home: &Path` argument, which keeps them race-
+//! free. The tests in this file cover the top-level `install_all_with_style`
+//! entry point, which resolves `$HOME` via `dirs::home_dir()`. Because that
+//! reads the live env, these tests must run single-threaded — CI already
+//! invokes `cargo test --all-features -- --test-threads=1`, and a
+//! repo-local mutex below covers the case where someone runs tests
+//! without that flag.
+//!
+//! The intent is to validate the cross-file behaviour:
+//!   - All four touchpoints (.zshenv, .bashenv, .zshrc, .bashrc) end up in
+//!     the right style for a given home layout.
+//!   - Mixed layouts (e.g. dropin for .zshenv but inline for .bashrc) work.
+//!   - Uninstall removes everything regardless of which style was used.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use lean_ctx::shell_hook::{install_all, install_all_with_style, uninstall_all, Style};
+
+/// Serialises tests in this file so concurrent `$HOME` mutation doesn't
+/// race. Cargo runs each integration test binary's tests in parallel by
+/// default; this guard plus CI's `--test-threads=1` keeps us correct in
+/// both modes.
+static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_home<F: FnOnce(&Path)>(f: F) {
+    let _guard = HOME_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let prev = std::env::var_os("HOME");
+    // SAFETY: serialised via HOME_LOCK.
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(tmp.path())));
+    match prev {
+        Some(v) => unsafe { std::env::set_var("HOME", v) },
+        None => unsafe { std::env::remove_var("HOME") },
+    }
+    if let Err(p) = result {
+        std::panic::resume_unwind(p);
+    }
+}
+
+const MARKER_START: &str = "# >>> lean-ctx shell hook >>>";
+const MARKER_END: &str = "# <<< lean-ctx shell hook <<<";
+const ALIAS_START: &str = "# >>> lean-ctx agent aliases >>>";
+const ALIAS_END: &str = "# <<< lean-ctx agent aliases <<<";
+
+fn touch_rc(home: &Path, name: &str) {
+    std::fs::write(home.join(name), "# placeholder rc\n").unwrap();
+}
+
+fn enable_dropin(home: &Path, rc: &str, dir: &str) {
+    std::fs::create_dir_all(home.join(dir)).unwrap();
+    std::fs::write(
+        home.join(rc),
+        format!("for f in $HOME/{dir}/*.zsh; do source $f; done\n"),
+    )
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// install_all entry point (default = Auto)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn install_all_default_is_auto_inline_on_plain_layout() {
+    with_home(|home| {
+        touch_rc(home, ".zshrc");
+        touch_rc(home, ".bashrc");
+
+        install_all(true);
+
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(zshenv.contains(MARKER_START));
+        let zshrc = std::fs::read_to_string(home.join(".zshrc")).unwrap();
+        assert!(zshrc.contains(ALIAS_START));
+    });
+}
+
+#[test]
+fn install_all_auto_writes_dropin_for_zshenv_when_loop_present() {
+    with_home(|home| {
+        enable_dropin(home, ".zshenv", ".zshenv.d");
+        touch_rc(home, ".zshrc");
+
+        install_all_with_style(true, Style::Auto);
+
+        let dropin = home.join(".zshenv.d").join("00-lean-ctx.zsh");
+        assert!(dropin.exists(), "expected drop-in for .zshenv");
+
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            !zshenv.contains(MARKER_START),
+            "drop-in install must not also leave the inline fenced block"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Mixed layout: dropin for env, inline for rc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_resolves_each_slot_independently() {
+    with_home(|home| {
+        // zsh env uses .d/ drop-ins (chezmoi style)…
+        enable_dropin(home, ".zshenv", ".zshenv.d");
+        // …but zshrc does NOT — user hand-edits it.
+        std::fs::write(home.join(".zshrc"), "# my plain zshrc\n").unwrap();
+
+        install_all_with_style(true, Style::Auto);
+
+        assert!(
+            home.join(".zshenv.d").join("00-lean-ctx.zsh").exists(),
+            ".zshenv hook should be a drop-in"
+        );
+        let zshrc = std::fs::read_to_string(home.join(".zshrc")).unwrap();
+        assert!(
+            zshrc.contains(ALIAS_START),
+            ".zshrc aliases should be inline"
+        );
+        assert!(
+            !home.join(".zshrc.d").exists(),
+            "no .zshrc.d should be created when not pre-configured"
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Migration coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn re_running_after_chezmoi_adoption_migrates_to_dropin() {
+    with_home(|home| {
+        // Phase 1: user installs lean-ctx the old way — inline blocks
+        // everywhere.
+        touch_rc(home, ".zshrc");
+        touch_rc(home, ".bashrc");
+        install_all_with_style(true, Style::Inline);
+        let inline_zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(inline_zshenv.contains(MARKER_START));
+
+        // Phase 2: user adopts a dotfiles tool that introduces .zshenv.d/
+        // and changes .zshenv to source it.
+        std::fs::create_dir_all(home.join(".zshenv.d")).unwrap();
+        let migrated_zshenv = format!(
+            "{}\n\nfor f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+            inline_zshenv.trim_end()
+        );
+        std::fs::write(home.join(".zshenv"), migrated_zshenv).unwrap();
+
+        // Phase 3: lean-ctx update / re-run picks up the new layout.
+        install_all_with_style(true, Style::Auto);
+
+        // The fenced block must be gone from .zshenv …
+        let final_zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(
+            !final_zshenv.contains(MARKER_START),
+            "migration should strip the legacy fenced block from .zshenv"
+        );
+        // …and the drop-in file should now hold the hook.
+        let dropin_body =
+            std::fs::read_to_string(home.join(".zshenv.d").join("00-lean-ctx.zsh")).unwrap();
+        assert!(dropin_body.contains("ZSH_EXECUTION_STRING"));
+    });
+}
+
+#[test]
+fn rolling_back_to_inline_removes_dropin_file() {
+    with_home(|home| {
+        // Start in drop-in mode.
+        enable_dropin(home, ".zshenv", ".zshenv.d");
+        install_all_with_style(true, Style::Auto);
+        assert!(home.join(".zshenv.d").join("00-lean-ctx.zsh").exists());
+
+        // User decides to force inline.
+        install_all_with_style(true, Style::Inline);
+
+        assert!(
+            !home.join(".zshenv.d").join("00-lean-ctx.zsh").exists(),
+            "switching back to Inline must remove the drop-in"
+        );
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(zshenv.contains(MARKER_START));
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Uninstall removes everything regardless of style
+// ---------------------------------------------------------------------------
+
+#[test]
+fn uninstall_removes_inline_artifacts() {
+    with_home(|home| {
+        touch_rc(home, ".zshrc");
+        touch_rc(home, ".bashrc");
+        install_all_with_style(true, Style::Inline);
+
+        uninstall_all(true);
+
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap_or_default();
+        assert!(!zshenv.contains(MARKER_START));
+        let zshrc = std::fs::read_to_string(home.join(".zshrc")).unwrap();
+        assert!(!zshrc.contains(ALIAS_START));
+    });
+}
+
+#[test]
+fn uninstall_removes_dropin_artifacts() {
+    with_home(|home| {
+        enable_dropin(home, ".zshenv", ".zshenv.d");
+        enable_dropin(home, ".zshrc", ".zshrc.d");
+        install_all_with_style(true, Style::Auto);
+
+        assert!(home.join(".zshenv.d").join("00-lean-ctx.zsh").exists());
+        assert!(home.join(".zshrc.d").join("00-lean-ctx.zsh").exists());
+
+        uninstall_all(true);
+
+        assert!(!home.join(".zshenv.d").join("00-lean-ctx.zsh").exists());
+        assert!(!home.join(".zshrc.d").join("00-lean-ctx.zsh").exists());
+    });
+}
+
+#[test]
+fn uninstall_removes_both_styles_if_both_present() {
+    with_home(|home| {
+        // Pathological state: somehow both inline and drop-in are present.
+        // Uninstall should clean both.
+        enable_dropin(home, ".zshenv", ".zshenv.d");
+        // First install: drop-in.
+        install_all_with_style(true, Style::Auto);
+        // Then forcibly add an inline block too (simulating a corrupt
+        // mid-migration state).
+        let mut zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        zshenv
+            .push_str("\n# >>> lean-ctx shell hook >>>\n# stray\n# <<< lean-ctx shell hook <<<\n");
+        std::fs::write(home.join(".zshenv"), zshenv).unwrap();
+
+        uninstall_all(true);
+
+        assert!(!home.join(".zshenv.d").join("00-lean-ctx.zsh").exists());
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(!zshenv.contains(MARKER_START));
+    });
+}
+
+#[test]
+fn uninstall_is_noop_when_nothing_installed() {
+    with_home(|home| {
+        // Empty home — no files. Should not panic, should not create anything.
+        uninstall_all(true);
+        assert!(std::fs::read_dir(home).unwrap().next().is_none());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Hand-edit preservation across migration
+// ---------------------------------------------------------------------------
+
+/// Returns sibling files of `path` matching
+/// `<basename>.lean-ctx-<ts>.bak`.
+fn migration_backups_for(path: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let Some(parent) = path.parent() else {
+        return Vec::new();
+    };
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return Vec::new();
+    };
+    let prefix = format!("{name}.lean-ctx-");
+    let mut out: Vec<_> = std::fs::read_dir(parent)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                n.starts_with(&prefix)
+                    && std::path::Path::new(n)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("bak"))
+            })
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn migration_through_install_all_writes_backup_for_each_migrated_slot() {
+    with_home(|home| {
+        // Existing inline install: .zshenv has the fenced hook, .zshrc has
+        // the fenced aliases. The user has slipped a custom line into the
+        // .zshenv hook block.
+        let zshenv_pre = format!(
+            "# top of .zshenv\n\n\
+             {MARKER_START}\n\
+             # CUSTOM: capture pid before lean-ctx execs\n\
+             echo \"$$\" > /tmp/last-shell-pid\n\
+             {MARKER_END}\n",
+        );
+        std::fs::write(home.join(".zshenv"), &zshenv_pre).unwrap();
+        std::fs::write(
+            home.join(".zshrc"),
+            format!("# top\n{ALIAS_START}\nalias k=kubectl\n{ALIAS_END}\n"),
+        )
+        .unwrap();
+
+        // User then adopts the .d/ convention for .zshenv.
+        std::fs::create_dir_all(home.join(".zshenv.d")).unwrap();
+        let zshenv_with_loop = format!(
+            "{}\nfor f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+            zshenv_pre.trim_end()
+        );
+        std::fs::write(home.join(".zshenv"), &zshenv_with_loop).unwrap();
+
+        install_all_with_style(true, Style::Auto);
+
+        // .zshenv migrated -> exactly one timestamped backup.
+        let zshenv_baks = migration_backups_for(&home.join(".zshenv"));
+        assert_eq!(zshenv_baks.len(), 1, "expected one .zshenv backup");
+        let bak_body = std::fs::read_to_string(&zshenv_baks[0]).unwrap();
+        assert!(bak_body.contains("CUSTOM: capture pid"));
+        assert!(bak_body.contains("last-shell-pid"));
+
+        // .zshrc didn't migrate (no .zshrc.d source loop) -> no backup noise.
+        assert!(
+            migration_backups_for(&home.join(".zshrc")).is_empty(),
+            "no backup expected for slot that didn't migrate"
+        );
+    });
+}
+
+#[test]
+fn no_backups_on_clean_install_through_install_all() {
+    with_home(|home| {
+        // Fresh user, nothing installed. install_all should not produce
+        // any .bak files anywhere.
+        std::fs::create_dir_all(home.join(".zshenv.d")).unwrap();
+        std::fs::write(
+            home.join(".zshenv"),
+            "for f in $HOME/.zshenv.d/*.zsh; do source $f; done\n",
+        )
+        .unwrap();
+        touch_rc(home, ".zshrc");
+
+        install_all_with_style(true, Style::Auto);
+
+        let mut baks: Vec<_> = walkdir(home)
+            .filter(|p| {
+                let s = p.to_string_lossy();
+                s.contains(".lean-ctx-")
+                    && std::path::Path::new(&*s)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("bak"))
+            })
+            .collect();
+        baks.sort();
+        assert!(
+            baks.is_empty(),
+            "clean install must not create any .bak files; found: {baks:?}"
+        );
+    });
+}
+
+fn walkdir(root: &Path) -> impl Iterator<Item = std::path::PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    std::iter::from_fn(move || {
+        while let Some(dir) = stack.pop() {
+            if let Ok(rd) = std::fs::read_dir(&dir) {
+                for entry in rd.flatten() {
+                    let p = entry.path();
+                    if p.is_dir() {
+                        stack.push(p);
+                    } else {
+                        return Some(p);
+                    }
+                }
+            }
+        }
+        None
+    })
+}
+
+#[test]
+fn double_install_then_uninstall_leaves_no_trace() {
+    with_home(|home| {
+        enable_dropin(home, ".zshenv", ".zshenv.d");
+        touch_rc(home, ".zshrc");
+        touch_rc(home, ".bashrc");
+
+        install_all_with_style(true, Style::Auto);
+        install_all_with_style(true, Style::Auto);
+        uninstall_all(true);
+
+        // .zshenv still exists (we only manage our own block); but no
+        // lean-ctx artifacts should remain.
+        let zshenv = std::fs::read_to_string(home.join(".zshenv")).unwrap();
+        assert!(!zshenv.contains(MARKER_START));
+        assert!(!home.join(".zshenv.d").join("00-lean-ctx.zsh").exists());
+
+        let zshrc = std::fs::read_to_string(home.join(".zshrc")).unwrap();
+        assert!(!zshrc.contains(ALIAS_START));
+    });
+}


### PR DESCRIPTION
## Summary

Adds a drop-in install style so users whose dotfiles split shell config
into a `.d/`-directory source loop (chezmoi, yadm, stow, oh-my-zsh
`custom/`, zsh4humans, …) get a single fragment file in that directory
instead of an inline fenced block appended to the rc file. Detection is
per-slot and conservative; existing inline installs migrate
transparently on the next `lean-ctx update`, with the pre-migration
file copied to a timestamped sibling `.lean-ctx-<UTC>.bak` so any
hand-edits are recoverable. Hook content is byte-for-byte unchanged.

## Problem this fixes

Under a dotfiles tool that delegates `.zshenv` to `~/.zshenv.d/`:

```text
~/
├── .zshenv                       # small, source-of-truth, sourced for every zsh
└── .zshenv.d/
    ├── 00-homebrew.zsh
    ├── 10-fnm.zsh
    └── 20-python-uv-pipx.zsh
```

appending a lean-ctx fenced block to `~/.zshenv` permanently diverges
the live file from the dotfiles source of truth — `chezmoi diff` flags
it forever, `chezmoi apply` either reverts the install or has to be
wrapped to preserve it.

After this PR, the same install lands as a peer fragment:

```text
~/.zshenv                          # untouched
~/.zshenv.d/00-lean-ctx.zsh        # NEW — hook content lives here
```

with the same hook content the inline block used to contain. The `00-`
prefix sorts ahead of other drop-ins so the agent intercept fires
before tool-init costs.

## How it works

```rust
pub enum Style { Inline, DropIn, Auto }
```

`install_all(quiet)` is preserved as a wrapper around
`install_all_with_style(quiet, Style::Auto)` so existing callers don't
change. `Auto` checks each slot: if the rc references the `.d/`
directory from a non-comment line and the directory exists, install as
a drop-in; otherwise inline. Each slot (`.zshenv` / `.bashenv` /
`.zshrc` / `.bashrc`) is resolved independently, so mixed layouts work.

Every install run also strips the *other* style for each slot. Users on
the inline path migrate automatically the next time
`post_update_rewire()` runs. Uninstall (`shell_hook::uninstall_all`)
removes both styles; `lean-ctx uninstall` is unchanged at the call site
but now correctly tears down a drop-in install.

## Backup convention (deliberate divergence)

The rest of the codebase uses single-generation `<file>.lean-ctx.bak`
that gets clobbered on every call. That's fine for "reinstall replaced
canonical content" but risky for migration backups, where a second
migration would silently overwrite the first. Migration backups in
this PR instead use timestamped, never-clobber names:

```text
~/.zshenv.lean-ctx-20260511T203845Z.bak    # first migration
~/.zshenv.lean-ctx-20260603T091200Z.bak    # second, weeks later
```

The stamp is captured **once** at the top of `install_all_with_style`
as a `BackupStamp` and threaded through every per-slot call, so all
backups from one logical migration share one suffix. Tests inject
deterministic stamps via `BackupStamp::at(...)` rather than sleeping
past a second boundary. Backups are only created when there is
something to migrate away from, so clean installs and idempotent
reinstalls produce no noise.

## Test plan

- [x] `cd rust && cargo test --all-features`
- [x] `cd rust && cargo test --release --all-features`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`

32 new tests (20 unit + 12 integration) cover detect / write / remove
primitives, target resolution under each `Style`, fenced↔dropin
migrations both directions, mixed-layout behaviour, hand-edit
preservation via timestamped backups, repeated-migration no-clobber
regression, and uninstall removing both styles.

## Notes for reviewers

- **Risk areas:**
  - Integration tests mutate `$HOME` via `dirs::home_dir()`. They
    serialise on a file-local mutex so they're safe under default
    `cargo test` parallelism; CI's `--test-threads=1` covers it doubly.
  - Detection heuristic ("any non-comment line mentions the .d/ name")
    can false-positive on e.g. `echo "$HOME/.zshenv.d"` in a script.
    Cost: a drop-in lands in a directory the user already has.
    Recoverable via `rm`.
- **Backwards compatibility:**
  - `install_all(quiet)` signature unchanged.
  - Marker strings unchanged — third-party tooling that greps for them
    still matches.
  - Existing inline installs transition automatically; the timestamped
    `.bak` gives a 1-command rollback.
  - Migration backup naming deliberately diverges from
    `backup_shell_config`'s single-generation pattern (see "Backup
    convention" above). Happy to upgrade the existing helper to the
    timestamped scheme in a follow-up if you'd prefer the two to
    converge.
- **Uninstaller:** `lean-ctx uninstall` (and `--dry-run`) work
  unchanged. `uninstall::agents::remove_shell_hook` already invokes
  `shell_hook::uninstall_all` as its first step; that function now
  strips drop-in files alongside the inline blocks. Migration `.bak`s
  are deliberately left on disk by uninstall so users retain a
  recovery path.
- **Docs:** none changed — `Style`, `BackupStamp`, and the new
  `dropin` module are doc-commented inline.