### PR TITLE
Add "bunx" in the default shell_allowlist command

### DIFF
--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -932,6 +932,7 @@ pub(crate) fn default_shell_allowlist() -> Vec<String> {
         "yarn",
         "pnpm",
         "bun",
+        "bunx",
         "make",
         "cmake",
         "pip",


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the default shell allowlist configuration by adding support for an additional tool.

- Added `"bunx"` to the list of allowed shells in the `default_shell_allowlist` function in `mod.rs`.