### PR TITLE
fix(proxy): add /v1/messages/count_tokens route

### DIFF
--- a/rust/src/proxy/mod.rs
+++ b/rust/src/proxy/mod.rs
@@ -107,6 +107,7 @@ pub async fn start_proxy_with_token(port: u16, auth_token: Option<String>) -> an
         .route("/health", get(health))
         .route("/status", get(status_handler))
         .route("/v1/messages", any(anthropic::handler))
+        .route("/v1/messages/count_tokens", any(anthropic::handler))
         .route("/v1/chat/completions", any(openai::handler))
         .route("/v1/references/{id}", get(v1_resolve_reference))
         .fallback(fallback_router)


### PR DESCRIPTION
## Problem

When Claude Code sends a token-counting request `POST /v1/messages/count_tokens` through the lean-ctx proxy, it gets a **404 Not Found** instead of being forwarded to Anthropic.

## Root Cause

The route `.route("/v1/messages", any(anthropic::handler))` is an exact match in axum. `/v1/messages/count_tokens` does **not** match this route and falls through to `fallback_router`, which returns:

```
lean-ctx proxy: no handler for POST /v1/messages/count_tokens
```

## Fix

Add an explicit route for the Anthropic token-counting endpoint:

```rust
.route("/v1/messages/count_tokens", any(anthropic::handler))
```

This mirrors the existing `/v1/messages` handler — same provider routing, same auth middleware, same upstream forwarding logic. One line.

## Testing

- Built from source, verified proxy forwards `/v1/messages/count_tokens` to Anthropic upstream (returns auth error with test key instead of 404)
- Existing proxy routes unaffected