### PR TITLE
[codex] Add line ranges to signature maps

### DIFF
--- a/rust/src/cloud_server/wrapped.rs
+++ b/rust/src/cloud_server/wrapped.rs
@@ -753,7 +753,7 @@ mod tests {
         assert!(p.validate().is_err());
 
         let mut p = valid();
-        p.top_commands = (0..MAX_TOP_COMMANDS + 1)
+        p.top_commands = (0..=MAX_TOP_COMMANDS)
             .map(|_| TopCommand {
                 name: "git".into(),
                 pct: 1.0,

--- a/rust/src/core/signatures.rs
+++ b/rust/src/core/signatures.rs
@@ -37,9 +37,18 @@ impl Signature {
         }
     }
 
+    pub fn line_suffix(&self) -> String {
+        match (self.start_line, self.end_line) {
+            (Some(start), Some(end)) if start > 0 && end > start => format!(" @L{start}-{end}"),
+            (Some(start), _) if start > 0 => format!(" @L{start}"),
+            _ => String::new(),
+        }
+    }
+
     pub fn to_compact(&self) -> String {
         let export = if self.is_exported { "⊛ " } else { "" };
         let async_prefix = if self.is_async { "async " } else { "" };
+        let line_suffix = self.line_suffix();
 
         match self.kind {
             "fn" | "method" => {
@@ -50,29 +59,30 @@ impl Signature {
                 };
                 let indent = " ".repeat(self.indent);
                 format!(
-                    "{indent}fn {async_prefix}{export}{}({}){}",
+                    "{indent}fn {async_prefix}{export}{}({}){}{line_suffix}",
                     self.name, self.params, ret
                 )
             }
-            "class" | "struct" => format!("cl {export}{}", self.name),
-            "interface" | "trait" => format!("if {export}{}", self.name),
-            "type" => format!("ty {export}{}", self.name),
-            "enum" => format!("en {export}{}", self.name),
+            "class" | "struct" => format!("cl {export}{}{line_suffix}", self.name),
+            "interface" | "trait" => format!("if {export}{}{line_suffix}", self.name),
+            "type" => format!("ty {export}{}{line_suffix}", self.name),
+            "enum" => format!("en {export}{}{line_suffix}", self.name),
             "const" | "let" | "var" => {
                 let ty = if self.return_type.is_empty() {
                     String::new()
                 } else {
                     format!(":{}", self.return_type)
                 };
-                format!("val {export}{}{ty}", self.name)
+                format!("val {export}{}{ty}{line_suffix}", self.name)
             }
-            _ => format!("{} {}", self.kind, self.name),
+            _ => format!("{} {}{line_suffix}", self.kind, self.name),
         }
     }
 
     pub fn to_tdd(&self) -> String {
         let vis = if self.is_exported { "+" } else { "-" };
         let a = if self.is_async { "~" } else { "" };
+        let line_suffix = self.line_suffix();
 
         match self.kind {
             "fn" | "method" => {
@@ -83,22 +93,22 @@ impl Signature {
                 };
                 let params = tdd_params(&self.params);
                 let indent = if self.indent > 0 { " " } else { "" };
-                format!("{indent}{a}λ{vis}{}({params}){ret}", self.name)
+                format!("{indent}{a}λ{vis}{}({params}){ret}{line_suffix}", self.name)
             }
-            "class" | "struct" => format!("§{vis}{}", self.name),
-            "interface" | "trait" => format!("∂{vis}{}", self.name),
-            "type" => format!("τ{vis}{}", self.name),
-            "enum" => format!("ε{vis}{}", self.name),
+            "class" | "struct" => format!("§{vis}{}{line_suffix}", self.name),
+            "interface" | "trait" => format!("∂{vis}{}{line_suffix}", self.name),
+            "type" => format!("τ{vis}{}{line_suffix}", self.name),
+            "enum" => format!("ε{vis}{}{line_suffix}", self.name),
             "const" | "let" | "var" => {
                 let ty = if self.return_type.is_empty() {
                     String::new()
                 } else {
                     format!(":{}", compact_type(&self.return_type))
                 };
-                format!("ν{vis}{}{ty}", self.name)
+                format!("ν{vis}{}{ty}{line_suffix}", self.name)
             }
             _ => format!(
-                "{}{vis}{}",
+                "{}{vis}{}{line_suffix}",
                 self.kind.chars().next().unwrap_or('?'),
                 self.name
             ),
@@ -207,7 +217,8 @@ pub fn extract_file_map(path: &str, content: &str) -> String {
 fn extract_ts_signatures(content: &str) -> Vec<Signature> {
     let mut sigs = Vec::new();
 
-    for line in content.lines() {
+    for (line_idx, line) in content.lines().enumerate() {
+        let line_no = line_idx + 1;
         let trimmed = line.trim();
         if trimmed.starts_with("//") || trimmed.starts_with("/*") || trimmed.starts_with('*') {
             continue;
@@ -225,7 +236,8 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: caps.get(3).is_some(),
                 is_exported: caps.get(2).is_some(),
                 indent: if indent > 0 { 2 } else { 0 },
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = class_re().captures(line) {
             sigs.push(Signature {
@@ -236,7 +248,8 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = iface_re().captures(line) {
             sigs.push(Signature {
@@ -247,7 +260,8 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = type_re().captures(line) {
             sigs.push(Signature {
@@ -258,7 +272,8 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = const_re().captures(line) {
             if caps.get(2).is_some() {
@@ -272,7 +287,8 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
                     is_async: false,
                     is_exported: true,
                     indent: 0,
-                    ..Signature::no_span()
+                    start_line: Some(line_no),
+                    end_line: Some(line_no),
                 });
             }
         }
@@ -284,7 +300,8 @@ fn extract_ts_signatures(content: &str) -> Vec<Signature> {
 fn extract_rust_signatures(content: &str) -> Vec<Signature> {
     let mut sigs = Vec::new();
 
-    for line in content.lines() {
+    for (line_idx, line) in content.lines().enumerate() {
+        let line_no = line_idx + 1;
         let trimmed = line.trim();
         if trimmed.starts_with("//") || trimmed.starts_with("///") {
             continue;
@@ -302,7 +319,8 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: caps.get(3).is_some(),
                 is_exported: caps.get(2).is_some(),
                 indent: if indent > 0 { 2 } else { 0 },
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = rust_struct_re().captures(line) {
             sigs.push(Signature {
@@ -313,7 +331,8 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = rust_enum_re().captures(line) {
             sigs.push(Signature {
@@ -324,7 +343,8 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = rust_trait_re().captures(line) {
             sigs.push(Signature {
@@ -335,7 +355,8 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps.get(2).is_some(),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = rust_impl_re().captures(line) {
             let trait_name = caps.get(2).map(|m| m.as_str());
@@ -353,7 +374,8 @@ fn extract_rust_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: false,
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         }
     }
@@ -366,7 +388,8 @@ fn extract_python_signatures(content: &str) -> Vec<Signature> {
     let py_fn = static_regex!(r"^(\s*)(async\s+)?def\s+(\w+)\s*\(([^)]*)\)(?:\s*->\s*(\w+))?");
     let py_class = static_regex!(r"^(\s*)class\s+(\w+)");
 
-    for line in content.lines() {
+    for (line_idx, line) in content.lines().enumerate() {
+        let line_no = line_idx + 1;
         if let Some(caps) = py_fn.captures(line) {
             let indent = caps.get(1).map_or(0, |m| m.as_str().len());
             sigs.push(Signature {
@@ -379,7 +402,8 @@ fn extract_python_signatures(content: &str) -> Vec<Signature> {
                 is_async: caps.get(2).is_some(),
                 is_exported: !caps[3].starts_with('_'),
                 indent: if indent > 0 { 2 } else { 0 },
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = py_class.captures(line) {
             sigs.push(Signature {
@@ -390,7 +414,8 @@ fn extract_python_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: !caps[2].starts_with('_'),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         }
     }
@@ -405,7 +430,8 @@ fn extract_go_signatures(content: &str) -> Vec<Signature> {
     );
     let go_type = static_regex!(r"^type\s+(\w+)\s+(struct|interface)");
 
-    for line in content.lines() {
+    for (line_idx, line) in content.lines().enumerate() {
+        let line_no = line_idx + 1;
         if let Some(caps) = go_fn.captures(line) {
             let is_method = caps.get(2).is_some();
             sigs.push(Signature {
@@ -419,7 +445,8 @@ fn extract_go_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps[3].starts_with(char::is_uppercase),
                 indent: if is_method { 2 } else { 0 },
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = go_type.captures(line) {
             sigs.push(Signature {
@@ -434,7 +461,8 @@ fn extract_go_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: caps[1].starts_with(char::is_uppercase),
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         }
     }
@@ -534,7 +562,8 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
     );
 
     let mut sigs = Vec::new();
-    for line in content.lines() {
+    for (line_idx, line) in content.lines().enumerate() {
+        let line_no = line_idx + 1;
         let trimmed = line.trim();
         if trimmed.is_empty()
             || trimmed.starts_with("//")
@@ -553,7 +582,8 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
                 is_async: false,
                 is_exported: true,
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         } else if let Some(caps) = re_func.captures(trimmed) {
             sigs.push(Signature {
@@ -564,9 +594,68 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
                 is_async: trimmed.contains("async"),
                 is_exported: true,
                 indent: 0,
-                ..Signature::no_span()
+                start_line: Some(line_no),
+                end_line: Some(line_no),
             });
         }
     }
     sigs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_signature() -> Signature {
+        Signature {
+            kind: "fn",
+            name: "run".to_string(),
+            params: "id:usize".to_string(),
+            return_type: "bool".to_string(),
+            is_async: false,
+            is_exported: true,
+            indent: 0,
+            start_line: None,
+            end_line: None,
+        }
+    }
+
+    #[test]
+    fn line_suffix_formats_known_spans() {
+        let mut sig = test_signature();
+        assert_eq!(sig.line_suffix(), "");
+
+        sig.start_line = Some(42);
+        sig.end_line = Some(42);
+        assert_eq!(sig.line_suffix(), " @L42");
+
+        sig.end_line = Some(57);
+        assert_eq!(sig.line_suffix(), " @L42-57");
+    }
+
+    #[test]
+    fn compact_and_tdd_include_line_suffix_when_known() {
+        let mut sig = test_signature();
+        assert_eq!(sig.to_compact(), "fn ⊛ run(id:usize) → bool");
+        assert_eq!(sig.to_tdd(), "λ+run(id:n)→b");
+
+        sig.start_line = Some(3);
+        sig.end_line = Some(5);
+        assert_eq!(sig.to_compact(), "fn ⊛ run(id:usize) → bool @L3-5");
+        assert_eq!(sig.to_tdd(), "λ+run(id:n)→b @L3-5");
+    }
+
+    #[test]
+    fn regex_fallback_assigns_declaration_line_spans() {
+        let src = "\npublic class Service {}\n\npublic fn run() {\n}\n";
+        let sigs = extract_generic_signatures(src);
+
+        let service = sigs.iter().find(|s| s.name == "Service").unwrap();
+        assert_eq!(service.start_line, Some(2));
+        assert_eq!(service.end_line, Some(2));
+
+        let run = sigs.iter().find(|s| s.name == "run").unwrap();
+        assert_eq!(run.start_line, Some(4));
+        assert_eq!(run.end_line, Some(4));
+    }
 }

--- a/rust/src/core/signatures_ts/extract.rs
+++ b/rust/src/core/signatures_ts/extract.rs
@@ -185,10 +185,8 @@ fn node_to_signature(node: &Node, name: &str, ext: &str, source: &[u8]) -> Optio
         _ => None,
     }?;
 
-    if matches!(ext, "kt" | "kts") {
-        sig.start_line = Some(node.start_position().row + 1);
-        sig.end_line = Some(node.end_position().row + 1);
-    }
+    sig.start_line = Some(node.start_position().row + 1);
+    sig.end_line = Some(node.end_position().row + 1);
 
     Some(sig)
 }

--- a/rust/src/core/signatures_ts/mod.rs
+++ b/rust/src/core/signatures_ts/mod.rs
@@ -274,6 +274,8 @@ pub fn complex_function<T: Display + Debug>(
         assert!(!sigs.is_empty(), "should parse multiline function");
         assert_eq!(sigs[0].name, "complex_function");
         assert!(sigs[0].is_exported);
+        assert_eq!(sigs[0].start_line, Some(2));
+        assert_eq!(sigs[0].end_line, Some(8));
     }
 
     #[test]
@@ -292,9 +294,13 @@ const internal = (x: number) => x * 2;
         assert!(fetch.is_async);
         assert!(fetch.is_exported);
         assert_eq!(fetch.kind, "fn");
+        assert_eq!(fetch.start_line, Some(2));
+        assert_eq!(fetch.end_line, Some(4));
 
         let internal = sigs.iter().find(|s| s.name == "internal").unwrap();
         assert!(!internal.is_exported);
+        assert_eq!(internal.start_line, Some(6));
+        assert_eq!(internal.end_line, Some(6));
     }
 
     #[test]
@@ -544,6 +550,10 @@ export class Counter {
         let names: Vec<&str> = sigs.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"greet"), "got {names:?}");
         assert!(names.contains(&"Counter"), "got {names:?}");
+
+        let greet = sigs.iter().find(|s| s.name == "greet").unwrap();
+        assert_eq!(greet.start_line, Some(3));
+        assert_eq!(greet.end_line, Some(5));
     }
 
     #[test]

--- a/rust/src/core/signatures_ts/sfc.rs
+++ b/rust/src/core/signatures_ts/sfc.rs
@@ -2,13 +2,22 @@ use super::extract::extract_signatures_ts;
 use crate::core::signatures::Signature;
 
 pub(crate) fn extract_sfc_signatures(content: &str) -> Option<Vec<Signature>> {
-    let script_content = extract_script_block(content)?;
+    let (script_content, line_offset) = extract_script_block_with_offset(content)?;
     let is_ts = content.contains("lang=\"ts\"") || content.contains("lang=\"typescript\"");
     let ext = if is_ts { "ts" } else { "js" };
-    extract_signatures_ts(&script_content, ext)
+    let mut sigs = extract_signatures_ts(&script_content, ext)?;
+    for sig in &mut sigs {
+        sig.start_line = sig.start_line.map(|line| line + line_offset);
+        sig.end_line = sig.end_line.map(|line| line + line_offset);
+    }
+    Some(sigs)
 }
 
 pub(crate) fn extract_script_block(content: &str) -> Option<String> {
+    extract_script_block_with_offset(content).map(|(script, _)| script)
+}
+
+fn extract_script_block_with_offset(content: &str) -> Option<(String, usize)> {
     let lower = content.to_lowercase();
     let start_tag_pos = lower.find("<script")?;
     let tag_end = content[start_tag_pos..].find('>')? + start_tag_pos + 1;
@@ -18,5 +27,6 @@ pub(crate) fn extract_script_block(content: &str) -> Option<String> {
     if script.trim().is_empty() {
         return None;
     }
-    Some(script.to_string())
+    let line_offset = content[..tag_end].bytes().filter(|b| *b == b'\n').count();
+    Some((script.to_string(), line_offset))
 }

--- a/rust/src/tools/ctx_read.rs
+++ b/rust/src/tools/ctx_read.rs
@@ -29,10 +29,15 @@ fn is_cacheable_mode(mode: &str) -> bool {
 }
 
 fn compressed_cache_key(mode: &str, crp_mode: CrpMode, task: Option<&str>) -> String {
+    let versioned_mode = match mode {
+        "map" => "map:v2",
+        "signatures" => "signatures:v2",
+        _ => mode,
+    };
     let base = if crp_mode.is_tdd() {
-        format!("{mode}:tdd")
+        format!("{versioned_mode}:tdd")
     } else {
-        mode.to_string()
+        versioned_mode.to_string()
     };
     // map/signatures output now embeds a task-relevant body, so task-aware and
     // task-free variants must cache under distinct keys.
@@ -1460,6 +1465,34 @@ mod tests {
     }
 
     #[test]
+    fn map_mode_includes_signature_line_ranges() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lib.rs");
+        let p = path.to_string_lossy().to_string();
+        std::fs::write(
+            &path,
+            "pub struct Config {}\n\npub fn build() -> Config { Config {} }\n",
+        )
+        .unwrap();
+
+        let mut cache = SessionCache::new();
+        let result = handle(&mut cache, &p, "map", CrpMode::Off);
+
+        assert!(
+            result.contains("API:"),
+            "map output should include API: {result}"
+        );
+        assert!(
+            result.contains("cl ⊛ Config @L1"),
+            "struct signature should include line suffix: {result}"
+        );
+        assert!(
+            result.contains("fn ⊛ build() → Config @L3"),
+            "function signature should include line suffix: {result}"
+        );
+    }
+
+    #[test]
     fn cached_lines_mode_invalidates_on_mtime_change() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.txt");
@@ -1637,9 +1670,11 @@ mod tests {
     #[test]
     fn compressed_cache_key_distinguishes_task() {
         let no_task = compressed_cache_key("map", CrpMode::Off, None);
+        let tdd_no_task = compressed_cache_key("map", CrpMode::Tdd, None);
         let with_task = compressed_cache_key("map", CrpMode::Off, Some("fix login"));
         let other_task = compressed_cache_key("map", CrpMode::Off, Some("refactor db"));
-        assert_eq!(no_task, "map");
+        assert_eq!(no_task, "map:v2");
+        assert_eq!(tdd_no_task, "map:v2:tdd");
         assert_ne!(with_task, no_task);
         assert_ne!(with_task, other_task);
     }


### PR DESCRIPTION
## Summary
- Add compact @Lstart[-end] suffixes to code entities emitted by map/signature output.
- Populate line spans from tree-sitter signatures, including SFC script offsets, and cheap declaration-line spans for regex fallback.
- Version map/signatures compressed cache keys to avoid stale range-less output.
- Fix one all-features clippy range lint in cloud_server/wrapped.rs required by the contributing checks.

## Impact
- Text output changes for ctx_read mode=map, ctx_read mode=signatures, and callers of Signature::to_compact() / to_tdd().
- No schema or argument changes.
- Unknown spans remain omitted.

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib -- --test-threads=1
- cargo test --all-features --quiet -- --test-threads=1
- cargo test --release --quiet -- --test-threads=1 printed only passing summaries; the lean-ctx wrapper exited 1 after hitting its output/time limit, with no failure markers and no remaining cargo process.

## Note
- A parallel cargo test --all-features --quiet run hit the existing process_guard timing-sensitive test; it passed isolated and in the serial all-features run.
