### PR TITLE
fix(pi-lean-ctx): shut down MCP bridge cleanly

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -745,6 +745,10 @@ export default async function (pi: ExtensionAPI) {
     : null;
 
   if (mcpBridge) {
+    pi.on("session_shutdown", async () => {
+      await mcpBridge?.shutdown();
+    });
+
     try {
       await mcpBridge.start(pi);
     } catch (err) {

--- a/packages/pi-lean-ctx/extensions/mcp-bridge.ts
+++ b/packages/pi-lean-ctx/extensions/mcp-bridge.ts
@@ -78,6 +78,8 @@ export class McpBridge {
   private extraEnv: Record<string, string>;
   private policy: BridgeToolPolicy;
   private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  private shuttingDown = false;
   private lastError: string | undefined;
   private lastHungTool: string | undefined;
   private lastRetry: McpBridgeRetryState | undefined;
@@ -104,6 +106,8 @@ export class McpBridge {
   }
 
   private async connect(): Promise<void> {
+    if (this.shuttingDown) return;
+
     this.transport = new StdioClientTransport({
       command: this.binary,
       args: [],
@@ -120,7 +124,7 @@ export class McpBridge {
     this.transport.onclose = () => {
       this.connected = false;
       this.lastError = "MCP transport closed";
-      this.scheduleReconnect();
+      if (!this.shuttingDown) this.scheduleReconnect();
     };
 
     this.transport.onerror = (err) => {
@@ -135,6 +139,8 @@ export class McpBridge {
   }
 
   private scheduleReconnect(): void {
+    if (this.shuttingDown) return;
+    if (this.reconnectTimer) return;
     if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
       this.lastError = `Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached.`;
       console.error(
@@ -146,18 +152,22 @@ export class McpBridge {
     this.reconnectAttempts++;
     const delay = RECONNECT_DELAY_MS * this.reconnectAttempts;
 
-    setTimeout(async () => {
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = undefined;
+      if (this.shuttingDown) return;
       try {
         await this.connect();
-        console.error("[lean-ctx MCP bridge] Reconnected successfully");
+        if (!this.shuttingDown) console.error("[lean-ctx MCP bridge] Reconnected successfully");
       } catch (error) {
         this.lastError = error instanceof Error ? error.message : String(error);
         this.scheduleReconnect();
       }
     }, delay);
+    (this.reconnectTimer as { unref?: () => void }).unref?.();
   }
 
   private async forceReconnect(): Promise<void> {
+    if (this.shuttingDown) return;
     this.connected = false;
     try {
       await this.client?.close();
@@ -405,7 +415,12 @@ export class McpBridge {
   }
 
   async shutdown(): Promise<void> {
+    this.shuttingDown = true;
     this.reconnectAttempts = MAX_RECONNECT_ATTEMPTS;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
     try {
       await this.client?.close();
     } catch {


### PR DESCRIPTION
## Summary

When Pi runs in print mode (-p / --print), the pi-lean-ctx MCP bridge can keep the session alive instead of shutting down cleanly, causing print mode to hang.                                                                                                                                      

This PR adds a session_shutdown hook so pi-lean-ctx shuts down the MCP bridge cleanly and lets Pi exit normally after print-mode output.

## Test plan

- [] `cd rust && cargo test`
    - Fails with 14 unrelated existing Rust test failures:                                                                                         
       - `core::sandbox::tests::execute_python_error`                                                                                               
       - `core::sandbox::tests::execute_python_hello`                                                                                               
       - `core::sandbox::tests::sandbox_env_is_set`                                                                                                 
       - `core::wrapped::tests::wrapped_ascii_box_lines_have_uniform_width`                                                                         
       - `shell::exec::exec_tests::exec_argv_passes_through_when_disabled`                                                                          
       - `shell::exec::exec_tests::exec_argv_runs_simple_command`                                                                                   
       - `shell::exec::exec_tests::exec_direct_preserves_args_with_special_chars`                                                                   
       - `shell::exec::exec_tests::exec_direct_runs_true`                                                                                           
       - `shell::exec::exec_tests::wait_with_limits_captures_output`                                                                                
       - `shell::exec::exec_tests::wait_with_limits_timeout_kills_process`                                                                          
       - `shell::exec::exec_tests::wait_with_limits_truncates_large_output`                                                                         
       - `tools::ctx_execute::tests::handle_error_shows_stderr`                                                                                     
       - `tools::ctx_execute::tests::handle_simple_python`                                                                                          
       - `tools::ctx_execute::tests::handle_with_intent`                                                                                            
     - Result: `4684 passed; 14 failed; 7 ignored`                                                                                                  
     - Failures appear unrelated to `packages/pi-lean-ctx` TypeScript MCP bridge changes.
- [] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
    - Fails with existing Rust/Windows clippy issues unrelated to this PR.                                                                         
    - Examples: unknown lint `clippy::duration_suboptimal_units`, `#[ignore]` without reason, unused `home`, `inefficient_to_string`, Windows raw pointer lint, `result_large_err`.
- [x] `cd rust && cargo fmt --check`
- [x] `cd packages/pi-lean-ctx && npx tsc --noEmit`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Changes

- Added a Pi session_shutdown hook in extensions/index.ts that calls mcpBridge.shutdown()
- Updated extensions/mcp-bridge.ts to track shutdown state.
- Skipped connect/reconnect attempts after shutdown starts.
- Cleared pending reconnect timers during shutdown.
- Unref’d reconnect timers so they do not keep Node alive.

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
