### PR TITLE
feat: handle VS Code paths for Insiders and dev containers

### DIFF
--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -446,13 +446,17 @@ fn detect_extension_installed(home: &Path, extension_id: &str) -> bool {
             return true;
         }
         if home
-            .join(format!(".config/Code - Insiders/User/globalStorage/{extension_id}"))
+            .join(format!(
+                ".config/Code - Insiders/User/globalStorage/{extension_id}"
+            ))
             .exists()
         {
             return true;
         }
         if home
-            .join(format!(".vscode-server/data/User/globalStorage/{extension_id}"))
+            .join(format!(
+                ".vscode-server/data/User/globalStorage/{extension_id}"
+            ))
             .exists()
         {
             return true;

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -445,6 +445,18 @@ fn detect_extension_installed(home: &Path, extension_id: &str) -> bool {
         {
             return true;
         }
+        if home
+            .join(format!(".config/Code - Insiders/User/globalStorage/{extension_id}"))
+            .exists()
+        {
+            return true;
+        }
+        if home
+            .join(format!(".vscode-server/data/User/globalStorage/{extension_id}"))
+            .exists()
+        {
+            return true;
+        }
     }
     #[cfg(target_os = "windows")]
     {
@@ -488,9 +500,15 @@ pub fn detect_vscode_path() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {
-            let vscode = home.join(".config/Code/User/settings.json");
-            if vscode.exists() {
-                return vscode;
+            let paths = vec![
+                home.join(".config/Code/User/settings.json"),
+                home.join(".config/Code - Insiders/User/settings.json"),
+                home.join(".vscode-server/data/User/settings.json"),
+            ];
+            for vscode in paths {
+                if vscode.exists() {
+                    return vscode;
+                }
             }
         }
     }

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -504,7 +504,7 @@ pub fn detect_vscode_path() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {
-            let paths = vec![
+            let paths = [
                 home.join(".config/Code/User/settings.json"),
                 home.join(".config/Code - Insiders/User/settings.json"),
                 home.join(".vscode-server/data/User/settings.json"),

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -130,7 +130,7 @@ fn resolve_vscode_global_storage(home: &Path, suffix: &str) -> PathBuf {
         ".config/Code - Insiders",
         ".config/Code - OSS",
         ".config/VSCodium",
-        ".vscode-server/data"
+        ".vscode-server/data",
     ];
     for base in CANDIDATES {
         let path = home.join(base);

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -122,13 +122,20 @@ pub fn roo_mcp_path() -> PathBuf {
 /// Resolves the correct VS Code-family base directory on Linux.
 /// Checks VSCodium, Code - OSS, and Code (in that order) — returns the first
 /// existing path, falling back to the standard `Code` path for fresh installs.
+/// Dev containers use `.vscode-server/data` instead of `.config`, so we check both.
 #[cfg(target_os = "linux")]
 fn resolve_vscode_global_storage(home: &Path, suffix: &str) -> PathBuf {
-    const CANDIDATES: &[&str] = &["VSCodium", "Code - OSS", "Code"];
+    const CANDIDATES: &[&str] = &[
+        ".config/Code",
+        ".config/Code - Insiders",
+        ".config/Code - OSS",
+        ".config/VSCodium",
+        ".vscode-server/data"
+    ];
     for base in CANDIDATES {
-        let path = home.join(".config").join(base).join(suffix);
+        let path = home.join(base);
         if path.exists() {
-            return path;
+            return path.join(suffix);
         }
     }
     home.join(".config/Code").join(suffix)
@@ -211,6 +218,17 @@ pub fn augment_vscode_mcp_path(home: &Path) -> PathBuf {
     }
     #[cfg(target_os = "linux")]
     {
+        for path in [
+            ".config/Code/User",
+            ".config/Code - Insiders/User",
+            ".vscode-server/data/User",
+        ] {
+            let full_path = home.join(path).join(TAIL);
+            if full_path.exists() {
+                return full_path;
+            }
+        }
+        // Fall back to primary path if none exist
         return home.join(".config/Code/User").join(TAIL);
     }
     #[cfg(target_os = "windows")]

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -120,16 +120,19 @@ pub fn roo_mcp_path() -> PathBuf {
 }
 
 /// Resolves the correct VS Code-family base directory on Linux.
-/// Checks VSCodium, Code - OSS, and Code (in that order) — returns the first
-/// existing path, falling back to the standard `Code` path for fresh installs.
-/// Dev containers use `.vscode-server/data` instead of `.config`, so we check both.
+/// Checks VSCodium, Code - OSS, Code, Code - Insiders, then the dev-container
+/// server dir (in that order) — returns the first existing path, falling back
+/// to the standard `Code` path for fresh installs. Most-specific first: a
+/// VSCodium user with a leftover `~/.config/Code` (one accidental Code launch
+/// is enough) must keep resolving to VSCodium. Dev containers use
+/// `.vscode-server/data` instead of `.config`, so we check both.
 #[cfg(target_os = "linux")]
 fn resolve_vscode_global_storage(home: &Path, suffix: &str) -> PathBuf {
     const CANDIDATES: &[&str] = &[
+        ".config/VSCodium",
+        ".config/Code - OSS",
         ".config/Code",
         ".config/Code - Insiders",
-        ".config/Code - OSS",
-        ".config/VSCodium",
         ".vscode-server/data",
     ];
     for base in CANDIDATES {

--- a/rust/src/core/editor_registry/plan_mode.rs
+++ b/rust/src/core/editor_registry/plan_mode.rs
@@ -40,9 +40,15 @@ pub fn vscode_settings_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {
-            let p = home.join(".config/Code/User/settings.json");
-            if p.parent().is_some_and(std::path::Path::exists) {
-                return Some(p);
+            let paths = vec![
+                home.join(".config/Code/User/settings.json"),
+                home.join(".config/Code - Insiders/User/settings.json"),
+                home.join(".vscode-server/data/User/settings.json"),
+            ];
+            for p in paths {
+                if p.parent().is_some_and(std::path::Path::exists) {
+                    return Some(p);
+                }
             }
         }
     }

--- a/rust/src/core/editor_registry/plan_mode.rs
+++ b/rust/src/core/editor_registry/plan_mode.rs
@@ -40,7 +40,7 @@ pub fn vscode_settings_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     {
         if let Some(home) = dirs::home_dir() {
-            let paths = vec![
+            let paths = [
                 home.join(".config/Code/User/settings.json"),
                 home.join(".config/Code - Insiders/User/settings.json"),
                 home.join(".vscode-server/data/User/settings.json"),

--- a/rust/src/doctor/common.rs
+++ b/rust/src/doctor/common.rs
@@ -330,7 +330,11 @@ pub(super) fn mcp_config_locations(home: &std::path::Path) -> Vec<McpLocation> {
             home.join(".config/Code - Insiders/User"),
             home.join(".vscode-server/data/User"),
         ];
-        let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+        let user_dir = user_dirs
+            .iter()
+            .find(|p| p.exists())
+            .cloned()
+            .unwrap_or_else(|| user_dirs[0].clone());
         let vscode_mcp = user_dir.join("mcp.json");
         let display = vscode_mcp.strip_prefix(&home).unwrap_or(&vscode_mcp);
         let display_str = format!("~/{}", display.display());

--- a/rust/src/doctor/common.rs
+++ b/rust/src/doctor/common.rs
@@ -325,10 +325,18 @@ pub(super) fn mcp_config_locations(home: &std::path::Path) -> Vec<McpLocation> {
     }
     #[cfg(target_os = "linux")]
     {
-        let vscode_mcp = home.join(".config/Code/User/mcp.json");
+        let user_dirs = [
+            home.join(".config/Code/User"),
+            home.join(".config/Code - Insiders/User"),
+            home.join(".vscode-server/data/User"),
+        ];
+        let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+        let vscode_mcp = user_dir.join("mcp.json");
+        let display = vscode_mcp.strip_prefix(&home).unwrap_or(&vscode_mcp);
+        let display_str = format!("~/{}", display.display());
         locations.push(McpLocation {
             name: "VS Code",
-            display: "~/.config/Code/User/mcp.json".into(),
+            display: display_str.into(),
             path: vscode_mcp,
         });
     }

--- a/rust/src/doctor/common.rs
+++ b/rust/src/doctor/common.rs
@@ -336,11 +336,11 @@ pub(super) fn mcp_config_locations(home: &std::path::Path) -> Vec<McpLocation> {
             .cloned()
             .unwrap_or_else(|| user_dirs[0].clone());
         let vscode_mcp = user_dir.join("mcp.json");
-        let display = vscode_mcp.strip_prefix(&home).unwrap_or(&vscode_mcp);
+        let display = vscode_mcp.strip_prefix(home).unwrap_or(&vscode_mcp);
         let display_str = format!("~/{}", display.display());
         locations.push(McpLocation {
             name: "VS Code",
-            display: display_str.into(),
+            display: display_str,
             path: vscode_mcp,
         });
     }

--- a/rust/src/rules_inject/detect.rs
+++ b/rust/src/rules_inject/detect.rs
@@ -128,13 +128,17 @@ fn detect_extension_installed(_home: &std::path::Path, extension_id: &str) -> bo
             return true;
         }
         if _home
-            .join(format!(".config/Code - Insiders/User/globalStorage/{extension_id}"))
+            .join(format!(
+                ".config/Code - Insiders/User/globalStorage/{extension_id}"
+            ))
             .exists()
         {
             return true;
         }
         if _home
-            .join(format!(".vscode-server/data/User/globalStorage/{extension_id}"))
+            .join(format!(
+                ".vscode-server/data/User/globalStorage/{extension_id}"
+            ))
             .exists()
         {
             return true;

--- a/rust/src/rules_inject/detect.rs
+++ b/rust/src/rules_inject/detect.rs
@@ -80,6 +80,12 @@ fn detect_vscode_installed(_home: &std::path::Path) -> bool {
     if check_dir(_home.join(".config/Code/User")) {
         return true;
     }
+    if check_dir(_home.join(".config/Code - Insiders/User")) {
+        return true;
+    }
+    if check_dir(_home.join(".vscode-server/data/User")) {
+        return true;
+    }
     #[cfg(target_os = "windows")]
     if let Ok(appdata) = std::env::var("APPDATA") {
         if check_dir(PathBuf::from(&appdata).join("Code/User")) {
@@ -117,6 +123,18 @@ fn detect_extension_installed(_home: &std::path::Path, extension_id: &str) -> bo
     {
         if _home
             .join(format!(".config/Code/User/globalStorage/{extension_id}"))
+            .exists()
+        {
+            return true;
+        }
+        if _home
+            .join(format!(".config/Code - Insiders/User/globalStorage/{extension_id}"))
+            .exists()
+        {
+            return true;
+        }
+        if _home
+            .join(format!(".vscode-server/data/User/globalStorage/{extension_id}"))
             .exists()
         {
             return true;

--- a/rust/src/rules_inject/targets.rs
+++ b/rust/src/rules_inject/targets.rs
@@ -185,7 +185,11 @@ fn copilot_instructions_path(home: &std::path::Path) -> PathBuf {
             home.join(".config/Code - Insiders/User"),
             home.join(".vscode-server/data/User"),
         ];
-        let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+        let user_dir = user_dirs
+            .iter()
+            .find(|p| p.exists())
+            .cloned()
+            .unwrap_or_else(|| user_dirs[0].clone());
         return user_dir.join("github-copilot-instructions.md");
     }
     #[cfg(target_os = "windows")]

--- a/rust/src/rules_inject/targets.rs
+++ b/rust/src/rules_inject/targets.rs
@@ -180,7 +180,13 @@ fn copilot_instructions_path(home: &std::path::Path) -> PathBuf {
     }
     #[cfg(target_os = "linux")]
     {
-        return home.join(".config/Code/User/github-copilot-instructions.md");
+        let user_dirs = [
+            home.join(".config/Code/User"),
+            home.join(".config/Code - Insiders/User"),
+            home.join(".vscode-server/data/User"),
+        ];
+        let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+        return user_dir.join("github-copilot-instructions.md");
     }
     #[cfg(target_os = "windows")]
     {

--- a/rust/src/uninstall/mod.rs
+++ b/rust/src/uninstall/mod.rs
@@ -51,7 +51,11 @@ pub(super) fn copilot_instructions_path(home: &Path) -> PathBuf {
             home.join(".config/Code - Insiders/User"),
             home.join(".vscode-server/data/User"),
         ];
-        let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+        let user_dir = user_dirs
+            .iter()
+            .find(|p| p.exists())
+            .cloned()
+            .unwrap_or_else(|| user_dirs[0].clone());
         return user_dir.join("github-copilot-instructions.md");
     }
     #[cfg(target_os = "windows")]

--- a/rust/src/uninstall/mod.rs
+++ b/rust/src/uninstall/mod.rs
@@ -46,7 +46,13 @@ pub(super) fn copilot_instructions_path(home: &Path) -> PathBuf {
     }
     #[cfg(target_os = "linux")]
     {
-        return home.join(".config/Code/User/github-copilot-instructions.md");
+        let user_dirs = [
+            home.join(".config/Code/User"),
+            home.join(".config/Code - Insiders/User"),
+            home.join(".vscode-server/data/User"),
+        ];
+        let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+        return user_dir.join("github-copilot-instructions.md");
     }
     #[cfg(target_os = "windows")]
     {

--- a/rust/tests/setup_ci_smoke.rs
+++ b/rust/tests/setup_ci_smoke.rs
@@ -500,8 +500,14 @@ fn init_augment_installs_lean_ctx_mcp_into_dot_augment_settings() {
                     home.join(".config/Code - Insiders/User"),
                     home.join(".vscode-server/data/User"),
                 ];
-                let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
-                user_dir.join("globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
+                let user_dir = user_dirs
+                    .iter()
+                    .find(|p| p.exists())
+                    .cloned()
+                    .unwrap_or_else(|| user_dirs[0].clone());
+                user_dir.join(
+                    "globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json",
+                )
             }
             #[cfg(target_os = "macos")]
             {

--- a/rust/tests/setup_ci_smoke.rs
+++ b/rust/tests/setup_ci_smoke.rs
@@ -495,7 +495,13 @@ fn init_augment_installs_lean_ctx_mcp_into_dot_augment_settings() {
         let vscode_path = {
             #[cfg(target_os = "linux")]
             {
-                home.join(".config/Code/User/globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
+                let user_dirs = [
+                    home.join(".config/Code/User"),
+                    home.join(".config/Code - Insiders/User"),
+                    home.join(".vscode-server/data/User"),
+                ];
+                let user_dir = user_dirs.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| user_dirs[0].clone());
+                user_dir.join("globalStorage/augment.vscode-augment/augment-global-state/mcpServers.json")
             }
             #[cfg(target_os = "macos")]
             {


### PR DESCRIPTION
## Summary

Dev containers and VSCode Insiders uses different paths for storing data. This PR changes all places I could find in the code so that both normal VS Code, VS Code Insiders, and VS Code with a dev container should work.

## Test plan

I don't have enough space on my disk to run the tests.

- [ ] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [ ] ~If cookbook/packages changed: relevant `npm test` / build steps~

## Notes for reviewers

- Risk areas / edge cases:
- Backwards compatibility:
- Docs updated (links/files):

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
