### PR TITLE
fix(jsonc): preserve UTF-8 strings in strip_json_comments

### DIFF
--- a/rust/src/core/jsonc.rs
+++ b/rust/src/core/jsonc.rs
@@ -8,26 +8,35 @@ pub fn parse_jsonc(input: &str) -> Result<Value, serde_json::Error> {
 }
 
 fn strip_json_comments(input: &str) -> String {
+    // Scan as bytes for ASCII delimiters (", /, *, \, \n) — these never appear
+    // inside multi-byte UTF-8 sequences, so byte-position math stays on char
+    // boundaries. Emit content via `push_str(&input[..])` slicing so multi-byte
+    // characters (e.g. "ó") roundtrip verbatim instead of being decomposed into
+    // Latin-1 codepoints and re-encoded (which would double their byte length
+    // on every pass).
     let bytes = input.as_bytes();
     let len = bytes.len();
     let mut out = String::with_capacity(len);
     let mut i = 0;
+    let mut copy_from = 0;
 
     while i < len {
         let b = bytes[i];
 
         if b == b'"' {
-            out.push('"');
+            // Walk past the string literal, including its contents. The bytes
+            // remain part of the current copy segment and will be flushed when
+            // we hit a comment or the end of input.
             i += 1;
             while i < len {
                 let c = bytes[i];
-                out.push(c as char);
-                i += 1;
-                if c == b'\\' && i < len {
-                    out.push(bytes[i] as char);
-                    i += 1;
+                if c == b'\\' && i + 1 < len {
+                    i += 2;
                 } else if c == b'"' {
+                    i += 1;
                     break;
+                } else {
+                    i += 1;
                 }
             }
             continue;
@@ -35,13 +44,16 @@ fn strip_json_comments(input: &str) -> String {
 
         if b == b'/' && i + 1 < len {
             if bytes[i + 1] == b'/' {
+                out.push_str(&input[copy_from..i]);
                 i += 2;
                 while i < len && bytes[i] != b'\n' {
                     i += 1;
                 }
+                copy_from = i;
                 continue;
             }
             if bytes[i + 1] == b'*' {
+                out.push_str(&input[copy_from..i]);
                 i += 2;
                 while i + 1 < len {
                     if bytes[i] == b'*' && bytes[i + 1] == b'/' {
@@ -50,14 +62,15 @@ fn strip_json_comments(input: &str) -> String {
                     }
                     i += 1;
                 }
+                copy_from = i;
                 continue;
             }
         }
 
-        out.push(b as char);
         i += 1;
     }
 
+    out.push_str(&input[copy_from..len]);
     out
 }
 
@@ -131,6 +144,34 @@ mod tests {
         let v = parse_jsonc(input).unwrap();
         assert_eq!(v["key"], "value");
         assert_eq!(v["num"], 42);
+    }
+
+    #[test]
+    fn preserves_non_ascii_strings_byte_for_byte() {
+        // Regression: strip_json_comments used to do `out.push(byte as char)`,
+        // which decomposed multi-byte UTF-8 sequences into Latin-1 codepoints
+        // and silently doubled their byte length on every roundtrip. Repeated
+        // install/repair cycles drove ~/.claude/settings.json past 2 GiB and
+        // segfaulted Claude Code.
+        let input = r#"{"msg": "Verificando optimización para iPhone/Safari..."}"#;
+        let original_len = input.len();
+        let mut current = input.to_string();
+        for _ in 0..5 {
+            let parsed = parse_jsonc(&current).unwrap();
+            current = serde_json::to_string(&parsed).unwrap();
+        }
+        // After 5 roundtrips the size must be stable, not exponentially growing.
+        assert!(
+            current.len() <= original_len + 4,
+            "roundtrip should be size-stable, got {} bytes (started at {})",
+            current.len(),
+            original_len
+        );
+        let v: Value = serde_json::from_str(&current).unwrap();
+        assert_eq!(
+            v["msg"], "Verificando optimización para iPhone/Safari...",
+            "non-ASCII string content must roundtrip unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #285

### Problema

`strip_json_comments` in `src/core/jsonc.rs` used `out.push(byte as char)` to copy
string literal contents byte-by-byte. In Rust, `u8 as char` treats the byte as a
Latin-1 codepoint (U+0000–U+00FF). When the byte is part of a multi-byte UTF-8
sequence (e.g. the Spanish character `ó` = bytes `0xC3 0xB3`), each byte becomes a
separate codepoint, and when the resulting `String` is serialised back to UTF-8 those
codepoints double their byte length:

```
ó  →  0xC3 0xB3  (2 bytes, valid UTF-8)
         ↓ push(0xC3 as char) + push(0xB3 as char)
Ã³  →  0xC3 0x83 0xC2 0xB3  (4 bytes)
         ↓ next roundtrip
ÃÂ³  →  8 bytes
         ↓ …
```

This bug triggered on every call to `install_claude_hook_config()` (run during
`lean-ctx install` / `lean-ctx setup` / `lean-ctx doctor --fix`). Any non-ASCII
value in `settings.json` — such as a `statusMessage` field containing `"ó"` — grew
exponentially with each invocation.

### Impact observed in the wild

**Symptom:** `claude` (Claude Code CLI) aborted with `Segmentation fault (core dumped)`
on every startup — the CLI was completely unusable.

**Root cause chain:** A `statusMessage: "Verificando optimización para iPhone/Safari..."`
(46 bytes) in a `PreToolUse` hook grew to **1 073 741 882 bytes (~1 GB)** after ~24
install/repair cycles, driving `~/.claude/settings.json` past the 2 GiB mark
(2 147 489 753 bytes = 2³¹ + 6 105). V8/Node.js cannot parse strings or buffers beyond
2 GiB, so Claude Code segfaulted on startup.

The doubling is confirmed by two consecutive backup snapshots with an exact **2.0000×**
size ratio.

### Fix

Replace `push(byte as char)` with `push_str(&input[start..end])` slice copies.
The byte scanner only uses ASCII delimiters (`"`, `/`, `*`, `\`, newline) which never
appear inside multi-byte UTF-8 sequences, so byte-position arithmetic stays on char
boundaries. Non-ASCII content is emitted verbatim by slicing the original `&str`.

```diff
-        let c = bytes[i];
-        out.push(c as char);
-        i += 1;
-        if c == b'\\' && i < len {
-            out.push(bytes[i] as char);
-            i += 1;
-        } else if c == b'"' {
-            break;
-        }
+        let c = bytes[i];
+        if c == b'\\' && i + 1 < len {
+            i += 2;
+        } else if c == b'"' {
+            i += 1;
+            break;
+        } else {
+            i += 1;
+        }
```

Comments are stripped by flushing accumulated content with `out.push_str(&input[copy_from..i])`
before each comment and advancing `copy_from` past it, then emitting the remainder at the end.

### Test added

`preserves_non_ascii_strings_byte_for_byte` — runs 5 parse→serialise roundtrips on a
JSON payload containing `"ó"` and asserts:
- size is stable (within 4 bytes of original)
- string content is unchanged after roundtrips

### Quality bar (all passing)

```
cargo fmt --check                                    ✅
cargo clippy --all-targets --all-features -D warnings  ✅ (0 warnings)
cargo test --all-features                            ✅ 2704 passed
cargo test --release                                 ✅ 2700 passed
```

Two pre-existing test failures unrelated to this change:
- `core::protocol::tests::detect_project_root_finds_outermost`
- `core::context_package::loader::tests::v2_graph_import_merges_with_existing`

Both fail on `main` before this patch. Verified with `git stash` + re-run.

### Checklist

- [x] Fix targets the root cause (byte-as-char coercion), not a workaround
- [x] All original `jsonc` tests pass unchanged
- [x] Regression test added
- [x] `cargo fmt`, `clippy -D warnings`, `test --all-features`, `test --release` all green
- [x] Single-theme PR (one file, one function)
- [x] Conventional commit message
