### PR TITLE
fix(stats): update session stats retrieval to use 'gain' command and …

### DIFF
--- a/vscode-extension/src/leanctx.ts
+++ b/vscode-extension/src/leanctx.ts
@@ -169,10 +169,12 @@ export function runLeanCtxCapture(
 
 export async function getSessionStats(): Promise<SessionStats> {
   try {
-    const raw = await runLeanCtx(["metrics", "--json"]);
-    const data = JSON.parse(raw);
+    const raw = await runLeanCtx(["gain", "--json"]);
+    const rawData = JSON.parse(raw);
+
+    const data = rawData.summary ?? rawData;
     return {
-      totalReads: data.total_reads ?? 0,
+      totalReads: data.total_commands ?? data.total_reads ?? 0,
       totalSearches: data.total_searches ?? 0,
       totalShells: data.total_shells ?? 0,
       tokensSaved: data.tokens_saved ?? 0,


### PR DESCRIPTION
This pull request updates the way session statistics are fetched and parsed in the `getSessionStats` function. 
The main change is to align the command and parsing logic with the updated output format of the underlying tool.

**Session statistics retrieval and parsing:**

* Changed the command from `metrics` to `gain` and updated the parsing logic to handle a possible `summary` object in the returned JSON, ensuring compatibility with the new output format.
* Updated the logic for `totalReads` to use `total_commands` as the primary value, falling back to `total_reads` if not present, to reflect changes in the metrics schema.

Note

1. `lean-ctx metrics` command not found, so use `lean-ctx gain` some parameters not exists.