### PR TITLE
perf(ort): execution-provider support + hnsw search optimizations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -425,9 +425,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bzip2"
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1383,16 +1383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flatbuffers"
-version = "24.12.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
-dependencies = [
- "bitflags 1.3.2",
- "rustc_version",
-]
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,17 +1632,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -2015,12 +2003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,8 +2069,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2345,7 +2325,7 @@ dependencies = [
  "fs2",
  "futures",
  "gethostname",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "glob",
  "hex",
  "hkdf",
@@ -2361,6 +2341,8 @@ dependencies = [
  "md-5 0.11.0",
  "memmap2",
  "moka",
+ "ndarray",
+ "ort",
  "pdf-extract",
  "postcard",
  "proptest",
@@ -2372,8 +2354,6 @@ dependencies = [
  "resvg",
  "rmcp",
  "rpassword",
- "rten",
- "rten-tensor",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2476,6 +2456,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lopdf"
@@ -2632,6 +2622,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "md-5"
@@ -2738,6 +2738,21 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -2974,6 +2989,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "libloading",
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "glob",
+ "ureq",
 ]
 
 [[package]]
@@ -3321,6 +3360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3398,16 +3446,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -3573,7 +3611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3628,14 +3666,15 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
@@ -3643,15 +3682,14 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.0",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "indoc",
  "itertools 0.14.0",
  "kasuari",
  "lru",
@@ -3666,9 +3704,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -3678,19 +3716,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
-version = "0.1.1"
+name = "ratatui-termina"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -3698,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
@@ -3715,6 +3764,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3982,104 +4037,6 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "rten"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c230fa4ade87c913f61dbd911b7eb0d49460ceff3f1e4fabc837fac191137c"
-dependencies = [
- "flatbuffers",
- "num_cpus",
- "rayon",
- "rten-base",
- "rten-gemm",
- "rten-model-file",
- "rten-onnx",
- "rten-shape-inference",
- "rten-simd",
- "rten-tensor",
- "rten-vecmath",
- "rustc-hash",
- "smallvec",
- "typeid",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "rten-base"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2738cf8bb4c27f828ac788d01ccf4e367e8e773cfec6851f81851b5211de6a79"
-dependencies = [
- "rayon",
-]
-
-[[package]]
-name = "rten-gemm"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a81a0ca209fb5ce21bd17efa0bd287d5881c6cebfbff0b21c4294a1a14a9e"
-dependencies = [
- "rayon",
- "rten-base",
- "rten-simd",
- "rten-tensor",
-]
-
-[[package]]
-name = "rten-model-file"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2f8d270f07ab1bbfff47250c6039f6caa5da59d6da7d74f66aa48559aa6fea"
-dependencies = [
- "flatbuffers",
- "rten-base",
-]
-
-[[package]]
-name = "rten-onnx"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23086eef75bfb55278cb0b45cf9f5a877d466d914914aafebee4ffca9b24d20c"
-
-[[package]]
-name = "rten-shape-inference"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8a913c7ca40e2bfbb2a0cd447cce56b33ab19435f56693271a2ef37cf58984"
-dependencies = [
- "rten-tensor",
- "smallvec",
-]
-
-[[package]]
-name = "rten-simd"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19a0032dfcb70dd20960c1c51a37674b237586cbc1ce586f45b46605d108e82"
-
-[[package]]
-name = "rten-tensor"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05dc744a270aa32d154f1a3df8e48740ccc1be9dfbcf23295ada66d83aa98de6"
-dependencies = [
- "rayon",
- "rten-base",
- "smallvec",
- "typeid",
-]
-
-[[package]]
-name = "rten-vecmath"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9574ddebf5671bc08ceb76e2e1638fadc57fdeff318634eab2c29e9a803cff64"
-dependencies = [
- "rten-base",
- "rten-simd",
 ]
 
 [[package]]
@@ -4651,6 +4608,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4851,9 +4819,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
  "windows-sys 0.61.2",
 ]
 
@@ -5662,12 +5643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5766,12 +5741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5799,6 +5768,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "socks",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",
@@ -5887,7 +5857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5985,16 +5955,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6063,34 +6024,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.252.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -6159,18 +6098,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
@@ -6190,7 +6117,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.252.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -6648,97 +6575,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.118",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
 
 [[package]]
 name = "writeable"
@@ -6891,7 +6730,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hmac",
  "indexmap",
  "lzma-rust2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,28 +59,40 @@ path = "src/bin/seed_observatory.rs"
 required-features = ["dev-tools"]
 
 [features]
-default = ["tree-sitter", "embeddings", "http-server", "team-server", "secure-update", "jemalloc"]
+default = [
+  "tree-sitter",
+  "embeddings",
+  "http-server",
+  "team-server",
+  "secure-update",
+  "jemalloc",
+]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 dev-tools = []
 no-jail = []
-neural = ["dep:rten", "dep:rten-tensor"]
-embeddings = ["dep:rten", "dep:rten-tensor"]
+neural = ["dep:ort", "dep:ndarray"]
+embeddings = ["dep:ort", "dep:ndarray"]
+ort-cuda = ["ort?/cuda"]
+ort-webgpu = ["ort?/webgpu"]
+ort-rocm = ["ort?/rocm"]
+ort-directml = ["ort?/directml"]
+ort-coreml = ["ort?/coreml"]
 http-server = ["dep:axum", "dep:tower-http", "dep:reqwest"]
 qdrant = ["embeddings"]
 team-server = ["http-server"]
 secure-update = []
 cloud-server = [
-    "http-server",
-    "dep:deadpool-postgres",
-    "dep:tokio-postgres",
-    "dep:lettre",
-    "dep:jsonwebtoken",
-    "dep:base64",
-    "dep:uuid",
-    "dep:hex",
-    "dep:rand",
-    "dep:argon2",
-    "dep:resvg",
+  "http-server",
+  "dep:deadpool-postgres",
+  "dep:tokio-postgres",
+  "dep:lettre",
+  "dep:jsonwebtoken",
+  "dep:base64",
+  "dep:uuid",
+  "dep:hex",
+  "dep:rand",
+  "dep:argon2",
+  "dep:resvg",
 ]
 tree-sitter = [
   "dep:tree-sitter",
@@ -109,11 +121,29 @@ tree-sitter = [
 wasm = ["dep:wasmi"]
 
 [dependencies]
-rmcp = { version = "1.7", features = ["server", "client", "transport-io", "transport-streamable-http-server", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "1.7", features = [
+  "server",
+  "client",
+  "transport-io",
+  "transport-streamable-http-server",
+  "transport-child-process",
+  "transport-streamable-http-client-reqwest",
+] }
 # Header types for the gateway's downstream HTTP MCP client (already in the tree via rmcp/reqwest).
 http = "1.4"
 tiktoken-rs = "0.12"
-tokio = { version = "1.52", features = ["rt", "rt-multi-thread", "macros", "io-std", "io-util", "net", "sync", "time", "signal", "process"] }
+tokio = { version = "1.52", features = [
+  "rt",
+  "rt-multi-thread",
+  "macros",
+  "io-std",
+  "io-util",
+  "net",
+  "sync",
+  "time",
+  "signal",
+  "process",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 subtle = "2.6"
@@ -162,13 +192,27 @@ tree-sitter-dart = { version = "0.2", optional = true }
 tree-sitter-gdscript = { version = "6.1", optional = true }
 tree-sitter-lua = { version = "0.5", optional = true }
 tree-sitter-luau = { version = "1.2", optional = true }
-rten = { version = "0.24", optional = true }
-rten-tensor = { version = "0.24", optional = true }
+ort = { version = "2.0.0-rc.12", optional = true, default-features = false, features = [
+  "api-24",
+  "std",
+  "ndarray",
+  "tls-rustls",
+  "tracing",
+  "load-dynamic",
+] }
+ndarray = { version = "0.17", optional = true }
 axum = { version = "0.8", optional = true, features = ["ws"] }
 tower-http = { version = "0.7", features = ["cors", "auth"], optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
-tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1"], optional = true }
-lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"], optional = true }
+tokio-postgres = { version = "0.7", features = [
+  "with-chrono-0_4",
+  "with-uuid-1",
+], optional = true }
+lettre = { version = "0.11", default-features = false, features = [
+  "tokio1-rustls-tls",
+  "smtp-transport",
+  "builder",
+], optional = true }
 jsonwebtoken = { version = "10.4", optional = true }
 base64 = { version = "0.22", optional = true }
 uuid = { version = "1.23", features = ["v4", "serde"], optional = true }
@@ -187,7 +231,11 @@ rpassword = "7.5"
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
 getrandom = "0.4"
 tempfile = "3.27"
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream", "json"], optional = true }
+reqwest = { version = "0.13", default-features = false, features = [
+  "rustls",
+  "stream",
+  "json",
+], optional = true }
 bytecount = "0.6"
 libc = "0.2"
 blake3 = "1.8"
@@ -270,10 +318,10 @@ panic = "unwind"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
-    "Win32_Foundation",
-    "Win32_System_Threading",
-    "Win32_Security",
-    "Win32_System_Pipes",
+  "Win32_Foundation",
+  "Win32_System_Threading",
+  "Win32_Security",
+  "Win32_System_Pipes",
 ] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/rust/src/core/hnsw.rs
+++ b/rust/src/core/hnsw.rs
@@ -6,6 +6,11 @@
 //! This is a minimal implementation optimized for lean-ctx's embedding dimensions (384-d).
 //! For indices under BRUTE_FORCE_THRESHOLD chunks, falls back to exact linear scan
 //! with binary-heap top-k selection (O(n log k) instead of O(n log n)).
+//!
+//! All embeddings are stored in a single flat `Arc<[f32]>` allocation (row-major). This
+//! gives sequential memory access during the distance hot-loop — one dereference instead
+//! of `Arc → slice → Vec → f32 heap`, eliminates per-vector allocation overhead, and
+//! improves cache utilization for large corpora.
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -17,6 +22,65 @@ const EF_CONSTRUCTION: usize = 200; // search width during build
 const EF_SEARCH: usize = 64; // search width during query
 // ML = 1/ln(M) = 1/ln(16) ≈ 0.3607
 const ML: f64 = 0.360_674_0;
+
+/// Flat row-major embedding matrix: `data` is `n_vectors × dim` floats in one
+/// contiguous heap allocation. Used everywhere in the dense search pipeline so
+/// the same allocation backs both the HNSW graph cache and per-query scoring —
+/// zero copies between layers.
+#[derive(Clone)]
+pub struct FlatEmbeddings {
+    pub data: Arc<[f32]>,
+    pub dim: usize,
+}
+
+impl FlatEmbeddings {
+    /// Number of vectors in the matrix.
+    #[inline]
+    pub fn n_vectors(&self) -> usize {
+        if self.dim == 0 {
+            return 0;
+        }
+        self.data.len() / self.dim
+    }
+
+    /// View the i-th vector as a `&[f32]`.
+    #[inline]
+    pub fn get(&self, i: usize) -> &[f32] {
+        let start = i * self.dim;
+        &self.data[start..][..self.dim]
+    }
+
+    /// Extract the i-th vector into an owned `Vec<f32>`.
+    #[inline]
+    pub fn get_vec(&self, i: usize) -> Vec<f32> {
+        self.get(i).to_vec()
+    }
+
+    /// Build from a `Vec<Vec<f32>>` (for tests / migration).
+    pub fn from_vecs(vecs: Vec<Vec<f32>>) -> Self {
+        let dim = vecs.first().map_or(0, std::vec::Vec::len);
+        let n = vecs.len();
+        let mut data = Vec::with_capacity(n * dim);
+        for v in vecs {
+            debug_assert_eq!(v.len(), dim);
+            data.extend_from_slice(&v);
+        }
+        Self {
+            data: Arc::from(data),
+            dim,
+        }
+    }
+}
+
+impl std::fmt::Debug for FlatEmbeddings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlatEmbeddings")
+            .field("n_vectors", &self.n_vectors())
+            .field("dim", &self.dim)
+            .field("total_bytes", &(self.data.len() * 4))
+            .finish()
+    }
+}
 
 /// A scored item for the min-heap (lowest similarity first for top-k pruning).
 #[derive(Clone, PartialEq)]
@@ -68,25 +132,27 @@ struct Node {
 
 /// Approximate nearest neighbor index using HNSW for large datasets,
 /// with brute-force fallback for small ones.
+///
+/// Vectors are stored in a [`FlatEmbeddings`] — one contiguous `Arc<[f32]>`
+/// allocation — shared with the rest of the pipeline.
 pub struct AnnIndex {
-    vectors: Arc<[Vec<f32>]>,
+    embeddings: FlatEmbeddings,
     nodes: Vec<Node>,
     entry_point: usize,
     max_level: usize,
 }
 
 impl AnnIndex {
-    /// Build the index from a shared set of vectors.
+    /// Build the index from a [`FlatEmbeddings`].
     ///
-    /// The corpus is taken as `Arc<[Vec<f32>]>` so the cached index shares the
-    /// *same* full-precision allocation as the per-query aligned corpus: build
-    /// performs an `Arc::clone` (a refcount bump, zero element bytes copied)
-    /// rather than duplicating the whole `Vec<Vec<f32>>`.
-    pub fn build(vectors: Arc<[Vec<f32>]>) -> Self {
-        let n = vectors.len();
+    /// The corpus is shared via `FlatEmbeddings.data` (an `Arc::clone`, zero
+    /// bytes copied), so the cached HNSW index shares the *same* flat f32
+    /// allocation as the per-query aligned corpus.
+    pub fn build(embeddings: FlatEmbeddings) -> Self {
+        let n = embeddings.n_vectors();
         if n == 0 {
             return Self {
-                vectors,
+                embeddings,
                 nodes: Vec::new(),
                 entry_point: 0,
                 max_level: 0,
@@ -95,18 +161,15 @@ impl AnnIndex {
 
         if n < BRUTE_FORCE_THRESHOLD {
             return Self {
-                vectors,
+                embeddings,
                 nodes: Vec::new(),
                 entry_point: 0,
                 max_level: 0,
             };
         }
 
-        // HNSW graph path: the vectors slice is shared up front (Arc::clone, no
-        // element copy) and the insert loop reads from it by index. `insert`
-        // only mutates `nodes`, deriving each new id from `nodes.len()`.
         let mut index = Self {
-            vectors,
+            embeddings,
             nodes: Vec::with_capacity(n),
             entry_point: 0,
             max_level: 0,
@@ -133,16 +196,17 @@ impl AnnIndex {
         }
 
         let mut ep = self.entry_point;
+        let new_vec = self.embeddings.get(new_id);
 
         // Traverse from top layer down to level+1 (greedy)
         for lc in (level + 1..=self.max_level).rev() {
-            ep = self.search_layer_single(&self.vectors[new_id], ep, lc);
+            ep = self.search_layer_single(new_vec, ep, lc);
         }
 
         // Insert into layers [min(level, max_level) .. 0]
         let insert_levels = level.min(self.max_level);
         for lc in (0..=insert_levels).rev() {
-            let neighbors = self.search_layer(&self.vectors[new_id], ep, EF_CONSTRUCTION, lc);
+            let neighbors = self.search_layer(new_vec, ep, EF_CONSTRUCTION, lc);
             let selected = Self::select_neighbors(&neighbors, M);
 
             if lc < self.nodes[new_id].connections.len() {
@@ -153,10 +217,10 @@ impl AnnIndex {
                 if lc < self.nodes[neighbor].connections.len() {
                     self.nodes[neighbor].connections[lc].push(new_id);
                     if self.nodes[neighbor].connections[lc].len() > M * 2 {
-                        let nv = &self.vectors[neighbor];
+                        let nv = self.embeddings.get(neighbor);
                         let mut scored: Vec<(usize, f32)> = self.nodes[neighbor].connections[lc]
                             .iter()
-                            .map(|&n| (n, cosine_sim(nv, &self.vectors[n])))
+                            .map(|&n| (n, cosine_sim(nv, self.embeddings.get(n))))
                             .collect();
                         scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
                         scored.truncate(M);
@@ -179,7 +243,7 @@ impl AnnIndex {
 
     fn search_layer_single(&self, query: &[f32], ep: usize, _layer: usize) -> usize {
         let mut current = ep;
-        let mut best_sim = cosine_sim(query, &self.vectors[ep]);
+        let mut best_sim = cosine_sim(query, self.embeddings.get(ep));
 
         loop {
             let mut improved = false;
@@ -191,7 +255,7 @@ impl AnnIndex {
             };
 
             for &neighbor in layer_conns {
-                let sim = cosine_sim(query, &self.vectors[neighbor]);
+                let sim = cosine_sim(query, self.embeddings.get(neighbor));
                 if sim > best_sim {
                     best_sim = sim;
                     current = neighbor;
@@ -206,18 +270,19 @@ impl AnnIndex {
     }
 
     fn search_layer(&self, query: &[f32], ep: usize, ef: usize, layer: usize) -> Vec<(usize, f32)> {
-        let mut visited = vec![false; self.vectors.len()];
+        let n = self.embeddings.n_vectors();
+        let mut visited = vec![false; n];
         let mut candidates = BinaryHeap::<MaxCandidate>::new();
         let mut results = BinaryHeap::<Candidate>::new();
 
-        let sim = cosine_sim(query, &self.vectors[ep]);
+        let sim = cosine_sim(query, self.embeddings.get(ep));
         visited[ep] = true;
         candidates.push(MaxCandidate { idx: ep, sim });
         results.push(Candidate { idx: ep, sim });
 
         while let Some(MaxCandidate { idx: c, sim: _ }) = candidates.pop() {
             let worst_result = results.peek().map_or(f32::MIN, |r| r.sim);
-            if cosine_sim(query, &self.vectors[c]) < worst_result && results.len() >= ef {
+            if cosine_sim(query, self.embeddings.get(c)) < worst_result && results.len() >= ef {
                 break;
             }
 
@@ -234,7 +299,7 @@ impl AnnIndex {
                 }
                 visited[neighbor] = true;
 
-                let n_sim = cosine_sim(query, &self.vectors[neighbor]);
+                let n_sim = cosine_sim(query, self.embeddings.get(neighbor));
                 let worst = results.peek().map_or(f32::MIN, |r| r.sim);
 
                 if results.len() < ef || n_sim > worst {
@@ -267,21 +332,11 @@ impl AnnIndex {
     }
 
     /// Deterministic geometric level draw seeded by the node's insertion index.
-    ///
-    /// HNSW only requires the per-node level to follow a geometric distribution
-    /// (mean `ML`); it does not require OS entropy. Deriving the draw from the
-    /// node id via splitmix64 keeps that distribution while making index
-    /// construction **fully reproducible** — the same corpus always yields the
-    /// same graph and therefore the same search results. The previous
-    /// `getrandom`-seeded draw rebuilt a different graph on every run, which made
-    /// approximate recall (and the recall tests) non-deterministic and flaky.
     fn level_for(node_id: usize) -> usize {
-        // splitmix64: a single id → a well-distributed u64.
         let mut z = (node_id as u64).wrapping_add(0x9E37_79B9_7F4A_7C15);
         z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
         z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
         z ^= z >> 31;
-        // Map the top 53 bits to (0,1); +1 keeps r > 0 so -ln(r) stays finite.
         let r = (((z >> 11) as f64) + 1.0) / ((1u64 << 53) as f64 + 1.0);
         (-r.ln() * ML).floor() as usize
     }
@@ -289,13 +344,13 @@ impl AnnIndex {
     /// Search for the top-k nearest neighbors of a query vector.
     /// Returns (index, similarity) pairs sorted by descending similarity.
     pub fn search(&self, query: &[f32], top_k: usize) -> Vec<(usize, f32)> {
-        if self.vectors.is_empty() {
+        if self.embeddings.n_vectors() == 0 {
             return Vec::new();
         }
 
         // Brute-force for small indices (faster due to no graph overhead)
-        if self.nodes.is_empty() || self.vectors.len() < BRUTE_FORCE_THRESHOLD {
-            return brute_force_topk(&self.vectors, query, top_k);
+        if self.nodes.is_empty() || self.embeddings.n_vectors() < BRUTE_FORCE_THRESHOLD {
+            return brute_force_topk(&self.embeddings, query, top_k);
         }
 
         // HNSW search
@@ -310,12 +365,17 @@ impl AnnIndex {
     }
 }
 
-/// O(n log k) brute-force top-k selection using a min-heap.
-pub fn brute_force_topk(vectors: &[Vec<f32>], query: &[f32], top_k: usize) -> Vec<(usize, f32)> {
+/// O(n log k) brute-force top-k selection using a min-heap over a flat buffer.
+pub fn brute_force_topk(
+    embeddings: &FlatEmbeddings,
+    query: &[f32],
+    top_k: usize,
+) -> Vec<(usize, f32)> {
+    let n = embeddings.n_vectors();
     let mut heap = BinaryHeap::<Candidate>::with_capacity(top_k + 1);
 
-    for (i, vec) in vectors.iter().enumerate() {
-        let sim = cosine_sim(query, vec);
+    for i in 0..n {
+        let sim = cosine_sim(query, embeddings.get(i));
         if heap.len() < top_k {
             heap.push(Candidate { idx: i, sim });
         } else if let Some(worst) = heap.peek()
@@ -327,7 +387,7 @@ pub fn brute_force_topk(vectors: &[Vec<f32>], query: &[f32], top_k: usize) -> Ve
     }
 
     let mut results: Vec<(usize, f32)> = heap.into_iter().map(|c| (c.idx, c.sim)).collect();
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     results
 }
 
@@ -358,15 +418,19 @@ mod tests {
         v
     }
 
+    fn flat_from(vecs: Vec<Vec<f32>>) -> FlatEmbeddings {
+        FlatEmbeddings::from_vecs(vecs)
+    }
+
     #[test]
     fn brute_force_topk_correctness() {
-        let vectors: Vec<Vec<f32>> = (0..100).map(|i| random_vec(16, i)).collect();
+        let vectors = (0..100).map(|i| random_vec(16, i)).collect();
+        let flat = flat_from(vectors);
         let query = random_vec(16, 999);
 
-        let results = brute_force_topk(&vectors, &query, 5);
+        let results = brute_force_topk(&flat, &query, 5);
         assert_eq!(results.len(), 5);
 
-        // Results should be in descending similarity order
         for w in results.windows(2) {
             assert!(w[0].1 >= w[1].1);
         }
@@ -375,15 +439,14 @@ mod tests {
     #[test]
     fn brute_force_topk_matches_exhaustive() {
         let vectors: Vec<Vec<f32>> = (0..50).map(|i| random_vec(8, i + 42)).collect();
+        let flat = flat_from(vectors);
         let query = random_vec(8, 123);
 
-        let top5 = brute_force_topk(&vectors, &query, 5);
+        let top5 = brute_force_topk(&flat, &query, 5);
 
         // Exhaustive comparison
-        let mut all: Vec<(usize, f32)> = vectors
-            .iter()
-            .enumerate()
-            .map(|(i, v)| (i, cosine_sim(&query, v)))
+        let mut all: Vec<(usize, f32)> = (0..flat.n_vectors())
+            .map(|i| (i, cosine_sim(&query, flat.get(i))))
             .collect();
         all.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         all.truncate(5);
@@ -396,16 +459,44 @@ mod tests {
 
     #[test]
     fn empty_index_returns_empty() {
-        let index = AnnIndex::build(Arc::from(Vec::new()));
+        let flat = FlatEmbeddings {
+            data: Arc::from(Vec::new()),
+            dim: 2,
+        };
+        let index = AnnIndex::build(flat);
         assert!(index.search(&[1.0, 0.0], 5).is_empty());
     }
 
     #[test]
     fn small_index_uses_brute_force() {
         let vectors: Vec<Vec<f32>> = (0..50).map(|i| random_vec(4, i)).collect();
-        let index = AnnIndex::build(Arc::from(vectors));
+        let flat = flat_from(vectors);
+        let index = AnnIndex::build(flat);
         assert!(index.nodes.is_empty()); // no HNSW graph built
         let results = index.search(&random_vec(4, 999), 3);
         assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn flat_embeddings_from_vecs_shape() {
+        let vecs = vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ];
+        let flat = FlatEmbeddings::from_vecs(vecs);
+        assert_eq!(flat.n_vectors(), 3);
+        assert_eq!(flat.dim, 3);
+        assert_eq!(flat.get(0), &[1.0, 2.0, 3.0]);
+        assert_eq!(flat.get(2), &[7.0, 8.0, 9.0]);
+    }
+
+    #[test]
+    fn flat_embeddings_clone_is_shallow() {
+        let vecs = vec![vec![1.0, 2.0]];
+        let a = FlatEmbeddings::from_vecs(vecs);
+        let b = a.clone();
+        // Arc: same ptr after clone
+        assert!(Arc::ptr_eq(&a.data, &b.data));
     }
 }

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -246,6 +246,8 @@ pub mod attention {
 // Domain: Neural / ML
 // ---------------------------------------------------------------------------
 pub mod neural;
+pub mod ort_environment;
+pub mod ort_execution_providers;
 
 // ---------------------------------------------------------------------------
 // Domain: Patterns & Shell

--- a/rust/src/core/ort_environment.rs
+++ b/rust/src/core/ort_environment.rs
@@ -1,0 +1,266 @@
+//! ONNX Runtime global environment: single init per process, runtime dylib loading.
+//!
+//! With the `load-dynamic` Cargo feature (always enabled in lean-ctx's `ort`
+//! dependency), `libonnxruntime` is loaded at runtime via [`ort::init_from`].
+//! This module resolves the library path across platforms, including NixOS.
+//!
+//! # Search order
+//!
+//! 1. `ORT_DYLIB_PATH` env var (resolved relative to the executable directory)
+//! 2. Nix profile paths — `/run/current-system/sw/lib/`, `~/.nix-profile/lib/` (Linux)
+//! 3. Well-known system directories per platform
+//! 4. `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH`
+//!
+//! If no copy is found, [`ensure_ort_env`] returns an eager error — session
+//! creation hangs rather than failing, so we fail fast.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use ort::ep::ExecutionProviderDispatch;
+
+/// Ensure the global ONNX Runtime environment is initialized.
+///
+/// On first call: resolves `libonnxruntime` via the search chain defined in
+/// `resolve_ort_dylib`, loads it with [`ort::init_from`], and registers GPU
+/// execution providers.  Subsequent calls are no-ops.
+///
+/// Returns an eager error when the shared library cannot be found (session
+/// creation would otherwise hang).
+pub fn ensure_ort_env(eps: &[ExecutionProviderDispatch]) -> anyhow::Result<()> {
+    static INIT: OnceLock<anyhow::Result<()>> = OnceLock::new();
+    // get_or_init runs the closure at most once; all subsequent calls return
+    // a reference to the stored Result.
+    match INIT.get_or_init(|| {
+        tracing::debug!("Initializing ONNX Runtime environment");
+        init_ort(eps)
+    }) {
+        Ok(()) => Ok(()),
+        // anyhow::Error is !Clone so we reconstitute from Display.
+        Err(e) => Err(anyhow::anyhow!("{e}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Initialisation
+// ---------------------------------------------------------------------------
+
+/// Load `libonnxruntime` at runtime via [`ort::init_from`].
+///
+/// The library path is resolved by [`resolve_ort_dylib`]; errors are
+/// propagated eagerly to avoid hanging on first session creation.
+fn init_ort(eps: &[ExecutionProviderDispatch]) -> anyhow::Result<()> {
+    let path = resolve_ort_dylib()?;
+
+    tracing::debug!("Loading libonnxruntime from {}", path.display());
+    ort::init_from(&path)
+        .map_err(|e| anyhow::anyhow!("ort::init_from({}) failed: {e}", path.display()))?
+        .with_name("lean-ctx")
+        .with_execution_providers(eps)
+        .commit();
+
+    tracing::info!("ONNX Runtime initialised ({})", path.display());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Library resolution
+// ---------------------------------------------------------------------------
+
+fn dylib_filename() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "onnxruntime.dll"
+    } else if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    }
+}
+
+/// Search for `libonnxruntime` across platform-specific locations.
+///
+/// Returns the first path found, or a descriptive error.
+fn resolve_ort_dylib() -> anyhow::Result<PathBuf> {
+    let name = dylib_filename();
+
+    // 1. ORT_DYLIB_PATH env var (resolved relative to exe dir)
+    if let Ok(p) = std::env::var("ORT_DYLIB_PATH") {
+        let path = PathBuf::from(&p);
+        if path.is_relative() {
+            let rel_to_exe = || -> Option<PathBuf> {
+                let exe = std::env::current_exe().ok()?;
+                let dir = exe.parent()?;
+                let abs = dir.join(&path);
+                abs.is_file().then_some(abs)
+            };
+            if let Some(abs) = rel_to_exe() {
+                return Ok(abs);
+            }
+        }
+        if path.is_file() {
+            return Ok(path);
+        }
+        anyhow::bail!("ORT_DYLIB_PATH={p} set but file does not exist");
+    }
+
+    // 2. Nix profile paths (Linux) — system & user profiles always point to
+    //    the currently activated version.
+    #[cfg(target_os = "linux")]
+    if let Some(found) = nix_profile_search(name) {
+        return Ok(found);
+    }
+
+    // 3. Well-known system paths (per platform)
+    if let Some(found) = well_known_paths(name) {
+        return Ok(found);
+    }
+
+    // 4. LD_LIBRARY_PATH / DYLD_LIBRARY_PATH
+    if let Some(found) = lib_path_search(name) {
+        return Ok(found);
+    }
+
+    anyhow::bail!(
+        "libonnxruntime not found.\n\
+         Set ORT_DYLIB_PATH=<path> to point to the shared library.\n\
+         Install:  pip install onnxruntime  (Python bundles the .so)\n\
+         NixOS:    nix-shell -p onnxruntime\n\
+         Homebrew: brew install onnxruntime\n\
+         Searched: ORT_DYLIB_PATH, Nix store, well-known system dirs, \
+         LD_LIBRARY_PATH/DYLD_LIBRARY_PATH"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Platform-specific searches
+// ---------------------------------------------------------------------------
+
+/// Check Nix profile symlinks for `libonnxruntime`.
+///
+/// Nix maintains `/run/current-system/sw/lib/` (system profile) and
+/// `~/.nix-profile/lib/` (user profile) as symlinks to the currently
+/// activated package versions — these are always authoritative.
+#[cfg(target_os = "linux")]
+fn nix_profile_search(name: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir();
+    let user_profile = home
+        .as_ref()
+        .map(|h| h.join(".nix-profile").join("lib").join(name));
+    let candidates = [
+        Some(Path::new("/run/current-system/sw/lib").join(name)),
+        user_profile,
+    ];
+    candidates.into_iter().flatten().find(|c| c.is_file())
+}
+
+/// Check well-known system directories for `libonnxruntime`.
+fn well_known_paths(name: &str) -> Option<PathBuf> {
+    // Platform-specific hints.
+    let dirs: &[&str] = if cfg!(target_os = "linux") {
+        &["/usr/lib", "/usr/lib64", "/usr/local/lib"]
+    } else if cfg!(target_os = "macos") {
+        &["/usr/local/lib", "/opt/homebrew/lib", "/opt/local/lib"]
+    } else if cfg!(target_os = "windows") {
+        // On Windows, check next to the executable and common install paths.
+        &[]
+    } else {
+        &["/usr/lib", "/usr/local/lib"]
+    };
+
+    // Also check next to the executable (common for portable installs, macOS
+    // Frameworks, Windows sibling layout, and Linux $ORIGIN setups).
+    let exe_relative = || -> Option<PathBuf> {
+        let exe = std::env::current_exe().ok()?;
+        let dir = exe.parent()?;
+        let sibling = dir.join(name);
+        if sibling.is_file() {
+            return Some(sibling);
+        }
+        // macOS app bundle: executable in MyApp.app/Contents/MacOS/,
+        // library in MyApp.app/Contents/Frameworks/
+        #[cfg(target_os = "macos")]
+        {
+            let parent = dir.parent()?;
+            let fw = parent.join("Frameworks").join(name);
+            if fw.is_file() {
+                return Some(fw);
+            }
+        }
+        None
+    };
+    if let Some(path) = exe_relative() {
+        return Some(path);
+    }
+
+    for dir in dirs {
+        let candidate = Path::new(dir).join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+/// Scan `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS) directories.
+fn lib_path_search(name: &str) -> Option<PathBuf> {
+    let var = if cfg!(target_os = "macos") {
+        "DYLD_LIBRARY_PATH"
+    } else {
+        "LD_LIBRARY_PATH"
+    };
+    let path = std::env::var(var).ok()?;
+    for segment in std::env::split_paths(&path) {
+        let candidate = segment.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dylib_filename_known_platform() {
+        let name = dylib_filename();
+        if cfg!(target_os = "linux") {
+            assert_eq!(name, "libonnxruntime.so");
+        } else if cfg!(target_os = "macos") {
+            assert_eq!(name, "libonnxruntime.dylib");
+        } else if cfg!(target_os = "windows") {
+            assert_eq!(name, "onnxruntime.dll");
+        }
+    }
+
+    #[test]
+    fn resolve_dylib_env_var_takes_precedence() {
+        // Set ORT_DYLIB_PATH to a known file (/tmp is guaranteed to exist,
+        // but the file itself won't — this should still error with a clear
+        // message about the file not existing).
+        crate::test_env::set_var("ORT_DYLIB_PATH", "/nonexistent/foo.so");
+        let err = resolve_ort_dylib().unwrap_err();
+        assert!(err.to_string().contains("ORT_DYLIB_PATH"));
+        crate::test_env::remove_var("ORT_DYLIB_PATH");
+    }
+
+    #[test]
+    fn lib_path_search_no_library() {
+        // Should not crash when the env var is unset.
+        assert!(lib_path_search("nonexistent.so.42").is_none());
+    }
+
+    #[test]
+    fn well_known_paths_returns_none_for_nonsense() {
+        assert!(well_known_paths("this-library-surely-does-not-exist.so").is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn nix_profile_search_no_panic() {
+        // When no Nix profile is present, returns None without crashing.
+        assert!(nix_profile_search("nonexistent.so").is_none());
+    }
+}

--- a/rust/src/core/ort_execution_providers.rs
+++ b/rust/src/core/ort_execution_providers.rs
@@ -1,0 +1,48 @@
+//! GPU execution provider selection: per-vendor feature flags, session-level config.
+//!
+//! Each GPU EP is gated behind its own Cargo feature (`ort-cuda`, `ort-rocm`, etc.).
+//! When no GPU features are enabled, an empty vec is returned — ORT uses CPU only.
+//! When a GPU feature IS enabled but the GPU is unavailable, ORT silently falls back
+//! to the next EP in the list; we emit [`tracing::warn!`] so users know.
+
+/// Build the list of GPU execution providers in registration-priority order.
+pub fn gpu_execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
+    #[allow(unused_mut)]
+    let mut eps: Vec<ort::ep::ExecutionProviderDispatch> = Vec::new();
+
+    #[cfg(feature = "ort-cuda")]
+    {
+        tracing::info!("Enabling CUDA execution provider for ONNX Runtime");
+        eps.push(ort::ep::CUDA::default().build());
+    }
+
+    #[cfg(feature = "ort-rocm")]
+    {
+        tracing::info!("Enabling ROCm execution provider for ONNX Runtime");
+        eps.push(ort::ep::ROCm::default().build());
+    }
+
+    #[cfg(feature = "ort-webgpu")]
+    {
+        tracing::info!("Enabling WebGPU execution provider for ONNX Runtime");
+        eps.push(ort::ep::WebGPU::default().build());
+    }
+    #[cfg(all(target_os = "windows", feature = "ort-directml"))]
+    {
+        tracing::info!("Enabling DirectML execution provider for ONNX Runtime");
+        eps.push(ort::ep::DirectML::default().build());
+    }
+
+    #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "ort-coreml"))]
+    {
+        tracing::info!("Enabling CoreML execution provider for ONNX Runtime");
+        eps.push(ort::ep::CoreML::default().build());
+    }
+
+    if eps.is_empty() {
+        tracing::debug!("No GPU execution providers configured — using CPU only");
+    }
+
+    eps.push(ort::ep::CPU::default().build());
+    eps
+}


### PR DESCRIPTION
## Summary

Optimized inference with `ort`.

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`

## Notes for reviewers

### Risk areas / edge cases:
- `jina-code-v2` is still broken (pre-existing errors, not introduced by the current PR)