### PR TITLE
Fix ctx_shell to show compression savings and improve shell command handling

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -278,7 +278,7 @@ function isMcpAdapterConfigured(): boolean {
 
 async function execLeanCtx(pi: ExtensionAPI, args: string[]) {
   const bin = resolveBinary();
-  const result = await pi.exec(bin, args, { env: { ...process.env, LEAN_CTX_COMPRESS: "1" } });
+  const result = await pi.exec(bin, args, { env: { ...process.env, LEAN_CTX_COMPRESS: "1", LEAN_CTX_SAVINGS_FOOTER: "always" } });
   if (result.code !== 0) {
     const msg = (result.stderr || result.stdout || `lean-ctx failed: ${args.join(" ")}`).trim();
     throw new Error(msg);
@@ -298,9 +298,9 @@ export default async function (pi: ExtensionAPI) {
     spawnHook: ({ command, cwd, env }) => {
       const bin = resolveBinary();
       return {
-        command: `${shellQuote(bin)} -c sh -lc ${shellQuote(command)}`,
+        command: `${shellQuote(bin)} -c ${shellQuote(command)}`,
         cwd,
-        env: { ...env, LEAN_CTX_COMPRESS: "1" },
+        env: { ...env, LEAN_CTX_COMPRESS: "1", LEAN_CTX_SAVINGS_FOOTER: "always" },
       };
     },
   });
@@ -535,7 +535,7 @@ export default async function (pi: ExtensionAPI) {
       searchArgs.push(params.pattern, absolutePath);
 
       const bin = resolveBinary();
-      const result = await pi.exec(bin, ["-c", ...searchArgs], { env: { ...process.env, LEAN_CTX_COMPRESS: "1" } });
+      const result = await pi.exec(bin, ["-c", ...searchArgs], { env: { ...process.env, LEAN_CTX_COMPRESS: "1", LEAN_CTX_SAVINGS_FOOTER: "always" } });
       if (result.code >= 2) {
         const msg = (result.stderr || result.stdout || `lean-ctx grep failed: ${params.pattern}`).trim();
         throw new Error(msg);


### PR DESCRIPTION
 Changes:

 1. Add compression savings footer (LEAN_CTX_SAVINGS_FOOTER=always)
     - Added to all exec and spawn hooks in packages/pi-lean-ctx/extensions/index.ts
     - Ensures users see token savings metrics after compressed commands
 2. Simplify shell command quoting
     - Removed redundant `sh -lc` wrapper from spawn hook command generation
     - Reduces unnecessary shell nesting and improves command clarity

 Why:
 - Users lacked visibility into actual token savings from compression. With the footer not showing, the `formatFooter()` method would fail to calculate the savings.
 - The `sh -lc` wrapper was causing the internal compression-engine to not pick up the best compression automatically. (Like `git blame` and `git status` for example). 

NOTE: This change bypasses the additional shell-login step, and relies purely on `lean-ctx -c` for executing shell commands. Personally I find this more lean and clean. (And this is also how other applications would expect to work)