### PR TITLE
perf(index): serialize the BM25 build cross-instance to stop the warm stampede

### DIFF
--- a/rust/src/core/index_orchestrator.rs
+++ b/rust/src/core/index_orchestrator.rs
@@ -93,6 +93,17 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Per-repo lock name for serializing the BM25 build across processes, mirroring
+/// the `graph-idx-<hash>` lock (see LOCK_ORDERING.md). The distinct `bm25-` vs
+/// `graph-` prefix keeps the graph and BM25 builds from serializing against each
+/// other while still preventing N processes from rebuilding either in parallel.
+fn bm25_index_lock_name(root: &Path) -> String {
+    format!(
+        "bm25-idx-{}",
+        &crate::core::index_namespace::namespace_hash(root)[..8]
+    )
+}
+
 fn start_component(c: &mut Component) {
     c.state = State::Building;
     c.started_ms = Some(now_ms());
@@ -270,20 +281,44 @@ pub fn ensure_all_background(project_root: &str) {
         }
         let bm = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let root_pb = Path::new(&root);
+            // Cross-instance build coordination: serialize the (expensive) BM25
+            // build per repo, mirroring the `graph-idx` lock in graph_index. The
+            // graph scan is already guarded this way; BM25 was the one component
+            // left to stampede when N sessions warm the same repo at once. On
+            // lock contention we load the index the holder is producing rather
+            // than running a second full build.
+            let lock_name = bm25_index_lock_name(root_pb);
+            let _lock = crate::core::startup_guard::try_acquire_lock(
+                &lock_name,
+                std::time::Duration::from_millis(800),
+                std::time::Duration::from_mins(3),
+            );
+            if _lock.is_none() {
+                tracing::info!(
+                    "[bm25: another process is building {root} — loading the shared index]"
+                );
+                let idx = BM25Index::load(root_pb).unwrap_or_default();
+                return (idx.doc_count, None);
+            }
             let idx = if content_cache.is_empty() {
                 BM25Index::load_or_build(root_pb)
             } else {
                 BM25Index::build_with_content_hint(root_pb, &content_cache)
             };
             let outcome = idx.save(root_pb);
-            (idx.doc_count, outcome)
+            (idx.doc_count, Some(outcome))
         }));
         if let Ok((doc_count, save_res)) = bm {
             let mut s = state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             finish_ok(&mut s.bm25);
-            s.bm25.note = Some(bm25_build_note(doc_count, &save_res));
+            s.bm25.note = Some(match save_res {
+                Some(outcome) => bm25_build_note(doc_count, &outcome),
+                None => format!(
+                    "loaded shared BM25 index ({doc_count} chunks) — build in progress in another process"
+                ),
+            });
         } else {
             let mut s = state
                 .lock()
@@ -737,5 +772,22 @@ mod tests {
         let primary_str = primary.to_string_lossy().to_string();
         // Should not spawn more than MAX_EXTRA_ROOT_BUILDS threads
         ensure_extra_roots_background(&primary_str, &extra);
+    }
+
+    #[test]
+    fn bm25_index_lock_name_is_per_repo_and_distinct_from_graph() {
+        let a = bm25_index_lock_name(Path::new("/tmp/repo-a"));
+        let b = bm25_index_lock_name(Path::new("/tmp/repo-b"));
+        assert!(a.starts_with("bm25-idx-"), "unexpected lock name: {a}");
+        assert_ne!(a, b, "lock name must be per-repo");
+        // Stable for the same repo across calls.
+        assert_eq!(a, bm25_index_lock_name(Path::new("/tmp/repo-a")));
+        // Must NOT collide with the graph lock for the same repo, or the two
+        // builds would serialize against each other unnecessarily.
+        let graph = format!(
+            "graph-idx-{}",
+            &crate::core::index_namespace::namespace_hash(Path::new("/tmp/repo-a"))[..8]
+        );
+        assert_ne!(a, graph, "bm25 and graph locks must be independent");
     }
 }


### PR DESCRIPTION
> ⚠️ **This is a small change but an architectural one — it adds cross-instance build coordination — so I'm explicitly asking for *your* call on the approach, not proposing a finished design.** I run a fleet of sessions and will be using this as a genuine improvement, but you own this surface: please push back, ask for more analysis, or harden it however you see fit. Concretely, **I have no idea how the file-locking behaves on macOS or Windows (or on network filesystems)** — I've flagged the specific risks at the bottom.

## Hi, and thanks for lean-ctx 👋

Daily fleet user here — I filed #460 after watching concurrent sessions saturate a workstation on startup, and measured it (19 `lean-ctx` processes, ~1 GB RSS, lots of duplicate same-repo indexing). This is the smallest real fix for the duplicated-work half of that.

## The pain

When N sessions warm the **same repo** at once, the **graph** build is already serialized per repo (the `graph-idx-<hash>` lock → load-on-contention). But the **BM25** build isn't — each of the N servers runs the full (expensive) tokenizer pass independently. The atomic rename keeps the written file correct, but the CPU/IO is duplicated N×. That's the stampede.

## What this adds

Serialize the BM25 build per repo, **mirroring your existing graph lock exactly**: take a `bm25-idx-<hash>` lock via `startup_guard::try_acquire_lock`; on contention, **load the index the lock-holder is producing** instead of running a second build.

**Single-instance behavior is unchanged** — the first/only indexer acquires uncontended and builds normally. Only the N-concurrent-same-repo case stops duplicating.

## Why this shape (and why I stopped here)

Reading the code first changed my plan: **persistence + incremental indexing already exist** for all four components (nicely done), so "warm starts" are already handled. The one remaining cross-instance stampede was BM25. Mirroring your proven graph pattern is the lowest-blast-radius way to close it — no format/schema change, no migration.

The bigger win — the ~1 GB of duplicate **in-RAM** indexes across same-repo sessions — needs the shared-index/daemon model, which is squarely your architecture call and deliberately out of scope here.

## Cross-platform / hardening questions for you (please vet)

- **The lock is `startup_guard`'s create-exclusive sentinel file, not flock/fcntl.** Correct locally; I can't vouch for it on **network filesystems** (NFS/SMB — common on macOS network homes, Windows UNC) where `O_EXCL`-create atomicity varies. The whole semaphore rests on that primitive.
- **Windows path casing:** `index_namespace::namespace_hash` hashes the normalized root — if the same repo is opened via different-cased paths/drive letters, two instances derive *different* lock names and the semaphore is defeated. Worth confirming normalization covers that.
- **PID-liveness reclaim** (`is_alive`) — confirm the Windows path, not just Unix.

## Changes

- `core/index_orchestrator.rs`: wrap the BM25 build in a per-repo `bm25-idx-<hash>` lock (reusing `startup_guard::try_acquire_lock` + `index_namespace::namespace_hash`), with a load-on-contention fallback that reports honestly (`loaded shared index … build in progress`). Small `bm25_index_lock_name` helper for a drift-proof test.

## CI / back-compat

`cargo fmt` + `clippy -D warnings` clean on the changed file; `cargo check --all-features` passes; unit test for the lock-name invariants (per-repo, stable, distinct from the graph lock so the two don't serialize against each other). No behavior change for a single instance.

Addresses #460 (the cross-instance BM25 piece).
