### PR TITLE
fix(patterns): VCS compress path must never inflate token count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `raw` and state that the allowlist still holds.
 
 ### Fixed
+- **Shell-output compression can no longer inflate token counts (Windows CI
+  flake).** The VCS branch of `compress_output` (git/jj/gh/glab/hg) returned its
+  authoritative compressor's result even when it was not strictly shorter — so a
+  compact `git log --oneline` stays verbatim — but it skipped the token guard the
+  other paths use. A tiny adversarial `git status` body could reshape into a
+  one-token-larger summary, breaking the `compress_output_never_inflates_tokens`
+  property on Windows. The VCS path now allows *equal* (verbatim) output but
+  rejects any growth, restoring the never-inflate invariant deterministically.
+  Pinned with a regression unit test for the exact failing input.
 - **Billing edge no longer downgrades a paying account on a billing-service blip
   (GL #785).** Entitlement resolution at the cloud edge now caches each user's
   last known plan (in-memory, short TTL) and, when the upstream billing service

--- a/rust/src/core/patterns/mod.rs
+++ b/rust/src/core/patterns/mod.rs
@@ -119,7 +119,15 @@ pub fn compress_output(command: &str, output: &str) -> Option<String> {
     // compact oneline log is preserved verbatim (full history intact) instead of
     // being reshaped by a generic heuristic.
     if has_vcs_owner(command) {
-        return try_specific_pattern(command, clean_output).filter(|c| !c.trim().is_empty());
+        // The VCS compressor is authoritative and is kept even when it is not
+        // strictly *shorter*, so a compact `git log --oneline` is preserved
+        // verbatim (full history intact). It must still never return *more*
+        // tokens than its input, though — a tiny adversarial `git status` body
+        // could otherwise reshape into a one-token-larger summary and break the
+        // never-inflate invariant. Allow equal (verbatim), reject only growth.
+        return try_specific_pattern(command, clean_output)
+            .filter(|c| !c.trim().is_empty())
+            .filter(|c| !inflates_tokens(c, output));
     }
 
     if let Some(compressed) = try_specific_pattern(command, clean_output)
@@ -164,6 +172,14 @@ pub(crate) fn has_vcs_owner(command: &str) -> bool {
 /// Collapse whitespace into single spaces so comparisons align with logical word tokens.
 fn normalize_shell_tokens(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// True when `compressed` carries *more* tokens than the raw `original` — i.e.
+/// the transform inflated rather than compressed. Compared against the raw
+/// (pre-ANSI-strip) output so the guard matches the public `compress_output`
+/// invariant exactly: the returned text never tokenizes larger than its input.
+fn inflates_tokens(compressed: &str, original: &str) -> bool {
+    count_tokens(compressed) > count_tokens(original)
 }
 
 fn shorter_only(compressed: String, original: &str) -> Option<String> {
@@ -515,6 +531,24 @@ mod tests {
     fn routes_git_commands() {
         let output = "On branch main\nnothing to commit";
         assert!(compress_output("git status", output).is_some());
+    }
+
+    #[test]
+    fn vcs_path_never_inflates_tokens() {
+        // Regression for the `compress_output_never_inflates_tokens` property
+        // (Windows CI): the VCS branch returned the git compressor's reshaped
+        // output without the `shorter_only` guard the other paths use, so this
+        // tiny adversarial `git status` body grew 10 -> 11 tokens. The result
+        // must now never tokenize larger than its input (None == use original).
+        let output = " Abu a\nAa aa_A00A\n\n-";
+        if let Some(compressed) = compress_output("git status", output) {
+            assert!(
+                count_tokens(&compressed) <= count_tokens(output),
+                "VCS compress inflated: {} > {}",
+                count_tokens(&compressed),
+                count_tokens(output),
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a flaky Windows CI failure of the `compress_output_never_inflates_tokens` property test that currently blocks **every** open PR.

The `has_vcs_owner` branch of `compress_output` (git/jj/gh/glab/hg) returns its dedicated compressor's result **even when it is not strictly shorter** — by design, so a compact `git log --oneline` is preserved verbatim with full history. But that branch skipped the `shorter_only` token guard the other paths use, so a tiny adversarial `git status` body (`" Abu a\nAa aa_A00A\n\n-"`) reshaped into a **one-token-larger** summary (10 → 11), violating the never-inflate invariant.

## What changed

- New `inflates_tokens()` helper compares against the raw (pre-ANSI-strip) output, matching the public `compress_output` invariant exactly.
- The VCS path now **allows equal-token (verbatim) output but rejects any growth** → falls back to `None` (caller uses the original). Compact logs stay verbatim; nothing can inflate.
- Regression unit test pins the exact failing input.

## Test plan

- [x] `cargo test --lib patterns::` (234 passed)
- [x] `cargo test --test property_compression` (8 passed)
- [x] `PROPTEST_CASES=1024 cargo test --test property_compression compress_output_never_inflates` (green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

Merging this first makes the shared property test deterministically green so the other open PRs can pass CI.

Made with [Cursor](https://cursor.com)