### PR TITLE
feat(pathjail): add read_only_roots for read-only access to sibling repos

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,13 @@ lean-ctx enforces a **project boundary** for filesystem I/O:
   - Env: `LEAN_CTX_ALLOW_PATH` (or `LCTX_ALLOW_PATH`) — a path list (`:` on Unix, `;` on Windows)
   - Config: `allow_paths` in `~/.lean-ctx/config.toml` (whitelist only); `extra_roots` (whitelist + multi-root scanning)
   - `~`, `$VAR` and `${VAR}` are expanded in these entries (no shell runs for config files)
+- **Read-only roots** (`read_only_roots` / `LEAN_CTX_READ_ONLY_ROOTS`): a narrower tier
+  that grants **read** access (`ctx_read`, `ctx_search`, `ctx_tree`) to additional roots
+  while **refusing all writes/edits** to them. A path that resolves only via a read-only
+  root is rejected by write/edit tools ("path is under a read-only root; reads are allowed,
+  writes are not"); the same symlink/TOCTOU re-validation as normal roots applies, so a
+  symlink escaping a read-only root is still caught. Prefer this over `extra_roots` when an
+  agent must read a sibling repo but must never modify it. Empty by default (no behavior change).
 - **Disabling the jail** (sandboxed environments where the OS is the boundary):
   - Config: `path_jail = false` in `~/.lean-ctx/config.toml`
   - Compile-time: the `no-jail` cargo feature

--- a/docs/reference/appendix-paths-and-config.md
+++ b/docs/reference/appendix-paths-and-config.md
@@ -104,6 +104,7 @@ var always wins.
 | `LEAN_CTX_NO_UPDATE_CHECK=1` | Disable update check | unset |
 | `LEAN_CTX_ALLOW_PATH` | Extra PathJail roots (path list; see §5) | unset |
 | `LEAN_CTX_EXTRA_ROOTS` | Multi-root workspace roots (path list; see §5) | unset |
+| `LEAN_CTX_READ_ONLY_ROOTS` | Read-only PathJail roots — readable, not writable (path list; see §5) | unset |
 
 ### Provider tokens (for `ctx_provider`)
 
@@ -175,26 +176,28 @@ between `<!-- lean-ctx -->` markers — your own content is preserved.
 
 ---
 
-## 5. Filesystem boundary — `path_jail`, `allow_paths`, `extra_roots` (GH #392)
+## 5. Filesystem boundary — `path_jail`, `allow_paths`, `extra_roots`, `read_only_roots` (GH #392)
 
 All tool file access (`ctx_read`, `ctx_edit`, `ctx_tree`, …) is jailed under the
-current `project_root` (**PathJail**). Three knobs widen or remove that boundary —
+current `project_root` (**PathJail**). Four knobs widen or remove that boundary —
 they overlap, so here is exactly what each one does:
 
 | Knob | Effect | Use when |
 |------|--------|----------|
 | `allow_paths = ["…"]` (root key) | **Adds** directories to PathJail's whitelist. Tools may read/edit under them, but `ctx_tree`/`ctx_search` do **not** scan them. | One extra directory needs to be readable/editable (e.g. a shared skills folder). |
 | `extra_roots = ["…"]` (root key) | Same whitelist effect as `allow_paths` **plus** multi-root scanning: `ctx_tree`, `ctx_search`, overview treat them as additional project roots. | Multi-repo workspaces. |
+| `read_only_roots = ["…"]` (root key) | **Read-only** widening: read tools (`ctx_read`, `ctx_search`, `ctx_tree`) may access these paths, but write/edit tools (`ctx_edit`, …) are **refused** with "path is under a read-only root; reads are allowed, writes are not". Narrower and safer than `extra_roots`. | A sibling repo the agent should read but never modify (e.g. an `apes` session reading a neighboring `servo-agent/` checkout). |
 | `path_jail = false` (root key) | **Disables PathJail entirely** — every absolute path is allowed. | Sandboxed environments (bwrap, containers, VMs) where the OS is the boundary. |
 
 Env equivalents (path-list syntax, `:` on Unix / `;` on Windows):
-`LEAN_CTX_ALLOW_PATH` (= `allow_paths`), `LEAN_CTX_EXTRA_ROOTS` (= `extra_roots`).
+`LEAN_CTX_ALLOW_PATH` (= `allow_paths`), `LEAN_CTX_EXTRA_ROOTS` (= `extra_roots`),
+`LEAN_CTX_READ_ONLY_ROOTS` (= `read_only_roots`).
 
 Notes that save debugging time:
 
 - **`~`, `$VAR` and `${VAR}` are expanded** in `allow_paths` / `extra_roots` /
-  the env vars (since v3.8.1). On older versions `"$HOME/code"` was matched
-  literally and silently never applied.
+  `read_only_roots` / the env vars (since v3.8.1). On older versions
+  `"$HOME/code"` was matched literally and silently never applied.
 - `allow_paths = ["/"]` technically whitelists everything; prefer the explicit
   `path_jail = false` — `lean-ctx doctor` flags the `"/"` pattern.
 - Config changes are picked up on the next tool call (mtime-based reload); no

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -47,6 +47,7 @@ Top-level configuration keys
 - `proxy_enabled` (bool?, default `null`) — Enable/disable the proxy layer. null = auto-detect, true = force on, false = force off
 - `proxy_port` (u16?, default `null`) — Custom proxy port (default: 4444). Useful for multi-user systems. Env: LEAN_CTX_PROXY_PORT
 - `proxy_timeout_ms` (u64?, default `null`) — Proxy reachability timeout in ms (default: 200). Override via LEAN_CTX_PROXY_TIMEOUT_MS
+- `read_only_roots` (string[], default `[]` — env `LEAN_CTX_READ_ONLY_ROOTS`) — Read-only extra roots: read tools (ctx_read/search/tree) may access them; write/edit tools are refused
 - `redirect_exclude` (string[], default `[]`) — URL patterns to exclude from proxy redirection
 - `reference_results` (bool, default `false` — env `LEAN_CTX_REFERENCE_RESULTS`) — Store large tool outputs as references instead of inline content
 - `response_verbosity` (enum: normal | compact | minimal, default `normal` — env `LEAN_CTX_RESPONSE_VERBOSITY`) — Controls how verbose tool responses are

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -233,6 +233,15 @@ pub struct Config {
     /// Override via LEAN_CTX_EXTRA_ROOTS env var (path-list separator).
     #[serde(default)]
     pub extra_roots: Vec<String>,
+    /// Read-only extra roots: PathJail permits READ tools (ctx_read / ctx_search /
+    /// ctx_tree) to access these paths, but WRITE/EDIT tools (ctx_edit, …) are
+    /// refused. Narrower and safer than `extra_roots`, which grants read+write.
+    /// Use for sibling repos you want an agent to read but never modify (e.g. an
+    /// `apes` session reading a neighboring `servo-agent/` checkout). Absolute
+    /// paths. Default empty = no behavior change. Additive with
+    /// `LEAN_CTX_READ_ONLY_ROOTS` env var (path-list separator).
+    #[serde(default)]
+    pub read_only_roots: Vec<String>,
     /// Enable content-defined chunking (Rabin-Karp) for cache-optimal output ordering.
     /// Stable chunks are emitted first to maximize prompt cache hits.
     #[serde(default)]
@@ -507,6 +516,7 @@ impl Default for Config {
             allow_paths: Vec::new(),
             allow_ide_config_dirs: false,
             extra_roots: Vec::new(),
+            read_only_roots: Vec::new(),
             content_defined_chunking: false,
             minimal_overhead: true,
             symbol_map_auto: false,
@@ -1279,6 +1289,9 @@ impl Config {
         }
         if !local.extra_roots.is_empty() {
             self.extra_roots.extend(local.extra_roots);
+        }
+        if !local.read_only_roots.is_empty() {
+            self.read_only_roots.extend(local.read_only_roots);
         }
         if local.minimal_overhead {
             self.minimal_overhead = true;

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -230,6 +230,15 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         ),
     );
     root.insert(
+        "read_only_roots".into(),
+        key_with_env(
+            "string[]",
+            serde_json::json!(cfg.read_only_roots),
+            "Read-only extra roots: read tools (ctx_read/search/tree) may access them; write/edit tools are refused",
+            "LEAN_CTX_READ_ONLY_ROOTS",
+        ),
+    );
+    root.insert(
         "content_defined_chunking".into(),
         key(
             "bool",

--- a/rust/src/core/config/tests.rs
+++ b/rust/src/core/config/tests.rs
@@ -633,6 +633,54 @@ mod loop_detection_config_tests {
 }
 
 #[cfg(test)]
+mod read_only_roots_tests {
+    use super::super::*;
+
+    #[test]
+    fn default_is_empty() {
+        let cfg = Config::default();
+        assert!(cfg.read_only_roots.is_empty());
+    }
+
+    #[test]
+    fn deserialization_from_toml() {
+        let cfg: Config =
+            toml::from_str(r#"read_only_roots = ["/sib/repo", "/ref/checkout"]"#).unwrap();
+        assert_eq!(cfg.read_only_roots, vec!["/sib/repo", "/ref/checkout"]);
+    }
+
+    #[test]
+    fn merge_extends() {
+        let mut base = Config {
+            read_only_roots: vec!["/base-ro".to_string()],
+            ..Config::default()
+        };
+        base.merge_local(r#"read_only_roots = ["/local-ro"]"#);
+        assert_eq!(base.read_only_roots, vec!["/base-ro", "/local-ro"]);
+    }
+
+    #[test]
+    fn round_trip_serialize_deserialize() {
+        let cfg = Config {
+            read_only_roots: vec!["/a".to_string(), "/b".to_string()],
+            ..Config::default()
+        };
+        let toml_s = toml::to_string(&cfg).unwrap();
+        let back: Config = toml::from_str(&toml_s).unwrap();
+        assert_eq!(back.read_only_roots, vec!["/a", "/b"]);
+    }
+
+    #[test]
+    fn independent_of_extra_roots() {
+        // read_only_roots and extra_roots are distinct tiers — setting one must
+        // not populate the other.
+        let cfg: Config = toml::from_str(r#"read_only_roots = ["/ro"]"#).unwrap();
+        assert_eq!(cfg.read_only_roots, vec!["/ro"]);
+        assert!(cfg.extra_roots.is_empty());
+    }
+}
+
+#[cfg(test)]
 mod extra_roots_tests {
     use super::super::*;
 

--- a/rust/src/core/path_resolve.rs
+++ b/rust/src/core/path_resolve.rs
@@ -48,11 +48,44 @@ pub fn resolve_tool_path(
 /// An empty `extra_roots` is identical to [`resolve_tool_path`]; this is how
 /// sync tool handlers honor MCP `roots/list` / config `extra_roots` for an
 /// explicit path without widening the global jail (#403).
+///
+/// Read-only roots are honored permissively here (`read_only_ok = true`): the
+/// shared sync resolver is used by both read and write handlers, and the
+/// write-side block is applied by callers that know they mutate (via
+/// [`resolve_tool_path_rw`] / the dispatch pre-resolution keyed on
+/// `is_readonly_tool`). A read-only-root path therefore resolves through this
+/// fn; an actual write to it is refused at the write choke point.
 pub fn resolve_tool_path_with_roots(
     project_root: Option<&str>,
     shell_cwd: Option<&str>,
     raw: &str,
     extra_roots: &[String],
+) -> Result<String, String> {
+    resolve_tool_path_inner(project_root, shell_cwd, raw, extra_roots, true)
+}
+
+/// Write-tier resolution: identical to [`resolve_tool_path_with_roots`] but a
+/// path that resolves *only* via a read-only root is REFUSED with a clear
+/// error. Write/edit handlers that resolve paths in-handler (rather than via the
+/// dispatch pre-resolution) call this so a read-only root is never writable.
+pub fn resolve_tool_path_rw(
+    project_root: Option<&str>,
+    shell_cwd: Option<&str>,
+    raw: &str,
+    extra_roots: &[String],
+) -> Result<String, String> {
+    resolve_tool_path_inner(project_root, shell_cwd, raw, extra_roots, false)
+}
+
+/// Shared body. `read_only_ok` gates the read-only tier: when false, a candidate
+/// permitted *only* because it lives under a read-only root is rejected (writes
+/// forbidden); when true, it resolves (reads allowed).
+fn resolve_tool_path_inner(
+    project_root: Option<&str>,
+    shell_cwd: Option<&str>,
+    raw: &str,
+    extra_roots: &[String],
+    read_only_ok: bool,
 ) -> Result<String, String> {
     let normalized = crate::core::pathutil::normalize_tool_path(raw);
     if normalized.is_empty() || normalized == "." {
@@ -80,12 +113,19 @@ pub fn resolve_tool_path_with_roots(
     };
 
     let jail_root_path = Path::new(&jail_root);
-    let jailed =
-        crate::core::pathjail::jail_path_with_roots(&resolved, jail_root_path, extra_roots)?;
-    crate::core::io_boundary::check_secret_path_for_tool("resolve_path", &jailed)?;
+    let jailed = crate::core::pathjail::jail_path_with_roots_ro(
+        &resolved,
+        jail_root_path,
+        extra_roots,
+        &[],
+    )?;
+    if jailed.read_only && !read_only_ok {
+        return Err(crate::core::pathjail::READ_ONLY_ROOT_WRITE_ERR.to_string());
+    }
+    crate::core::io_boundary::check_secret_path_for_tool("resolve_path", &jailed.path)?;
 
     Ok(crate::core::pathutil::normalize_tool_path(
-        &jailed.to_string_lossy().replace('\\', "/"),
+        &jailed.path.to_string_lossy().replace('\\', "/"),
     ))
 }
 
@@ -216,6 +256,78 @@ mod tests {
         assert!(out.ends_with("missing.rs"), "got {out}");
         let _ = fs::remove_dir_all(&tmp);
     }
+
+    /// Security: a path under a read-only root RESOLVES for a read (the
+    /// permissive resolver) but is REFUSED for a write (`resolve_tool_path_rw`)
+    /// with the canonical read-only-write error. This is the resolver-level
+    /// guarantee that a read_only root is never writable. Serialized on the env
+    /// lock; isolated data dir so the jail is on.
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn read_only_root_resolves_for_read_but_refuses_write() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let _rol = READ_ONLY_ENV_LOCK.lock().unwrap();
+
+        let base = tempfile::tempdir().unwrap();
+        let root = base.path().join("project");
+        let ro = base.path().join("sibling");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&ro).unwrap();
+        let in_ro = ro.join("a.txt");
+        fs::write(&in_ro, "x").unwrap();
+
+        let root_s = root.to_string_lossy().to_string();
+        let ro_canon = crate::core::pathjail::canonicalize_or_self(&ro);
+        let file_abs = in_ro.to_string_lossy().to_string();
+
+        crate::test_env::set_var(
+            "LEAN_CTX_READ_ONLY_ROOTS",
+            ro_canon.to_string_lossy().as_ref(),
+        );
+        // Read tier: resolves.
+        let read = resolve_tool_path_with_roots(Some(&root_s), None, &file_abs, &[]);
+        // Write tier: refused with the canonical message.
+        let write = resolve_tool_path_rw(Some(&root_s), None, &file_abs, &[]);
+        crate::test_env::remove_var("LEAN_CTX_READ_ONLY_ROOTS");
+
+        assert!(
+            read.is_ok(),
+            "read must resolve a read_only-root path: {read:?}"
+        );
+        let err = write.expect_err("write to a read_only-root path must be refused");
+        assert_eq!(err, crate::core::pathjail::READ_ONLY_ROOT_WRITE_ERR);
+    }
+
+    /// A normal `extra_root` stays read-WRITE through the write-tier resolver: it
+    /// is NOT a read-only root, so `resolve_tool_path_rw` resolves it. Guards
+    /// against the read-only gate over-firing on the existing read-write tier.
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn extra_root_remains_writable_through_rw_resolver() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let _rol = READ_ONLY_ENV_LOCK.lock().unwrap();
+        crate::test_env::remove_var("LEAN_CTX_READ_ONLY_ROOTS");
+
+        let base = tempfile::tempdir().unwrap();
+        let root = base.path().join("project");
+        let rw = base.path().join("worktree");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&rw).unwrap();
+        let in_rw = rw.join("b.txt");
+        fs::write(&in_rw, "y").unwrap();
+
+        let root_s = root.to_string_lossy().to_string();
+        let extra = vec![rw.to_string_lossy().to_string()];
+        let out = resolve_tool_path_rw(Some(&root_s), None, &in_rw.to_string_lossy(), &extra);
+        assert!(
+            out.is_ok(),
+            "a read-write extra_root must stay writable through the rw resolver: {out:?}"
+        );
+    }
+
+    /// Serializes tests mutating `LEAN_CTX_READ_ONLY_ROOTS`.
+    #[cfg(not(feature = "no-jail"))]
+    static READ_ONLY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     // GH #397: on Unix an absolute path under a single-letter root (`/c/…`)
     // was rewritten to `C:/…`, which `Path::is_absolute()` rejects on Unix —

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -1,5 +1,12 @@
 use std::path::{Path, PathBuf};
 
+/// Error returned when a write/edit tool targets a path that resolved *only*
+/// via a read-only root. Centralized so the message is identical everywhere it
+/// is enforced (dispatch pre-resolution + in-handler write resolvers) and so
+/// tests can assert against a single source of truth.
+pub const READ_ONLY_ROOT_WRITE_ERR: &str =
+    "path is under a read-only root; reads are allowed, writes are not";
+
 const IDE_CONFIG_DIRS: &[&str] = &[
     ".lean-ctx",
     ".cursor",
@@ -110,6 +117,31 @@ pub fn allow_paths_from_env_and_config() -> Vec<PathBuf> {
     out
 }
 
+/// Read-only extra roots, sourced exactly like the read-write allow-list but
+/// kept in a separate tier: a candidate under one of these is *readable* yet
+/// must be *refused to write/edit tools*. Sourced from config `read_only_roots`
+/// and the additive `LEAN_CTX_READ_ONLY_ROOTS` env var (mirrors `extra_roots`).
+///
+/// Canonicalized the same (security, symlink-resolving) way as the candidate so
+/// `is_under_prefix` compares like with like — identical to the read-write tier.
+pub fn read_only_roots_from_env_and_config() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let cfg = crate::core::config::Config::load();
+
+    for p in &cfg.read_only_roots {
+        out.push(canonicalize_secure(&expand_user_path(p)));
+    }
+
+    let env = std::env::var("LEAN_CTX_READ_ONLY_ROOTS").unwrap_or_default();
+    if !env.trim().is_empty() {
+        for p in std::env::split_paths(&env) {
+            out.push(canonicalize_secure(&expand_user_path(&p.to_string_lossy())));
+        }
+    }
+
+    out
+}
+
 /// Home-level allow-dirs for the jail. `~/.lean-ctx` (own state) is always
 /// allowed; the *other* IDE config dirs (~/.cursor, ~/.claude, …) expose
 /// foreign projects' sessions, MCP configs and credentials to any agent, so
@@ -167,6 +199,20 @@ pub fn jail_path(candidate: &Path, jail_root: &Path) -> Result<PathBuf, String> 
     jail_path_with_roots(candidate, jail_root, &[])
 }
 
+/// Outcome of a jailed path resolution that also tracks the read-only tier.
+///
+/// `read_only` is true when the candidate was permitted *only* because it lives
+/// under a [`read_only_roots_from_env_and_config`] root (or a session-supplied
+/// `read_only_roots` entry) — i.e. it is NOT under the jail root, the
+/// read-write allow-list, or `extra_roots`. Read tools may use `path`; write/
+/// edit tools MUST refuse it. A path reachable via a read-write root is never
+/// flagged (read-write wins), so the flag is strictly the "writes forbidden" bit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JailedPath {
+    pub path: PathBuf,
+    pub read_only: bool,
+}
+
 /// Like [`jail_path`], but also accepts paths under any of `extra_roots`.
 ///
 /// `extra_roots` are session-scoped trusted roots (MCP `roots/list` and config
@@ -181,21 +227,49 @@ pub fn jail_path_with_roots(
     jail_root: &Path,
     extra_roots: &[String],
 ) -> Result<PathBuf, String> {
+    jail_path_with_roots_ro(candidate, jail_root, extra_roots, &[]).map(|j| j.path)
+}
+
+/// Like [`jail_path_with_roots`], but also accepts paths under any
+/// `read_only_roots` (session-supplied) plus the config/env read-only tier, and
+/// reports — via [`JailedPath::read_only`] — whether the candidate was permitted
+/// *only* because it lives under a read-only root.
+///
+/// Read tools call this and use the path regardless of the flag; write/edit
+/// tools call this and MUST refuse when `read_only` is true. A read-only root is
+/// therefore readable but never writable. Every other PathJail invariant
+/// (canonicalize-secure, symlink/TOCTOU re-validation, post-canonicalize
+/// recheck, null-byte rejection, `path_jail=false`/`no-jail` bypass) is
+/// preserved unchanged; an empty `read_only_roots` plus an empty config/env
+/// read-only tier makes this byte-for-byte identical to
+/// [`jail_path_with_roots`].
+pub fn jail_path_with_roots_ro(
+    candidate: &Path,
+    jail_root: &Path,
+    extra_roots: &[String],
+    read_only_roots: &[String],
+) -> Result<JailedPath, String> {
     if candidate.to_string_lossy().as_bytes().contains(&0) {
         return Err("path contains null byte".to_string());
     }
 
     #[cfg(feature = "no-jail")]
     {
-        let _ = (jail_root, extra_roots);
-        return Ok(canonicalize_or_self(candidate));
+        let _ = (jail_root, extra_roots, read_only_roots);
+        return Ok(JailedPath {
+            path: canonicalize_or_self(candidate),
+            read_only: false,
+        });
     }
 
     #[allow(unreachable_code)]
     {
         let cfg = crate::core::config::Config::load();
         if cfg.path_jail == Some(false) {
-            return Ok(canonicalize_or_self(candidate));
+            return Ok(JailedPath {
+                path: canonicalize_or_self(candidate),
+                read_only: false,
+            });
         }
 
         let root = canonicalize_secure(jail_root);
@@ -212,10 +286,22 @@ pub fn jail_path_with_roots(
             resolved.as_path()
         };
 
+        // Read-write allow-list: jail root ∪ config/env allow-list ∪ session
+        // `extra_roots`. A candidate under any of these is fully read-write.
         let mut allow = allow_paths_from_env_and_config();
         // Session-scoped roots widen the allow-list for this call only.
         allow.extend(
             extra_roots
+                .iter()
+                .filter(|r| !r.is_empty())
+                .map(|r| canonicalize_secure(Path::new(r))),
+        );
+
+        // Read-only tier (config/env + session): permits reads, forbids writes.
+        // Kept separate from `allow` so we can tag the resolution accordingly.
+        let mut ro_allow = read_only_roots_from_env_and_config();
+        ro_allow.extend(
+            read_only_roots
                 .iter()
                 .filter(|r| !r.is_empty())
                 .map(|r| canonicalize_secure(Path::new(r))),
@@ -228,13 +314,14 @@ pub fn jail_path_with_roots(
             )
         })?;
 
-        let allowed =
+        let under_rw =
             is_under_prefix(&base, &root) || allow.iter().any(|p| is_under_prefix(&base, p));
-
         #[cfg(windows)]
-        let allowed = allowed || is_under_prefix_windows(&base, &root);
+        let under_rw = under_rw || is_under_prefix_windows(&base, &root);
 
-        if !allowed {
+        let under_ro = ro_allow.iter().any(|p| is_under_prefix(&base, p));
+
+        if !under_rw && !under_ro {
             let base_msg = format!(
                 "path escapes project root: {} (root: {})",
                 candidate.display(),
@@ -261,22 +348,32 @@ pub fn jail_path_with_roots(
 
         // Re-validate after reconstruction: if the final path exists, canonicalize
         // and re-check to close TOCTOU window (symlink created between check and use).
+        // The recheck spans BOTH tiers so a symlink escaping into a read-only root
+        // is still validated; the read-only flag is recomputed from the canonical
+        // target so a symlink from a read-write area into a read-only root (or vice
+        // versa) is classified by where it actually lands.
+        let mut read_only = under_ro && !under_rw;
         if out.exists() {
             let final_canon = canonicalize_secure(&out);
-            let final_ok = is_under_prefix(&final_canon, &root)
+            let final_rw = is_under_prefix(&final_canon, &root)
                 || allow.iter().any(|p| is_under_prefix(&final_canon, p));
             #[cfg(windows)]
-            let final_ok = final_ok || is_under_prefix_windows(&final_canon, &root);
-            if !final_ok {
+            let final_rw = final_rw || is_under_prefix_windows(&final_canon, &root);
+            let final_ro = ro_allow.iter().any(|p| is_under_prefix(&final_canon, p));
+            if !final_rw && !final_ro {
                 return Err(format!(
                     "post-canonicalize jail escape detected: {} resolves to {}",
                     candidate.display(),
                     final_canon.display()
                 ));
             }
+            read_only = final_ro && !final_rw;
         }
 
-        Ok(out)
+        Ok(JailedPath {
+            path: out,
+            read_only,
+        })
     }
 }
 
@@ -638,4 +735,149 @@ mod tests {
         // Empty entries are ignored (no accidental allow-all).
         assert!(jail_path_with_roots(&outside, &root, &[String::new()]).is_err());
     }
+
+    /// read_only_roots (config/env tier): a path under a read-only root is
+    /// READABLE and TAGGED `read_only`; a normal `extra_root` stays read-write
+    /// (`read_only=false`); a path outside ALL roots still escapes. Holds the
+    /// read-only env lock so a parallel test mutating `LEAN_CTX_READ_ONLY_ROOTS`
+    /// cannot leak in, plus the allow-path lock and an isolated data dir.
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn read_only_root_is_readable_but_tagged_read_only() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let _alp = ALLOW_PATH_ENV_LOCK.lock().unwrap();
+        let _rol = READ_ONLY_ROOTS_ENV_LOCK.lock().unwrap();
+        crate::test_env::remove_var("LEAN_CTX_READ_ONLY_ROOTS");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let ro = tmp.path().join("sibling");
+        let rw = tmp.path().join("worktree");
+        let elsewhere = tmp.path().join("elsewhere");
+        for d in [&root, &ro, &rw, &elsewhere] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        let in_ro = ro.join("a.txt");
+        std::fs::write(&in_ro, "x").unwrap();
+        let in_rw = rw.join("b.txt");
+        std::fs::write(&in_rw, "y").unwrap();
+        let outside = elsewhere.join("c.txt");
+        std::fs::write(&outside, "z").unwrap();
+
+        let ro_roots = vec![ro.to_string_lossy().to_string()];
+        let rw_roots = vec![rw.to_string_lossy().to_string()];
+
+        // Read-only root: permitted, flagged read_only.
+        let j = jail_path_with_roots_ro(&in_ro, &root, &[], &ro_roots)
+            .expect("path under read_only root must resolve");
+        assert!(j.read_only, "path under a read_only root must be flagged");
+        assert!(j.path.ends_with("a.txt"));
+
+        // Read-write extra_root: permitted, NOT flagged (writes allowed).
+        let j2 = jail_path_with_roots_ro(&in_rw, &root, &rw_roots, &[])
+            .expect("path under extra_root must resolve");
+        assert!(!j2.read_only, "a read-write extra_root must not be flagged");
+
+        // A read_only root must NOT grant write semantics via the bare RW helper's
+        // contract: the flag is the only signal, and here it is set.
+        // Path outside every root still escapes, even with a read_only root present.
+        assert!(
+            jail_path_with_roots_ro(&outside, &root, &[], &ro_roots).is_err(),
+            "a path outside all roots must still escape"
+        );
+
+        // Empty read_only entries are ignored (no accidental allow-all).
+        assert!(jail_path_with_roots_ro(&outside, &root, &[], &[String::new()]).is_err());
+    }
+
+    /// A symlink inside the jail root that escapes into a read-only root is still
+    /// caught by the post-canonicalize recheck — and, because it lands in the
+    /// read-only root, is flagged read_only (so writes through it are refused too).
+    #[cfg(all(unix, not(feature = "no-jail")))]
+    #[test]
+    fn symlink_into_read_only_root_is_revalidated_and_flagged() {
+        use std::os::unix::fs::symlink;
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let _alp = ALLOW_PATH_ENV_LOCK.lock().unwrap();
+        let _rol = READ_ONLY_ROOTS_ENV_LOCK.lock().unwrap();
+        crate::test_env::remove_var("LEAN_CTX_READ_ONLY_ROOTS");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let ro = tmp.path().join("sibling");
+        let outside = tmp.path().join("outside");
+        for d in [&root, &ro, &outside] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+        let target = ro.join("secret.txt");
+        std::fs::write(&target, "ro").unwrap();
+        let escaped = outside.join("secret.txt");
+        std::fs::write(&escaped, "no").unwrap();
+
+        let ro_roots = vec![ro.to_string_lossy().to_string()];
+
+        // A symlink in the jail root pointing INTO the read-only root: the post-
+        // canonicalize recheck spans the read-only tier, so it resolves — and the
+        // flag reflects where it actually lands (read-only).
+        let link_ro = root.join("link_ro.txt");
+        symlink(&target, &link_ro).unwrap();
+        let j = jail_path_with_roots_ro(&link_ro, &root, &[], &ro_roots)
+            .expect("symlink into a read_only root resolves (read allowed)");
+        assert!(
+            j.read_only,
+            "a symlink resolving into a read_only root must be flagged read_only"
+        );
+
+        // A symlink escaping to a path under NEITHER tier is still rejected.
+        let link_bad = root.join("link_bad.txt");
+        symlink(&escaped, &link_bad).unwrap();
+        assert!(
+            jail_path_with_roots_ro(&link_bad, &root, &[], &ro_roots).is_err(),
+            "a symlink escaping all roots must still be rejected"
+        );
+    }
+
+    /// `LEAN_CTX_READ_ONLY_ROOTS` is parsed (path-list separator) and feeds the
+    /// read-only tier: a path under an env-listed root resolves and is flagged.
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn read_only_roots_env_var_is_parsed() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let _alp = ALLOW_PATH_ENV_LOCK.lock().unwrap();
+        let _rol = READ_ONLY_ROOTS_ENV_LOCK.lock().unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let ro = tmp.path().join("sibling");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&ro).unwrap();
+        let in_ro = ro.join("a.txt");
+        std::fs::write(&in_ro, "x").unwrap();
+
+        // Canonicalize: the env tier is compared against the canonical candidate.
+        let ro_canon = canonicalize_or_self(&ro);
+        crate::test_env::set_var(
+            "LEAN_CTX_READ_ONLY_ROOTS",
+            ro_canon.to_string_lossy().as_ref(),
+        );
+        let parsed = read_only_roots_from_env_and_config();
+        let j = jail_path_with_roots_ro(&in_ro, &root, &[], &[]);
+        crate::test_env::remove_var("LEAN_CTX_READ_ONLY_ROOTS");
+
+        assert!(
+            parsed.iter().any(|p| in_ro.starts_with(p)),
+            "env read_only root must be parsed into the tier: {parsed:?}"
+        );
+        let j = j.expect("env read_only root must permit the read");
+        assert!(
+            j.read_only,
+            "env-sourced read_only root must flag read_only"
+        );
+    }
+
+    /// Serializes tests mutating `LEAN_CTX_READ_ONLY_ROOTS` (process-global env).
+    /// Gated like its only users so `--features no-jail` (which filters those
+    /// tests out) does not see an unused static.
+    #[cfg(not(feature = "no-jail"))]
+    static READ_ONLY_ROOTS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 }

--- a/rust/src/server/dispatch/mod.rs
+++ b/rust/src/server/dispatch/mod.rs
@@ -192,10 +192,15 @@ impl LeanCtxServer {
             let mut resolved_paths = std::collections::HashMap::new();
             let mut path_errors: std::collections::HashMap<String, String> =
                 std::collections::HashMap::new();
+            // Read-only-root gate: only known read tools may resolve a path that
+            // lands under a `read_only_roots` entry. Every other tool (any writer,
+            // including unknown/future ones) is denied by default — a read-only
+            // root is therefore never writable through the path pre-resolution.
+            let read_only_ok = crate::server::dynamic_tools::is_readonly_tool(name);
             for key in PATH_LIKE_KEYS {
                 if let Some(val) = args_map.get(*key) {
                     if let Some(raw) = val.as_str() {
-                        match self.resolve_path(raw).await {
+                        match self.resolve_path_ro(raw, read_only_ok).await {
                             Ok(resolved) => {
                                 if !["path", "project_root", "root"].contains(key) {
                                     tracing::trace!(
@@ -252,6 +257,7 @@ impl LeanCtxServer {
                 autonomy: Some(self.autonomy.clone()),
                 pressure_snapshot,
                 path_errors,
+                read_only_ok,
                 bm25_cache: Some(self.bm25_cache.clone()),
                 progress_sender: Some(self.progress_sender.clone()),
             };

--- a/rust/src/server/multi_path.rs
+++ b/rust/src/server/multi_path.rs
@@ -145,6 +145,7 @@ mod tests {
             autonomy: None,
             pressure_snapshot: None,
             path_errors: std::collections::HashMap::new(),
+            read_only_ok: true,
             bm25_cache: None,
             progress_sender: None,
         }

--- a/rust/src/server/tool_trait.rs
+++ b/rust/src/server/tool_trait.rs
@@ -161,6 +161,13 @@ pub struct ToolContext {
     /// Errors from path resolution (PathJail rejection, secret path, etc.).
     /// Keyed by argument name (e.g. "path" -> "path escapes project root: ...").
     pub path_errors: std::collections::HashMap<String, String>,
+    /// Whether this tool may resolve paths that land under a read-only root.
+    /// Set at dispatch to `is_readonly_tool(name)`: known read tools = true,
+    /// every other (write-capable) tool = false. Gates in-handler
+    /// [`Self::resolve_path_sync`] so a read-only root is never writable even via
+    /// a handler that resolves its own paths. Default true (read-permissive) for
+    /// the one-shot CLI / test contexts that don't carry a tool classification.
+    pub read_only_ok: bool,
     /// Shared in-memory BM25 index cache for semantic search.
     pub bm25_cache: Option<crate::core::bm25_cache::SharedBm25Cache>,
     /// MCP progress notification sender for long-running operations.
@@ -190,6 +197,7 @@ impl Default for ToolContext {
             autonomy: None,
             pressure_snapshot: None,
             path_errors: std::collections::HashMap::new(),
+            read_only_ok: true,
             bm25_cache: None,
             progress_sender: None,
         }
@@ -207,15 +215,26 @@ impl ToolContext {
     }
 
     /// Sync path resolution using `project_root` + session `extra_roots`. Thin
-    /// wrapper over [`crate::core::path_resolve::resolve_tool_path_with_roots`]
-    /// for sync tool handlers.
+    /// wrapper over the shared resolver. When this context is for a write-capable
+    /// tool (`read_only_ok == false`) a path under a read-only root is refused;
+    /// read tools resolve it. This mirrors the dispatch pre-resolution gate so a
+    /// handler that resolves its own paths cannot write a read-only root.
     pub fn resolve_path_sync(&self, path: &str) -> Result<String, String> {
-        crate::core::path_resolve::resolve_tool_path_with_roots(
-            Some(&self.project_root),
-            None,
-            path,
-            &self.extra_roots,
-        )
+        if self.read_only_ok {
+            crate::core::path_resolve::resolve_tool_path_with_roots(
+                Some(&self.project_root),
+                None,
+                path,
+                &self.extra_roots,
+            )
+        } else {
+            crate::core::path_resolve::resolve_tool_path_rw(
+                Some(&self.project_root),
+                None,
+                path,
+                &self.extra_roots,
+            )
+        }
     }
 }
 

--- a/rust/src/tools/registered/ctx_multi_read.rs
+++ b/rust/src/tools/registered/ctx_multi_read.rs
@@ -205,6 +205,7 @@ mod tests {
             autonomy: None,
             pressure_snapshot: None,
             path_errors: std::collections::HashMap::new(),
+            read_only_ok: true,
             bm25_cache: None,
             progress_sender: None,
         }

--- a/rust/src/tools/server_paths.rs
+++ b/rust/src/tools/server_paths.rs
@@ -22,7 +22,19 @@ impl LeanCtxServer {
     /// Resolves a (possibly relative) tool path against the session's project_root.
     /// Absolute paths and "." are returned as-is. Relative paths like "src/main.rs"
     /// are joined with project_root so tools work regardless of the server's cwd.
+    ///
+    /// Read-permissive: a path under a read-only root resolves. The write-tier
+    /// gate lives in [`Self::resolve_path_ro`] (called by dispatch with
+    /// `read_only_ok=false` for non-readonly tools).
     pub async fn resolve_path(&self, path: &str) -> Result<String, String> {
+        self.resolve_path_ro(path, true).await
+    }
+
+    /// Like [`Self::resolve_path`] but `read_only_ok` gates the read-only tier:
+    /// when false, a path that resolves *only* via a read-only root is refused
+    /// (writes forbidden). Dispatch passes `is_readonly_tool(name)` so only known
+    /// read tools may resolve read-only-root paths; every other tool is denied.
+    pub async fn resolve_path_ro(&self, path: &str, read_only_ok: bool) -> Result<String, String> {
         let normalized = crate::core::pathutil::normalize_tool_path(path);
         if normalized.is_empty() || normalized == "." {
             return Ok(normalized);
@@ -61,10 +73,11 @@ impl LeanCtxServer {
         };
 
         let jail_root_path = std::path::Path::new(&jail_root);
-        let jailed = match crate::core::pathjail::jail_path_with_roots(
+        let jailed = match crate::core::pathjail::jail_path_with_roots_ro(
             &resolved,
             jail_root_path,
             &extra_roots,
+            &[],
         ) {
             Ok(p) => p,
             Err(e) => {
@@ -96,10 +109,11 @@ impl LeanCtxServer {
                                 .or_else(|| Some(new_root_str.clone()));
                             let _ = session.save();
 
-                            crate::core::pathjail::jail_path_with_roots(
+                            crate::core::pathjail::jail_path_with_roots_ro(
                                 &resolved,
                                 &new_root,
                                 &extra_roots,
+                                &[],
                             )?
                         } else {
                             return Err(e);
@@ -113,10 +127,17 @@ impl LeanCtxServer {
             }
         };
 
-        crate::core::io_boundary::check_secret_path_for_tool("resolve_path", &jailed)?;
+        // Read-only-root gate: a write/edit tool (dispatch passes read_only_ok =
+        // is_readonly_tool(name) = false) may not resolve a path that landed only
+        // under a read-only root. Read tools (read_only_ok = true) resolve it.
+        if jailed.read_only && !read_only_ok {
+            return Err(crate::core::pathjail::READ_ONLY_ROOT_WRITE_ERR.to_string());
+        }
+
+        crate::core::io_boundary::check_secret_path_for_tool("resolve_path", &jailed.path)?;
 
         Ok(crate::core::pathutil::normalize_tool_path(
-            &jailed.to_string_lossy().replace('\\', "/"),
+            &jailed.path.to_string_lossy().replace('\\', "/"),
         ))
     }
 


### PR DESCRIPTION
## Hi, and thanks for lean-ctx 👋

Daily user here. This adds `read_only_roots` — a small, safe extension to the
existing multi-root support that solved a real pain for us.

For context, my workflow is often in a mono-repo STYLE. A parent directory with many sibling projects. From the PARENT directory, I will work on orchestrating and high level tasks. BUT --- in one of the child directories, there is often handoff or context that is useful from a sibling. It would be possible in such cases to manage a multi-agent orchestration layer, but I have found this increases overhead. A more straightforward approach of simply expanding an agent working in a given project to the siblings is my preference.

## The pain

A session pinned to one project root can't read a sibling checkout (e.g. an
orchestration project that needs to read a neighboring repo) — it errors
`path escapes project root`. `extra_roots` lifts that, but it also grants **write**
access.

## What this adds

`read_only_roots` (config field + `LEAN_CTX_READ_ONLY_ROOTS` env, mirroring
`extra_roots`): a tier of roots that **read** tools may access but **write/edit**
tools may not. It is strictly narrower than `extra_roots`, so it is a safety
*improvement* — external repos become readable without becoming writable.

## Tradeoff / Tension

Obvious blast radius implication. Workflow specific - not everyone will have a similar workflow.

## Security design

- `jail_path_with_roots_ro` returns `JailedPath { path, read_only }`. Read-write
  always wins, so the flag is strictly the "writes forbidden" bit.
- Enforced at two choke points: the dispatch resolver (`read_only_ok` derived
  from `is_readonly_tool`) **and** an in-handler write-tier resolver
  (`resolve_tool_path_rw`). A read-only root is never writable via any path tool.
- Every existing PathJail invariant is preserved (canonicalize-secure, symlink/
  TOCTOU re-validation, post-canonicalize recheck). An empty `read_only_roots` is
  byte-for-byte identical to today.

## Tests

Read resolves / write refused with the canonical error; a normal `extra_root`
stays writable (guards against the read-only gate over-firing); symlink escape
from a read-only root is still caught; env parsing; config round-trip. (pathjail,
config, and path_resolve suites green.)

## CI / back-compat

`cargo fmt` and `clippy -D warnings` clean on the changed files; relevant lib
tests green. Additive, default-empty → no behavior change.
