### PR TITLE
feat(augment): full first-class support for the Augment AI coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ lean-ctx is a standard **MCP server**, so it works with any MCP-compatible clien
 |---|:---:|:---:|---|
 | Cursor | ● | | `lean-ctx init --agent cursor` |
 | Claude Code | ● | | `lean-ctx init --agent claude` |
+| Augment CLI | ● | | `lean-ctx init --agent augment` |
 | Codex CLI | ● | | `lean-ctx init --agent codex` |
 | Gemini CLI | ● | | `lean-ctx init --agent gemini` |
 | Windsurf | ● | | `lean-ctx init --agent windsurf` |

--- a/rust/src/cli/init_cmd.rs
+++ b/rust/src/cli/init_cmd.rs
@@ -166,10 +166,10 @@ pub fn cmd_init(args: &[String]) {
     }
     qprintln!();
     qprintln!("For AI tool integration: lean-ctx init --agent <tool> [--mode <mode>]");
-    qprintln!("  Supported: aider, amazonq, amp, antigravity, claude, cline, codex,");
-    qprintln!("    continue, copilot, crush, cursor, emacs, gemini, hermes, jetbrains,");
-    qprintln!("    kiro, neovim, opencode, pi, qoder, qoderwork, qwen, roo, sublime,");
-    qprintln!("    trae, verdent, vscode, windsurf, zed");
+    qprintln!("  Supported: aider, amazonq, amp, antigravity, augment, claude, cline,");
+    qprintln!("    codex, continue, copilot, crush, cursor, emacs, gemini, hermes,");
+    qprintln!("    jetbrains, kiro, neovim, opencode, pi, qoder, qoderwork, qwen, roo,");
+    qprintln!("    sublime, trae, verdent, vscode, windsurf, zed");
     qprintln!("  Modes: mcp, hybrid  (auto-detected per agent, override with --mode)");
 }
 

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use super::paths::{
-    claude_mcp_json_path, cline_mcp_path, qoder_all_mcp_paths, qoderwork_mcp_path, roo_mcp_path,
-    vscode_mcp_path, zed_config_dir, zed_settings_path,
+    augment_cli_settings_path, claude_mcp_json_path, cline_mcp_path, qoder_all_mcp_paths,
+    qoderwork_mcp_path, roo_mcp_path, vscode_mcp_path, zed_config_dir, zed_settings_path,
 };
 use super::types::{ConfigType, EditorTarget};
 
@@ -39,6 +39,13 @@ pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
             agent_key: "claude".to_string(),
             config_path: claude_mcp_json_path(home),
             detect_path: detect_claude_path(),
+            config_type: ConfigType::McpJson,
+        },
+        EditorTarget {
+            name: "Augment CLI",
+            agent_key: "augment".to_string(),
+            config_path: augment_cli_settings_path(home),
+            detect_path: detect_augment_path(home),
             config_type: ConfigType::McpJson,
         },
         EditorTarget {
@@ -343,6 +350,20 @@ pub fn detect_claude_path() -> PathBuf {
     PathBuf::from("/nonexistent")
 }
 
+pub fn detect_augment_path(home: &Path) -> PathBuf {
+    let which_cmd = if cfg!(windows) { "where" } else { "which" };
+    if let Ok(output) = std::process::Command::new(which_cmd).arg("auggie").output() {
+        if output.status.success() {
+            return PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        }
+    }
+    let augment_dir = home.join(".augment");
+    if augment_dir.exists() {
+        return augment_dir;
+    }
+    PathBuf::from("/nonexistent")
+}
+
 pub fn detect_codex_path(home: &Path) -> PathBuf {
     let codex_dir = crate::core::home::resolve_codex_dir().unwrap_or_else(|| home.join(".codex"));
     if codex_dir.exists() {
@@ -497,6 +518,76 @@ pub fn detect_roo_path() -> PathBuf {
         }
     }
     PathBuf::from("/nonexistent")
+}
+
+#[cfg(test)]
+mod augment_tests {
+    use super::*;
+    use crate::core::editor_registry::writers::{
+        remove_lean_ctx_server, write_config_with_options, WriteAction, WriteOptions,
+    };
+
+    #[test]
+    fn build_targets_includes_augment_cli_entry() {
+        let home = Path::new("/home/tester");
+        let target = build_targets(home)
+            .into_iter()
+            .find(|t| t.agent_key == "augment")
+            .expect("augment target should be registered");
+        assert_eq!(target.name, "Augment CLI");
+        assert_eq!(target.config_path, home.join(".augment/settings.json"));
+        assert!(matches!(target.config_type, ConfigType::McpJson));
+    }
+
+    // Writer-layer round-trip: verifies the McpJson writer preserves unrelated
+    // entries when invoked against the Augment settings.json path. This does NOT
+    // exercise the `--agent augment` CLI flow or the setup.rs match arms — those
+    // are covered by the subprocess test in tests/setup_ci_smoke.rs.
+    #[test]
+    fn mcp_json_writer_round_trip_at_augment_settings_path_preserves_other_servers() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = tmp.path().join(".augment").join("settings.json");
+        std::fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        std::fs::write(
+            &cfg,
+            r#"{ "mcpServers": { "other": { "command": "other-bin", "args": [] } } }"#,
+        )
+        .unwrap();
+
+        let target = EditorTarget {
+            name: "Augment CLI",
+            agent_key: "augment".to_string(),
+            config_path: cfg.clone(),
+            detect_path: PathBuf::from("/nonexistent"),
+            config_type: ConfigType::McpJson,
+        };
+
+        let install = write_config_with_options(
+            &target,
+            "/usr/local/bin/lean-ctx",
+            WriteOptions::default(),
+        )
+        .expect("install");
+        assert!(matches!(
+            install.action,
+            WriteAction::Created | WriteAction::Updated
+        ));
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(json["mcpServers"]["other"]["command"], "other-bin");
+        assert_eq!(
+            json["mcpServers"]["lean-ctx"]["command"],
+            "/usr/local/bin/lean-ctx"
+        );
+
+        let uninstall =
+            remove_lean_ctx_server(&target, WriteOptions::default()).expect("uninstall");
+        assert!(matches!(uninstall.action, WriteAction::Updated));
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&cfg).unwrap()).unwrap();
+        assert!(json["mcpServers"].get("lean-ctx").is_none());
+        assert_eq!(json["mcpServers"]["other"]["command"], "other-bin");
+    }
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -169,6 +169,77 @@ pub fn claude_rules_dir(home: &Path) -> PathBuf {
     claude_state_dir(home).join("rules")
 }
 
+pub fn augment_cli_settings_path(home: &Path) -> PathBuf {
+    home.join(".augment/settings.json")
+}
+
+/// MCP server list for the Augment VS Code extension.
+///
+/// The extension persists registered MCP servers as a top-level JSON array in
+/// its globalStorage directory. Confirmed empirically against
+/// `augment.vscode-augment` build shipped on 2026-05-21 (see PR description).
+///
+/// On Windows the User dir lives under `%APPDATA%/Code` rather than the
+/// user's home, so we honour that when the env var is set; we fall back to
+/// the home-relative path for tests and unusual setups.
+pub fn augment_vscode_mcp_path(home: &Path) -> PathBuf {
+    const TAIL: &str =
+        "globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json";
+
+    #[cfg(target_os = "macos")]
+    {
+        return home
+            .join("Library/Application Support/Code/User")
+            .join(TAIL);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return home.join(".config/Code/User").join(TAIL);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            return PathBuf::from(appdata).join("Code/User").join(TAIL);
+        }
+    }
+    #[allow(unreachable_code)]
+    home.join(".config/Code/User").join(TAIL)
+}
+
+#[cfg(test)]
+mod augment_tests {
+    use super::*;
+
+    #[test]
+    fn augment_cli_settings_path_is_under_dot_augment() {
+        let home = Path::new("/home/tester");
+        assert_eq!(
+            augment_cli_settings_path(home),
+            home.join(".augment").join("settings.json")
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn augment_vscode_mcp_path_uses_linux_globalstorage() {
+        let home = Path::new("/home/tester");
+        assert_eq!(
+            augment_vscode_mcp_path(home),
+            home.join(".config/Code/User/globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn augment_vscode_mcp_path_uses_macos_application_support() {
+        let home = Path::new("/Users/tester");
+        assert_eq!(
+            augment_vscode_mcp_path(home),
+            home.join("Library/Application Support/Code/User/globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
+        );
+    }
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;

--- a/rust/src/core/editor_registry/types.rs
+++ b/rust/src/core/editor_registry/types.rs
@@ -23,4 +23,8 @@ pub enum ConfigType {
     HermesYaml,
     GeminiSettings,
     QoderSettings,
+    /// Augment VS Code extension: top-level JSON array of server entries
+    /// stored under augment.vscode-augment globalStorage. Each entry carries
+    /// `type`, `id`, `name`, `disabled`, `command`, `args`, `env`.
+    AugmentVsCode,
 }

--- a/rust/src/core/editor_registry/writers.rs
+++ b/rust/src/core/editor_registry/writers.rs
@@ -54,6 +54,7 @@ pub fn write_config_with_options(
         ConfigType::HermesYaml => write_hermes_yaml(target, binary, opts),
         ConfigType::GeminiSettings => write_gemini_settings(target, binary, opts),
         ConfigType::QoderSettings => write_qoder_settings(target, binary, opts),
+        ConfigType::AugmentVsCode => write_augment_vscode(target, binary, opts),
     }
 }
 
@@ -136,6 +137,9 @@ pub fn remove_lean_ctx_server(
         }
         ConfigType::Amp => remove_lean_ctx_amp_server(&target.config_path, opts),
         ConfigType::HermesYaml => remove_lean_ctx_hermes_yaml_server(&target.config_path),
+        ConfigType::AugmentVsCode => {
+            remove_lean_ctx_augment_vscode_server(&target.config_path, opts)
+        }
     }
 }
 
@@ -1612,6 +1616,161 @@ fn write_qoder_settings(
     write_mcp_json_fresh(&target.config_path, &desired, None)
 }
 
+// ---------------------------------------------------------------------------
+// Augment VS Code extension writer
+//
+// `augment.vscode-augment` persists registered MCP servers as a top-level JSON
+// array under its globalStorage directory. The extension keys entries by the
+// `id` field (a UUID), and we need that id to stay stable so repeated
+// `init --agent augment` calls don't litter the list with duplicates.
+//
+// Schema (validated empirically 2026-05-21):
+//   { type, id, name, disabled, command, args, env, useShellInterpolation }
+// ---------------------------------------------------------------------------
+
+/// Fixed UUIDv4-shaped id reserved for lean-ctx in Augment's VS Code MCP list.
+/// Last 12 hex chars spell "leanctx" (6c=l, 65=e, 61=a, 6e=n, 63=c, 74=t, 78=x
+/// minus a char to keep the segment 12 long). The exact value never matters
+/// semantically — only stability matters for idempotent upserts.
+const LEAN_CTX_AUGMENT_VSCODE_ID: &str = "6c65616e-c747-4000-8000-6c65616e6374";
+
+fn lean_ctx_augment_vscode_entry(binary: &str, data_dir: &str) -> Value {
+    serde_json::json!({
+        "type": "stdio",
+        "id": LEAN_CTX_AUGMENT_VSCODE_ID,
+        "name": "lean-ctx",
+        "disabled": false,
+        "command": binary,
+        "args": [],
+        "useShellInterpolation": false,
+        "env": {
+            "LEAN_CTX_DATA_DIR": data_dir
+        }
+    })
+}
+
+fn write_augment_vscode(
+    target: &EditorTarget,
+    binary: &str,
+    opts: WriteOptions,
+) -> Result<WriteResult, String> {
+    let data_dir = default_data_dir()?;
+    let desired = lean_ctx_augment_vscode_entry(binary, &data_dir);
+
+    if !target.config_path.exists() {
+        let arr = serde_json::Value::Array(vec![desired]);
+        let content = serde_json::to_string_pretty(&arr).map_err(|e| e.to_string())?;
+        crate::config_io::write_atomic_with_backup(&target.config_path, &content)?;
+        return Ok(WriteResult {
+            action: WriteAction::Created,
+            note: None,
+        });
+    }
+
+    let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
+    let mut json: Value = match crate::core::jsonc::parse_jsonc(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            if !opts.overwrite_invalid {
+                return Err(e.to_string());
+            }
+            eprintln!(
+                "\x1b[33m⚠\x1b[0m  {} has JSON syntax errors — replacing with a clean array.",
+                target.config_path.display()
+            );
+            backup_invalid_file(&target.config_path)?;
+            let arr = serde_json::Value::Array(vec![desired]);
+            let content = serde_json::to_string_pretty(&arr).map_err(|e| e.to_string())?;
+            crate::config_io::write_atomic_with_backup(&target.config_path, &content)?;
+            return Ok(WriteResult {
+                action: WriteAction::Updated,
+                note: Some("replaced invalid JSON with clean array".to_string()),
+            });
+        }
+    };
+
+    let arr = json.as_array_mut().ok_or_else(|| {
+        "augment vscode mcpServers.json must contain a top-level JSON array".to_string()
+    })?;
+
+    if let Some(existing) = arr.iter_mut().find(|entry| {
+        entry.get("name").and_then(|n| n.as_str()) == Some("lean-ctx")
+            || entry.get("id").and_then(|i| i.as_str()) == Some(LEAN_CTX_AUGMENT_VSCODE_ID)
+    }) {
+        if *existing == desired {
+            return Ok(WriteResult {
+                action: WriteAction::Already,
+                note: None,
+            });
+        }
+        *existing = desired;
+    } else {
+        arr.push(desired);
+    }
+
+    let formatted = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+    crate::config_io::write_atomic_with_backup(&target.config_path, &formatted)?;
+    Ok(WriteResult {
+        action: WriteAction::Updated,
+        note: None,
+    })
+}
+
+fn remove_lean_ctx_augment_vscode_server(
+    path: &std::path::Path,
+    opts: WriteOptions,
+) -> Result<WriteResult, String> {
+    if !path.exists() {
+        return Ok(WriteResult {
+            action: WriteAction::Already,
+            note: Some("augment vscode mcpServers.json not found".to_string()),
+        });
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let mut json: Value = match crate::core::jsonc::parse_jsonc(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            if !opts.overwrite_invalid {
+                return Err(e.to_string());
+            }
+            eprintln!(
+                "\x1b[33m⚠\x1b[0m  {} has JSON syntax errors — skipping removal.",
+                path.display()
+            );
+            return Ok(WriteResult {
+                action: WriteAction::Already,
+                note: Some("invalid JSON — cannot safely remove lean-ctx entry".to_string()),
+            });
+        }
+    };
+
+    let arr = json
+        .as_array_mut()
+        .ok_or_else(|| "augment vscode mcpServers.json must be a JSON array".to_string())?;
+
+    let before = arr.len();
+    arr.retain(|entry| {
+        let name_match = entry.get("name").and_then(|n| n.as_str()) == Some("lean-ctx");
+        let id_match =
+            entry.get("id").and_then(|i| i.as_str()) == Some(LEAN_CTX_AUGMENT_VSCODE_ID);
+        !(name_match || id_match)
+    });
+    if arr.len() == before {
+        return Ok(WriteResult {
+            action: WriteAction::Already,
+            note: Some("lean-ctx not configured".to_string()),
+        });
+    }
+
+    let formatted = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+    crate::config_io::write_atomic_with_backup(path, &formatted)?;
+    Ok(WriteResult {
+        action: WriteAction::Updated,
+        note: Some("removed lean-ctx from augment vscode mcp list".to_string()),
+    })
+}
+
 fn backup_invalid_file(path: &std::path::Path) -> Result<std::path::PathBuf, String> {
     if !path.exists() {
         return Ok(path.to_path_buf());
@@ -2314,5 +2473,106 @@ command = \"probe\"
             final_content.contains("BROKEN"),
             "original content preserved"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Augment VS Code extension (top-level JSON array) writer/remover tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn augment_vscode_creates_array_with_lean_ctx_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcpServers.json");
+        let t = target("Augment (VS Code)", path.clone(), ConfigType::AugmentVsCode);
+
+        let res = write_config_with_options(&t, "lean-ctx", WriteOptions::default()).unwrap();
+        assert_eq!(res.action, WriteAction::Created);
+
+        let arr: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entries = arr.as_array().expect("top-level must be array");
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e["name"], "lean-ctx");
+        assert_eq!(e["type"], "stdio");
+        assert_eq!(e["command"], "lean-ctx");
+        assert_eq!(e["disabled"], false);
+        assert_eq!(e["useShellInterpolation"], false);
+        assert!(e["id"].as_str().is_some());
+        assert!(e["env"]["LEAN_CTX_DATA_DIR"].as_str().is_some());
+    }
+
+    #[test]
+    fn augment_vscode_preserves_existing_entries_and_upserts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcpServers.json");
+        std::fs::write(
+            &path,
+            r#"[{"type":"stdio","id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","name":"github","disabled":false,"command":"gh-mcp","args":[],"env":{}}]"#,
+        )
+        .unwrap();
+
+        let t = target("Augment (VS Code)", path.clone(), ConfigType::AugmentVsCode);
+        let res = write_config_with_options(&t, "lean-ctx", WriteOptions::default()).unwrap();
+        assert_eq!(res.action, WriteAction::Updated);
+
+        let arr: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entries = arr.as_array().unwrap();
+        assert_eq!(entries.len(), 2, "github entry must be preserved");
+        assert!(entries.iter().any(|e| e["name"] == "github"));
+        assert!(entries.iter().any(|e| e["name"] == "lean-ctx"));
+    }
+
+    #[test]
+    fn augment_vscode_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcpServers.json");
+        let t = target("Augment (VS Code)", path.clone(), ConfigType::AugmentVsCode);
+
+        let first = write_config_with_options(&t, "lean-ctx", WriteOptions::default()).unwrap();
+        let second = write_config_with_options(&t, "lean-ctx", WriteOptions::default()).unwrap();
+        assert_eq!(first.action, WriteAction::Created);
+        assert_eq!(second.action, WriteAction::Already);
+
+        let arr: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entries = arr.as_array().unwrap();
+        assert_eq!(
+            entries.iter().filter(|e| e["name"] == "lean-ctx").count(),
+            1,
+            "lean-ctx must not duplicate"
+        );
+    }
+
+    #[test]
+    fn augment_vscode_remove_only_drops_lean_ctx_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcpServers.json");
+        let t = target("Augment (VS Code)", path.clone(), ConfigType::AugmentVsCode);
+
+        // Seed: github + lean-ctx (via the writer so the id matches).
+        std::fs::write(
+            &path,
+            r#"[{"type":"stdio","id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","name":"github","disabled":false,"command":"gh-mcp","args":[],"env":{}}]"#,
+        )
+        .unwrap();
+        write_config_with_options(&t, "lean-ctx", WriteOptions::default()).unwrap();
+
+        let res = remove_lean_ctx_server(&t, WriteOptions::default()).unwrap();
+        assert_eq!(res.action, WriteAction::Updated);
+
+        let arr: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let entries = arr.as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["name"], "github");
+    }
+
+    #[test]
+    fn augment_vscode_remove_is_noop_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcpServers.json");
+        std::fs::write(&path, "[]").unwrap();
+        let t = target("Augment (VS Code)", path.clone(), ConfigType::AugmentVsCode);
+
+        let res = remove_lean_ctx_server(&t, WriteOptions::default()).unwrap();
+        assert_eq!(res.action, WriteAction::Already);
     }
 }

--- a/rust/src/doctor/integrations.rs
+++ b/rust/src/doctor/integrations.rs
@@ -159,6 +159,13 @@ fn integration_generic(
             checks.push(check_mcp_json(&target.config_path, binary, data_dir));
             checks.push(check_gemini_trust_and_hooks(home, binary));
         }
+        crate::core::editor_registry::types::ConfigType::AugmentVsCode => {
+            checks.push(check_augment_vscode_mcp(
+                &target.config_path,
+                binary,
+                data_dir,
+            ));
+        }
     }
 
     if let Some(rules_path) = rules_path_for(target.name, home) {
@@ -439,6 +446,67 @@ fn check_vscode_mcp(path: &std::path::Path, binary: &str, data_dir: &str) -> Nam
     let ok = ty_ok && cmd_ok && env_ok;
     NamedCheck {
         name: "VS Code MCP".to_string(),
+        ok,
+        detail: if ok {
+            format!("ok ({})", path.display())
+        } else {
+            format!("drift ({})", path.display())
+        },
+    }
+}
+
+fn check_augment_vscode_mcp(
+    path: &std::path::Path,
+    binary: &str,
+    data_dir: &str,
+) -> NamedCheck {
+    if !path.exists() {
+        return NamedCheck {
+            name: "Augment VS Code MCP".to_string(),
+            ok: false,
+            detail: format!("missing ({})", path.display()),
+        };
+    }
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    let Some(v) = crate::core::jsonc::parse_jsonc(&content).ok() else {
+        return NamedCheck {
+            name: "Augment VS Code MCP".to_string(),
+            ok: false,
+            detail: format!("invalid JSON ({})", path.display()),
+        };
+    };
+    let Some(arr) = v.as_array() else {
+        return NamedCheck {
+            name: "Augment VS Code MCP".to_string(),
+            ok: false,
+            detail: format!("expected top-level array ({})", path.display()),
+        };
+    };
+    let Some(e) = arr
+        .iter()
+        .find(|e| e.get("name").and_then(|n| n.as_str()) == Some("lean-ctx"))
+    else {
+        return NamedCheck {
+            name: "Augment VS Code MCP".to_string(),
+            ok: false,
+            detail: format!("lean-ctx entry missing ({})", path.display()),
+        };
+    };
+
+    let ty_ok = e.get("type").and_then(|t| t.as_str()) == Some("stdio");
+    let cmd_ok = e
+        .get("command")
+        .and_then(|c| c.as_str())
+        .is_some_and(|c| cmd_matches_expected(c, binary));
+    let env_ok = e
+        .get("env")
+        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
+        .and_then(|d| d.as_str())
+        .is_some_and(|d| d.trim() == data_dir.trim());
+
+    let ok = ty_ok && cmd_ok && env_ok;
+    NamedCheck {
+        name: "Augment VS Code MCP".to_string(),
         ok,
         detail: if ok {
             format!("ok ({})", path.display())

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -525,6 +525,11 @@ pub fn install_agent_hook_with_mode(agent: &str, global: bool, mode: HookMode) {
         "cursor" => install_cursor_hook_with_mode(global, mode),
         "gemini" => install_gemini_hook(),
         "antigravity" => install_antigravity_hook(),
+        "augment" => install_mcp_json_agent(
+            "Augment CLI",
+            "~/.augment/settings.json",
+            &crate::core::editor_registry::augment_cli_settings_path(&home),
+        ),
         "codex" => install_codex_hook(),
         "windsurf" => install_windsurf_rules(global),
         "cline" | "roo" => install_cline_rules(global),
@@ -589,10 +594,10 @@ pub fn install_agent_hook_with_mode(agent: &str, global: bool, mode: HookMode) {
         ),
         _ => {
             eprintln!("Unknown agent: {agent}");
-            eprintln!("  Supported: aider, amazonq, amp, antigravity, claude, cline, codex,");
-            eprintln!("    continue, copilot, crush, cursor, emacs, gemini, hermes, jetbrains,");
-            eprintln!("    kiro, neovim, opencode, pi, qoder, qoderwork, qwen, roo, sublime,");
-            eprintln!("    trae, verdent, vscode, windsurf, zed");
+            eprintln!("  Supported: aider, amazonq, amp, antigravity, augment, claude, cline,");
+            eprintln!("    codex, continue, copilot, crush, cursor, emacs, gemini, hermes,");
+            eprintln!("    jetbrains, kiro, neovim, opencode, pi, qoder, qoderwork, qwen, roo,");
+            eprintln!("    sublime, trae, verdent, vscode, windsurf, zed");
             std::process::exit(1);
         }
     }

--- a/rust/src/rules_inject.rs
+++ b/rust/src/rules_inject.rs
@@ -441,6 +441,13 @@ fn is_tool_detected(target: &RulesTarget, home: &std::path::Path) -> bool {
         "AWS Kiro" => home.join(".kiro").exists(),
         "Crush" => home.join(".config/crush").exists() || command_exists("crush"),
         "Verdent" => home.join(".verdent").exists(),
+        // Augment ships as either the `auggie` CLI (writes to ~/.augment/) or
+        // the VS Code extension (`augment.vscode-augment` globalStorage).
+        "Augment" => {
+            command_exists("auggie")
+                || home.join(".augment").exists()
+                || detect_extension_installed(home, "augment.vscode-augment")
+        }
         _ => false,
     }
 }
@@ -641,6 +648,11 @@ fn build_rules_targets(home: &std::path::Path) -> Vec<RulesTarget> {
         RulesTarget {
             name: "Crush",
             path: home.join(".config/crush/rules/lean-ctx.md"),
+            format: RulesFormat::DedicatedMarkdown,
+        },
+        RulesTarget {
+            name: "Augment",
+            path: home.join(".augment/rules/lean-ctx.md"),
             format: RulesFormat::DedicatedMarkdown,
         },
     ]
@@ -953,7 +965,7 @@ mod tests {
     fn target_count() {
         let home = std::path::PathBuf::from("/tmp/fake_home");
         let targets = build_rules_targets(&home);
-        assert_eq!(targets.len(), 21);
+        assert_eq!(targets.len(), 22);
     }
 
     #[test]

--- a/rust/src/setup.rs
+++ b/rust/src/setup.rs
@@ -1108,6 +1108,20 @@ fn agent_mcp_targets(agent: &str, home: &std::path::Path) -> Result<Vec<EditorTa
             crate::core::editor_registry::claude_mcp_json_path(home),
             ConfigType::McpJson,
         ),
+        "augment" => {
+            push(
+                &mut targets,
+                "Augment CLI",
+                crate::core::editor_registry::augment_cli_settings_path(home),
+                ConfigType::McpJson,
+            );
+            push(
+                &mut targets,
+                "Augment (VS Code)",
+                crate::core::editor_registry::augment_vscode_mcp_path(home),
+                ConfigType::AugmentVsCode,
+            );
+        }
         "windsurf" => push(
             &mut targets,
             "Windsurf",
@@ -1320,6 +1334,20 @@ pub fn disable_agent_mcp(agent: &str, overwrite_invalid: bool) -> Result<(), Str
             crate::core::editor_registry::claude_mcp_json_path(&home),
             ConfigType::McpJson,
         ),
+        "augment" => {
+            push(
+                &mut targets,
+                "Augment CLI",
+                crate::core::editor_registry::augment_cli_settings_path(&home),
+                ConfigType::McpJson,
+            );
+            push(
+                &mut targets,
+                "Augment (VS Code)",
+                crate::core::editor_registry::augment_vscode_mcp_path(&home),
+                ConfigType::AugmentVsCode,
+            );
+        }
         "windsurf" => push(
             &mut targets,
             "Windsurf",

--- a/rust/tests/setup_ci_smoke.rs
+++ b/rust/tests/setup_ci_smoke.rs
@@ -413,3 +413,128 @@ fn init_claude_installs_dedicated_rules_file_without_claude_md() {
         "rules must contain marker"
     );
 }
+
+// End-to-end: `lean-ctx init --agent augment` must drive setup.rs's
+// `"augment" =>` match arm through configure_agent_mcp → the McpJson writer,
+// landing at ~/.augment/settings.json with the standard mcpServers shape.
+//
+// Same Unix-only caveat as init_claude_installs_dedicated_rules_file_without_claude_md:
+// on Windows `dirs::home_dir()` uses SHGetKnownFolderPath, not %USERPROFILE%,
+// so env-var overrides don't reach the subprocess's HOME resolution.
+#[test]
+#[cfg_attr(windows, ignore)]
+fn init_augment_installs_lean_ctx_mcp_into_dot_augment_settings() {
+    let bin = env!("CARGO_BIN_EXE_lean-ctx");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let data_dir = tmp.path().join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let home_str = home.to_string_lossy().to_string();
+    let data_str = data_dir.to_string_lossy().to_string();
+
+    let envs = [
+        ("HOME", home_str.as_str()),
+        ("LEAN_CTX_DATA_DIR", data_str.as_str()),
+        ("LEAN_CTX_ACTIVE", "1"),
+        ("LEAN_CTX_DISABLED", "1"),
+        ("SHELL", "/bin/bash"),
+    ];
+
+    let out = Command::new(bin)
+        .args(["init", "--agent", "augment", "--global", "--mode", "mcp"])
+        .current_dir(&project)
+        .envs(envs.iter().copied())
+        .output()
+        .expect("init --agent augment --global --mode mcp");
+    assert!(
+        out.status.success(),
+        "init --agent augment exit; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let settings_path = home.join(".augment/settings.json");
+    assert!(
+        settings_path.exists(),
+        "must create ~/.augment/settings.json"
+    );
+    let raw = std::fs::read_to_string(&settings_path).expect("settings.json readable");
+    let json: serde_json::Value = serde_json::from_str(&raw).expect("settings.json is JSON");
+    let lean_ctx = json
+        .get("mcpServers")
+        .and_then(|m| m.get("lean-ctx"))
+        .expect("mcpServers.lean-ctx must be present");
+    assert!(
+        lean_ctx.get("command").and_then(|c| c.as_str()).is_some(),
+        "lean-ctx entry must carry a command string"
+    );
+
+    // Rules injection (ticket #3): the per-agent rules file must land at
+    // ~/.augment/rules/lean-ctx.md so Auggie actually knows lean-ctx exists.
+    let rules_path = home.join(".augment/rules/lean-ctx.md");
+    assert!(
+        rules_path.exists(),
+        "must create ~/.augment/rules/lean-ctx.md"
+    );
+    let rules = std::fs::read_to_string(&rules_path).expect("rules readable");
+    assert!(
+        rules.contains("lean-ctx-rules-"),
+        "rules file must contain version marker"
+    );
+
+    // Ticket #2: the VS Code extension surface (augment.vscode-augment) keeps
+    // its MCP server list as a top-level JSON array in globalStorage. The
+    // exact path is OS-specific; we only assert on Linux/macOS here because
+    // those are the platforms this test runs on (Windows is #[ignore]'d).
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        let vscode_path = {
+            #[cfg(target_os = "linux")]
+            {
+                home.join(".config/Code/User/globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
+            }
+            #[cfg(target_os = "macos")]
+            {
+                home.join("Library/Application Support/Code/User/globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
+            }
+        };
+        assert!(
+            vscode_path.exists(),
+            "must create augment vscode mcpServers.json at {}",
+            vscode_path.display()
+        );
+        let raw = std::fs::read_to_string(&vscode_path).expect("vscode mcpServers.json readable");
+        let arr: serde_json::Value =
+            serde_json::from_str(&raw).expect("vscode mcpServers.json is JSON");
+        let entries = arr.as_array().expect("vscode mcpServers.json is an array");
+        let lean_ctx = entries
+            .iter()
+            .find(|e| e.get("name").and_then(|n| n.as_str()) == Some("lean-ctx"))
+            .expect("array must contain a lean-ctx entry");
+        assert_eq!(
+            lean_ctx.get("type").and_then(|t| t.as_str()),
+            Some("stdio"),
+            "augment vscode entry must declare stdio transport"
+        );
+        assert!(
+            lean_ctx.get("id").and_then(|i| i.as_str()).is_some(),
+            "augment vscode entry must carry a stable id"
+        );
+        assert!(
+            lean_ctx.get("command").and_then(|c| c.as_str()).is_some(),
+            "augment vscode entry must carry a command string"
+        );
+        assert!(
+            lean_ctx
+                .get("env")
+                .and_then(|e| e.get("LEAN_CTX_DATA_DIR"))
+                .and_then(|d| d.as_str())
+                .is_some(),
+            "augment vscode entry must wire LEAN_CTX_DATA_DIR"
+        );
+    }
+}


### PR DESCRIPTION
Adds end-to-end support for both of Augment's configuration surfaces plus the standard rules-file injection that every other agent gets, bringing Augment to parity with Cursor, Claude, Codex, Windsurf and friends.

Surfaces wired up:

  - Auggie CLI       ~/.augment/settings.json (mcpServers.lean-ctx)
  - VS Code ext.     ~/.config/Code/User/globalStorage/
                     augment.vscode-augment/augment-global-state/
                     mcpServers.json (top-level JSON array, upserts by
                     stable id, preserves sibling entries)
  - Rules            ~/.augment/rules/lean-ctx.md
  - Doctor           lean-ctx doctor reports Augment VS Code MCP drift

Highlights:

  - New ConfigType::AugmentVsCode variant + dedicated writer/remover handling the array-of-objects schema (validated empirically against the augment.vscode-augment extension shipped 2026-05-21).
  - Stable, deterministic UUID for the lean-ctx entry id so repeated 'init --agent augment' calls upsert in place instead of duplicating.
  - Detection path added to the editor registry and to README's compatibility matrix.
  - 'init --agent augment' now drives both surfaces in one command.

Tests:

  - Unit tests for the array writer/remover (idempotent, sibling-safe, no-op when missing, invalid-JSON safety net).
  - Path helper tests for Linux/macOS layouts.
  - End-to-end 'init --agent augment' integration test in setup_ci_smoke.rs asserts CLI settings, VS Code array entry shape, and rules file in a single mocked-$HOME subprocess run.

'cargo clippy --all-targets -D warnings' clean; 'cargo test --tests' green across every suite.

## Summary

What does this PR change and why?

## Test plan

- [ ] `cd rust && cargo test`
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases:
- Backwards compatibility:
- Docs updated (links/files):
