### PR TITLE
fix(graph): build synchronously on cold open_or_build to fix "No graph available"

### DIFF
--- a/rust/src/core/graph_provider.rs
+++ b/rust/src/core/graph_provider.rs
@@ -305,6 +305,19 @@ impl GraphProvider {
 }
 
 pub fn open_best_effort(project_root: &str) -> Option<OpenGraphProvider> {
+    open_best_effort_inner(project_root, true)
+}
+
+/// `trigger_background`: external callers that return fast and warm lazily pass
+/// `true` to kick off a one-shot background build when the graph is empty. The
+/// synchronous [`open_or_build`] path passes `false` — it builds inline right
+/// after, so a background build there would only race that inline build for the
+/// `graph-idx` lock and make it return an empty index. That race was the cause of
+/// "No graph available" on the very first cold open of a fresh project.
+fn open_best_effort_inner(
+    project_root: &str,
+    trigger_background: bool,
+) -> Option<OpenGraphProvider> {
     let t0 = std::time::Instant::now();
 
     // Backend selection (#682): `legacy` never consults the property graph —
@@ -351,7 +364,7 @@ pub fn open_best_effort(project_root: &str) -> Option<OpenGraphProvider> {
         }
     }
 
-    if !pg_populated {
+    if !pg_populated && trigger_background {
         trigger_lazy_graph_build(project_root);
     }
 
@@ -442,7 +455,11 @@ pub fn build_property_graph(project_root: &str) -> anyhow::Result<()> {
 }
 
 pub fn open_or_build(project_root: &str) -> Option<OpenGraphProvider> {
-    if let Some(p) = open_best_effort(project_root) {
+    // Open without triggering the lazy *background* build: this function builds
+    // synchronously below when nothing is cached, and a background build would
+    // only race that synchronous build for the `graph-idx` lock — returning an
+    // empty index that surfaces as "No graph available" on the first cold open.
+    if let Some(p) = open_best_effort_inner(project_root, false) {
         return Some(p);
     }
     let idx = super::graph_index::load_or_build(project_root);

--- a/rust/tests/graph_provider_cold_open.rs
+++ b/rust/tests/graph_provider_cold_open.rs
@@ -1,0 +1,37 @@
+//! Regression: the first *cold* `open_or_build` on a fresh project must return a
+//! built graph synchronously — not `None`.
+//!
+//! `open_best_effort` kicks off a one-shot background graph build the first time
+//! a project is opened cold. That background build acquires the `graph-idx` lock;
+//! the synchronous `load_or_build` fallback inside `open_or_build` then contended
+//! on the same lock and returned an empty index, so the very first
+//! `ctx_graph` / `export_graph_html` on a fresh repo failed with
+//! "No graph available" until a retry. This is an integration test on purpose:
+//! the library is compiled without `cfg!(test)`, so the background-build path
+//! (skipped under unit `cfg!(test)`) actually runs and reproduces the race.
+
+#[test]
+fn open_or_build_returns_graph_on_first_cold_open() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"cold_open\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub fn hello() -> &'static str { \"hi\" }\n",
+    )
+    .expect("write lib.rs");
+    let root_str = root.to_string_lossy().to_string();
+
+    // First call, no warm-up, no retry — must build synchronously.
+    let provider = lean_ctx::core::graph_provider::open_or_build(&root_str);
+    assert!(
+        provider.is_some(),
+        "first cold open_or_build must build the graph synchronously \
+         (regression: returned None / \"No graph available\")"
+    );
+}


### PR DESCRIPTION
> Found while getting my other PRs green: the first **cold** `ctx_graph` / `export_graph_html` on a fresh project returns `"No graph available"` until a retry. It also makes `tests/graph_export_contract.rs::graph_export_writes_single_file_html` fail on a clean checkout (all OSes) — which is why several in-flight PRs show a red **Test** check they didn't cause.

## The fix

`open_or_build` now opens *without* triggering the lazy **background** build, then builds synchronously.

Previously it called `open_best_effort`, which — on a cold project — kicks off a background graph build that grabs the `graph-idx` lock. The synchronous `load_or_build` fallback right below then contended on that same lock and got an empty index back → `None` → `"No graph available"`. The background build is redundant in this path (the function builds synchronously immediately after), so it only ever **raced** that build. Opening with the lazy-warm trigger disabled removes the race.

One-line behavior change; two integration tests cover it.

## Root cause

```
open_or_build(root)
  └─ open_best_effort(root)
       └─ trigger_lazy_graph_build(root)   // ensure_all_background → holds graph-idx lock
       └─ try_load_graph_index(root) → None // background build hasn't persisted yet
     → None
  └─ load_or_build(root)                    // contends on graph-idx lock → returns empty
     → idx.files.is_empty() → None          // "No graph available"
```

## Why it reproduces in CI but not unit tests

`trigger_lazy_graph_build` is a no-op under `cfg!(test)` (a deliberate guard against a per-test data-dir flake), so **unit** tests never hit the race. **Integration** tests link the library compiled normally, so the background build runs — and reliably wins the lock — making `graph_export_contract` fail on every CI run, on every OS.

## Changes

- `core/graph_provider.rs`: split `open_best_effort` into a thin public wrapper + `open_best_effort_inner(root, trigger_background)`. External callers keep the lazy warm (`true`); `open_or_build` passes `false` and builds synchronously, with no competing background build.
- `tests/graph_provider_cold_open.rs`: focused regression — the first cold `open_or_build` must return a built graph.

## Verification

`cargo fmt --check` + `clippy -D warnings` clean on the changed file; `graph_export_contract` and the new `graph_provider_cold_open` test pass; the `graph_provider` unit tests are unchanged; `cargo check --all-features` is green.
