### PR TITLE
fix(codex): rewrite PreToolUse commands with updatedInput instead of blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [3.8.2] — 2026-06-12
 
 ### Fixed
+- **Codex PreToolUse shell compression no longer blocks with a manual re-run
+  prompt**: Codex now supports native `updatedInput` rewrites for `PreToolUse`
+  hooks, so `hook codex-pretooluse` emits the documented allow+rewrite JSON on
+  stdout instead of exiting 2 with "Re-run with ..." feedback. Rewritable Bash
+  commands are transparently replaced with the `lean-ctx -c ...` command while
+  preserving normal tool execution.
 - **Linux: `ctx_*` tools broke for projects under `/c/…` and other
   single-letter roots (#397)**: the MSYS2/Git-Bash drive mapping
   (`/c/Users/…` → `C:/Users/…`) in the MCP path normalizer ran

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3212,9 +3212,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3230,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -4995,9 +4995,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -684,10 +684,17 @@ fn should_passthrough(path: &str) -> bool {
         })
 }
 
-fn codex_reroute_message(rewritten: &str) -> String {
-    format!(
-        "Command should run via lean-ctx for compact output. Do not retry the original command. Re-run with: {rewritten}"
-    )
+fn codex_rewrite_output(rewritten: &str) -> String {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": {
+                "command": rewritten
+            }
+        }
+    })
+    .to_string()
 }
 
 pub fn handle_codex_pretooluse() {
@@ -709,12 +716,7 @@ pub fn handle_codex_pretooluse() {
     };
 
     if let Some(rewritten) = rewrite_candidate(&cmd, &binary) {
-        if is_quiet() {
-            eprintln!("Re-run: {rewritten}");
-        } else {
-            eprintln!("{}", codex_reroute_message(&rewritten));
-        }
-        std::process::exit(2);
+        print!("{}", codex_rewrite_output(&rewritten));
     }
 }
 

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -261,12 +261,16 @@ fn rewrite_candidate_passes_through_heredoc_compound() {
 }
 
 #[test]
-fn codex_reroute_message_includes_exact_rewritten_command() {
-    let message = codex_reroute_message("lean-ctx -c 'git status'");
+fn codex_rewrite_output_uses_native_updated_input_contract() {
+    let output = codex_rewrite_output("lean-ctx -c 'git status'");
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid hook JSON");
+
+    assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+    assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
     assert_eq!(
-            message,
-            "Command should run via lean-ctx for compact output. Do not retry the original command. Re-run with: lean-ctx -c 'git status'"
-        );
+        parsed["hookSpecificOutput"]["updatedInput"]["command"],
+        "lean-ctx -c 'git status'"
+    );
 }
 
 #[test]

--- a/rust/tests/shell_and_agent_tests.rs
+++ b/rust/tests/shell_and_agent_tests.rs
@@ -280,8 +280,15 @@ fn codex_pretooluse_rewrites_rewritable_bash_with_updated_input() {
     let command = parsed["hookSpecificOutput"]["updatedInput"]["command"]
         .as_str()
         .expect("updated command should be a string");
+    let expected_binary = if cfg!(windows) {
+        "lean-ctx.exe"
+    } else {
+        "lean-ctx"
+    };
     assert!(
-        command.ends_with("lean-ctx -c 'git status'"),
+        command.contains(expected_binary)
+            && command.contains("-c")
+            && command.contains("git status"),
         "updated command should wrap git status with lean-ctx: {command}"
     );
 }

--- a/rust/tests/shell_and_agent_tests.rs
+++ b/rust/tests/shell_and_agent_tests.rs
@@ -265,21 +265,24 @@ fn agent_init_unknown_agent_fails() {
 }
 
 #[test]
-fn codex_pretooluse_blocks_rewritable_bash_with_reroute_message() {
+fn codex_pretooluse_rewrites_rewritable_bash_with_updated_input() {
     let input =
         r#"{"tool_name":"Bash","tool_input":{"command":"git status"},"command":"git status"}"#;
     let (stdout, stderr, code) = run_hook_test(&["hook", "codex-pretooluse"], &[], Some(input));
-    assert_eq!(code, 2, "hook should block and reroute: {stderr}");
+    assert_eq!(code, 0, "hook should rewrite without blocking: {stderr}");
     assert!(
-        stdout.trim().is_empty(),
-        "stdout should stay empty: {stdout}"
+        stderr.trim().is_empty(),
+        "stderr should stay empty for non-blocking rewrites: {stderr}"
     );
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout should contain hook JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "allow");
+    let command = parsed["hookSpecificOutput"]["updatedInput"]["command"]
+        .as_str()
+        .expect("updated command should be a string");
     assert!(
-        stderr.contains("Re-run with:")
-            && stderr.contains("lean-ctx")
-            && stderr.contains("-c")
-            && stderr.contains("git status"),
-        "stderr should contain reroute command: {stderr}"
+        command.ends_with("lean-ctx -c 'git status'"),
+        "updated command should wrap git status with lean-ctx: {command}"
     );
 }
 


### PR DESCRIPTION
## Summary

This updates the Codex `PreToolUse` hook path to use Codex's native non-blocking rewrite contract instead of the older block-and-reroute workaround.

For rewritable Bash commands, `hook codex-pretooluse` now emits:

- `hookSpecificOutput.hookEventName = "PreToolUse"`
- `permissionDecision = "allow"`
- `updatedInput.command = "<lean-ctx rewritten command>"`

and exits successfully, allowing Codex to execute the rewritten command directly.

## Why

The existing Codex hook behavior exits with code `2` and asks the model to manually retry:

```text
Command should run via lean-ctx for compact output. Do not retry the original command. Re-run with: ...
```

That was useful when Codex did not support `updatedInput` for this path, but current Codex supports native `PreToolUse` input rewrites. Blocking is now unnecessary and creates a worse UX: the first tool call fails, Codex receives feedback, and the model has to issue another command.

This PR switches Codex to the same intended model as other rewrite hooks: allow the tool call, but replace its input.

## Changes

- Replaced the Codex reroute feedback helper with `codex_rewrite_output()`.
- Changed `handle_codex_pretooluse()` to print the Codex `allow + updatedInput` JSON instead of writing to stderr and exiting `2`.
- Updated unit coverage for the Codex hook output contract.
- Updated the shell/agent integration test to assert:
  - exit code `0`
  - empty stderr
  - valid hook JSON on stdout
  - rewritten `updatedInput.command`
- Added a changelog entry.

## Validation

Ran targeted Rust checks:

```bash
cargo fmt --check
cargo test --lib codex_rewrite_output_uses_native_updated_input_contract
cargo test --test shell_and_agent_tests codex_pretooluse_rewrites_rewritable_bash_with_updated_input
```

Also ran a real Codex smoke test with `codex exec`.

Setup:

- Used the existing Codex `PreToolUse` hook configuration.
- Temporarily pointed `/opt/homebrew/bin/lean-ctx` at the locally built patched binary.
- Restored the original binary immediately after the smoke test.

Observed Codex executing the rewritten command directly:

```text
/bin/zsh -lc "/opt/homebrew/bin/lean-ctx -c 'git status'"
```

Observed compressed output:

```text
main
staged: +smoke.txt
─── 36 → 9 tok (↓75%) ───
```

This confirms Codex applied `updatedInput` instead of treating the hook as a blocking reroute.

The original `/opt/homebrew/bin/lean-ctx` was restored after the smoke test.
