### PR TITLE
fix: prevent panic on UTF-8 char boundary in string truncation

### DIFF
--- a/rust/src/core/archive.rs
+++ b/rust/src/core/archive.rs
@@ -86,7 +86,7 @@ pub fn store(tool: &str, command: &str, content: &str, session_id: Option<&str>)
     }
 
     let content = if content.len() > MAX_ARCHIVE_SIZE {
-        &content[..MAX_ARCHIVE_SIZE]
+        &content[..content.floor_char_boundary(MAX_ARCHIVE_SIZE)]
     } else {
         content
     };

--- a/rust/src/core/codebook.rs
+++ b/rust/src/core/codebook.rs
@@ -124,7 +124,10 @@ impl Codebook {
         for entry in &self.entries {
             if refs_used.contains(&entry.id) {
                 let short = if entry.pattern.len() > 60 {
-                    format!("{}...", &entry.pattern[..57])
+                    format!(
+                        "{}...",
+                        &entry.pattern[..entry.pattern.floor_char_boundary(57)]
+                    )
                 } else {
                     entry.pattern.clone()
                 };

--- a/rust/src/core/patterns/cargo.rs
+++ b/rust/src/core/patterns/cargo.rs
@@ -123,7 +123,11 @@ fn compress_test(output: &str) -> String {
                 .strip_prefix("test ")
                 .and_then(|s| s.strip_suffix(" ... ok"))
             {
-                let short_name = if name.len() > 50 { &name[..50] } else { name };
+                let short_name = if name.len() > 50 {
+                    &name[..name.floor_char_boundary(50)]
+                } else {
+                    name
+                };
                 passed_tests.push(short_name.to_string());
             }
         }

--- a/rust/src/core/patterns/curl.rs
+++ b/rust/src/core/patterns/curl.rs
@@ -52,7 +52,8 @@ fn compress_large_text(output: &str) -> String {
     ));
     for line in lines.iter().take(head_count) {
         if line.len() > 200 {
-            result.push_str(&line[..200]);
+            let end = line.floor_char_boundary(200);
+            result.push_str(&line[..end]);
             result.push_str("…\n");
         } else {
             result.push_str(line);
@@ -66,7 +67,8 @@ fn compress_large_text(output: &str) -> String {
         ));
         for line in lines.iter().skip(total_lines - tail_count) {
             if line.len() > 200 {
-                result.push_str(&line[..200]);
+                let end = line.floor_char_boundary(200);
+                result.push_str(&line[..end]);
                 result.push_str("…\n");
             } else {
                 result.push_str(line);

--- a/rust/src/core/patterns/just.rs
+++ b/rust/src/core/patterns/just.rs
@@ -87,7 +87,7 @@ fn compress_run(output: &str) -> String {
         }
 
         let echo_key = if trimmed.len() > 80 {
-            trimmed[..80].to_string()
+            trimmed[..trimmed.floor_char_boundary(80)].to_string()
         } else {
             trimmed.to_string()
         };

--- a/rust/src/core/patterns/test.rs
+++ b/rust/src/core/patterns/test.rs
@@ -84,7 +84,7 @@ fn try_pytest(output: &str) -> Option<String> {
             if name.len() <= 50 {
                 passed_names.push(name.to_string());
             } else {
-                passed_names.push(format!("{}...", &name[..47]));
+                passed_names.push(format!("{}...", &name[..name.floor_char_boundary(47)]));
             }
         }
     }

--- a/rust/src/server/helpers.rs
+++ b/rust/src/server/helpers.rs
@@ -50,8 +50,10 @@ pub fn hash_fast(s: &str) -> String {
     if s.len() <= THRESHOLD {
         crate::core::hasher::hash_str(s)
     } else {
-        let prefix = &s[..4096];
-        let suffix = &s[s.len().saturating_sub(4096)..];
+        let prefix_end = s.floor_char_boundary(4096);
+        let suffix_start = s.ceil_char_boundary(s.len().saturating_sub(4096));
+        let prefix = &s[..prefix_end];
+        let suffix = &s[suffix_start..];
         let key = format!("{}{}{}", prefix, s.len(), suffix);
         crate::core::hasher::hash_str(&key)
     }

--- a/rust/tests/utf8_char_boundary.rs
+++ b/rust/tests/utf8_char_boundary.rs
@@ -1,0 +1,42 @@
+#[test]
+fn slice_at_multibyte_boundary_does_not_panic() {
+    // '→' is 3 bytes (E2 86 92). Place it so byte 200 falls inside it.
+    let mut s = "a".repeat(198);
+    s.push('→'); // bytes 198..201
+    s.push_str("tail");
+
+    // Byte 200 is inside '→'; floor_char_boundary should snap back to 198.
+    let end = s.floor_char_boundary(200);
+    assert_eq!(end, 198);
+    // Slicing at the floor boundary must not panic.
+    let _ = &s[..end];
+
+    // ceil_char_boundary should advance to 201.
+    let start = s.ceil_char_boundary(200);
+    assert_eq!(start, 201);
+    let _ = &s[start..];
+}
+
+#[test]
+fn hash_fast_does_not_panic_on_multibyte_at_prefix_boundary() {
+    // Construct a string > 16KB where byte 4096 falls inside a multi-byte char.
+    let mut s = "a".repeat(4094);
+    s.push('→'); // 3-byte char at bytes 4094..4097, so byte 4096 is inside it
+    while s.len() <= 16 * 1024 {
+        s.push('x');
+    }
+    let _hash = lean_ctx::server::helpers::hash_fast(&s);
+}
+
+#[test]
+fn hash_fast_does_not_panic_on_multibyte_at_suffix_boundary() {
+    // Construct a string > 16KB where the suffix start falls inside a multi-byte char.
+    let target_len = 20_000;
+    let suffix_start = target_len - 4096; // = 15904
+    let mut s = "a".repeat(suffix_start - 1);
+    s.push('→'); // 3-byte char, some byte of which aligns with suffix_start
+    while s.len() < target_len {
+        s.push('x');
+    }
+    let _hash = lean_ctx::server::helpers::hash_fast(&s);
+}


### PR DESCRIPTION
## Summary

- Fix 7 string truncation sites that slice at fixed byte offsets without checking UTF-8 char boundaries, causing panics on multi-byte characters like `→`
- Use `str::floor_char_boundary()` / `str::ceil_char_boundary()` (stable since Rust 1.73) instead of raw byte slicing
- Add 3 integration tests covering multi-byte boundary slicing and `hash_fast` prefix/suffix paths

Fixes #265

## Affected sites

| File | Truncation | Fix |
|------|-----------|-----|
| `server/helpers.rs` | `hash_fast` prefix at 4096, suffix at `len-4096` | `floor_char_boundary` / `ceil_char_boundary` |
| `core/patterns/curl.rs` | Line truncation at 200 (2 sites) | `floor_char_boundary` |
| `core/patterns/just.rs` | Echo dedup key at 80 | `floor_char_boundary` |
| `core/patterns/cargo.rs` | Test name at 50 | `floor_char_boundary` |
| `core/patterns/test.rs` | Test name at 47 | `floor_char_boundary` |
| `core/archive.rs` | Content at 10MB | `floor_char_boundary` |
| `core/codebook.rs` | Pattern display at 57 | `floor_char_boundary` |

## Test plan

- `cargo fmt --check` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — pass
- `cargo test --test utf8_char_boundary` — 3 tests pass
- `cargo test --all-features` — no new failures (9 pre-existing failures unrelated to this change)
