### PR TITLE
fix(uninstall): `uninstall --help` no longer runs a real uninstall (#476)

### DIFF
--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -624,6 +624,12 @@ pub fn run() {
                 return;
             }
             "uninstall" => {
+                // Safety: `--help`/`-h` must NEVER fall through to a real
+                // uninstall (issue #476). Short-circuit before any removal.
+                if rest.iter().any(|a| a == "--help" || a == "-h") {
+                    uninstall::print_help();
+                    return;
+                }
                 let dry_run = rest.iter().any(|a| a == "--dry-run");
                 let keep_config = rest.iter().any(|a| a == "--keep-config");
                 let keep_binary = rest.iter().any(|a| a == "--keep-binary");

--- a/rust/src/uninstall/mod.rs
+++ b/rust/src/uninstall/mod.rs
@@ -91,6 +91,44 @@ pub(super) fn safe_remove(path: &Path, dry_run: bool) -> Result<(), std::io::Err
 }
 
 // ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+/// Print usage for `lean-ctx uninstall`.
+///
+/// This MUST stay side-effect free: `lean-ctx uninstall --help` previously fell
+/// through to [`run`] and removed everything, so help is now short-circuited in
+/// the CLI dispatch before any removal happens.
+pub fn print_help() {
+    println!(
+        "\
+lean-ctx uninstall — remove lean-ctx cleanly
+
+USAGE:
+    lean-ctx uninstall [OPTIONS]
+
+OPTIONS:
+    --dry-run        Preview every change without modifying anything
+    --keep-config    Preserve MCP configs and rules (for a later reinstall)
+    --keep-binary    Leave the lean-ctx binary in place
+    -h, --help       Show this help and exit (does NOT uninstall)
+
+WHAT IT REMOVES:
+    • Running processes (daemon, proxy) and autostart entries
+    • Shell hooks and proxy environment from your shell rc files
+    • MCP server configs and rules from every detected AI tool/IDE
+    • Skill directories and project integration files
+    • The data directory and the lean-ctx binary
+
+    Modified files are backed up as <file>.lean-ctx.bak before removal.
+
+EXAMPLES:
+    lean-ctx uninstall --dry-run     # see exactly what would change
+    lean-ctx uninstall               # full clean removal"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Main entry
 // ---------------------------------------------------------------------------
 

--- a/rust/tests/uninstall_help_safety_476.rs
+++ b/rust/tests/uninstall_help_safety_476.rs
@@ -1,0 +1,94 @@
+//! #476: `lean-ctx uninstall --help` (and `-h`) must print usage and remove
+//! NOTHING. Previously the `uninstall` dispatch arm ignored `--help`, so the
+//! flag fell through to a real, irreversible uninstall.
+//!
+//! These run the real binary as a subprocess inside a fully isolated tempdir so
+//! that — even if the guard ever regresses — no developer file is touched.
+#![cfg(unix)]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+/// Isolated environment: HOME + all lean-ctx dirs redirected into a tempdir,
+/// with a marker file in the data dir whose survival proves "nothing removed".
+struct Sandbox {
+    _root: tempfile::TempDir,
+    home: PathBuf,
+    data: PathBuf,
+    marker: PathBuf,
+}
+
+impl Sandbox {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = root.path().join("home");
+        let data = root.path().join("data");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        let marker = data.join("marker.txt");
+        std::fs::write(&marker, "do-not-delete").unwrap();
+        Self {
+            _root: root,
+            home,
+            data,
+            marker,
+        }
+    }
+
+    fn run_uninstall(&self, flag: &str) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_lean-ctx"))
+            .args(["uninstall", flag])
+            .env("HOME", &self.home)
+            .env("LEAN_CTX_DATA_DIR", &self.data)
+            .env("LEAN_CTX_HOOK_CHILD", "1")
+            .env("LEAN_CTX_QUIET", "1")
+            .output()
+            .expect("spawn lean-ctx uninstall")
+    }
+}
+
+/// Removal log lines that must NEVER appear when only asking for help.
+const REMOVAL_MARKERS: &[&str] = &[
+    "Processes stopped",
+    "Data directory removed",
+    "Binary removed",
+    "fully removed",
+];
+
+fn assert_is_help_not_uninstall(out: &Output, flag: &str, marker: &std::path::Path) {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "`uninstall {flag}` should exit 0; got {}\nstdout:\n{stdout}",
+        out.status
+    );
+    assert!(
+        stdout.contains("USAGE") && stdout.contains("--dry-run"),
+        "`uninstall {flag}` must print usage; stdout was:\n{stdout}"
+    );
+    for needle in REMOVAL_MARKERS {
+        assert!(
+            !stdout.contains(needle),
+            "`uninstall {flag}` must not perform removal, but emitted {needle:?}:\n{stdout}"
+        );
+    }
+    assert!(
+        marker.exists(),
+        "`uninstall {flag}` deleted the data dir marker — it ran a real uninstall!"
+    );
+}
+
+#[test]
+fn uninstall_long_help_shows_usage_and_removes_nothing() {
+    let sandbox = Sandbox::new();
+    let out = sandbox.run_uninstall("--help");
+    assert_is_help_not_uninstall(&out, "--help", &sandbox.marker);
+}
+
+#[test]
+fn uninstall_short_help_shows_usage_and_removes_nothing() {
+    let sandbox = Sandbox::new();
+    let out = sandbox.run_uninstall("-h");
+    assert_is_help_not_uninstall(&out, "-h", &sandbox.marker);
+}


### PR DESCRIPTION
## Summary
- `lean-ctx uninstall --help` / `-h` previously fell through the dispatch arm and executed a **full, irreversible uninstall** (binary, all IDE MCP configs, shell hooks, data dir).
- Adds a side-effect-free `uninstall::print_help()` and short-circuits `--help`/`-h` before any removal.
- Adds an isolated end-to-end regression test covering both `--help` and `-h`.

## Why
A user running `uninstall --help` to learn the command would accidentally wipe their installation. High-severity, accidental data loss from a help flag.

## Test plan
- [x] `cargo test --test uninstall_help_safety_476` (2 passed)
- [x] `cargo clippy --lib --tests` (zero warnings)
- [x] `cargo fmt --check` (clean)
- [x] Manual: `lean-ctx uninstall --help` prints usage and removes nothing

Closes #476

Made with [Cursor](https://cursor.com)