### PR TITLE
fix: respect CLAUDE_CONFIG_DIR in MCP instructions path reference

### DIFF
--- a/rust/src/core/instruction_compiler.rs
+++ b/rust/src/core/instruction_compiler.rs
@@ -74,8 +74,9 @@ pub fn compile(
 
     let mut rules_files = Vec::new();
     if opts.include_rules_files && client_id == "claude-code" {
+        let config_dir = crate::instructions::claude_config_dir_display();
         rules_files.push(CompiledRuleFile {
-            path: "~/.claude/rules/lean-ctx.md".to_string(),
+            path: format!("{config_dir}/rules/lean-ctx.md"),
             content: crate::rules_inject::rules_dedicated_markdown().to_string(),
         });
     }

--- a/rust/src/instructions.rs
+++ b/rust/src/instructions.rs
@@ -1,7 +1,8 @@
 use crate::tools::CrpMode;
 
 /// Claude Code truncates MCP server instructions at 2048 characters.
-/// Full instructions are installed as `~/.claude/rules/lean-ctx.md` instead.
+/// Full instructions are installed as `$CLAUDE_CONFIG_DIR/rules/lean-ctx.md`
+/// (defaulting to `~/.claude/rules/lean-ctx.md`) instead.
 const CLAUDE_CODE_INSTRUCTION_CAP: usize = 2048;
 
 /// Universal instruction cap for all MCP clients.
@@ -52,8 +53,30 @@ fn is_claude_code_client(client_name: &str) -> bool {
     lower.contains("claude") && !lower.contains("cursor")
 }
 
+pub fn claude_config_dir_display() -> String {
+    match std::env::var("CLAUDE_CONFIG_DIR") {
+        Ok(dir) if !dir.trim().is_empty() => {
+            let dir = dir.trim().to_string();
+            if dir.starts_with('~') {
+                dir
+            } else if let Some(home) = dirs::home_dir() {
+                let home_str = home.to_string_lossy();
+                if let Some(rest) = dir.strip_prefix(home_str.as_ref()) {
+                    format!("~{rest}")
+                } else {
+                    dir
+                }
+            } else {
+                dir
+            }
+        }
+        _ => "~/.claude".to_string(),
+    }
+}
+
 fn build_claude_code_instructions() -> String {
     let shell_hint = build_shell_hint();
+    let config_dir = claude_config_dir_display();
     let instr = format!("\
 ALWAYS use lean-ctx MCP tools instead of native equivalents.
 
@@ -80,7 +103,7 @@ CEP: 1.ACT FIRST 2.DELTA ONLY 3.STRUCTURED(+/-/~) 4.ONE LINE 5.QUALITY
 Prefer: ctx_read>Read | ctx_shell>Shell | ctx_search>Grep | ctx_tree>ls
 Edit: native Edit/StrReplace preferred, ctx_edit if Edit unavailable.
 Never echo tool output. Never narrate. Show only changed code.
-Full instructions at ~/.claude/CLAUDE.md (imports rules/lean-ctx.md)");
+Full instructions at {config_dir}/CLAUDE.md (imports rules/lean-ctx.md)");
 
     if shell_hint.is_empty() {
         debug_assert!(

--- a/rust/tests/claude_config_dir.rs
+++ b/rust/tests/claude_config_dir.rs
@@ -1,0 +1,80 @@
+//! Tests for CLAUDE_CONFIG_DIR support in instructions and compiler output.
+//!
+//! These tests modify process-global env vars, so they run with `--test-threads=1`
+//! via `#[serial_test::serial]` or should be run in isolation.
+
+#[test]
+fn claude_code_instructions_default_path() {
+    // Ensure CLAUDE_CONFIG_DIR is unset so we get the default.
+    let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
+    unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") };
+
+    let instr = lean_ctx::instructions::claude_code_instructions();
+    assert!(
+        instr.contains("Full instructions at ~/.claude/CLAUDE.md"),
+        "Default instructions should reference ~/.claude/CLAUDE.md, got:\n{instr}"
+    );
+
+    // Restore.
+    if let Some(v) = prev {
+        unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", v) };
+    }
+}
+
+#[test]
+fn claude_code_instructions_custom_config_dir() {
+    let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
+    unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", "~/.arc/claude") };
+
+    let instr = lean_ctx::instructions::claude_code_instructions();
+    assert!(
+        instr.contains("Full instructions at ~/.arc/claude/CLAUDE.md"),
+        "Custom CLAUDE_CONFIG_DIR should appear in instructions, got:\n{instr}"
+    );
+    assert!(
+        !instr.contains("Full instructions at ~/.claude/CLAUDE.md"),
+        "Default path should NOT appear when CLAUDE_CONFIG_DIR is set"
+    );
+
+    // Restore.
+    match prev {
+        Some(v) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", v) },
+        None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+    }
+}
+
+#[test]
+fn claude_config_dir_display_resolves_home() {
+    let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
+
+    let home = dirs::home_dir().expect("need home dir for test");
+    let custom = format!("{}/.arc/claude", home.display());
+    unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", &custom) };
+
+    let display = lean_ctx::instructions::claude_config_dir_display();
+    assert_eq!(
+        display, "~/.arc/claude",
+        "Absolute path under $HOME should be collapsed to tilde form"
+    );
+
+    // Restore.
+    match prev {
+        Some(v) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", v) },
+        None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+    }
+}
+
+#[test]
+fn claude_config_dir_display_tilde_passthrough() {
+    let prev = std::env::var("CLAUDE_CONFIG_DIR").ok();
+    unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", "~/.custom/claude") };
+
+    let display = lean_ctx::instructions::claude_config_dir_display();
+    assert_eq!(display, "~/.custom/claude");
+
+    // Restore.
+    match prev {
+        Some(v) => unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", v) },
+        None => unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") },
+    }
+}


### PR DESCRIPTION
## Summary

- Resolve the config directory display path from `CLAUDE_CONFIG_DIR` env var when set, falling back to `~/.claude` otherwise
- Fix hardcoded `~/.claude` path in `build_claude_code_instructions()` (instructions.rs) and in the instruction compiler's rules file metadata (instruction_compiler.rs)
- Add `claude_config_dir_display()` helper that collapses absolute paths under `$HOME` to tilde form for display

## Context

Claude Code supports `CLAUDE_CONFIG_DIR` to relocate its config directory. Wrapper tools like [ARC](https://github.com/actualyze-ai/arc) use this to isolate sessions under `~/.arc/claude/`. The MCP instructions previously always referenced `~/.claude/CLAUDE.md`, which doesn't exist when the config dir is relocated.

The doctor integration checks (`integration_claude` in integrations.rs) already correctly use `claude_rules_dir(home)` which respects the env var — this fix brings the instruction output into alignment.

Fixes #235

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — no new failures (pre-existing flaky tests in http_server/process_guard/dashboard unchanged)
- [x] `cargo test --release --test claude_config_dir -- --test-threads=1` — 4/4 pass
- [x] New integration test `claude_config_dir.rs` covers:
  - Default path (`~/.claude`) when `CLAUDE_CONFIG_DIR` unset
  - Custom path appears in instructions when `CLAUDE_CONFIG_DIR` set
  - Absolute `$HOME/...` paths collapsed to `~/...` tilde form
  - Tilde-prefixed paths passed through unchanged
- [x] Verified instructions stay within 2048-char Claude Code cap with `CLAUDE_CONFIG_DIR=~/.arc/claude`
