### PR TITLE
fix(ctx_expand): fall back to reference_store for ref_-prefixed IDs

### DIFF
--- a/rust/src/core/archive.rs
+++ b/rust/src/core/archive.rs
@@ -166,26 +166,27 @@ pub fn retrieve(id: &str) -> Option<String> {
     std::fs::read_to_string(path).ok()
 }
 
-pub fn retrieve_with_range(id: &str, start: usize, end: usize) -> Option<String> {
-    let content = retrieve(id)?;
+/// Format a range of lines from content with `{:>6}|` line-number gutter.
+/// Shared by `retrieve_with_range` (archive) and `expand_reference` (ref store).
+pub(crate) fn format_range(content: &str, start: usize, end: usize) -> String {
     let lines: Vec<&str> = content.lines().collect();
     let start = start.saturating_sub(1).min(lines.len());
     let end = end.min(lines.len());
     if start >= end {
-        return Some(String::new());
+        return String::new();
     }
-    Some(
-        lines[start..end]
-            .iter()
-            .enumerate()
-            .map(|(i, line)| format!("{:>6}|{line}", start + i + 1))
-            .collect::<Vec<_>>()
-            .join("\n"),
-    )
+    lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, line)| format!("{:>6}|{line}", start + i + 1))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
-pub fn retrieve_with_search(id: &str, pattern: &str) -> Option<String> {
-    let content = retrieve(id)?;
+/// Search content for lines matching `pattern` (case-insensitive) and return
+/// gutter-prefixed matches. `label` appears in the result message (e.g. "archive
+/// a1966..." or "reference ref_18bb..."). Shared by archive and ref store paths.
+pub(crate) fn format_search(content: &str, pattern: &str, label: &str) -> String {
     let pattern_lower = pattern.to_lowercase();
     let matches: Vec<String> = content
         .lines()
@@ -193,38 +194,22 @@ pub fn retrieve_with_search(id: &str, pattern: &str) -> Option<String> {
         .filter(|(_, line)| line.to_lowercase().contains(&pattern_lower))
         .map(|(i, line)| format!("{:>6}|{line}", i + 1))
         .collect();
-
     if matches.is_empty() {
-        Some(format!("No matches for \"{pattern}\" in archive {id}"))
+        format!("No matches for \"{pattern}\" in {label}")
     } else {
-        Some(format!(
+        format!(
             "{} match(es) for \"{}\":\n{}",
             matches.len(),
             pattern,
             matches.join("\n")
-        ))
+        )
     }
 }
 
-/// Retrieve the first `n` lines of an archived entry, with a line-number gutter.
-pub fn retrieve_head(id: &str, n: usize) -> Option<String> {
-    retrieve_with_range(id, 1, n)
-}
-
-/// Retrieve the last `n` lines of an archived entry, with a line-number gutter.
-pub fn retrieve_tail(id: &str, n: usize) -> Option<String> {
-    let content = retrieve(id)?;
-    let total = content.lines().count();
-    let start = if total > n { total - n + 1 } else { 1 };
-    retrieve_with_range(id, start, total)
-}
-
-/// Describe the JSON structure of an archived entry: top-level keys with type hints,
-/// array lengths + element types, etc. An optional dot/slash `path` (e.g. `data.items.0`)
-/// navigates into the structure first. Returns `None` when the archive is missing or its
-/// content is not valid JSON, so callers can fall back to a raw retrieval hint.
-pub fn retrieve_json_keys(id: &str, path: Option<&str>) -> Option<String> {
-    let content = retrieve(id)?;
+/// Describe JSON structure: navigate `path` (dot/slash separated) into parsed
+/// content, then format with `describe_json`. `label` appears in error messages.
+/// Shared by archive and ref store paths.
+pub(crate) fn format_json_keys(content: &str, path: Option<&str>, label: &str) -> Option<String> {
     let root: serde_json::Value = serde_json::from_str(content.trim()).ok()?;
     let mut cur = &root;
     let mut walked = String::from("$");
@@ -242,9 +227,7 @@ pub fn retrieve_json_keys(id: &str, path: Option<&str>) -> Option<String> {
                     walked.push_str(seg);
                 }
                 None => {
-                    return Some(format!(
-                        "Path '{p}' not found at '{walked}' in archive {id}"
-                    ));
+                    return Some(format!("Path '{p}' not found at '{walked}' in {label}"));
                 }
             }
         }
@@ -252,7 +235,36 @@ pub fn retrieve_json_keys(id: &str, path: Option<&str>) -> Option<String> {
     Some(format!("{walked} => {}", describe_json(cur)))
 }
 
-fn json_type_hint(v: &serde_json::Value) -> String {
+pub fn retrieve_with_range(id: &str, start: usize, end: usize) -> Option<String> {
+    let content = retrieve(id)?;
+    Some(format_range(&content, start, end))
+}
+
+pub fn retrieve_with_search(id: &str, pattern: &str) -> Option<String> {
+    let content = retrieve(id)?;
+    Some(format_search(&content, pattern, &format!("archive {id}")))
+}
+
+/// Retrieve the first `n` lines of an archived entry, with a line-number gutter.
+pub fn retrieve_head(id: &str, n: usize) -> Option<String> {
+    retrieve_with_range(id, 1, n)
+}
+
+/// Retrieve the last `n` lines of an archived entry, with a line-number gutter.
+pub fn retrieve_tail(id: &str, n: usize) -> Option<String> {
+    let content = retrieve(id)?;
+    let total = content.lines().count();
+    let start = if total > n { total - n + 1 } else { 1 };
+    retrieve_with_range(id, start, total)
+}
+
+/// Describe the JSON structure of an archived entry.
+pub fn retrieve_json_keys(id: &str, path: Option<&str>) -> Option<String> {
+    let content = retrieve(id)?;
+    format_json_keys(&content, path, &format!("archive {id}"))
+}
+
+pub(crate) fn json_type_hint(v: &serde_json::Value) -> String {
     use serde_json::Value;
     match v {
         Value::Object(m) => format!("object({})", m.len()),
@@ -271,7 +283,7 @@ fn json_type_hint(v: &serde_json::Value) -> String {
     }
 }
 
-fn describe_json(v: &serde_json::Value) -> String {
+pub(crate) fn describe_json(v: &serde_json::Value) -> String {
     use serde_json::Value;
     match v {
         Value::Object(map) => {

--- a/rust/src/tools/ctx_expand.rs
+++ b/rust/src/tools/ctx_expand.rs
@@ -79,15 +79,98 @@ fn handle_retrieve(args: &serde_json::Value) -> String {
         return expand_tee_file(&path, args);
     }
 
-    // Structured drilldown selectors (head / tail / json_keys).
+    // Route structured accessors by ID prefix. Archive IDs are hex-only, ref
+    // IDs are `ref_+hex` — the prefix tells us the exact store to query.
+    if id.starts_with("ref_") {
+        return expand_reference(id, args);
+    }
+    expand_archive(id, args)
+}
+
+/// Expand a reference-store entry (`ref_`-prefixed ID). Resolves content from
+/// the in-memory reference store and formats via `archive::format_*` — the same
+/// gutter/JSON formatters the archive path uses — so output is consistent
+/// regardless of which store backed the ID.
+fn expand_reference(id: &str, args: &serde_json::Value) -> String {
+    let Some(content) = crate::server::reference_store::resolve(id) else {
+        return format!(
+            "Reference '{id}' not found or expired (5-min TTL). \
+             Use the HTTP proxy at /v1/references/{id} if available."
+        );
+    };
+    let label = format!("reference {id}");
+
     if let Some(n) = args.get("head").and_then(serde_json::Value::as_u64) {
-        return match archive::retrieve_head(id, n as usize) {
+        let n = (n as usize).min(content.lines().count());
+        return format!(
+            "Reference {id} head {n}:\n{}",
+            archive::format_range(&content, 1, n)
+        );
+    }
+    if let Some(n) = args.get("tail").and_then(serde_json::Value::as_u64) {
+        let n = n as usize;
+        let total = content.lines().count();
+        let start = if total > n { total - n + 1 } else { 1 };
+        return format!(
+            "Reference {id} tail {n}:\n{}",
+            archive::format_range(&content, start, total)
+        );
+    }
+    if args.get("json_keys").and_then(serde_json::Value::as_bool) == Some(true)
+        || args.get("json_path").is_some()
+    {
+        let path = args.get("json_path").and_then(|v| v.as_str());
+        match archive::format_json_keys(&content, path, &label) {
+            Some(out) => return out,
+            None => {
+                return format!(
+                    "Reference '{id}' is not valid JSON. Use ctx_expand(id=\"{id}\") for raw content."
+                );
+            }
+        }
+    }
+    if let Some(pattern) = args.get("search").and_then(|v| v.as_str()) {
+        return format!(
+            "Reference {id}:\n{}",
+            archive::format_search(&content, pattern, &label)
+        );
+    }
+
+    let start = args
+        .get("start_line")
+        .and_then(serde_json::Value::as_u64)
+        .map(|v| v as usize);
+    let end = args
+        .get("end_line")
+        .and_then(serde_json::Value::as_u64)
+        .map(|v| v as usize);
+    if let (Some(s), Some(e)) = (start, end) {
+        return format!(
+            "Reference {id} lines {s}-{e}:\n{}",
+            archive::format_range(&content, s, e)
+        );
+    }
+
+    // Full content
+    let lines = content.lines().count();
+    let chars = content.len();
+    format!("Reference {id} ({chars} chars, {lines} lines):\n{content}")
+}
+
+/// Expand an archive entry (hex-only ID). Delegates to `archive::retrieve*`
+/// functions which handle on-disk lookup, cleanup-aware TTL checks, and
+/// line-number-guttered output formatting.
+fn expand_archive(id: &str, args: &serde_json::Value) -> String {
+    if let Some(n) = args.get("head").and_then(serde_json::Value::as_u64) {
+        let n = n as usize;
+        return match archive::retrieve_head(id, n) {
             Some(result) => format!("Archive {id} head {n}:\n{result}"),
             None => format!("Archive '{id}' not found or expired."),
         };
     }
     if let Some(n) = args.get("tail").and_then(serde_json::Value::as_u64) {
-        return match archive::retrieve_tail(id, n as usize) {
+        let n = n as usize;
+        return match archive::retrieve_tail(id, n) {
             Some(result) => format!("Archive {id} tail {n}:\n{result}"),
             None => format!("Archive '{id}' not found or expired."),
         };
@@ -103,7 +186,6 @@ fn handle_retrieve(args: &serde_json::Value) -> String {
             ),
         };
     }
-
     if let Some(pattern) = args.get("search").and_then(|v| v.as_str()) {
         return match archive::retrieve_with_search(id, pattern) {
             Some(result) => result,
@@ -121,12 +203,9 @@ fn handle_retrieve(args: &serde_json::Value) -> String {
         .get("end_line")
         .and_then(serde_json::Value::as_u64)
         .map(|v| v as usize);
-
     if let (Some(s), Some(e)) = (start, end) {
         return match archive::retrieve_with_range(id, s, e) {
-            Some(result) => {
-                format!("Archive {id} lines {s}-{e}:\n{result}")
-            }
+            Some(result) => format!("Archive {id} lines {s}-{e}:\n{result}"),
             None => format!("Archive '{id}' not found or expired."),
         };
     }


### PR DESCRIPTION
## Summary

ctx_expand only queried the on-disk archive store, so any output stored by the reference_results feature (ref_-prefixed IDs, in-memory) returned 'not found or expired.'

Fix: route by ID prefix — ref_ → reference_store, hex → archive. Extract shared format_range/format_search/format_json_keys into archive.rs so both paths use the same gutter/JSON formatting.

What does this PR change and why?

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`