### PR TITLE
fix(mcp): stop pinning LEAN_CTX_DATA_DIR in agent MCP configs

### DIFF
--- a/docs/guides/aider.md
+++ b/docs/guides/aider.md
@@ -41,9 +41,9 @@ mcp-servers:
   - lean-ctx:
       command: lean-ctx
       args: []
-      env:
-        LEAN_CTX_DATA_DIR: ~/.lean-ctx
 ```
+
+> **Note**: lean-ctx auto-detects its data directory at runtime — don't hardcode `LEAN_CTX_DATA_DIR` unless you intentionally relocate it. Running `lean-ctx init --agent aider` writes this config for you.
 
 Or pass it via command line:
 

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -43,9 +43,6 @@ lean-ctx registers itself via `claude mcp add-json --scope user` when available.
   "mcpServers": {
     "lean-ctx": {
       "command": "lean-ctx",
-      "env": {
-        "LEAN_CTX_DATA_DIR": "~/.lean-ctx"
-      },
       "autoApprove": [
         "ctx_read",
         "ctx_shell",

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -95,7 +95,7 @@ Codex CLI runs in a sandboxed environment for safety. lean-ctx integrates with t
 |--------|----------|
 | File reads | Work normally — lean-ctx reads files within the sandbox |
 | Shell commands | Compressed within sandbox constraints |
-| Data directory | `LEAN_CTX_DATA_DIR` must be accessible from the sandbox |
+| Data directory | the lean-ctx data directory (`~/.lean-ctx` / XDG, or `LEAN_CTX_DATA_DIR` if you relocated it) must be accessible from the sandbox |
 | Network | lean-ctx is local-first, no network needed |
 
 ### Sandbox Permissions

--- a/docs/guides/gemini-cli.md
+++ b/docs/guides/gemini-cli.md
@@ -34,9 +34,6 @@ lean-ctx configures `~/.gemini/settings.json` with the Gemini-specific format:
   "mcpServers": {
     "lean-ctx": {
       "command": "lean-ctx",
-      "env": {
-        "LEAN_CTX_DATA_DIR": "~/.lean-ctx"
-      },
       "trust": true
     }
   }

--- a/docs/guides/opencode.md
+++ b/docs/guides/opencode.md
@@ -37,10 +37,7 @@ lean-ctx configures OpenCode's MCP settings with the OpenCode-specific format:
     "lean-ctx": {
       "type": "local",
       "command": ["lean-ctx"],
-      "enabled": true,
-      "environment": {
-        "LEAN_CTX_DATA_DIR": "~/.lean-ctx"
-      }
+      "enabled": true
     }
   }
 }
@@ -244,10 +241,7 @@ Each project can have its own `opencode.json` with lean-ctx MCP config:
     "lean-ctx": {
       "type": "local",
       "command": ["lean-ctx"],
-      "enabled": true,
-      "environment": {
-        "LEAN_CTX_DATA_DIR": "~/.lean-ctx"
-      }
+      "enabled": true
     }
   }
 }

--- a/docs/guides/windsurf.md
+++ b/docs/guides/windsurf.md
@@ -35,16 +35,13 @@ Add lean-ctx to Windsurf's MCP configuration:
 {
   "mcpServers": {
     "lean-ctx": {
-      "command": "lean-ctx",
-      "env": {
-        "LEAN_CTX_DATA_DIR": "~/.lean-ctx"
-      }
+      "command": "lean-ctx"
     }
   }
 }
 ```
 
-> **Note**: Run `lean-ctx init --agent windsurf` to get the correct `LEAN_CTX_DATA_DIR` path auto-configured for your system.
+> **Note**: lean-ctx auto-detects its data directory at runtime — don't hardcode `LEAN_CTX_DATA_DIR` unless you intentionally relocate it (a wrong path splits config and data across two locations). Running `lean-ctx init --agent windsurf` writes this config for you.
 
 ### Step 2: Agent Rules
 

--- a/rust/src/core/editor_registry/writers/install.rs
+++ b/rust/src/core/editor_registry/writers/install.rs
@@ -14,12 +14,11 @@ pub(super) fn write_mcp_json(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = default_data_dir()?;
     let include_aa = supports_auto_approve(target);
     let desired = if target.agent_key.is_empty() {
-        lean_ctx_server_entry(binary, &data_dir, include_aa)
+        lean_ctx_server_entry(binary, include_aa)
     } else {
-        lean_ctx_server_entry_with_instructions(binary, &data_dir, include_aa, &target.agent_key)
+        lean_ctx_server_entry_with_instructions(binary, include_aa, &target.agent_key)
     };
 
     // Claude Code manages ~/.claude.json and may overwrite it on first start.
@@ -306,10 +305,7 @@ pub(super) fn write_vscode_mcp(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
-    let desired = serde_json::json!({ "type": "stdio", "command": binary, "args": [], "env": { "LEAN_CTX_DATA_DIR": data_dir } });
+    let desired = serde_json::json!({ "type": "stdio", "command": binary, "args": [] });
 
     if target.config_path.exists() {
         let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
@@ -362,11 +358,8 @@ pub(super) fn write_vscode_mcp_fresh(
     binary: &str,
     note: Option<String>,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let content = serde_json::to_string_pretty(&serde_json::json!({
-        "servers": { "lean-ctx": { "type": "stdio", "command": binary, "args": [], "env": { "LEAN_CTX_DATA_DIR": data_dir } } }
+        "servers": { "lean-ctx": { "type": "stdio", "command": binary, "args": [] } }
     }))
     .map_err(|e| e.to_string())?;
     crate::config_io::write_atomic_with_backup(path, &content)?;
@@ -385,14 +378,10 @@ pub(super) fn write_copilot_cli(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let desired = serde_json::json!({
         "type": "local",
         "command": binary,
         "args": ["mcp"],
-        "env": { "LEAN_CTX_DATA_DIR": data_dir },
         "tools": ["*"]
     });
 
@@ -449,7 +438,6 @@ pub(super) fn write_copilot_cli(
                 "type": "local",
                 "command": binary,
                 "args": ["mcp"],
-                "env": { "LEAN_CTX_DATA_DIR": data_dir },
                 "tools": ["*"]
             }
         }
@@ -467,14 +455,10 @@ pub(super) fn write_opencode_config(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let desired = serde_json::json!({
         "type": "local",
         "command": [binary],
-        "enabled": true,
-        "environment": { "LEAN_CTX_DATA_DIR": data_dir }
+        "enabled": true
     });
 
     if target.config_path.exists() {
@@ -525,12 +509,9 @@ pub(super) fn write_opencode_fresh(
     binary: &str,
     note: Option<String>,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let content = serde_json::to_string_pretty(&serde_json::json!({
         "$schema": "https://opencode.ai/config.json",
-        "mcp": { "lean-ctx": { "type": "local", "command": [binary], "enabled": true, "environment": { "LEAN_CTX_DATA_DIR": data_dir } } }
+        "mcp": { "lean-ctx": { "type": "local", "command": [binary], "enabled": true } }
     }))
     .map_err(|e| e.to_string())?;
     crate::config_io::write_atomic_with_backup(path, &content)?;
@@ -549,16 +530,12 @@ pub(super) fn write_jetbrains_config(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     // JetBrains AI Assistant expects an "mcpServers" mapping in the JSON snippet
     // you paste into Settings | Tools | AI Assistant | Model Context Protocol (MCP).
     // We write that snippet to a file for easy copy/paste.
     let desired = serde_json::json!({
         "command": binary,
-        "args": [],
-        "env": { "LEAN_CTX_DATA_DIR": data_dir }
+        "args": []
     });
 
     if target.config_path.exists() {
@@ -618,12 +595,8 @@ pub(super) fn write_amp_config(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let entry = serde_json::json!({
-        "command": binary,
-        "env": { "LEAN_CTX_DATA_DIR": data_dir }
+        "command": binary
     });
 
     if target.config_path.exists() {
@@ -682,13 +655,9 @@ pub(super) fn write_crush_config(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let desired = serde_json::json!({
         "type": "stdio",
-        "command": binary,
-        "env": { "LEAN_CTX_DATA_DIR": data_dir }
+        "command": binary
     });
 
     if target.config_path.exists() {
@@ -841,12 +810,8 @@ pub(super) fn write_gemini_settings(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .map_err(|_| "LEAN_CTX_DATA_DIR unavailable".to_string())?;
     let entry = serde_json::json!({
         "command": binary,
-        "env": { "LEAN_CTX_DATA_DIR": data_dir },
         "trust": true,
     });
 
@@ -906,19 +871,14 @@ pub(super) fn write_hermes_yaml(
     binary: &str,
     _opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = default_data_dir()?;
-
-    let lean_ctx_block = format!(
-        "  lean-ctx:\n    command: \"{binary}\"\n    env:\n      LEAN_CTX_DATA_DIR: \"{data_dir}\""
-    );
+    let lean_ctx_block = format!("  lean-ctx:\n    command: \"{binary}\"");
 
     if target.config_path.exists() {
         let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
 
         if content.contains("lean-ctx") {
             let has_correct_binary = content.contains(binary);
-            let has_correct_data_dir = content.contains(&data_dir);
-            if has_correct_binary && has_correct_data_dir {
+            if has_correct_binary {
                 return Ok(WriteResult {
                     action: WriteAction::Already,
                     note: None,
@@ -1010,15 +970,11 @@ pub(super) fn write_qoder_settings(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = default_data_dir()?;
     // Core toolset by default — no LEAN_CTX_FULL_TOOLS (GitHub #385, see
     // hooks::full_server_entry).
     let desired = serde_json::json!({
         "command": binary,
-        "args": [],
-        "env": {
-            "LEAN_CTX_DATA_DIR": data_dir
-        }
+        "args": []
     });
 
     if target.config_path.exists() {
@@ -1154,10 +1110,8 @@ pub(super) fn write_openclaw_config(
     binary: &str,
     _opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = default_data_dir()?;
     let desired = serde_json::json!({
-        "command": binary,
-        "env": { "LEAN_CTX_DATA_DIR": data_dir }
+        "command": binary
     });
 
     if !target.config_path.exists() {
@@ -1261,7 +1215,7 @@ pub(super) fn write_openclaw_config(
 //   { type, id, name, disabled, command, args, env, useShellInterpolation }
 // ---------------------------------------------------------------------------
 
-pub(super) fn lean_ctx_augment_vscode_entry(binary: &str, data_dir: &str) -> Value {
+pub(super) fn lean_ctx_augment_vscode_entry(binary: &str) -> Value {
     serde_json::json!({
         "type": "stdio",
         "id": LEAN_CTX_AUGMENT_VSCODE_ID,
@@ -1269,10 +1223,7 @@ pub(super) fn lean_ctx_augment_vscode_entry(binary: &str, data_dir: &str) -> Val
         "disabled": false,
         "command": binary,
         "args": [],
-        "useShellInterpolation": false,
-        "env": {
-            "LEAN_CTX_DATA_DIR": data_dir
-        }
+        "useShellInterpolation": false
     })
 }
 
@@ -1281,8 +1232,7 @@ pub(super) fn write_augment_vscode(
     binary: &str,
     opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    let data_dir = default_data_dir()?;
-    let desired = lean_ctx_augment_vscode_entry(binary, &data_dir);
+    let desired = lean_ctx_augment_vscode_entry(binary);
 
     if !target.config_path.exists() {
         let arr = serde_json::Value::Array(vec![desired]);

--- a/rust/src/core/editor_registry/writers/shared.rs
+++ b/rust/src/core/editor_registry/writers/shared.rs
@@ -79,16 +79,13 @@ pub fn auto_approve_tools() -> Vec<&'static str> {
     ]
 }
 
-pub(super) fn lean_ctx_server_entry(
-    binary: &str,
-    data_dir: &str,
-    include_auto_approve: bool,
-) -> Value {
+pub(super) fn lean_ctx_server_entry(binary: &str, include_auto_approve: bool) -> Value {
+    // No `env` block: lean-ctx auto-detects its per-category dirs (config/data/
+    // state/cache) at runtime. Pinning `LEAN_CTX_DATA_DIR` here would set that var
+    // in the server's environment, forcing single-dir mode and collapsing
+    // config/state/cache onto the data dir — defeating the XDG split (GH #408).
     let mut entry = serde_json::json!({
-        "command": binary,
-        "env": {
-            "LEAN_CTX_DATA_DIR": data_dir
-        }
+        "command": binary
     });
     if include_auto_approve {
         entry["autoApprove"] = serde_json::json!(auto_approve_tools());
@@ -98,11 +95,10 @@ pub(super) fn lean_ctx_server_entry(
 
 pub(super) fn lean_ctx_server_entry_with_instructions(
     binary: &str,
-    data_dir: &str,
     include_auto_approve: bool,
     agent_key: &str,
 ) -> Value {
-    let mut entry = lean_ctx_server_entry(binary, data_dir, include_auto_approve);
+    let mut entry = lean_ctx_server_entry(binary, include_auto_approve);
     let mode = crate::core::rules_canonical::Mode::from_hook_mode(
         &crate::hooks::recommend_hook_mode(agent_key),
     );
@@ -123,12 +119,6 @@ pub(super) fn lean_ctx_server_entry_with_instructions(
 pub(super) fn supports_auto_approve(target: &EditorTarget) -> bool {
     crate::core::client_constraints::by_editor_name(target.name)
         .is_some_and(|c| c.supports_auto_approve)
-}
-
-pub(super) fn default_data_dir() -> Result<String, String> {
-    Ok(crate::core::data_dir::lean_ctx_data_dir()?
-        .to_string_lossy()
-        .to_string())
 }
 
 /// Fixed UUIDv4-shaped id reserved for lean-ctx in Augment's VS Code MCP list.

--- a/rust/src/core/editor_registry/writers/tests.rs
+++ b/rust/src/core/editor_registry/writers/tests.rs
@@ -244,9 +244,8 @@ fn qoder_mcp_config_preserves_probe_and_upserts_lean_ctx() {
         serde_json::json!([])
     );
     assert!(
-        json["mcpServers"]["lean-ctx"]["env"]["LEAN_CTX_DATA_DIR"]
-            .as_str()
-            .is_some_and(|s| !s.trim().is_empty())
+        json["mcpServers"]["lean-ctx"]["env"].is_null(),
+        "data dir is auto-detected at runtime, not pinned into the config (GH #408)"
     );
     assert!(json["mcpServers"]["lean-ctx"]["identifier"].is_null());
     assert!(json["mcpServers"]["lean-ctx"]["source"].is_null());
@@ -559,7 +558,10 @@ fn augment_vscode_creates_array_with_lean_ctx_entry() {
     assert_eq!(e["disabled"], false);
     assert_eq!(e["useShellInterpolation"], false);
     assert!(e["id"].as_str().is_some());
-    assert!(e["env"]["LEAN_CTX_DATA_DIR"].as_str().is_some());
+    assert!(
+        e["env"].is_null(),
+        "data dir is auto-detected at runtime, not pinned into the config (GH #408)"
+    );
 }
 
 #[test]

--- a/rust/src/doctor/integrations.rs
+++ b/rust/src/doctor/integrations.rs
@@ -361,6 +361,24 @@ fn integration_codebuddy(
     }
 }
 
+/// Validates an optionally-pinned `LEAN_CTX_DATA_DIR` in an MCP server entry.
+///
+/// lean-ctx no longer pins the data dir into agent configs (GH #408): it
+/// auto-detects its per-category dirs (config/data/state/cache) at runtime, and a
+/// pinned `LEAN_CTX_DATA_DIR` would force single-dir mode and collapse
+/// config/state/cache onto the data dir. So an absent env block is healthy. A
+/// config that still carries the var (legacy install, intentional relocation)
+/// must point at the resolved data dir — a stale pin is genuine drift.
+fn pinned_data_dir_ok(env_obj: Option<&serde_json::Value>, data_dir: &str) -> bool {
+    match env_obj
+        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
+        .and_then(|d| d.as_str())
+    {
+        Some(d) => d.trim() == data_dir.trim(),
+        None => true,
+    }
+}
+
 fn check_mcp_json(path: &std::path::Path, binary: &str, data_dir: &str) -> NamedCheck {
     if !path.exists() {
         return NamedCheck {
@@ -403,11 +421,7 @@ fn check_mcp_json(path: &std::path::Path, binary: &str, data_dir: &str) -> Named
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
 
     let ok = cmd_ok && env_ok;
     let detail = if ok {
@@ -601,11 +615,7 @@ fn check_vscode_mcp(path: &std::path::Path, binary: &str, data_dir: &str) -> Nam
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
 
     let ok = ty_ok && cmd_ok && env_ok;
     NamedCheck {
@@ -658,11 +668,7 @@ fn check_augment_vscode_mcp(path: &std::path::Path, binary: &str, data_dir: &str
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
     // The Augment VS Code panel persists user toggles via the `disabled` flag.
     // An entry with `disabled: true` is present-but-inert, so doctor must
     // surface that as drift instead of silently passing. A missing key,
@@ -713,11 +719,7 @@ fn check_copilot_cli_mcp(path: &std::path::Path, binary: &str, data_dir: &str) -
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
 
     let ok = cmd_ok && env_ok;
     NamedCheck {
@@ -762,11 +764,7 @@ fn check_opencode_config(path: &std::path::Path, binary: &str, data_dir: &str) -
         .and_then(|a| a.first())
         .and_then(|x| x.as_str());
     let cmd_ok = cmd.is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("environment")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("environment"), data_dir);
     let ok = cmd_ok && env_ok;
     NamedCheck {
         name: "OpenCode MCP".to_string(),
@@ -808,11 +806,7 @@ fn check_crush_config(path: &std::path::Path, binary: &str, data_dir: &str) -> N
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
     let ok = cmd_ok && env_ok;
     NamedCheck {
         name: "Crush MCP".to_string(),
@@ -878,11 +872,7 @@ fn check_openclaw_config(path: &std::path::Path, binary: &str, data_dir: &str) -
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
     let ok = cmd_ok && env_ok;
     NamedCheck {
         name,
@@ -924,11 +914,7 @@ fn check_amp_config(path: &std::path::Path, binary: &str, data_dir: &str) -> Nam
         .get("command")
         .and_then(|c| c.as_str())
         .is_some_and(|c| cmd_matches_expected(c, binary));
-    let env_ok = e
-        .get("env")
-        .and_then(|env| env.get("LEAN_CTX_DATA_DIR"))
-        .and_then(|d| d.as_str())
-        .is_some_and(|d| d.trim() == data_dir.trim());
+    let env_ok = pinned_data_dir_ok(e.get("env"), data_dir);
     let ok = cmd_ok && env_ok;
     NamedCheck {
         name: "Amp MCP".to_string(),
@@ -1102,7 +1088,8 @@ fn check_hermes_yaml(path: &std::path::Path, binary: &str, data_dir: &str) -> Na
     let has_mcp = content.contains("mcp_servers:") && content.contains("lean-ctx:");
     let has_cmd =
         content.contains("command:") && (content.contains(binary) || content.contains("lean-ctx"));
-    let has_env = content.contains("LEAN_CTX_DATA_DIR") && content.contains(data_dir);
+    // Absent ⇒ healthy (auto-detected); present ⇒ must point at the resolved dir.
+    let has_env = !content.contains("LEAN_CTX_DATA_DIR") || content.contains(data_dir);
     let ok = has_mcp && has_cmd && has_env;
     NamedCheck {
         name: "Hermes MCP".to_string(),

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -789,19 +789,17 @@ fn make_executable(_path: &PathBuf) {}
 /// Env key/value pairs for the lean-ctx MCP server entry written into agent
 /// configs (Codex TOML + the JSON agents).
 ///
-/// Always emits `LEAN_CTX_DATA_DIR`; adds `LEAN_CTX_PROJECT_ROOT` and
-/// `LEAN_CTX_EXTRA_ROOTS` when known (process env first, then config). Without
-/// these, a long-lived MCP server spawned by the agent loses the project /
-/// worktree scope captured at `init`, so an explicit path under a sibling
-/// worktree is wrongly rejected as a jail escape (#403). Single source of truth
-/// so every agent installer stays consistent.
+/// Deliberately does NOT pin `LEAN_CTX_DATA_DIR`: lean-ctx auto-detects its
+/// per-category dirs (config/data/state/cache) at runtime, and pinning the data
+/// dir would set that var in the server's environment, forcing single-dir mode
+/// and collapsing config/state/cache onto the data dir — defeating the XDG split
+/// (GH #408). Emits `LEAN_CTX_PROJECT_ROOT` and `LEAN_CTX_EXTRA_ROOTS` when known
+/// (process env first, then config). Without these, a long-lived MCP server
+/// spawned by the agent loses the project / worktree scope captured at `init`,
+/// so an explicit path under a sibling worktree is wrongly rejected as a jail
+/// escape (#403). Single source of truth so every agent installer stays consistent.
 pub(crate) fn mcp_server_env_pairs() -> Vec<(String, String)> {
     let mut pairs = Vec::new();
-
-    let data_dir = crate::core::data_dir::lean_ctx_data_dir()
-        .map(|d| d.to_string_lossy().to_string())
-        .unwrap_or_default();
-    pairs.push(("LEAN_CTX_DATA_DIR".to_string(), data_dir));
 
     let cfg = crate::core::config::Config::load();
 
@@ -916,8 +914,8 @@ mod tests {
         let pairs = mcp_server_env_pairs();
         let get = |k: &str| pairs.iter().find(|(p, _)| p == k).map(|(_, v)| v.as_str());
         assert!(
-            get("LEAN_CTX_DATA_DIR").is_some(),
-            "data dir always emitted"
+            get("LEAN_CTX_DATA_DIR").is_none(),
+            "data dir is auto-detected at runtime, never pinned into the config (GH #408)"
         );
         assert_eq!(get("LEAN_CTX_PROJECT_ROOT"), Some("/work/main"));
         assert_eq!(get("LEAN_CTX_EXTRA_ROOTS"), Some("/work/wt-a:/work/wt-b"));
@@ -932,15 +930,16 @@ mod tests {
 
     #[test]
     fn mcp_env_pairs_omit_roots_when_unset() {
-        // No project context configured anywhere ⇒ only the data dir is emitted,
-        // so we never write empty/placeholder root keys into agent configs.
+        // No project context configured anywhere ⇒ no env vars are emitted: the
+        // data dir is auto-detected (never pinned, GH #408) and we never write
+        // empty/placeholder root keys into agent configs.
         let _iso = crate::core::data_dir::isolated_data_dir();
         crate::test_env::remove_var("LEAN_CTX_PROJECT_ROOT");
         crate::test_env::remove_var("LEAN_CTX_EXTRA_ROOTS");
 
         let pairs = mcp_server_env_pairs();
         let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_str()).collect();
-        assert!(keys.contains(&"LEAN_CTX_DATA_DIR"));
+        assert!(!keys.contains(&"LEAN_CTX_DATA_DIR"));
         assert!(!keys.contains(&"LEAN_CTX_PROJECT_ROOT"));
         assert!(!keys.contains(&"LEAN_CTX_EXTRA_ROOTS"));
     }

--- a/rust/tests/setup_ci_smoke.rs
+++ b/rust/tests/setup_ci_smoke.rs
@@ -558,12 +558,8 @@ fn init_augment_installs_lean_ctx_mcp_into_dot_augment_settings() {
             "augment vscode entry must carry a command string"
         );
         assert!(
-            lean_ctx
-                .get("env")
-                .and_then(|e| e.get("LEAN_CTX_DATA_DIR"))
-                .and_then(|d| d.as_str())
-                .is_some(),
-            "augment vscode entry must wire LEAN_CTX_DATA_DIR"
+            lean_ctx.get("env").is_none(),
+            "data dir is auto-detected at runtime, not pinned into the config (GH #408)"
         );
     }
 }


### PR DESCRIPTION
## Problem

When lean-ctx registers its MCP server with an agent (Claude Code, Cursor, …), the generated server entry hard-codes an `env` block:

```json
"lean-ctx": { "command": "lean-ctx", "env": { "LEAN_CTX_DATA_DIR": "<resolved data dir>" } }
```

But `LEAN_CTX_DATA_DIR` is overloaded: besides naming the data dir, it is the **single-dir-mode trigger** in `core/paths.rs::single_dir_override`. So when the agent launches the lean-ctx MCP server with that variable set, *every* category resolver (config/state/cache/data) collapses onto the data dir.

On a fresh, XDG-split install (GH #408) this is a real bug:

| Process | config | data | state | cache |
|---|---|---|---|---|
| CLI / shell-hook (no env) | `~/.config/lean-ctx` | `~/.local/share/lean-ctx` | `~/.local/state/lean-ctx` | `~/.cache/lean-ctx` |
| **MCP server (pinned env)** | `~/.local/share/lean-ctx` ❌ | `~/.local/share/lean-ctx` | `~/.local/share/lean-ctx` ❌ | `~/.local/share/lean-ctx` ❌ |

The `config.toml` written by `lean-ctx setup` at `$XDG_CONFIG_HOME/lean-ctx` is **silently ignored** by the MCP-launched server, which looks for it under the data dir and falls back to defaults. State/cache diverge the same way.

## Fix

lean-ctx already auto-detects its per-category dirs at runtime (XDG + legacy markers), so the pin is both unnecessary and harmful — and the guides already advise against hard-coding `LEAN_CTX_DATA_DIR` (`docs/guides/cursor.md`). This PR removes the pin everywhere it is written.

The variable was injected through **two independent paths**, both fixed:

- **`hooks::mcp_server_env_pairs`** — the single source for the Codex TOML path and every JSON-config agent (Aider, Continue, Qwen, Trae, Amazon Q, Verdent, Kiro, Zed, Crush, OpenCode, Amp, Copilot, Cline, JetBrains, …). Dropped `LEAN_CTX_DATA_DIR`; **kept** `LEAN_CTX_PROJECT_ROOT` / `LEAN_CTX_EXTRA_ROOTS`, which do not trigger the collapse and are needed for worktree scope (#403).
- **`editor_registry` writers** — dropped the `env` block from every per-agent entry (Claude Code/Cursor and all `McpJson` agents, VS Code, Copilot, OpenCode, JetBrains, Amp, Crush, Gemini, Hermes, Qoder, OpenClaw, Augment VS Code).

### `doctor`

A pinned `LEAN_CTX_DATA_DIR` is now **optional**: an absent env block is healthy (auto-detected), but a config that *still* carries the var (legacy install / intentional relocation) must point at the resolved data dir — so a **stale pin is still reported as drift**. Without this, `doctor` would flag every integration as broken after the change.

### Docs

Aligned the manual-setup examples (`claude-code`, `gemini-cli`, `opencode`, `windsurf`, `aider`, `codex-cli`) with the env-less config that `setup` now writes.

## Notes / follow-ups

- **Relocation still works:** if a user sets `LEAN_CTX_DATA_DIR` in their shell, the agent-spawned server inherits it at runtime (terminal-launched agents). GUI-launched agents that don't inherit shell env follow the documented "intentionally relocate → set it yourself" path.
- **Existing configs:** `editor_registry` agents (Claude Code, Cursor, …) self-heal on the next `lean-ctx setup`/`init` (the writer overwrites the entry without `env`). Agents written via the hook JSON path skip when a `lean-ctx` entry already exists, so a pre-existing stale pin lingers until it is removed manually; `doctor` tolerates both states. Active scrubbing of old pins (`doctor --fix`) is intentionally out of scope here.

## Testing

- `cargo check --all-targets`: clean, no warnings from the crate.
- Unit tests for writers, `mcp_server_env_pairs`, `doctor::integrations`, and the Codex rewriter: pass (79).
- Integration: `setup_ci_smoke` (5/5), `mcp_optout_281` (4/4).