### PR TITLE
perf: bound index-build rayon threads (LEANCTX_INDEX_THREADS) to tame startup CPU herd

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -32,6 +32,7 @@ Top-level configuration keys
 - `graph_index_max_files` (u64, default `0`) — Maximum files in graph index. 0 = unlimited (default). Set >0 to cap for constrained systems
 - `journal_enabled` (bool, default `true`) — Write human-readable activity journal to ~/.lean-ctx/journal.md
 - `max_disk_mb` (u64, default `0` — env `LEAN_CTX_MAX_DISK_MB`) — Simplified disk budget in MB (0 = disabled). Distributes: archive ~25%, BM25 ~10%
+- `max_index_threads` (usize, default `0` — env `LEANCTX_INDEX_THREADS`) — Cap rayon threads for the CPU-heavy index build (0 = all cores). Bounds per-instance CPU so concurrent sessions don't saturate the host on startup
 - `max_ram_percent` (u8, default `5` — env `LEAN_CTX_MAX_RAM_PERCENT`) — Maximum percentage of system RAM that lean-ctx may use (1-50, default 5)
 - `max_staleness_days` (u32, default `0` — env `LEAN_CTX_MAX_STALENESS_DAYS`) — Auto-purge data older than N days (0 = disabled). Flows into archive.max_age_hours
 - `memory_cleanup` (enum: aggressive | shared, default `aggressive` — env `LEAN_CTX_MEMORY_CLEANUP`) — Controls how aggressively memory is freed when idle

--- a/rust/src/cli/dispatch/server.rs
+++ b/rust/src/cli/dispatch/server.rs
@@ -37,6 +37,17 @@ pub(super) fn run_mcp_server() -> Result<()> {
     let worker_threads = resolve_worker_threads(parallelism);
     let max_blocking_threads = (worker_threads * 4).clamp(8, 32);
 
+    // The Tokio caps above bound async work, but the CPU-heavy index build runs
+    // on rayon, whose global pool otherwise grabs *every* core — so a fleet of
+    // concurrent sessions still spikes the host on startup. Bound it too.
+    // Opt-in: 0 keeps rayon's all-cores default; LEANCTX_INDEX_THREADS > config.
+    let index_threads = crate::core::config::Config::load().max_index_threads_effective();
+    if index_threads > 0 {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(index_threads)
+            .build_global();
+    }
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(worker_threads)
         .max_blocking_threads(max_blocking_threads)

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -364,6 +364,12 @@ pub struct Config {
     /// Flows into archive.max_age_hours and lifecycle idle TTL.
     #[serde(default)]
     pub max_staleness_days: u32,
+    /// Cap on the rayon worker threads used by the CPU-heavy index build
+    /// (call graph etc.). 0 = rayon default (all cores). Set >0 to bound
+    /// per-instance CPU so a fleet of concurrent sessions can't saturate the
+    /// host on startup. Override via LEANCTX_INDEX_THREADS env var.
+    #[serde(default)]
+    pub max_index_threads: usize,
     /// Controls visibility of token savings footers in tool output.
     /// Values: "always" (default, show on every response), "never", "auto" (legacy compatibility).
     /// Override via LEAN_CTX_SAVINGS_FOOTER or LEAN_CTX_SHOW_SAVINGS=1|0 env var.
@@ -545,6 +551,7 @@ impl Default for Config {
             max_ram_percent: serde_defaults::default_max_ram_percent(),
             max_disk_mb: 0,
             max_staleness_days: 0,
+            max_index_threads: 0,
             savings_footer: SavingsFooter::default(),
             project_root: None,
             lsp: std::collections::HashMap::new(),
@@ -681,6 +688,15 @@ impl Config {
             ),
             Err(_) => self.prefer_native_editor,
         }
+    }
+
+    /// Cap on the rayon index-build worker threads. `LEANCTX_INDEX_THREADS` wins
+    /// over config; `0` means "no cap" — rayon's all-cores default is kept.
+    pub fn max_index_threads_effective(&self) -> usize {
+        std::env::var("LEANCTX_INDEX_THREADS")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<usize>().ok())
+            .unwrap_or(self.max_index_threads)
     }
 
     /// Whether `name` is a lean-ctx edit operation that must be blocked from

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -429,6 +429,15 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         ),
     );
     root.insert(
+        "max_index_threads".into(),
+        key_with_env(
+            "usize",
+            serde_json::json!(cfg.max_index_threads),
+            "Cap rayon threads for the CPU-heavy index build (0 = all cores). Bounds per-instance CPU so concurrent sessions don't saturate the host on startup",
+            "LEANCTX_INDEX_THREADS",
+        ),
+    );
+    root.insert(
         "max_staleness_days".into(),
         key_with_env(
             "u32",

--- a/rust/src/core/config/tests.rs
+++ b/rust/src/core/config/tests.rs
@@ -1364,3 +1364,46 @@ mod persist_global_tests {
         assert_eq!(cfg2.max_ram_percent, Config::default().max_ram_percent);
     }
 }
+
+#[cfg(test)]
+mod max_index_threads_tests {
+    use super::super::*;
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(Config::default().max_index_threads, 0);
+    }
+
+    #[test]
+    fn absent_in_toml_defaults_to_zero() {
+        let cfg: Config = toml::from_str("").unwrap();
+        assert_eq!(cfg.max_index_threads, 0);
+    }
+
+    #[test]
+    fn parses_explicit_cap_from_toml() {
+        let cfg: Config = toml::from_str("max_index_threads = 8").unwrap();
+        assert_eq!(cfg.max_index_threads, 8);
+    }
+
+    #[test]
+    fn effective_uses_config_when_env_unset() {
+        // Only meaningful when LEANCTX_INDEX_THREADS is unset; skip otherwise.
+        if std::env::var("LEANCTX_INDEX_THREADS").is_ok() {
+            return;
+        }
+        let cfg = Config {
+            max_index_threads: 4,
+            ..Default::default()
+        };
+        assert_eq!(cfg.max_index_threads_effective(), 4);
+    }
+
+    #[test]
+    fn effective_zero_means_no_cap() {
+        if std::env::var("LEANCTX_INDEX_THREADS").is_ok() {
+            return;
+        }
+        assert_eq!(Config::default().max_index_threads_effective(), 0);
+    }
+}


### PR DESCRIPTION
## Hi, and thanks for lean-ctx 👋

Daily user here, usually with **several agent sessions running at once** on one
machine. This is a small, opt-in mitigation for the startup CPU spikes that come
with that — the interim knob from #460.

For context — when a wave of sessions (re)starts together (boot, resume,
reconnect, crash recovery), each `lean-ctx` server indexes on startup, and they
all do it at the same moment. On a busy machine that's a brief but real host-wide
CPU saturation.

## The pain

The server already hardens startup well — a `startup_guard` lock smooths the herd
and the Tokio worker pool is capped (`LEAN_CTX_WORKER_THREADS`). But the
**CPU-heavy index build runs on rayon** (e.g. the call-graph `par_iter`), and
rayon's global pool grabs **every core** regardless of those Tokio caps. So N
concurrent sessions each spin all cores at once.

## What this adds

A per-instance cap on the rayon index pool — `max_index_threads` (config) /
**`LEANCTX_INDEX_THREADS`** (env, wins over config). When set, the server bounds
rayon's global pool once at startup, so a fleet of sessions can index without
saturating the host (`LEANCTX_INDEX_THREADS=2`, say).

**Opt-in: `0` (the default) keeps rayon's all-cores behavior — zero change unless
you set it.**

## Tradeoff / Tension

This is the **interim mitigation** #460 lists, not the big fix. The structural win
is still a shared indexer daemon + persistent on-disk index (so N sessions cost
~one index pass) — out of scope here. This PR just gives fleets a lever today, and
composes with the existing `startup_guard` + Tokio caps. A sane *default* cap
could mitigate the herd out-of-the-box too; I left the default at "no cap" to keep
this strictly additive, but happy to add one if you'd prefer.

## Changes

- `core/config/mod.rs`: add `max_index_threads: usize` (default `0`) +
  `max_index_threads_effective()` (env over config), beside the other resource
  knobs.
- `core/config/schema/sections_core.rs`: document the key (+ env).
- `cli/dispatch/server.rs`: at startup, if the cap is set, bound rayon's global
  pool (`ThreadPoolBuilder::build_global`) — right next to the existing Tokio
  concurrency hardening.

## CI / back-compat

`cargo fmt` + `clippy -D warnings` clean on the changed files; `cargo check
--all-features` passes; config tests added (default, TOML round-trip,
env-vs-config resolution). Default `0` = no behavior change.

Addresses #460 (the per-instance interim mitigation).
