### PR TITLE
fix(jetbrains): write port file to XDG_DATA_HOME, matching Rust data_dir

### DIFF
--- a/packages/jetbrains-lean-ctx/src/main/kotlin/com/leanctx/plugin/server/LeanCtxPaths.kt
+++ b/packages/jetbrains-lean-ctx/src/main/kotlin/com/leanctx/plugin/server/LeanCtxPaths.kt
@@ -9,18 +9,67 @@ import java.security.MessageDigest
  * Rust and Kotlin MUST resolve byte-identically (spec §5.5).
  */
 object LeanCtxPaths {
-    private val DATA_MARKERS = listOf("stats.json", "config.toml", "sessions")
+    /**
+     * Data markers, byte-identical to Rust `core/data_dir.rs::DATA_MARKERS`.
+     * `config.toml` is deliberately EXCLUDED (GH #408): after the XDG split it
+     * legitimately lives alone in the config dir, so treating it as a data marker
+     * would re-collapse a clean four-dir install back onto the config dir.
+     */
+    private val DATA_MARKERS = listOf("stats.json", "sessions", "vectors", "graphs", "knowledge")
 
-    /** Priority: LEAN_CTX_DATA_DIR → ~/.lean-ctx (if has data) → $XDG_CONFIG_HOME/lean-ctx (default ~/.config/lean-ctx). */
+    /** XDG layout pin (GL #623), lives in the config dir alongside `config.toml`. */
+    private const val LAYOUT_FILE = "layout.toml"
+
+    /**
+     * Resolve the data dir, mirroring Rust `core/data_dir.rs::lean_ctx_data_dir` +
+     * `core/paths.rs::single_dir_override` (GH #408 XDG split):
+     *   1. `LEAN_CTX_DATA_DIR` env (explicit override)
+     *   2. single-dir back-compat: legacy `~/.lean-ctx` / mixed `$XDG_CONFIG_HOME/lean-ctx`
+     *      that still holds data markers — UNLESS the install is XDG-pinned (#623).
+     *   3. fresh / fully-split install -> `$XDG_DATA_HOME/lean-ctx` (default
+     *      `~/.local/share/lean-ctx`), NOT the config dir — so the port file lands
+     *      where the Rust reader (`lsp/port_discovery.rs`) looks for it.
+     */
     fun resolveDataDir(env: Map<String, String>, home: Path): Path {
         env["LEAN_CTX_DATA_DIR"]?.trim()?.takeIf { it.isNotEmpty() }?.let { return Paths.get(it) }
-        val legacy = home.resolve(".lean-ctx")
-        if (hasDataFiles(legacy)) return legacy
-        val xdgBase = env["XDG_CONFIG_HOME"]?.trim()?.takeIf { it.isNotEmpty() }
+        val xdgConfigBase = env["XDG_CONFIG_HOME"]?.trim()?.takeIf { it.isNotEmpty() }
             ?.let { Paths.get(it) } ?: home.resolve(".config")
-        val xdg = xdgBase.resolve("lean-ctx")
-        if (hasDataFiles(xdg)) return xdg
-        return if (legacy.toFile().exists()) legacy else xdg
+        singleDirOverride(home, xdgConfigBase)?.let { return it }
+        val xdgDataBase = env["XDG_DATA_HOME"]?.trim()?.takeIf { it.isNotEmpty() }
+            ?.let { Paths.get(it) } ?: home.resolve(".local").resolve("share")
+        return xdgDataBase.resolve("lean-ctx")
+    }
+
+    /**
+     * Single directory that all categories collapse onto for back-compat, or null
+     * for a fresh/split install. Mirrors Rust `single_dir_override_fs`: an XDG pin
+     * wins (never re-collapse onto a stray marker, #623); otherwise a legacy or
+     * mixed install that still carries real data markers keeps resolving in place.
+     */
+    private fun singleDirOverride(home: Path, xdgConfigBase: Path): Path? {
+        if (isXdgPinnedIn(xdgConfigBase)) return null
+        val legacy = home.resolve(".lean-ctx")
+        if (legacy.toFile().exists() && hasDataFiles(legacy)) return legacy
+        val mixed = xdgConfigBase.resolve("lean-ctx")
+        if (mixed.toFile().exists() && hasDataFiles(mixed)) return mixed
+        return null
+    }
+
+    /** `true` when `<configBase>/lean-ctx/layout.toml` pins `mode = "xdg"` (Rust `is_xdg_pinned_in`). */
+    private fun isXdgPinnedIn(xdgConfigBase: Path): Boolean =
+        readPinMode(xdgConfigBase.resolve("lean-ctx").resolve(LAYOUT_FILE)) == "xdg"
+
+    /** Parse `mode = "..."`, ignoring comments/blanks (mirrors Rust `layout_pin::read_mode`). */
+    private fun readPinMode(path: Path): String? = try {
+        path.toFile().readLines().firstNotNullOfOrNull { line ->
+            val trimmed = line.trim()
+            if (!trimmed.startsWith("mode")) return@firstNotNullOfOrNull null
+            val afterMode = trimmed.removePrefix("mode").trimStart()
+            if (!afterMode.startsWith("=")) return@firstNotNullOfOrNull null
+            afterMode.removePrefix("=").trim().trim('"').trim().takeIf { it.isNotEmpty() }
+        }
+    } catch (_: Exception) {
+        null
     }
 
     /**
@@ -33,7 +82,24 @@ object LeanCtxPaths {
         return resolveDataDir(System.getenv(), Paths.get(System.getProperty("user.home")))
     }
 
-    private fun hasDataFiles(dir: Path): Boolean = DATA_MARKERS.any { dir.resolve(it).toFile().exists() }
+    private fun hasDataFiles(dir: Path): Boolean = DATA_MARKERS.any { markerHasData(dir.resolve(it)) }
+
+    /**
+     * A marker counts only when it carries real data — a non-empty file, or a
+     * directory with at least one entry (mirrors Rust `data_dir.rs::marker_has_data`,
+     * GL #623/#625). An empty `sessions/` or a zero-byte `stats.json` must NOT
+     * collapse the whole layout onto a dir that holds no real data.
+     */
+    private fun markerHasData(path: Path): Boolean = try {
+        val f = path.toFile()
+        when {
+            !f.exists() -> false
+            f.isDirectory -> (f.list()?.isNotEmpty() ?: false)
+            else -> f.length() > 0
+        }
+    } catch (_: Exception) {
+        false
+    }
 
     /** sha256(canonical(root))[..8] as 16 lowercase hex; mirrors Rust project_hash. */
     fun projectHash(projectRoot: String): String {

--- a/packages/jetbrains-lean-ctx/src/test/kotlin/com/leanctx/plugin/server/LeanCtxPathsTest.kt
+++ b/packages/jetbrains-lean-ctx/src/test/kotlin/com/leanctx/plugin/server/LeanCtxPathsTest.kt
@@ -29,13 +29,80 @@ class LeanCtxPathsTest {
     }
 
     @Test
-    fun xdgWhenLegacyEmpty() {
+    fun freshSplitDefaultsToXdgDataHome() {
+        // GH #408 flip: no legacy/mixed data anywhere → DATA resolves to
+        // $XDG_DATA_HOME/lean-ctx (where the Rust reader looks), NOT the config dir.
         val home = Files.createTempDirectory("lc-home3")
-        val xdgBase = Files.createTempDirectory("lc-xdg")
-        Files.createDirectories(xdgBase.resolve("lean-ctx"))
-        Files.writeString(xdgBase.resolve("lean-ctx/config.toml"), "")
-        val env = mapOf("XDG_CONFIG_HOME" to xdgBase.toString())
-        assertEquals(xdgBase.resolve("lean-ctx"), LeanCtxPaths.resolveDataDir(env, home))
+        val xdgConfig = Files.createTempDirectory("lc-xdg-cfg")
+        val xdgData = Files.createTempDirectory("lc-xdg-data")
+        val env = mapOf(
+            "XDG_CONFIG_HOME" to xdgConfig.toString(),
+            "XDG_DATA_HOME" to xdgData.toString(),
+        )
+        assertEquals(xdgData.resolve("lean-ctx"), LeanCtxPaths.resolveDataDir(env, home))
+    }
+
+    @Test
+    fun configTomlAloneIsNotADataMarker() {
+        // The exact bug: config.toml in the config dir must NOT pin DATA onto it,
+        // otherwise the port file lands in ~/.config and the Rust reader misses it.
+        val home = Files.createTempDirectory("lc-home4")
+        val xdgConfig = Files.createTempDirectory("lc-xdg-cfg4")
+        val xdgData = Files.createTempDirectory("lc-xdg-data4")
+        Files.createDirectories(xdgConfig.resolve("lean-ctx"))
+        Files.writeString(xdgConfig.resolve("lean-ctx/config.toml"), "tool_profile = \"power\"\n")
+        val env = mapOf(
+            "XDG_CONFIG_HOME" to xdgConfig.toString(),
+            "XDG_DATA_HOME" to xdgData.toString(),
+        )
+        assertEquals(xdgData.resolve("lean-ctx"), LeanCtxPaths.resolveDataDir(env, home))
+    }
+
+    @Test
+    fun mixedConfigWithRealDataWins() {
+        // A pre-split mixed install that still carries a real data marker keeps
+        // resolving onto the config dir (back-compat), matching Rust.
+        val home = Files.createTempDirectory("lc-home5")
+        val xdgConfig = Files.createTempDirectory("lc-xdg-cfg5")
+        val xdgData = Files.createTempDirectory("lc-xdg-data5")
+        Files.createDirectories(xdgConfig.resolve("lean-ctx"))
+        Files.writeString(xdgConfig.resolve("lean-ctx/stats.json"), "{\"total\":1}")
+        val env = mapOf(
+            "XDG_CONFIG_HOME" to xdgConfig.toString(),
+            "XDG_DATA_HOME" to xdgData.toString(),
+        )
+        assertEquals(xdgConfig.resolve("lean-ctx"), LeanCtxPaths.resolveDataDir(env, home))
+    }
+
+    @Test
+    fun xdgPinForcesDataHomeEvenWithMixedMarker() {
+        // GL #623: a layout.toml pin must beat a stray mixed data marker, so a
+        // committed XDG install never re-collapses onto the config dir.
+        val home = Files.createTempDirectory("lc-home6")
+        val xdgConfig = Files.createTempDirectory("lc-xdg-cfg6")
+        val xdgData = Files.createTempDirectory("lc-xdg-data6")
+        Files.createDirectories(xdgConfig.resolve("lean-ctx"))
+        Files.writeString(xdgConfig.resolve("lean-ctx/stats.json"), "{\"total\":1}")
+        Files.writeString(xdgConfig.resolve("lean-ctx/layout.toml"), "# pin\nmode = \"xdg\"\n")
+        val env = mapOf(
+            "XDG_CONFIG_HOME" to xdgConfig.toString(),
+            "XDG_DATA_HOME" to xdgData.toString(),
+        )
+        assertEquals(xdgData.resolve("lean-ctx"), LeanCtxPaths.resolveDataDir(env, home))
+    }
+
+    @Test
+    fun emptyMarkerDirDoesNotCount() {
+        // GL #625: an empty sessions/ must not flip the layout onto the config dir.
+        val home = Files.createTempDirectory("lc-home7")
+        val xdgConfig = Files.createTempDirectory("lc-xdg-cfg7")
+        val xdgData = Files.createTempDirectory("lc-xdg-data7")
+        Files.createDirectories(xdgConfig.resolve("lean-ctx/sessions"))
+        val env = mapOf(
+            "XDG_CONFIG_HOME" to xdgConfig.toString(),
+            "XDG_DATA_HOME" to xdgData.toString(),
+        )
+        assertEquals(xdgData.resolve("lean-ctx"), LeanCtxPaths.resolveDataDir(env, home))
     }
 
     @Test


### PR DESCRIPTION
Summary

  The JetBrains plugin wrote its backend port file to the wrong directory, so every IDE-backed refactor (ctx_refactor reformat/rename/symbols_overview/…) failed with BACKEND_REQUIRED: no live port file / health check failed even with the IDE running.

  Root cause: LeanCtxPaths.resolveDataDir still encoded the pre-#408 layout and had silently drifted from the Rust reader, despite the doc comment claiming "Rust and Kotlin MUST resolve byte-identically":

  - treated config.toml as a data marker → resolved a clean split install onto ~/.config/lean-ctx
  - final fallback was $XDG_CONFIG_HOME/lean-ctx instead of $XDG_DATA_HOME/lean-ctx
  - bare-existence marker check instead of "real data"; no XDG-pin awareness

  Meanwhile the Rust reader (lsp/port_discovery.rs → core/data_dir.rs::lean_ctx_data_dir + core/paths.rs::single_dir_override) resolves a split install to ~/.local/share/lean-ctx. Writer and reader pointed at different dirs → the port file was never found.

  This aligns resolveDataDir byte-for-byte with the Rust resolution:

  - drop config.toml from DATA_MARKERS; adopt the full Rust set (stats.json, sessions, vectors, graphs, knowledge)
  - marker_has_data semantics (non-empty file / non-empty dir, not bare existence)
  - honor the layout.toml XDG pin (mode = "xdg")
  - fall back to $XDG_DATA_HOME/lean-ctx

  Test plan

  - [ ] cd rust && cargo test — n/a (no Rust changes; reader side already correct)
  - [ ] cd rust && cargo clippy --all-targets --all-features -- -D warnings — n/a
  - [ ] cd rust && cargo fmt --check — n/a
  - [x] Packages changed: cd packages/jetbrains-lean-ctx && ./gradlew test → BUILD SUCCESSFUL (5 new parity tests in LeanCtxPathsTest)
  - [x] ./gradlew buildPlugin, installed from disk, restarted IDE → port file now lands in ~/.local/share/lean-ctx; ctx_refactor reformat succeeds end-to-end (was BACKEND_REQUIRED)

  Notes for reviewers

  - Risk areas / edge cases: path resolution only. The parity tests cover the five branches: fresh split → $XDG_DATA_HOME; config.toml-alone is not a marker; mixed install with a real marker still wins (back-compat); XDG pin beats a stray mixed marker; empty marker dir doesn't count. projectHash and the port-file name are unchanged (parity anchor a0317725f24b01df still
  holds).
  - Backwards compatibility: preserved. Legacy ~/.lean-ctx and pre-split mixed $XDG_CONFIG_HOME/lean-ctx installs that still carry real data markers keep resolving in place — identical to the Rust single-dir back-compat. Only genuinely-split/fresh installs change target (the bug being fixed). Users with a stale ~/.config/lean-ctx/jetbrains-*.port can delete it after
  upgrading.
  - Docs updated (links/files): none needed — LeanCtxPaths.kt is now self-documenting with explicit Rust cross-references (core/data_dir.rs, core/paths.rs, core/layout_pin.rs).