### PR TITLE
feat: autoupdate example (macOS/Linux/Windows)

### DIFF
--- a/cookbook/examples/autoupdate/README.md
+++ b/cookbook/examples/autoupdate/README.md
@@ -1,0 +1,55 @@
+# autoupdate
+
+Background auto-updater for lean-ctx. Checks GitHub for a new release every 6 hours and runs `lean-ctx update` only when one is found — avoiding unnecessary daemon restarts.
+
+| Platform | Script | Scheduler |
+|---|---|---|
+| macOS | `autoupdate.sh` | LaunchAgent (every 6 h) |
+| Linux | `autoupdate.sh` | cron `0 */6 * * *` |
+| Windows | `autoupdate.ps1` | Task Scheduler (every 6 h) |
+
+## macOS install
+
+```bash
+cp autoupdate.sh ~/.lean-ctx/autoupdate.sh
+chmod +x ~/.lean-ctx/autoupdate.sh
+
+# generate plist with your actual paths and register it
+SCRIPT="$HOME/.lean-ctx/autoupdate.sh"
+PLIST="$HOME/Library/LaunchAgents/com.leactx.autoupdate.plist"
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.leactx.autoupdate</string>
+  <key>ProgramArguments</key>
+  <array><string>/bin/bash</string><string>$SCRIPT</string></array>
+  <key>StartInterval</key><integer>21600</integer>
+  <key>RunAtLoad</key><false/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key><string>$HOME</string>
+  </dict>
+  <key>StandardOutPath</key><string>$HOME/.lean-ctx/autoupdate-stdout.log</string>
+  <key>StandardErrorPath</key><string>$HOME/.lean-ctx/autoupdate-stderr.log</string>
+</dict></plist>
+EOF
+launchctl load "$PLIST"
+```
+
+## Linux install
+
+```bash
+cp autoupdate.sh ~/.lean-ctx/autoupdate.sh
+chmod +x ~/.lean-ctx/autoupdate.sh
+(crontab -l 2>/dev/null; echo "0 */6 * * * bash $HOME/.lean-ctx/autoupdate.sh") | crontab -
+```
+
+## Windows install
+
+Copy `autoupdate.ps1` to `$env:USERPROFILE\.lean-ctx\autoupdate.ps1`, then run the install block at the top of the file in an elevated PowerShell session.
+
+## Logs
+
+`~/.lean-ctx/autoupdate.log` (auto-rotated at 500 lines)

--- a/cookbook/examples/autoupdate/autoupdate.ps1
+++ b/cookbook/examples/autoupdate/autoupdate.ps1
@@ -1,0 +1,37 @@
+# lean-ctx auto-updater — Windows (PowerShell)
+# Checks GitHub API first; only calls `lean-ctx update` when a newer version exists.
+#
+# Install (run once as Admin):
+#   $s = "$env:USERPROFILE\.lean-ctx\autoupdate.ps1"
+#   $a = New-ScheduledTaskAction -Execute "pwsh" -Argument "-NonInteractive -WindowStyle Hidden -File `"$s`""
+#   $t = New-ScheduledTaskTrigger -RepetitionInterval (New-TimeSpan -Hours 6) -Once -At (Get-Date)
+#   Register-ScheduledTask -TaskName "lean-ctx autoupdate" -Action $a -Trigger $t -RunLevel Highest -Force
+
+$lc = (Get-Command lean-ctx -ErrorAction SilentlyContinue)?.Source
+if (-not $lc) { Write-Error "lean-ctx not in PATH"; exit 1 }
+
+$log = "$env:USERPROFILE\.lean-ctx\autoupdate.log"
+function Log($msg) { "$(Get-Date -f 'yyyy-MM-dd HH:mm:ss') $msg" | Add-Content $log }
+function Notify($msg) {
+    Add-Type -AssemblyName System.Windows.Forms
+    $n = [System.Windows.Forms.NotifyIcon]::new()
+    $n.Icon = [System.Drawing.SystemIcons]::Information
+    $n.Visible = $true
+    $n.ShowBalloonTip(5000, "lean-ctx", $msg, [System.Windows.Forms.ToolTipIcon]::Info)
+    Start-Sleep 3; $n.Dispose()
+}
+function GetVersion { (& $lc status --json | ConvertFrom-Json).version }
+
+$current = GetVersion
+$latest  = (Invoke-RestMethod "https://api.github.com/repos/yvgude/lean-ctx/releases/latest").tag_name.TrimStart('v')
+
+if (-not $current -or -not $latest) { Log "WARN: version check failed"; exit 0 }
+Log "current=v$current latest=v$latest"
+if ($current -eq $latest) { exit 0 }
+
+Log "Updating v$current → v$latest"
+& $lc update 2>&1 | Add-Content $log
+
+$new = GetVersion
+Notify "v$current → v$new · Restart IDE to reconnect MCP"
+Log "Done: v$new"

--- a/cookbook/examples/autoupdate/autoupdate.sh
+++ b/cookbook/examples/autoupdate/autoupdate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# lean-ctx auto-updater — macOS / Linux
+# Checks GitHub API first; only calls `lean-ctx update` when a newer
+# version exists, avoiding unnecessary daemon restarts.
+#
+# Install (macOS): see install-macos.sh
+# Install (Linux): add to crontab — `0 */6 * * * bash ~/.lean-ctx/autoupdate.sh`
+
+LEAN_CTX=$(command -v lean-ctx 2>/dev/null) || { echo "lean-ctx not in PATH"; exit 1; }
+LOG="$HOME/.lean-ctx/autoupdate.log"
+API="https://api.github.com/repos/yvgude/lean-ctx/releases/latest"
+
+log()    { printf '[%s] %s\n' "$(date '+%F %T')" "$1" >> "$LOG"; }
+notify() {
+    case "$(uname)" in
+        Darwin) osascript -e "display notification \"$1\" with title \"lean-ctx\" sound name \"Glass\"" 2>/dev/null ;;
+        Linux)  command -v notify-send &>/dev/null && notify-send "lean-ctx" "$1" ;;
+    esac
+}
+ver() { "$LEAN_CTX" status --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])" 2>/dev/null; }
+
+# Rotate log at 500 lines
+[[ -f "$LOG" ]] && (( $(wc -l < "$LOG") > 500 )) && tail -500 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+
+CURRENT=$(ver)
+LATEST=$(curl -sf --max-time 10 "$API" | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))" 2>/dev/null)
+
+[[ -z "$CURRENT" || -z "$LATEST" ]] && { log "WARN: version check failed (current='$CURRENT' latest='$LATEST')"; exit 0; }
+log "current=v$CURRENT latest=v$LATEST"
+[[ "$CURRENT" == "$LATEST" ]] && exit 0
+
+log "Updating v$CURRENT → v$LATEST"
+"$LEAN_CTX" update >> "$LOG" 2>&1 || { log "ERROR: lean-ctx update failed"; notify "Update failed — check $LOG"; exit 1; }
+
+NEW=$(ver)
+SAVINGS=$("$LEAN_CTX" stats 2>/dev/null | grep -oE 'Saved:.*' | head -1)
+notify "v$CURRENT → v$NEW${SAVINGS:+ · $SAVINGS} · Restart IDE to reconnect MCP"
+log "Done: v$NEW${SAVINGS:+ · $SAVINGS}"


### PR DESCRIPTION
Closes #233

Adds `cookbook/examples/autoupdate/` with:

- `autoupdate.sh` — macOS + Linux (LaunchAgent / cron)
- `autoupdate.ps1` — Windows (Task Scheduler)
- `README.md` — install instructions for each platform

**Design:** hits GitHub API first, calls `lean-ctx update` only when a newer version exists — no daemon restart when already current.