### PR TITLE
Rename .leanctx to .lean-ctx across codebase

### DIFF
--- a/rust/src/cli/rules_cmd.rs
+++ b/rust/src/cli/rules_cmd.rs
@@ -87,7 +87,7 @@ fn cmd_lint(ops: &ContextOps) {
         }
         Err(e) => {
             eprintln!("Error: {e}");
-            eprintln!("Run `lean-ctx rules init` first to create .leanctx/rules.toml");
+            eprintln!("Run `lean-ctx rules init` first to create .lean-ctx/rules.toml");
             std::process::exit(1);
         }
     }
@@ -100,7 +100,7 @@ fn cmd_status(ops: &ContextOps) {
     let has_config = ops.has_config();
     println!();
     if has_config {
-        println!("Central config: ✓ (.leanctx/rules.toml)");
+        println!("Central config: ✓ (.lean-ctx/rules.toml)");
     } else {
         println!("Central config: ✗ (run `lean-ctx rules init` to create)");
     }
@@ -108,17 +108,17 @@ fn cmd_status(ops: &ContextOps) {
 
 fn cmd_init(ops: &ContextOps) {
     if ops.has_config() {
-        eprintln!("Config already exists at .leanctx/rules.toml");
+        eprintln!("Config already exists at .lean-ctx/rules.toml");
         eprintln!("Delete it first if you want to reinitialize.");
         std::process::exit(1);
     }
 
     match ops.init() {
         Ok(_config) => {
-            println!("Created .leanctx/rules.toml from existing rules.");
+            println!("Created .lean-ctx/rules.toml from existing rules.");
             println!();
             println!("Next steps:");
-            println!("  1. Review .leanctx/rules.toml");
+            println!("  1. Review .lean-ctx/rules.toml");
             println!("  2. Run `lean-ctx rules lint` to check consistency");
             println!("  3. Run `lean-ctx rules sync` to distribute");
         }
@@ -141,7 +141,7 @@ fn print_help() {
              diff              Show drift between central and distributed rules\n    \
              lint              Check rules for consistency and completeness\n    \
              status            Show sync status for all targets\n    \
-             init              Create .leanctx/rules.toml from existing rules\n    \
+             init              Create .lean-ctx/rules.toml from existing rules\n    \
              help              Show this help"
     );
 }

--- a/rust/src/core/contextops/config.rs
+++ b/rust/src/core/contextops/config.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 const CONFIG_FILENAME: &str = "rules.toml";
-const CONFIG_DIR: &str = ".leanctx";
+const CONFIG_DIR: &str = ".lean-ctx";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RulesConfig {
@@ -135,7 +135,7 @@ mod tests {
     fn config_path_is_correct() {
         let root = PathBuf::from("/tmp/project");
         let path = RulesConfig::config_path(&root);
-        assert_eq!(path, PathBuf::from("/tmp/project/.leanctx/rules.toml"));
+        assert_eq!(path, PathBuf::from("/tmp/project/.lean-ctx/rules.toml"));
     }
 
     #[test]

--- a/rust/src/tools/ctx_rules.rs
+++ b/rust/src/tools/ctx_rules.rs
@@ -41,7 +41,7 @@ pub fn handle(action: &str, agent: Option<&str>) -> String {
         "lint" => match ops.lint() {
             Ok(warnings) => contextops::format_lint(&warnings),
             Err(e) => {
-                format!("Error: {e}\nRun ctx_rules(action=\"init\") to create .leanctx/rules.toml")
+                format!("Error: {e}\nRun ctx_rules(action=\"init\") to create .lean-ctx/rules.toml")
             }
         },
         "status" => {
@@ -49,7 +49,7 @@ pub fn handle(action: &str, agent: Option<&str>) -> String {
             let mut output = contextops::format_status(&statuses);
             output.push('\n');
             if ops.has_config() {
-                output.push_str("\nCentral config: present (.leanctx/rules.toml)");
+                output.push_str("\nCentral config: present (.lean-ctx/rules.toml)");
             } else {
                 output.push_str(
                     "\nCentral config: missing (run ctx_rules(action=\"init\") to create)",
@@ -59,10 +59,10 @@ pub fn handle(action: &str, agent: Option<&str>) -> String {
         }
         "init" => {
             if ops.has_config() {
-                return "Config already exists at .leanctx/rules.toml. Delete it first to reinitialize.".to_string();
+                return "Config already exists at .lean-ctx/rules.toml. Delete it first to reinitialize.".to_string();
             }
             match ops.init() {
-                Ok(_) => "Created .leanctx/rules.toml from existing rules.\nRun ctx_rules(action=\"lint\") to check, then ctx_rules(action=\"sync\") to distribute.".to_string(),
+                Ok(_) => "Created .lean-ctx/rules.toml from existing rules.\nRun ctx_rules(action=\"lint\") to check, then ctx_rules(action=\"sync\") to distribute.".to_string(),
                 Err(e) => format!("Error: {e}"),
             }
         }


### PR DESCRIPTION
## Summary

Aligns directory naming with the project name convention. Updates all user-facing messages, help text, error strings, the CONFIG_DIR constant, and test assertions.

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps