### PR TITLE
fix(test): unstick quality_loop_golden after the 6000-token compression floor

### DIFF
--- a/rust/tests/quality_loop_golden.rs
+++ b/rust/tests/quality_loop_golden.rs
@@ -70,9 +70,14 @@ fn edit_fail_after_map_read_escalates_and_penalizes() {
     let other = tmp.path().join("other.rs");
     std::fs::write(&other, "fn unrelated() { 2 }\n".repeat(60)).unwrap();
     let other_path = other.to_string_lossy().to_string();
+    // token_count must clear heuristic_mode's 6000-token code-compression floor so
+    // this `.rs` file resolves to `map` on its own — only then is the rs|map risk
+    // penalty observable (it escalates a *compressed* mode to full; an already-
+    // `full` heuristic result masks it). That floor was raised 3000 -> 6000 in the
+    // #683 default-cascade refactor, which this golden test had to catch up to.
     let other_ctx = AutoModeContext {
         path: &other_path,
-        token_count: 3000,
+        token_count: 7000,
         task: None,
         cache: None,
     };


### PR DESCRIPTION
> The second of two pre-existing test failures on `main` (the first is the cold-graph fix in #471). `tests/quality_loop_golden.rs` fails on a clean checkout, all OSes: `left: "heuristic"`, `right: "edit_quality_penalty"`.

## The fix

Bump the golden test's probe file from **3000 → 7000 tokens**. That's the whole change — it's a stale test input, not a code bug.

## Why

`heuristic_mode` returns `full` for code files at ≤ 6000 tokens — that floor was deliberately raised 3000 → 6000 in the #683 default-cascade refactor, with a documented round-trip rationale. The test's rs|map risk-penalty assertion uses a **3000-token** `.rs` file, expecting it to resolve to `map` so the penalty escalates it to `full` with source `edit_quality_penalty`.

But at 3000 tokens it now resolves to `full` **directly** via the heuristic, and the penalty branch only fires on a *compressed* mode:

```rust
let r = resolve_inner(ctx);
if r.mode != "full" && edit_quality::is_risky_mode(ctx.path, &r.mode) {
    return resolved("full", "edit_quality_penalty");   // preempted when r.mode is already "full"
}
```

So the source comes back `heuristic`. The penalty feature is correct; the test's token_count just hadn't caught up to the raised floor. **7000** clears it, the file resolves to `map`, and the rs|map penalty is observable again.

## Changes

- `tests/quality_loop_golden.rs`: probe file 3000 → 7000 tokens, plus a comment pinning the 6000-token floor so a future heuristic tweak doesn't silently re-break the golden.

## Verification

`cargo test --test quality_loop_golden` passes. Test-only change; no production code touched.
