### PR TITLE
docs: contributor build & disk-usage guidance + leaner default dev profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Thanks for your interest in lean-ctx — contributions are welcome.
 
 - Rust (stable) via [rustup](https://rustup.rs/)
 - Git
+- A C toolchain (`cc`, plus `cmake` for `aws-lc`) — several dependencies
+  (jemalloc, `aws-lc`, …) build from source
 
 ### Setup
 
@@ -27,6 +29,59 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all-features
 cargo test --release
 ```
+
+## Building across worktrees & disk usage
+
+lean-ctx pulls in a **heavy native-dependency tree** (jemalloc, an `aws-lc`
+crypto build, tree-sitter grammars, …), so a debug build is larger than the Rust
+source alone suggests. A couple of things worth knowing so it doesn't surprise
+your disk:
+
+- **Each `git worktree` gets its own `target/`.** Keep several PR checkouts open
+  and Cargo compiles the full native tree *per worktree*, sharing nothing
+  between them.
+- **`target/debug` never garbage-collects.** Stale incremental units and old
+  dependency versions accumulate, so one heavily-rebuilt `target/` can reach
+  **tens of GB** (vs. ~2 GB for a clean build).
+
+### A shared compilation cache (recommended)
+
+[`sccache`](https://github.com/mozilla/sccache) deduplicates dependency compiles
+across worktrees and branches, without the build-lock contention a shared
+`CARGO_TARGET_DIR` introduces:
+
+```bash
+cargo install sccache
+export RUSTC_WRAPPER=sccache   # add to your shell profile
+```
+
+> A single shared `CARGO_TARGET_DIR` also dedups, but Cargo holds a per-target
+> build lock, so concurrent builds across worktrees **serialize**.
+
+### Prune stale artifacts
+
+[`cargo-sweep`](https://github.com/holmgr/cargo-sweep) drops build artifacts past
+a cutoff so `target/` can't grow without bound:
+
+```bash
+cargo install cargo-sweep
+cargo sweep --time 7      # remove artifacts unused for > 7 days
+```
+
+### Reclaim space fast
+
+`target/` is always safe to delete — it's pure build output and regenerates on
+the next build:
+
+```bash
+cargo clean               # this checkout's target/
+du -sh target             # check current size
+```
+
+Debug info is the bulk of that size: this repo sets
+`[profile.dev] debug = "line-tables-only"`, which keeps `file:line` in panics and
+backtraces while dropping full variable-level data. Set `debug = 2` in a local
+profile override if you need to step-debug.
 
 ## Cookbook / SDK / extensions (optional)
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -254,6 +254,13 @@ trivially_copy_pass_by_ref = "allow"
 # --- HashMap: we always use default hasher ---
 implicit_hasher = "allow"
 
+# Debug info is the bulk of `target/debug` size, and `target/` never GCs — a
+# heavily-rebuilt worktree can reach tens of GB. Line-table debuginfo keeps
+# `file:line` in panics and backtraces while dropping full variable-level data.
+# Set `debug = 2` in a local profile override if you need to step-debug.
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
 opt-level = "z"
 lto = true


### PR DESCRIPTION
## Hi, and thanks for lean-ctx 👋

Daily user here. I filed #461 after a build run nearly wedged my workstation's
disk; this is the fix for it.

For context — I had several `git worktree` checkouts of lean-ctx open at
once (a couple of PR branches plus main). So this is very much an engineer
 quality of life upgrade. That said - the trap was that each
worktree builds the full native-dependency tree into its *own* `target/`, and
those never shrink.

## The pain

lean-ctx pulls in a heavy native-dependency tree (jemalloc, an `aws-lc` crypto
build, tree-sitter grammars, …). Combined with two facts —

- each worktree gets its **own `target/`**, sharing nothing, and
- `target/debug` **never garbage-collects** stale incremental/dep artifacts —

a heavily-rebuilt `target/` balloons to **tens of GB** (vs ~2 GB clean) and can
run a disk to 100 % mid-link.

## What this adds

A small, mostly-documentation change that addresses the foot-guns directly:

- **A leaner default dev profile** — the single biggest lever, since debug info
  is the bulk of `target/debug` size.
- **A CONTRIBUTING "Building across worktrees & disk usage" section** — `sccache`
  (recommended), `cargo-sweep`, reclaim one-liners, and the worktree gotcha
  spelled out, plus the native-toolchain prerequisite.

## Tradeoff / Tension

The one behavior-affecting line is `[profile.dev] debug = "line-tables-only"`:
it keeps `file:line` in panics and backtraces (so `RUST_BACKTRACE` and test
failures stay readable) but drops full variable-level debug data, so a debugger
shows less. For a test-driven codebase that felt like the right default — but if
you'd rather keep full debuginfo, say so and I'll move it to a documented opt-in
and keep this PR docs-only.

## Changes

- `rust/Cargo.toml`: add `[profile.dev]` with `debug = "line-tables-only"`
  (commented; `debug = 2` locally for step-debugging).
- `CONTRIBUTING.md`: new "Building across worktrees & disk usage" section
  (sccache vs shared `CARGO_TARGET_DIR` tradeoff, `cargo-sweep`, reclaiming
  space) + a C-toolchain prerequisite note.

## CI / back-compat

`cargo check --all-features` passes under the new profile. No source/API change;
release builds are untouched. Backtraces remain `file:line`-accurate.

Closes #461.
