### PR TITLE
fix: Windows daemon — named pipe IPC reliability

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -231,6 +231,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
     "Win32_Security",
+    "Win32_System_Pipes",
 ] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/rust/src/cli/dispatch.rs
+++ b/rust/src/cli/dispatch.rs
@@ -5,6 +5,7 @@ use crate::{
 use anyhow::Result;
 
 pub fn run() {
+    crate::core::logging::init_logging();
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() > 1 {

--- a/rust/src/core/logging.rs
+++ b/rust/src/core/logging.rs
@@ -3,11 +3,11 @@ use tracing_subscriber::EnvFilter;
 /// Initialize the tracing subscriber for CLI or MCP server usage.
 ///
 /// Respects `LEAN_CTX_LOG` and `RUST_LOG` environment variables for filter control.
-/// Defaults to `warn` level if neither is set.
+/// Defaults to `info` level if neither is set.
 pub fn init_logging() {
     let filter = std::env::var("LEAN_CTX_LOG")
         .or_else(|_| std::env::var("RUST_LOG"))
-        .unwrap_or_else(|_| "warn".to_string());
+        .unwrap_or_else(|_| "info".to_string());
 
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::new(filter))

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -72,12 +72,10 @@ pub fn start_daemon(args: &[String]) -> Result<()> {
         .create(true)
         .write(true)
         .truncate(true)
-        .open(&stderr_log)
-        .ok();
-
+        .open(&stderr_log);
     let stderr_cfg = match stderr_file {
-        Some(f) => std::process::Stdio::from(f),
-        None => std::process::Stdio::null(),
+        Ok(f) => std::process::Stdio::from(f),
+        Err(_) => std::process::Stdio::inherit(),
     };
 
     let child = Command::new(&exe)

--- a/rust/src/ipc/windows.rs
+++ b/rust/src/ipc/windows.rs
@@ -20,9 +20,23 @@ pub(super) fn pipe_exists(name: &str) -> bool {
 pub(super) async fn connect(
     pipe_name: &str,
 ) -> Result<tokio::net::windows::named_pipe::NamedPipeClient> {
-    ClientOptions::new()
-        .open(pipe_name)
-        .with_context(|| format!("connect to daemon pipe {pipe_name}"))
+    use std::time::Duration;
+    use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+
+    loop {
+        match ClientOptions::new().open(pipe_name) {
+            Ok(client) => return Ok(client),
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    || e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) =>
+            {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => {
+                anyhow::bail!("connect to daemon pipe {pipe_name}: {e}");
+            }
+        }
+    }
 }
 
 /// Server-side named-pipe listener, analogous to `UnixListener`.

--- a/rust/src/ipc/windows.rs
+++ b/rust/src/ipc/windows.rs
@@ -84,20 +84,19 @@ impl NamedPipeListener {
 #[cfg(all(test, windows))]
 mod tests {
     use super::*;
-    use tokio::net::windows::named_pipe::{ClientOptions, ServerOptions};
     use std::time::Duration;
+    use tokio::net::windows::named_pipe::{ClientOptions, ServerOptions};
 
     /// connect() retries NotFound, does not return a hard error before test timeout.
     #[tokio::test]
     async fn connect_retries_notfound() {
         let pipe_name = r"\\.\pipe\lean-ctx-test-notfound";
-        let result = tokio::time::timeout(
-            Duration::from_millis(150),
-            connect(pipe_name),
-        )
-        .await;
+        let result = tokio::time::timeout(Duration::from_millis(150), connect(pipe_name)).await;
         // Must time out (retries), NOT return a hard error.
-        assert!(result.is_err(), "should retry and be killed by timeout, not hard-error");
+        assert!(
+            result.is_err(),
+            "should retry and be killed by timeout, not hard-error"
+        );
     }
 
     // TODO: connect_retries_pipe_busy — needs reliable ERROR_PIPE_BUSY reproduction.
@@ -118,7 +117,10 @@ mod tests {
             connect("invalid_pipe_format_no_backslash_prefix"),
         )
         .await;
-        assert!(result.is_err(), "should not succeed (NotFound → retry → timeout)");
+        assert!(
+            result.is_err(),
+            "should not succeed (NotFound → retry → timeout)"
+        );
     }
 
     /// WaitNamedPipeW returns true for an existing pipe.

--- a/rust/src/ipc/windows.rs
+++ b/rust/src/ipc/windows.rs
@@ -80,3 +80,80 @@ impl NamedPipeListener {
         &self.name
     }
 }
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use tokio::net::windows::named_pipe::{ClientOptions, ServerOptions};
+    use std::time::Duration;
+
+    /// connect() retries NotFound, does not return a hard error before test timeout.
+    #[tokio::test]
+    async fn connect_retries_notfound() {
+        let pipe_name = r"\\.\pipe\lean-ctx-test-notfound";
+        let result = tokio::time::timeout(
+            Duration::from_millis(150),
+            connect(pipe_name),
+        )
+        .await;
+        // Must time out (retries), NOT return a hard error.
+        assert!(result.is_err(), "should retry and be killed by timeout, not hard-error");
+    }
+
+    // TODO: connect_retries_pipe_busy — needs reliable ERROR_PIPE_BUSY reproduction.
+    // PIPE_BUSY occurs when a pipe instance exists but all instances are busy (real
+    // mid-rotation race). Constructing this in a unit test is fragile; verify on
+    // Windows manually or via integration test with concurrent clients.
+
+    /// connect() bails immediately on non-retryable errors.
+    #[tokio::test]
+    async fn connect_fails_on_hard_error() {
+        // An invalid pipe name should fail immediately (not NotFound, not PIPE_BUSY).
+        let result = connect("invalid_pipe_format_no_backslash_prefix").await;
+        assert!(result.is_err());
+    }
+
+    /// WaitNamedPipeW returns true for an existing pipe.
+    #[test]
+    fn pipe_exists_true() {
+        let pipe_name = r"\\.\pipe\lean-ctx-test-exists";
+        let _server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(pipe_name)
+            .expect("create test pipe");
+        assert!(pipe_exists(pipe_name));
+    }
+
+    /// WaitNamedPipeW returns false for a nonexistent pipe.
+    #[test]
+    fn pipe_exists_false() {
+        let pipe_name = r"\\.\pipe\lean-ctx-test-gone-bogus";
+        assert!(!pipe_exists(pipe_name));
+    }
+
+    /// accept_pipe() waits for current, creates next, returns connected server.
+    /// Two sequential client→accept→drop cycles verify instance rotation.
+    #[tokio::test]
+    async fn accept_pipe_rotates_after_connect() {
+        let pipe_name = r"\\.\pipe\lean-ctx-test-rotate";
+        let mut listener = NamedPipeListener::bind(pipe_name).expect("bind");
+
+        // Client 1
+        let c1 = tokio::spawn({
+            let n = pipe_name.to_string();
+            async move { ClientOptions::new().open(&n) }
+        });
+        let s1 = listener.accept_pipe().await.expect("accept 1");
+        let _c1 = c1.await.unwrap().expect("client 1 connect");
+        drop(s1);
+
+        // Client 2 — the rotated instance should be ready.
+        let c2 = tokio::spawn({
+            let n = pipe_name.to_string();
+            async move { ClientOptions::new().open(&n) }
+        });
+        let s2 = listener.accept_pipe().await.expect("accept 2");
+        let _c2 = c2.await.unwrap().expect("client 2 connect");
+        drop(s2);
+    }
+}

--- a/rust/src/ipc/windows.rs
+++ b/rust/src/ipc/windows.rs
@@ -105,12 +105,20 @@ mod tests {
     // mid-rotation race). Constructing this in a unit test is fragile; verify on
     // Windows manually or via integration test with concurrent clients.
 
-    /// connect() bails immediately on non-retryable errors.
+    /// connect() retries non-retryable-looking errors that map to NotFound.
+    /// Since a bare filename (without \\.\pipe\ prefix) also produces NotFound
+    /// on Windows via CreateFileW, it hits the retry loop, so we use a timeout
+    /// to prevent a hang.
     #[tokio::test]
     async fn connect_fails_on_hard_error() {
-        // An invalid pipe name should fail immediately (not NotFound, not PIPE_BUSY).
-        let result = connect("invalid_pipe_format_no_backslash_prefix").await;
-        assert!(result.is_err());
+        // A path without \\.\pipe\ prefix that will produce NotFound on Windows,
+        // which connect() retries. Timeout proves it doesn't succeed.
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            connect("invalid_pipe_format_no_backslash_prefix"),
+        )
+        .await;
+        assert!(result.is_err(), "should not succeed (NotFound → retry → timeout)");
     }
 
     /// WaitNamedPipeW returns true for an existing pipe.

--- a/rust/src/ipc/windows.rs
+++ b/rust/src/ipc/windows.rs
@@ -24,6 +24,9 @@ pub(super) fn pipe_exists(name: &str) -> bool {
     unsafe { WaitNamedPipeW(wide.as_ptr(), 1) != 0 }
 }
 
+/// Retries indefinitely on `NotFound` / `ERROR_PIPE_BUSY` (transient
+/// conditions during named-pipe instance rotation). Callers should wrap
+/// with `tokio::time::timeout` to prevent unbounded waits.
 pub(super) async fn connect(
     pipe_name: &str,
 ) -> Result<tokio::net::windows::named_pipe::NamedPipeClient> {
@@ -104,14 +107,12 @@ mod tests {
     // mid-rotation race). Constructing this in a unit test is fragile; verify on
     // Windows manually or via integration test with concurrent clients.
 
-    /// connect() retries non-retryable-looking errors that map to NotFound.
-    /// Since a bare filename (without \\.\pipe\ prefix) also produces NotFound
-    /// on Windows via CreateFileW, it hits the retry loop, so we use a timeout
-    /// to prevent a hang.
+    /// connect() retries when an invalid pipe path produces NotFound on Windows.
+    /// A bare filename (without \\.\pipe\ prefix) triggers ERROR_FILE_NOT_FOUND
+    /// via CreateFileW, which maps to NotFound → hits the retry loop.
+    /// Timeout proves it doesn't succeed from a malformed path.
     #[tokio::test]
-    async fn connect_fails_on_hard_error() {
-        // A path without \\.\pipe\ prefix that will produce NotFound on Windows,
-        // which connect() retries. Timeout proves it doesn't succeed.
+    async fn connect_retries_notfound_on_invalid_format() {
         let result = tokio::time::timeout(
             Duration::from_millis(100),
             connect("invalid_pipe_format_no_backslash_prefix"),

--- a/rust/src/ipc/windows.rs
+++ b/rust/src/ipc/windows.rs
@@ -13,8 +13,15 @@ pub(super) fn default_pipe_name() -> String {
 }
 
 pub(super) fn pipe_exists(name: &str) -> bool {
-    use std::fs;
-    fs::metadata(name).is_ok()
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::System::Pipes::WaitNamedPipeW;
+
+    let wide: Vec<u16> = OsStr::new(name)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    unsafe { WaitNamedPipeW(wide.as_ptr(), 1) != 0 }
 }
 
 pub(super) async fn connect(


### PR DESCRIPTION
## Summary

Fixes Windows daemon (named-pipe IPC) so `lean-ctx serve --daemon` works reliably on Windows. Previously the daemon was broken on Windows due to 4 issues:

- **No logging on daemon start** — errors were invisible (`init_logging()` never called)
- **Silently discarded daemon errors** — `Stdio::null()` swallowed stderr when log file couldn't open
- **No retry on transient pipe errors** — `connect()` failed immediately on `ERROR_PIPE_BUSY` / `NotFound` (normal during NPFS instance rotation)
- **Broken pipe existence check** — `fs::metadata()` doesn't work for `\\.\pipe\...` paths

## Changes (5 files, ~128 insertions)

| File | Change |
|------|--------|
| `rust/Cargo.toml` | Add `Win32_System_Pipes` feature to windows-sys |
| `rust/src/cli/dispatch.rs` | Call `init_logging()` first in `run()` |
| `rust/src/core/logging.rs` | Default level `warn` → `info` (avoids shadowing MCP server) |
| `rust/src/daemon.rs` | Stderr fallback `Stdio::null()` → `Stdio::inherit()` |
| `rust/src/ipc/windows.rs` | `connect()` retry loop + `WaitNamedPipeW` + unit tests |

## Test plan

### Linux
```
cargo fmt --check          # ✅
cargo clippy -D warnings   # ✅
cargo test --lib           # ✅ 2021 passed
cargo check --target x86_64-pc-windows-gnu  # ✅
cargo build --release --target x86_64-pc-windows-gnu  # ✅
```

### Windows (real hardware verification)
```
serve --daemon   # ✅ PID 21236, pipe created
serve --status   # ✅ "ready"
overview "test"  # ✅ IPC round-trip
serve --stop     # ✅ graceful shutdown
serve --status   # ✅ "Daemon not running"
```

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)