### PR TITLE
fix(mcp): reduce lock contention when concurrent subagents read same file

### DIFF
--- a/rust/LOCK_ORDERING.md
+++ b/rust/LOCK_ORDERING.md
@@ -27,6 +27,7 @@ All `std::sync::Mutex` unless noted otherwise.
 | L14 | `ACTIVE_ROLE_NAME` | `core/roles.rs:12` | `OnceLock<Mutex<String>>` | Currently active role name |
 | L15 | `PROVIDER_CACHE` | `core/providers/cache.rs:5` | `LazyLock<Mutex<ProviderCache>>` | Cached provider metadata |
 | L16 | `LAST_BANDIT_ARM` | `core/adaptive_thresholds.rs:337` | `Mutex<Option<(String, String, String)>>` | Last bandit arm selection for adaptive thresholds |
+| L17 | `FILE_LOCKS` | `tools/registered/ctx_read.rs` | `OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>>` | Per-file read serialization for concurrent subagents |
 
 ### Test / Environment Locks (serialise env-var mutations)
 
@@ -83,6 +84,32 @@ L1 (REGISTRY outer map)
 The `entry_for()` function in `index_orchestrator.rs` enforces this: it locks L1, clones the
 `Arc<Mutex<ProjectBuild>>`, **drops** L1, then the caller locks L2 independently. This avoids
 deadlock by ensuring L1 and L2 are never held simultaneously.
+
+### Per-file Read Lock (L17)
+
+L17 uses the same outer/inner pattern as L1/L2: the outer `Mutex<HashMap>` is held briefly to
+clone the per-path `Arc<Mutex<()>>`, then dropped before the per-file lock is acquired. The
+per-file lock is acquired inside the spawned OS thread (timeout guard), before `cache_lock.blocking_write()`.
+This serializes concurrent reads of the same path so only one thread at a time contends on the
+global cache write lock per file. Threads reading different files proceed independently.
+
+This prevents the thundering-herd scenario where N concurrent subagents all requesting the same
+file simultaneously contend on the global cache lock, each holding it during disk I/O.
+
+```
+thread::spawn {
+    L17 outer (FILE_LOCKS map)       — held briefly to clone Arc, then dropped
+     └─► L17 inner (per-file Mutex)  — NEVER hold outer while locking inner
+          └─► cache (session RwLock) — per-file lock acquired BEFORE cache write lock
+}
+```
+
+### Worker Thread Tuning
+
+The Tokio runtime worker thread count defaults to `available_parallelism().clamp(1, 4)`.
+Override via `LEAN_CTX_WORKER_THREADS` (positive integer) for environments with many
+concurrent subagents. Example: `LEAN_CTX_WORKER_THREADS=8`. The blocking thread pool
+is always `worker_threads * 4`, clamped to `[8, 32]`.
 
 ### Independent Static Locks (L3–L16)
 

--- a/rust/src/cli/dispatch.rs
+++ b/rust/src/cli/dispatch.rs
@@ -1356,6 +1356,8 @@ fn run_mcp_server() -> Result<()> {
     // Concurrency hardening:
     // - Smooths "thundering herd" MCP startups (multiple agent sessions).
     // - Limits Tokio worker/blocking threads to avoid host degradation.
+    // - LEAN_CTX_WORKER_THREADS overrides the default for environments
+    //   with many concurrent subagents (e.g. parallel review pipelines).
     let startup_lock = crate::core::startup_guard::try_acquire_lock(
         "mcp-startup",
         std::time::Duration::from_secs(3),
@@ -1363,7 +1365,7 @@ fn run_mcp_server() -> Result<()> {
     );
 
     let parallelism = std::thread::available_parallelism().map_or(2, std::num::NonZeroUsize::get);
-    let worker_threads = parallelism.clamp(1, 4);
+    let worker_threads = resolve_worker_threads(parallelism);
     let max_blocking_threads = (worker_threads * 4).clamp(8, 32);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -1778,4 +1780,48 @@ fn resolve_install_path() -> std::path::PathBuf {
     }
 
     std::path::PathBuf::from("/usr/local/bin/lean-ctx")
+}
+
+fn resolve_worker_threads(parallelism: usize) -> usize {
+    std::env::var("LEAN_CTX_WORKER_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or_else(|| parallelism.clamp(1, 4))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_threads_default_clamps_low() {
+        std::env::remove_var("LEAN_CTX_WORKER_THREADS");
+        assert_eq!(resolve_worker_threads(1), 1);
+    }
+
+    #[test]
+    fn worker_threads_default_clamps_high() {
+        std::env::remove_var("LEAN_CTX_WORKER_THREADS");
+        assert_eq!(resolve_worker_threads(32), 4);
+    }
+
+    #[test]
+    fn worker_threads_default_passthrough() {
+        std::env::remove_var("LEAN_CTX_WORKER_THREADS");
+        assert_eq!(resolve_worker_threads(3), 3);
+    }
+
+    #[test]
+    fn worker_threads_env_override() {
+        std::env::set_var("LEAN_CTX_WORKER_THREADS", "12");
+        assert_eq!(resolve_worker_threads(2), 12);
+        std::env::remove_var("LEAN_CTX_WORKER_THREADS");
+    }
+
+    #[test]
+    fn worker_threads_env_invalid_falls_back() {
+        std::env::set_var("LEAN_CTX_WORKER_THREADS", "not_a_number");
+        assert_eq!(resolve_worker_threads(3), 3);
+        std::env::remove_var("LEAN_CTX_WORKER_THREADS");
+    }
 }

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -1,9 +1,29 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
 use rmcp::model::Tool;
 use rmcp::ErrorData;
 use serde_json::{json, Map, Value};
 
 use crate::server::tool_trait::{get_bool, get_int, get_str, McpTool, ToolContext, ToolOutput};
 use crate::tool_defs::tool_def;
+
+/// Per-file lock that serializes concurrent reads of the same path.
+///
+/// When multiple subagents read sequentially through a shared set of files,
+/// they tend to hit the same path at the same time. Without per-file locking
+/// they all contend on the global cache write lock while doing redundant I/O.
+/// This lock ensures only one thread reads a given file from disk; the others
+/// wait cheaply on the per-file mutex, then hit the warm cache.
+fn per_file_lock(path: &str) -> Arc<Mutex<()>> {
+    static FILE_LOCKS: std::sync::OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
+        std::sync::OnceLock::new();
+    let map = FILE_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = map.lock().unwrap();
+    map.entry(path.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
 
 pub struct CtxReadTool;
 
@@ -147,6 +167,11 @@ impl CtxReadTool {
             let path_owned = path.to_string();
             let (tx, rx) = std::sync::mpsc::sync_channel(1);
             std::thread::spawn(move || {
+                // Per-file lock: serialize concurrent reads of the same path so
+                // only one thread does I/O while the others wait on a cheap
+                // std::sync::Mutex, reducing contention on the global cache lock.
+                let file_lock = per_file_lock(&path_owned);
+                let _file_guard = file_lock.lock().unwrap();
                 let task_ref = task_owned.as_deref();
                 let mut cache = cache_lock.blocking_write();
                 let read_output = if fresh {
@@ -312,5 +337,80 @@ fn auto_degrade_read_mode(mode: &str) -> String {
             other => other.to_string(),
         },
         DegradationVerdictV1::Block => "signatures".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn per_file_lock_same_path_returns_same_mutex() {
+        let lock_a1 = per_file_lock("/tmp/test_same_path.txt");
+        let lock_a2 = per_file_lock("/tmp/test_same_path.txt");
+        assert!(Arc::ptr_eq(&lock_a1, &lock_a2));
+    }
+
+    #[test]
+    fn per_file_lock_different_paths_return_different_mutexes() {
+        let lock_a = per_file_lock("/tmp/test_path_a.txt");
+        let lock_b = per_file_lock("/tmp/test_path_b.txt");
+        assert!(!Arc::ptr_eq(&lock_a, &lock_b));
+    }
+
+    #[test]
+    fn per_file_lock_serializes_concurrent_access() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+        let path = "/tmp/test_concurrent_serialization.txt";
+        let mut handles = Vec::new();
+
+        for _ in 0..5 {
+            let counter = counter.clone();
+            let max_concurrent = max_concurrent.clone();
+            let path = path.to_string();
+            handles.push(std::thread::spawn(move || {
+                let lock = per_file_lock(&path);
+                let _guard = lock.lock().unwrap();
+                let active = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                max_concurrent.fetch_max(active, Ordering::SeqCst);
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                counter.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(max_concurrent.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn per_file_lock_allows_parallel_different_paths() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+
+        for i in 0..4 {
+            let counter = counter.clone();
+            let max_concurrent = max_concurrent.clone();
+            let path = format!("/tmp/test_parallel_{i}.txt");
+            handles.push(std::thread::spawn(move || {
+                let lock = per_file_lock(&path);
+                let _guard = lock.lock().unwrap();
+                let active = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                max_concurrent.fetch_max(active, Ordering::SeqCst);
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                counter.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(max_concurrent.load(Ordering::SeqCst) > 1);
     }
 }


### PR DESCRIPTION
## Summary

Add per-file mutex to `ctx_read` that serializes concurrent reads of the same path, preventing global cache lock contention that causes deadlocks with multiple concurrent subagents. Also make worker thread count configurable via `LEAN_CTX_WORKER_THREADS`.

Fixes #226

## What changed

**`rust/src/tools/registered/ctx_read.rs`**
- Per-file `std::sync::Mutex` acquired inside the spawned timeout-guard thread, before `cache_lock.blocking_write()`
- Only one thread at a time contends on the global cache lock per file path
- Threads reading different files proceed independently without contention

**`rust/src/cli/dispatch.rs`**
- `LEAN_CTX_WORKER_THREADS` env var overrides the default `clamp(1,4)` worker thread count
- Defaults unchanged — env var is opt-in for operators with many concurrent subagents

**`rust/LOCK_ORDERING.md`**
- L17 entry documenting the per-file lock, acquisition order, and worker thread tuning

## Before / after

5 concurrent Claude Code review agents reading 20 shared files (~40KB each, 816KB total):

| | Before | After |
|---|---|---|
| Agents completing | 0-3 of 5 | 5 of 5 |
| Stall point | `shared_prefix_7.md` (convergence) | No stalls |
| Recovery | Session must be killed | N/A |

## Test plan

```bash
cargo fmt --check        # pass
cargo clippy --all-targets --all-features -- -D warnings  # pass
cargo test --all-features  # 2085 pass (8 pre-existing failures, unchanged)
```

- 4 new unit tests for `per_file_lock` (same-path identity, different-path isolation, serialization, parallel independence)
- 5 new unit tests for `resolve_worker_threads` (clamp bounds, env override, invalid fallback)
- End-to-end: 5 concurrent review agents × 20 files — all complete successfully
