### PR TITLE
docs: fixed obsolete values for memory_profile

### DIFF
--- a/docs/reference/14-performance-tuning.md
+++ b/docs/reference/14-performance-tuning.md
@@ -47,16 +47,16 @@ config + env + defaults into one view and tags the **source** of each value:
 individually.
 
 ```toml
-memory_profile = "balanced"     # balanced | performance | conservative
+memory_profile = "balanced"     # low | balanced | performance
 ```
 
 ```bash
 # or per-process, no config edit:
-LEAN_CTX_MEMORY_PROFILE=conservative lean-ctx serve --daemon
+LEAN_CTX_MEMORY_PROFILE="low" lean-ctx serve --daemon
 ```
 
-Reach for `conservative` on small CI runners or low-RAM machines; `performance`
-trades disk for speed on a workstation.
+Reach for `low` on small CI runners or low-RAM machines; `performance`
+trades disk for speed on a workstation. `balanced` is in between.
 
 ---
 


### PR DESCRIPTION
## Summary

What does this PR change and why?

small docs fixes

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
