### PR TITLE
fix(gain): aggregate stats across split data dirs so MCP savings show (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   permanent first-sighting that never repacks. All three are cache-safe by construction
   (deterministic re-compression) and covered by new N→N+1, restart, and marker-stability
   tests. Thanks to @phawrylak for the precise analysis.
+- **`gain` no longer reports `0` saved when MCP tools wrote to a different data
+  dir (#500).** The savings headline, gain score, cost view and net-of-injection
+  line now **sum stats across every auto-resolved data dir** that holds a
+  `stats.json`. When an agent host launches the lean-ctx MCP server with a
+  different `HOME`/`XDG_*` than the user's shell (e.g. a containerised Hermes
+  Agent) the savings landed in a sibling tree while the CLI read an empty primary
+  dir and showed a false zero. Aggregation is a **no-op without a split** and is
+  skipped entirely when `LEAN_CTX_DATA_DIR` pins one dir, so non-split users are
+  unaffected. The empty-state screen now also cross-checks the tamper-evident
+  savings ledger and, when it holds events that `stats.json` does not, names the
+  data-dir split outright (`lean-ctx savings` / `lean-ctx doctor`). Finally, the
+  proxy "bridge OFF — savings cannot be measured" caveat is suppressed whenever
+  there are real (MCP-measured) savings to show, since `gain` measures MCP-tool
+  savings directly and needs no proxy. Thanks to the reporter for the detailed
+  Hermes + OpenRouter writeup.
 - **Billing edge no longer downgrades a paying account on a billing-service blip
   (GL #785).** Entitlement resolution at the cloud edge now caches each user's
   last known plan (in-memory, short TTL) and, when the upstream billing service

--- a/rust/src/cli/dispatch/analytics/gain.rs
+++ b/rust/src/cli/dispatch/analytics/gain.rs
@@ -227,6 +227,7 @@ pub(in crate::cli::dispatch) fn cmd_gain(rest: &[String]) {
         }
         print_support_hint();
         print_bridge_warning();
+        print_split_hint();
         crate::cli::wrapped_publish::maybe_auto_publish(&period);
         print_community_hint();
     }
@@ -243,14 +244,44 @@ fn print_measured_spend_hint() {
     }
 }
 
-/// When the bridge is not engaged, the hero card is built from locally
-/// persisted stats the proxy is no longer feeding live. Surface that caveat so
-/// `gain` never implies savings it cannot currently measure (GitHub #361/#271).
+/// When the bridge is not engaged, the proxy is no longer feeding live request
+/// stats. Surface that caveat so `gain` never implies savings it cannot measure
+/// (GitHub #361/#271) — **but only when there are genuinely no savings to show**.
+///
+/// `gain` also measures MCP-tool savings directly (reads/search/shell via the
+/// savings ledger + stats), which need no proxy at all. Emitting a "proxy down —
+/// savings cannot be measured" line above a real, MCP-measured headline wrongly
+/// told MCP-only users their numbers were untrustworthy (#500). Gate on the
+/// displayed total so the warning fires only for a true zero.
 fn print_bridge_warning() {
     use crate::core::gain::bridge_status::{BridgeEngagement, BridgeStatus};
+    let store = core::stats::load_for_display();
+    let saved = store
+        .total_input_tokens
+        .saturating_sub(store.total_output_tokens);
+    if saved > 0 {
+        return;
+    }
     let bridge = BridgeStatus::detect();
     if bridge.engagement != BridgeEngagement::Engaged {
         eprintln!("\n  \x1b[33m⚠ {}\x1b[0m", bridge.summary_line());
+    }
+}
+
+/// When stats live in more than one auto-resolved data dir, `gain` now sums them
+/// for display (#500) — but each process still *writes* to its own dir, so the
+/// split persists. Nudge toward consolidation once, non-alarmingly, since the
+/// headline is already correct. Suppressed when `LEAN_CTX_DATA_DIR` pins one dir.
+fn print_split_hint() {
+    if std::env::var_os("LEAN_CTX_DATA_DIR").is_some() {
+        return;
+    }
+    let dirs = core::data_dir::all_data_dirs_with_stats();
+    if dirs.len() >= 2 {
+        eprintln!(
+            "\n  \x1b[2m💡 Stats span {} data dirs (summed above). Consolidate them with `lean-ctx doctor`.\x1b[0m",
+            dirs.len()
+        );
     }
 }
 

--- a/rust/src/core/gain/mod.rs
+++ b/rust/src/core/gain/mod.rs
@@ -85,7 +85,9 @@ pub struct FileGainRow {
 impl GainEngine {
     pub fn load() -> Self {
         Self {
-            stats: crate::core::stats::load(),
+            // Aggregate across split data dirs so the gain score, cost view and
+            // net-of-injection line agree with the hero headline (#500).
+            stats: crate::core::stats::load_for_display(),
             costs: crate::core::a2a::cost_attribution::CostStore::load(),
             heatmap: crate::core::heatmap::HeatMap::load(),
             pricing: ModelPricing::load(),

--- a/rust/src/core/stats/format/dashboard.rs
+++ b/rust/src/core/stats/format/dashboard.rs
@@ -24,7 +24,9 @@ pub fn format_gain_hero() -> String {
 
 /// Hero gain with specific theme.
 pub fn format_gain_hero_themed(t: &Theme) -> String {
-    let store = crate::core::stats::load();
+    // Aggregate across split data dirs so an MCP-server/CLI XDG split does not
+    // hide savings behind a false `0` (#500).
+    let store = crate::core::stats::load_for_display();
     let rst = theme::rst();
     let bold = theme::bold();
     let dim = theme::dim();
@@ -227,7 +229,8 @@ pub fn format_gain_footer() -> String {
 
 #[allow(clippy::many_single_char_names)] // ANSI formatting: t=theme, r=reset, b=bold, d=dim
 fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
-    let store = crate::core::stats::load();
+    // Aggregate across split data dirs (#500) — see `format_gain_hero_themed`.
+    let store = crate::core::stats::load_for_display();
     let mut out = Vec::new();
     let rst = theme::rst();
     let bold = theme::bold();
@@ -270,6 +273,22 @@ fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
         } else {
             String::new()
         };
+        // Cross-check the tamper-evident savings ledger (#500): if it recorded
+        // events while stats.json stayed empty, the MCP server and the CLI are
+        // almost certainly resolving different data dirs — name that explicitly
+        // instead of the bare "expected" message so the user can act.
+        let ledger = crate::core::savings_ledger::summary();
+        let ledger_hint = if ledger.total_events > 0 {
+            format!(
+                "\n{dim}⚠ {} savings events (~{} tokens) ARE in the ledger but not in stats.json —{rst}\
+                 \n{dim}  the MCP server likely writes to a different data dir than this CLI.{rst}\
+                 \n{dim}  Inspect: lean-ctx savings   ·   Diagnose: lean-ctx doctor{rst}",
+                ledger.total_events,
+                crate::core::wrapped::format_tokens(ledger.saved_tokens),
+            )
+        } else {
+            String::new()
+        };
         return format!(
             "{bold}No savings recorded yet — and that's expected.{rst}\
              \n\n  {dim}Savings appear after your AI tool uses lean-ctx for the first time.{rst}\
@@ -278,7 +297,7 @@ fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
              \n    2. Fully restart your AI tool so it reconnects to lean-ctx.\
              \n    3. Ask it to read a file or run a command — then check back here.\
              \n\n  {dim}Tip: track a shell command yourself with {rst}{cmd}lean-ctx -c \"git status\"{rst}\
-             \n\n  {dim}Stats path: {data_dir}{rst}{mcp_hint}{split_hint}",
+             \n\n  {dim}Stats path: {data_dir}{rst}{mcp_hint}{split_hint}{ledger_hint}",
             cmd = t.secondary.fg(),
         );
     }

--- a/rust/src/core/stats/io.rs
+++ b/rust/src/core/stats/io.rs
@@ -22,6 +22,17 @@ pub(super) fn load_from_disk() -> StatsStore {
     }
 }
 
+/// Loads `stats.json` from a *specific* directory (no in-process buffer applied).
+/// Used by [`crate::core::stats::load_for_display`] to fold sibling data dirs
+/// into the displayed total when an XDG split (#408/#414/#500) spread savings
+/// across more than one tree. Missing/corrupt files degrade to an empty store.
+pub(super) fn load_from_dir(dir: &std::path::Path) -> StatsStore {
+    match std::fs::read_to_string(dir.join("stats.json")) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => StatsStore::default(),
+    }
+}
+
 fn write_to_disk(store: &StatsStore) {
     let Some(dir) = stats_dir() else { return };
 

--- a/rust/src/core/stats/mod.rs
+++ b/rust/src/core/stats/mod.rs
@@ -32,6 +32,49 @@ pub fn load() -> StatsStore {
     io::load_from_disk()
 }
 
+/// Loads stats for **display**, summing across every auto-resolved data dir that
+/// holds a `stats.json` (#500). When the MCP server process and the CLI resolve
+/// different XDG dirs — the documented #408/#414 split, common when an agent host
+/// (e.g. a containerised Hermes) launches the MCP server with a different `HOME`
+/// or `XDG_*` than the user's shell — the bulk of the savings can land in a
+/// sibling tree. Reading only the primary dir then makes `gain` report `0` while
+/// the real data sits one directory over. Folding the siblings in keeps the
+/// headline honest regardless of which process wrote where.
+///
+/// Safe by construction:
+/// - **No-op without a split** — when only the primary dir has stats (the
+///   overwhelmingly common case) the result equals [`load`].
+/// - **Respects an explicit pin** — when `LEAN_CTX_DATA_DIR` is set the user has
+///   chosen exactly one dir, so nothing is auto-merged.
+/// - **Read-only** — never writes back; recording still targets the primary dir.
+pub fn load_for_display() -> StatsStore {
+    let primary = load();
+    // An explicit override means "use exactly this dir" — never auto-merge.
+    if std::env::var_os("LEAN_CTX_DATA_DIR").is_some() {
+        return primary;
+    }
+    let primary_dir = crate::core::data_dir::lean_ctx_data_dir()
+        .ok()
+        .and_then(|p| std::fs::canonicalize(&p).ok());
+    let siblings: Vec<StatsStore> = crate::core::data_dir::all_data_dirs_with_stats()
+        .into_iter()
+        .filter(|d| std::fs::canonicalize(d).ok() != primary_dir)
+        .map(|d| io::load_from_dir(&d))
+        .collect();
+    aggregate_for_display(primary, &siblings)
+}
+
+/// Folds sibling-dir stores into the primary for display. Pure (no I/O, no
+/// globals) so the cross-dir summation is unit-testable. Reuses
+/// [`io::apply_deltas`] with a zero baseline so each sibling store is added in
+/// full (delta-from-empty == the whole store).
+fn aggregate_for_display(primary: StatsStore, siblings: &[StatsStore]) -> StatsStore {
+    let zero = StatsStore::default();
+    siblings
+        .iter()
+        .fold(primary, |acc, other| io::apply_deltas(&acc, other, &zero))
+}
+
 pub fn save(store: &StatsStore) {
     io::locked_write(store);
 }
@@ -325,6 +368,37 @@ mod tests {
             total_output_tokens: output,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn aggregate_for_display_is_noop_without_siblings() {
+        // The common case: only the primary dir has stats. Aggregation must
+        // return the primary untouched so non-split users see no change (#500).
+        let primary = make_store(7, 1000, 250);
+        let agg = aggregate_for_display(primary.clone(), &[]);
+        assert_eq!(agg.total_commands, 7);
+        assert_eq!(agg.total_input_tokens, 1000);
+        assert_eq!(agg.total_output_tokens, 250);
+    }
+
+    #[test]
+    fn aggregate_for_display_sums_split_dirs() {
+        // A data-dir split (#408/#414/#500): the CLI's primary dir is empty but
+        // the MCP server wrote its savings into a sibling tree. The displayed
+        // total must reflect both so `gain` no longer reports a false `0`.
+        let primary = make_store(0, 0, 0);
+        let mcp_dir = make_store(12, 8000, 1200);
+        let legacy_dir = make_store(3, 500, 100);
+
+        let agg = aggregate_for_display(primary, &[mcp_dir, legacy_dir]);
+
+        assert_eq!(agg.total_commands, 15, "12 (mcp) + 3 (legacy)");
+        assert_eq!(agg.total_input_tokens, 8500);
+        assert_eq!(agg.total_output_tokens, 1300);
+        let saved = agg
+            .total_input_tokens
+            .saturating_sub(agg.total_output_tokens);
+        assert_eq!(saved, 7200, "savings surface despite an empty primary dir");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #500 — `lean-ctx gain` reported **0 tokens saved** despite active usage through the MCP tools (reported with Hermes Agent + OpenRouter on a Debian LXC).

Root cause: `gain` derived its headline from a **single** data dir. When an agent host launches the lean-ctx MCP server with a different `HOME`/`XDG_*` than the user's interactive shell, MCP savings are written into a *sibling* data tree (the documented #408/#414 split) while the CLI reads an empty primary `stats.json` and shows a false zero. The user's mental model ("gain only tracks the proxy") was reinforced by a proxy-centric warning that wrongly implied savings could not be measured at all.

## What changed

- **`stats::load_for_display()`** — sums `stats.json` across every auto-resolved data dir (`all_data_dirs_with_stats`). The hero, full dashboard and `GainEngine` (score, cost, net-of-injection) all route through it, so every number agrees.
  - **No-op without a split** (result == `load()` when only one dir has stats).
  - **Skipped** entirely when `LEAN_CTX_DATA_DIR` pins one dir.
  - **Read-only** — recording still targets the primary dir.
- **Empty-state cross-check** — when the tamper-evident savings ledger holds events that `stats.json` lacks, the screen names the data-dir split outright and points at `lean-ctx savings` / `lean-ctx doctor` instead of the bare "expected" message.
- **Honest bridge caveat** — the proxy "bridge OFF — savings cannot be measured" line is suppressed when real (MCP-measured) savings exist, since `gain` measures MCP-tool savings directly and needs no proxy. A one-line, non-alarming consolidation hint is added when stats span >1 dir.

## Tests

- `aggregate_for_display_is_noop_without_siblings` — non-split users are unaffected.
- `aggregate_for_display_sums_split_dirs` — savings surface even when the primary dir is empty.
- Existing `core::stats` (15), `core::gain` (20), `bridge_status` (6), `analytics::gain` (6) all green.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo build --release` all clean.

## Note for the reporter

This makes `gain` robust to the most common cause (an XDG/data-dir split between the MCP-server process and the CLI). If `gain` still shows `0` after upgrading, please run `lean-ctx doctor` and share the output plus the `Stats path:` line from `lean-ctx gain` — that will pin down whether the MCP server writes somewhere `all_data_dirs_with_stats` does not yet scan (e.g. a fully custom dir).

Made with [Cursor](https://cursor.com)