### PR TITLE
Replaces the previous "override builtins" approach with explicit `ctx_`-prefixed tool names, and disables the builtins they replace via `pi.setActiveTools()` on session start.

### DIFF
--- a/packages/pi-lean-ctx/README.md
+++ b/packages/pi-lean-ctx/README.md
@@ -1,34 +1,36 @@
 # pi-lean-ctx
 
-CLI-first [Pi Coding Agent](https://github.com/badlogic/pi-mono) extension that routes Pi’s built-in tools through [lean-ctx](https://leanctx.com) for **60–90% token savings**.
+[Pi Coding Agent](https://github.com/badlogic/pi-mono) extension that provides `ctx_`-prefixed tools backed by [lean-ctx](https://leanctx.com) for **60–90% token savings**.
 
 - **Default**: CLI-only (no MCP required)
 - **Optional**: enable MCP tools (`LEAN_CTX_PI_ENABLE_MCP=1`) or run `lean-ctx init --agent pi --mode mcp`
 
 ## What it does
 
-### Built-in Tool Overrides (CLI)
+### ctx_ Tools (CLI-backed)
 
-Overrides Pi's built-in tools to route them through `lean-ctx`:
+Replaces Pi's built-in `read`, `bash`, `ls`, `find`, `grep` with `ctx_`-prefixed versions:
 
-| Tool | Compression |
-|------|------------|
-| `bash` | All shell commands compressed via lean-ctx's 95+ patterns |
-| `read` | Smart mode selection (full/map/signatures) based on file type and size |
-| `grep` | Results grouped and compressed via ripgrep + lean-ctx |
-| `find` | File listings compressed and .gitignore-aware |
-| `ls` | Directory output compressed |
+| Tool | Replaces | Compression |
+|------|----------|-------------|
+| `ctx_read` | `read` | Smart mode selection (full/map/signatures) based on file type and size |
+| `ctx_shell` | `bash` | All shell commands compressed via lean-ctx's 95+ patterns |
+| `ctx_grep` | `grep` | Results grouped and compressed via ripgrep + lean-ctx |
+| `ctx_find` | `find` | File listings compressed and .gitignore-aware |
+| `ctx_ls` | `ls` | Directory output compressed |
+
+Pi's `edit` and `write` builtins remain unchanged.
 
 ### Direct lean-ctx CLI tool
 
-The extension registers a `lean_ctx` tool that runs `lean-ctx` directly (no nested compression).
+The `lean_ctx` tool runs `lean-ctx` directly (no nested compression).
 Use it for commands like:
 
-- `lean-ctx overview`
-- `lean-ctx session …`
-- `lean-ctx knowledge …`
-- `lean-ctx gain` / `lean-ctx stats`
-- `lean-ctx index …`
+- `lean_ctx overview`
+- `lean_ctx session …`
+- `lean_ctx knowledge …`
+- `lean_ctx gain` / `lean_ctx stats`
+- `lean_ctx index …`
 
 ### Optional MCP Tools (Embedded Bridge)
 
@@ -43,24 +45,11 @@ server and registers advanced tools directly in Pi:
 | `ctx_overview` | Codebase overview and architecture analysis |
 | `ctx_compress` | Manual compression control |
 | `ctx_metrics` | Token savings dashboard |
-| `ctx_agent` | Multi-agent coordination and handoffs |
-| `ctx_graph` | Dependency graph analysis |
-| `ctx_discover` | Smart code discovery |
-| `ctx_context` | Context window management |
-| `ctx_preload` | Predictive file preloading |
-| `ctx_delta` | Changed-lines-only reads |
-| `ctx_edit` | Read-modify-write in one call |
-| `ctx_dedup` | Duplicate context elimination |
-| `ctx_fill` | Template completion |
-| `ctx_intent` | Intent-based task routing |
-| `ctx_response` | Response optimization |
-| `ctx_wrapped` | Wrapped command execution |
-| `ctx_benchmark` | Compression benchmarking |
-| `ctx_analyze` | Code analysis |
-| `ctx_cache` | Cache management |
-| `ctx_execute` | Direct command execution |
+| `ctx_multi_read` | Batch file reads |
+| `ctx_search` | MCP-native search |
+| `ctx_tree` | File tree listing |
 
-If you don’t want MCP: keep it disabled and use the CLI overrides + `lean_ctx` tool only.
+If you don't want MCP: keep it disabled and use the `ctx_` CLI tools + `lean_ctx` tool only.
 
 ## Install
 
@@ -83,14 +72,17 @@ lean-ctx init --agent pi
 
 ## How it works
 
-### CLI overrides (bash, read, grep, find, ls)
+### ctx_ tools (CLI-backed)
 
-These tools invoke the `lean-ctx` binary via CLI with `LEAN_CTX_COMPRESS=1`. The output is parsed for compression stats and displayed with a token savings footer.
+These tools invoke the `lean-ctx` binary via CLI with `LEAN_CTX_COMPRESS=1`.
+The built-in tools they replace (`read`, `bash`, `ls`, `find`, `grep`) are disabled
+via `pi.setActiveTools()` so only the `ctx_` versions are available to the LLM.
 
 ### Optional MCP bridge (all other tools)
 
 If you enable the MCP bridge, pi-lean-ctx spawns the `lean-ctx` binary as an MCP server (JSON-RPC over stdio).
-It discovers available tools via `list_tools`, filters out those already covered by CLI overrides, and registers the rest as native Pi tools.
+It discovers available tools via `list_tools`, filters out those already covered by `ctx_` CLI tools,
+and registers the rest as native Pi tools.
 
 If `lean-ctx` is already configured as an MCP server via [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) in `~/.pi/agent/mcp.json`, the embedded bridge is skipped to avoid duplicate tools.
 
@@ -150,7 +142,7 @@ The extension locates the `lean-ctx` binary in this order:
 
 ## Smart Read Modes
 
-The `read` tool automatically selects the optimal lean-ctx mode:
+The `ctx_read` tool automatically selects the optimal lean-ctx mode:
 
 | File Type | Size | Mode |
 |-----------|------|------|
@@ -166,7 +158,7 @@ The `read` tool automatically selects the optimal lean-ctx mode:
 Use `/lean-ctx` in Pi to check:
 - Which binary is being used
 - MCP bridge status (disabled / embedded / adapter)
-- Number and names of registered MCP tools
+- Active `ctx_` tool names
 
 ## Disabling specific tools
 

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -2,7 +2,6 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import {
   createBashToolDefinition,
   createReadToolDefinition,
-  DEFAULT_MAX_BYTES,
   DEFAULT_MAX_LINES,
   getLanguageFromPath,
   highlightCode,
@@ -36,10 +35,22 @@ const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
 const CODE_FULL_READ_MAX_BYTES = 8 * 1024;
 const CODE_SIGNATURES_MIN_BYTES = 96 * 1024;
 
+// Pi builtins we replace with ctx_ prefixed versions
+const DISABLED_BUILTIN_TOOLS = new Set(["read", "bash", "ls", "find", "grep"]);
+// Max bytes constant for truncation warnings (same as Pi's DEFAULT_MAX_BYTES)
+const DEFAULT_MAX_BYTES = 8192;
+
+const readModeSchema = Type.Union([
+  Type.Literal("full"),
+  Type.Literal("map"),
+  Type.Literal("signatures"),
+], { description: "Override auto-selection: full (complete content), map (deps+API signatures), signatures (AST only)" });
+
 const readSchema = Type.Object({
   path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
   offset: Type.Optional(Type.Number({ description: "Line number to start reading from (1-indexed)" })),
   limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
+  mode: Type.Optional(readModeSchema),
 });
 
 const lsSchema = Type.Object({
@@ -276,6 +287,13 @@ async function execLeanCtx(pi: ExtensionAPI, args: string[]) {
 }
 
 export default async function (pi: ExtensionAPI) {
+  // Defer setActiveTools to session_start — runtime actions aren't available during extension load
+  // Must run on every session_start since active tools are per-session
+  pi.on("session_start", () => {
+    const activeTools = pi.getActiveTools().filter((name) => !DISABLED_BUILTIN_TOOLS.has(name));
+    pi.setActiveTools(activeTools);
+  });
+
   const baseBashTool = createBashToolDefinition(process.cwd(), {
     spawnHook: ({ command, cwd, env }) => {
       const bin = resolveBinary();
@@ -295,19 +313,21 @@ export default async function (pi: ExtensionAPI) {
     raw: Type.Optional(Type.Boolean({ description: "Skip compression, return full uncompressed output" })),
   });
 
+  // ── ctx_shell (replaces bash) ─────────────────────────────────────────
   pi.registerTool({
-    ...baseBashTool,
-    parameters: bashSchemaWithRaw,
+    name: "ctx_shell",
+    label: "ctx_shell",
     description:
-      "Execute a bash command. Output is auto-compressed by lean-ctx. "
-      + "IMPORTANT: Do NOT use bash to read files (cat/head/tail) — use the read tool instead. "
-      + "Do NOT use bash for grep/find/ls — use the dedicated tools. "
+      "Execute a shell command. Output is auto-compressed by lean-ctx. "
+      + "IMPORTANT: Do NOT use ctx_shell to read files (cat/head/tail) — use ctx_read instead. "
+      + "Do NOT use ctx_shell for grep/find/ls — use ctx_grep, ctx_find, ctx_ls. "
       + "Set raw=true to skip compression when exact output matters. "
       + "Use timeout (seconds) to prevent hanging commands.",
-    promptSnippet: "Run shell commands (not for file reading — use read tool)",
+    promptSnippet: "Run shell commands (not for file reading — use ctx_read)",
     promptGuidelines: [
-      "Use bash only for commands with side effects: build, test, install, git, run scripts.",
+      "Use ctx_shell only for commands with side effects: build, test, install, git, run scripts.",
     ],
+    parameters: bashSchemaWithRaw,
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const isRaw = !!params.raw;
       const toolParams = { command: params.command, timeout: params.timeout };
@@ -335,19 +355,22 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
+  // ── ctx_read (replaces read) ──────────────────────────────────────────
   const nativeReadTool = createReadToolDefinition(process.cwd());
 
   pi.registerTool({
-    name: "read",
-    label: "Read",
+    name: "ctx_read",
+    label: "ctx_read",
     description:
-      "Read file contents. ALWAYS use this instead of cat/head/tail via bash. "
+      "Read file contents. ALWAYS use ctx_read instead of cat/head/tail via ctx_shell. "
       + "Auto-selects mode: configs (.yaml/.json/.toml/.env) are always full-read. "
       + "Code files: full (<8KB), map (8-96KB), signatures (>96KB). "
+      + "Add mode=full to get complete file content (bypasses cache). "
       + "Use offset and limit to read specific line ranges.",
     promptSnippet: "Read file contents (always use instead of cat)",
     promptGuidelines: [
-      "Use read to inspect file contents instead of cat or less.",
+      "Use ctx_read to inspect file contents instead of cat or less.",
+      "Use mode=full if you need the complete file content.",
     ],
     parameters: readSchema,
     renderCall(args, theme, context) {
@@ -386,11 +409,11 @@ export default async function (pi: ExtensionAPI) {
         | undefined;
       if (truncation?.truncated) {
         if (truncation.firstLineExceedsLimit) {
-          text += `\n${theme.fg("warning", `[First line exceeds ${Math.round((truncation.maxBytes ?? DEFAULT_MAX_BYTES) / 1024)}KB limit]`)}`;
+          text += `\n${theme.fg("warning", `[First line exceeds ${Math.round((truncation.maxBytes ?? 8192) / 1024)}KB limit]`)}`;
         } else if (truncation.truncatedBy === "lines") {
           text += `\n${theme.fg("warning", `[Truncated: ${truncation.outputLines} of ${truncation.totalLines} lines]`)}`;
         } else {
-          text += `\n${theme.fg("warning", `[Truncated: ${truncation.outputLines} lines (${Math.round((truncation.maxBytes ?? DEFAULT_MAX_BYTES) / 1024)}KB limit)]`)}`;
+          text += `\n${theme.fg("warning", `[Truncated: ${truncation.outputLines} lines (${Math.round((truncation.maxBytes ?? 8192) / 1024)}KB limit)]`)}`;
         }
       }
 
@@ -431,8 +454,9 @@ export default async function (pi: ExtensionAPI) {
         return nativeReadTool.execute(_toolCallId, { ...params, path: absolutePath }, signal, onUpdate, ctx);
       }
 
-      const mode = await chooseReadMode(absolutePath);
-      const args = mode === "full" ? ["read", absolutePath] : ["read", absolutePath, "-m", mode];
+      const isExplicitFull = params.mode === "full";
+      const mode = params.mode ?? await chooseReadMode(absolutePath);
+      const args = ["read", absolutePath, "-m", mode, ...(isExplicitFull ? ["--fresh"] : [])];
       const output = await execLeanCtx(pi, args);
       const originalText = await readFile(absolutePath, "utf8");
       const decorated = withFooter(output, { originalText, always: true, preferEstimate: true });
@@ -444,9 +468,10 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
+  // ── ctx_ls (replaces ls) ──────────────────────────────────────────────
   pi.registerTool({
-    name: "ls",
-    label: "ls",
+    name: "ctx_ls",
+    label: "ctx_ls",
     description: "List directory contents. Use limit to reduce output size.",
     promptSnippet: "List directory contents",
     parameters: lsSchema,
@@ -462,9 +487,10 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
+  // ── ctx_find (replaces find) ──────────────────────────────────────────
   pi.registerTool({
-    name: "find",
-    label: "find",
+    name: "ctx_find",
+    label: "ctx_find",
     description: "Find files by glob pattern (respects .gitignore). Use limit to reduce output size.",
     promptSnippet: "Find files by glob pattern",
     parameters: findSchema,
@@ -480,9 +506,10 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
+  // ── ctx_grep (replaces grep) ──────────────────────────────────────────
   pi.registerTool({
-    name: "grep",
-    label: "grep",
+    name: "ctx_grep",
+    label: "ctx_grep",
     description: "Search file contents with ripgrep. Use limit to cap matches and context for surrounding lines.",
     promptSnippet: "Search file contents for patterns",
     parameters: grepSchema,
@@ -512,6 +539,7 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
+  // ── lean_ctx (CLI passthrough) ────────────────────────────────────────
   pi.registerTool({
     name: "lean_ctx",
     label: "lean_ctx",
@@ -573,6 +601,12 @@ export default async function (pi: ExtensionAPI) {
         if (status.lastError) {
           lines.push(`Last bridge error: ${status.lastError}`);
         }
+      }
+
+      // Show active ctx_ tools
+      const ctxTools = pi.getActiveTools().filter((n) => n.startsWith("ctx_") || n === "lean_ctx");
+      if (ctxTools.length > 0) {
+        lines.push(`Active tools: ${ctxTools.join(", ")}`);
       }
 
       const ok = found && (adapterConfigured || !enableMcpBridge || (status?.connected ?? false));

--- a/packages/pi-lean-ctx/extensions/mcp-bridge.ts
+++ b/packages/pi-lean-ctx/extensions/mcp-bridge.ts
@@ -12,8 +12,7 @@ const CLI_OVERRIDE_TOOLS = new Set([
   "ctx_tree",
 ]);
 
-// Extension-registered tool prefix — skip these to avoid double-registration
-const EXTENSION_TOOL_PREFIX = "ctx_";
+// No additional prefix filter — CLI_OVERRIDE_TOOLS covers exactly the tools we overwrite
 
 const MAX_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_DELAY_MS = 2000;
@@ -150,7 +149,6 @@ export class McpBridge {
 
     for (const tool of tools) {
       if (CLI_OVERRIDE_TOOLS.has(tool.name)) continue;
-      if (tool.name.startsWith(EXTENSION_TOOL_PREFIX)) continue;
       this.registerMcpTool(pi, tool);
     }
   }

--- a/packages/pi-lean-ctx/extensions/mcp-bridge.ts
+++ b/packages/pi-lean-ctx/extensions/mcp-bridge.ts
@@ -12,6 +12,9 @@ const CLI_OVERRIDE_TOOLS = new Set([
   "ctx_tree",
 ]);
 
+// Extension-registered tool prefix — skip these to avoid double-registration
+const EXTENSION_TOOL_PREFIX = "ctx_";
+
 const MAX_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_DELAY_MS = 2000;
 const TOOL_CALL_TIMEOUT_MS = 120000;
@@ -147,6 +150,7 @@ export class McpBridge {
 
     for (const tool of tools) {
       if (CLI_OVERRIDE_TOOLS.has(tool.name)) continue;
+      if (tool.name.startsWith(EXTENSION_TOOL_PREFIX)) continue;
       this.registerMcpTool(pi, tool);
     }
   }

--- a/packages/pi-lean-ctx/package.json
+++ b/packages/pi-lean-ctx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-lean-ctx",
   "version": "3.5.25",
-  "description": "Pi Coding Agent extension (CLI-first) \u2014 routes bash/read/grep/find/ls through lean-ctx CLI for strong token savings. Optional MCP bridge can register advanced tools.",
+  "description": "Pi Coding Agent extension (CLI-first) — routes bash/read/grep/find/ls through lean-ctx CLI for strong token savings. Optional MCP bridge can register advanced tools.",
   "keywords": [
     "pi-package",
     "lean-ctx",
@@ -36,5 +36,8 @@
   "files": [
     "extensions/",
     "README.md"
-  ]
+  ],
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
 }


### PR DESCRIPTION
   ## Changes

   ### Tool Renaming
   - `bash` → `ctx_shell`
   - `read` → `ctx_read`
   - `ls` → `ctx_ls`
   - `find` → `ctx_find`
   - `grep` → `ctx_grep`

   Pi's `edit` and `write` builtins remain unchanged.

   ### Disable Replaced Builtins
   - Builtins (`read`, `bash`, `ls`, `find`, `grep`) are now removed from the active toolset on `session_start` so only the `ctx_` versions are available to the LLM.
   - Deferred to `session_start` hook since runtime actions aren't available during extension load, and active tools are per-session.

   ### ctx_read Improvements
   - Added explicit `mode` parameter (`full` | `map` | `signatures`) to the tool schema.
   - `mode=full` passes `--fresh` to lean-ctx to bypass cache.

   ### MCP Bridge Cleanup
   - Removed redundant CLI tool prefix filter — `CLI_OVERRIDE_TOOLS` set already covers exactly the tools being replaced, no heuristic prefix matching needed.

   ### Documentation
   - Updated README to reflect `ctx_` naming, clarify "replace" vs "override" semantics, and simplify the MCP tool list.
   - Fixed description typo in `package.json`.

   ### Other
   - Added TypeScript dev dependency.

   ## Files Changed

   | File | Changes |
   |------|---------|
   | `extensions/index.ts` | Tool renames, `setActiveTools` on session_start, `mode` param for ctx_read, status display update |
   | `extensions/mcp-bridge.ts` | Remove redundant prefix filter |
   | `README.md` | Rewritten docs for new naming convention, simplified MCP tool list |
   | `package.json` | Description typo fix, added TypeScript devDep |