### PR TITLE
refactor(tools): workflow-first power-tier descriptions + rules cleanup (#505)

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -8,46 +8,48 @@ lean-ctx registers **77 MCP tools** (granular profile). Each entry below lists t
 
 ## `ctx_agent`
 
-Multi-agent coordination: shared message bus, persistent diaries, stigmergic scent field. Actions: register (agent_type+role), post (message+category), read (poll), status (active|idle|finished), handoff (transfer task+summary), sync (agents + messages + scent: claims/stuck/hot), claim/release (atomic file/task claim, message=target), brief (sub-agent briefing pack: message=task, priority=budget), return (distill sub-agent report into knowledge: message='category/key: value' lines), diary (log discovery/decision/blocker/progress/insight), recall_diary, diaries, list, info.
+Multi-agent coordination — shared message bus, persistent diaries, stigmergic scent field. Actions: register (agent_type+role), post (message+category), read (poll), status (active|idle|finished), handoff (task+summary), sync (agents+messages+scent), claim/release (file/task claim), brief (sub-agent briefing), return (distill report into knowledge), diary, recall_diary, list, info. Use when orchestrating multiple LLM agents across a shared workspace.
 
 Parameters: `action`*, `agent_type`, `category`, `message`, `role`, `status`, `to_agent`
 
 ## `ctx_analyze`
 
-Entropy analysis — recommends optimal compression mode for a file.
+Entropy analysis — recommends optimal compression mode for a file path. Use before ctx_read to pick the best mode (full/signatures/auto) that balances size vs information retention.
 
 Parameters: `path`*
 
 ## `ctx_architecture`
 
-Architecture analysis: action=overview→high-level; clusters|communities→groupings
-layers|cycles→dependency violations; entrypoints|hotspots→risk areas; health→quality.
-Use to understand module structure without reading every file. action=module path='src/' to zoom.
+Architecture analysis — understand module structure without reading every file.
+action=overview→high-level; clusters|communities→groupings;
+layers|cycles→dependency violations; entrypoints|hotspots→risk areas;
+health→quality; module path='src/' to zoom into a specific module.
 
 Parameters: `action`, `format`, `path`, `root`
 
 ## `ctx_artifacts`
 
-Context artifact registry + BM25 index. Actions: list|status|index|reindex|search|remove.
+Context artifact registry with BM25 search — manage and query indexed code artifacts. Actions: list|status|index|reindex|search|remove. Use search with query for semantic retrieval across artifacts.
 
 Parameters: `action`*, `format`, `name`, `project_root`, `query`, `top_k`
 
 ## `ctx_benchmark`
 
-Benchmark compression modes for a file or project.
+Benchmark compression modes — measures token savings across all available modes for a file or project. Provide a file path, or use action=project format=json|markdown for project-wide results.
 
 Parameters: `action`, `format`, `path`*
 
 ## `ctx_cache`
 
-Cache ops: status|clear|invalidate.
+Cache operations — inspect, clear, or invalidate the read cache. Actions: status lists cached files; clear empties all; invalidate path=... refreshes a single entry. Use to diagnose stale content or recover budget.
 
 Parameters: `action`*, `path`
 
 ## `ctx_call`
 
-Invoke any non-core lean-ctx tool by name.
-Categories: arch, debug, memory, batch, agent, util. Find exact names with ctx_discover_tools (query=keyword; empty query lists all).
+Invoke any non-core lean-ctx tool by name — for tools not exposed as standalone MCP tools.
+Categories: arch, debug, memory, batch, agent, util. Find exact names with
+ctx_discover_tools (query=keyword; empty query lists all). Cannot invoke itself.
 
 Parameters: `arguments`, `name`*
 
@@ -64,16 +66,17 @@ Parameters: `action`, `depth`, `file`, `from`, `symbol`, `to`
 
 ## `ctx_checkpoint`
 
-Local shadow git history of the agent's changes (separate from the user's .git).
-actions: snapshot (record current state) | log (list checkpoints) | diff (vs a checkpoint) | restore (revert files).
-Snapshot before+after a change to capture exactly what the LLM modified; diff/restore to review or roll back.
+Local shadow git history of the agent's changes — separate from the user's .git.
+Actions: snapshot (record current state), log (list checkpoints),
+diff (compare against a checkpoint), restore (revert files).
+Snapshot before+after changes to capture exactly what was modified.
 Never touches the user's repository.
 
 Parameters: `action`, `from`, `limit`, `message`, `path`, `ref`, `to`
 
 ## `ctx_compile`
 
-Context compilation (CFT). Builds minimal context package via greedy knapsack + Boltzmann view selection. Modes: handles|compressed|full.
+Context compilation (CFT) — builds minimal context package via greedy knapsack + Boltzmann view selection. Modes: handles|compressed|full. Use to produce focused context for handoff or subagent tasks.
 
 Parameters: `budget`, `mode`
 
@@ -90,39 +93,40 @@ Parameters: `path`, `task`*
 
 ## `ctx_compress`
 
-Context checkpoint: compresses read cache to free budget in long sessions
+Compress read cache to free token budget in long sessions.
 include_signatures=true (default) preserves API surface in compressed state.
-Does not affect session state or knowledge—only the read cache compaction.
+Does not affect session state or knowledge — only read cache compaction.
+Use when nearing context limit to reclaim space for new content.
 
 Parameters: `include_signatures`
 
 ## `ctx_compress_memory`
 
-Compress a memory/config file (CLAUDE.md, .cursorrules) preserving code, URLs, paths. Creates .original.md backup.
+Compress a memory/config file (CLAUDE.md, .cursorrules) preserving code, URLs, and paths. Creates .original.md backup. Use to reduce token overhead of persistent instruction files.
 
 Parameters: `path`*
 
 ## `ctx_context`
 
-Session context overview — cached files, seen files, session state.
+Session context overview — shows cached files, seen files, session state, and current CRP mode. No arguments needed. Call periodically to track what's in your context window and remaining budget.
 
 Parameters: _none_
 
 ## `ctx_control`
 
-Universal context manipulation (Context Field Theory). Actions: exclude|include|pin|unpin|set_view|set_priority|mark_outdated|reset|list|history. Overlay-based, reversible, scoped.
+Universal context manipulation (CFT) — fine-tune what appears in context. Actions: exclude|include|pin|unpin|set_view|set_priority|mark_outdated|reset|list|history. Overlay-based, reversible, scoped to call/session/project.
 
 Parameters: `action`*, `reason`, `scope`, `target`, `value`
 
 ## `ctx_cost`
 
-Cost attribution (local-first). Actions: report|agent|tools|json|reset.
+Cost attribution — track tokens and cost per agent and tool call. Actions: report (summary), agent (per-agent), tools (per-tool), json (machine-readable), reset (zero counters). Local-first, no external billing calls.
 
 Parameters: `action`, `agent_id`, `limit`
 
 ## `ctx_dedup`
 
-Cross-file dedup: analyze or apply shared block references.
+Cross-file deduplication — detect and eliminate repeated content across files. action=analyze (default) finds shared blocks; action=apply registers them for auto-dedup in ctx_read output.
 
 Parameters: `action`
 
@@ -137,77 +141,88 @@ Parameters: `path`*
 
 ## `ctx_discover`
 
-Find missed compression opportunities in shell history.
+Identify compression misses in shell history — use when context feels bloated.
+Shows commands that would save tokens via lean-ctx patterns. limit=N caps results.
+No params needed for quick health check.
 
 Parameters: `limit`
 
 ## `ctx_discover_tools`
 
-Search available lean-ctx tools by keyword. Returns matching tool names and descriptions.
+Search available lean-ctx tools by keyword — use to find the right tool.
+Empty query lists all tools. query="keyword" returns matching names and descriptions.
+Use before ctx_call or when unsure which tool fits your task.
 
 Parameters: `query`
 
 ## `ctx_edit`
 
-Search-and-replace edit: old_string must be unique unless replace_all=true
-create=true writes new files from new_string. TOCTOU-guarded with preimage hash verification.
-backup creates .bak before modifying. Supports MD5/size/mtime pre-guards for race-free edits.
+Search-and-replace edit with TOCTOU safety — for simple text replacement in a single file.
+Use INSTEAD of native Edit when Read is unavailable. old_string must be unique unless replace_all=true.
+create=true writes new files. backup creates .bak. MD5/size/mtime pre-guards prevent race conditions.
+Do NOT loop on failures — switch to ctx_edit. For LSP-aware refactoring (rename, move, inline), use ctx_refactor.
 
 Parameters: `create`, `new_string`*, `old_string`, `path`*, `replace_all`
 
 ## `ctx_execute`
 
 Run code in sandbox (11 languages) — use when compute beats shell glue.
-action=code (default) for one-shot transform/math/generation; action=batch for parallel
-multi-language scripts; action=file to process a project file (extension auto-detects
-language). Pass intent to focus large output and save tokens. Prefer over ctx_shell when
-logic, conditionals, multi-line scripts, or cross-language data munging — stdout-only,
-no argv escaping. Languages: javascript, typescript, python, shell, ruby, go, rust, php,
-perl, r, elixir.
+action=code (default) for one-shot scripts; action=batch for parallel multi-language;
+action=file to process a project file (extension auto-detects language).
+Pass intent to focus large output. Prefer over ctx_shell for conditionals,
+multi-line scripts, or cross-language data munging. Languages: javascript,
+typescript, python, shell, ruby, go, rust, php, perl, r, elixir.
 
 Parameters: `action`, `code`, `intent`, `items`, `language`, `path`, `timeout`
 
 ## `ctx_expand`
 
 Retrieve archived tool output by ID (e.g. id=@F1 from [Archived:ID] hints).
-Use when you see an [Archived:ID] reference in tool output and need the full
-content. Supports head/tail/search to filter lines. action=search_all across
-all archives. action=list shows available archives. Zero-loss: original preserved.
+Use when you see an [Archived:ID] reference and need the full content.
+Supports head/tail/search to filter lines. action=search_all across all archives.
+action=list shows available archives. Zero-loss: original preserved.
 For reading files, use ctx_read or ctx_compose instead.
 
 Parameters: `action`, `end_line`, `head`, `id`, `json_keys`, `json_path`, `query`, `search`, `session_id`, `start_line`, `tail`
 
 ## `ctx_feedback`
 
-Harness feedback for LLM output tokens/latency (local-first). Actions: record|report|json|reset|status.
+Record and report LLM token/latency metrics (local-first) — use to track efficiency.
+Actions: record (log event), report (readable summary), json (machine-readable),
+reset (clear data), status (storage info). record requires llm_input_tokens + llm_output_tokens.
 
 Parameters: `action`, `agent_id`, `intent`, `latency_ms`, `limit`, `llm_input_tokens`, `llm_output_tokens`, `model`, `note`
 
 ## `ctx_fill`
 
-Budget-aware context fill — auto-selects compression per file within token limit.
+Budget-aware context fill — given a list of paths, auto-compresses each to fit within a token budget.
+Pass paths array + budget=N. task="..." enables intent-driven pruning for relevance.
+Does NOT decide what to include (use ctx_plan for project-wide selection).
+Use instead of reading each file individually when you have many files and a budget.
 
 Parameters: `budget`*, `paths`*, `task`
 
 ## `ctx_gain`
 
-Gain report (includes Wrapped via action=wrapped).
+Gain report — shows token savings from lean-ctx compression. Use to measure efficiency.
+action=wrapped for periodic/annual summary. Other actions: status|report|score|cost|tasks|heatmap|agents|json.
+period="week"|"month"|"all" scopes the report.
 
 Parameters: `action`, `limit`, `model`, `period`
 
 ## `ctx_git_read`
 
-Read a remote git repository via a cached shallow clone (not HTML scraping).
-modes: overview (tree + README) | tree (file list) | read (a file) | grep (search).
-Accepts repo URLs and GitHub/GitLab blob/tree links (ref + path auto-detected). https-only, SSRF-guarded, bounded.
-Use instead of ctx_url_read when you need a whole repo's files/structure.
+Read remote git repos via cached shallow clone (not HTML scraping).
+modes: overview (tree + README) | tree (file list) | read (file content) | grep (search).
+Accepts repo URLs and GitHub/GitLab blob/tree links (ref+path auto-detected).
+https-only, SSRF-guarded. Use instead of ctx_url_read for a whole repo.
 
 Parameters: `max_tokens`, `mode`, `path`, `query`, `ref`, `timeout_secs`, `url`*
 
 ## `ctx_glob`
 
-Find files by glob pattern. Respects .gitignore;
-supports multi-root via `paths` array. max_results=N sets limit.
+Find files by glob pattern — use to locate files by name or extension.
+Respects .gitignore. Supports multi-root via paths array. max_results=N sets limit.
 For file content search, use ctx_search (pattern) or ctx_semantic_search (meaning).
 
 Parameters: `ignore_gitignore`, `max_results`, `path`, `paths`, `pattern`*
@@ -215,7 +230,7 @@ Parameters: `ignore_gitignore`, `max_results`, `path`, `paths`, `pattern`*
 ## `ctx_graph`
 
 Code graph queries — find usages, relationships, and dependency chains.
-action=symbol path='file.rs::fnName' finds all usages of a symbol.
+action=symbol path="file.rs::fnName" finds all usages of a symbol.
 action=neighbors shows adjacent nodes; action=path from→to shows dependency
 chains between files. action=diff since=HEAD~1 for git change impact.
 For understanding code end-to-end, use ctx_compose FIRST. Use ctx_graph for
@@ -225,41 +240,50 @@ Parameters: `action`*, `depth`, `format`, `kind`, `path`, `project_root`, `since
 
 ## `ctx_handoff`
 
-Context Ledger Protocol (hashed, deterministic, local-first). Actions: create|show|list|pull|clear|export|import.
+Context handoff protocol (hashed, deterministic, local-first).
+Actions: create|show|list|pull|clear|export|import. Stores curated file refs with hashes.
+Use before ending a session or when handing off work to another agent.
 
 Parameters: `action`, `apply_knowledge`, `apply_session`, `apply_workflow`, `filename`, `format`, `path`, `paths`, `privacy`, `write`
 
 ## `ctx_heatmap`
 
-File access heatmap — shows most frequently accessed files.
+File access heatmap — shows most frequently accessed files per session.
+action=status (default) for summary, action=detail for per-file access counts.
+Use to identify hot files and optimize context usage.
 
 Parameters: `action`, `path`
 
 ## `ctx_impact`
 
-Change impact: action=analyze path='file.rs'→blast radius; depth=N; action=diff→git refs
-action=chain from→to→dependency path. depth controls traversal (default 5).
-Use before refactoring to assess risk. path can be file path or type/class name.
+Change impact analysis — assess blast radius before refactoring.
+action=analyze path="file.rs" maps downstream dependents; action=diff compares git refs;
+action=chain traces from→to dependency paths. depth controls traversal (default 5).
+Use before any significant refactor to understand risk.
 
 Parameters: `action`, `depth`, `format`, `path`, `root`
 
 ## `ctx_index`
 
-Index orchestration. Actions: status|build|build-full.
+Index orchestration — manage the code graph index.
+Actions: status (current state), build (incremental update), build-full (complete rebuild).
+Use when the graph index is stale and ctx_graph returns empty or outdated results.
 
 Parameters: `action`*, `project_root`
 
 ## `ctx_intent`
 
-Structured intent input (optional) — submit compact JSON or short text; server also infers intents automatically from tool calls.
+Structured intent input (optional) — submit compact task goals as JSON or short text.
+Server also auto-infers intent from tool calls. Use to guide context prioritization,
+preloading, and cache optimization. query=task|JSON; project_root=scope.
 
 Parameters: `project_root`, `query`*
 
 ## `ctx_knowledge`
 
-Persistent memory across sessions — remember decisions, patterns, and facts.
+Persistent memory across sessions — remember decisions, patterns, and facts for recall.
 action=remember saves a fact; action=recall query='X' retrieves it.
-Use to persist architecture decisions, gotchas, and patterns for future sessions.
+Use to persist architecture decisions, gotchas, and patterns between sessions.
 action=gotcha trigger='X' resolution='Y' for known pitfalls.
 mode=semantic|exact for recall. category groups related facts.
 
@@ -267,19 +291,28 @@ Parameters: `action`*, `as_of`, `category`, `confidence`, `examples`, `key`, `mo
 
 ## `ctx_ledger`
 
-Context ledger ops: status|reset|evict. Manages persistent context pressure.
+Context ledger operations — track and manage persistent context pressure.
+action=status shows pressure (%), top files by cost, and recommendations;
+action=reset clears all entries; action=evict targets=paths removes files
+and excludes them from re-accumulation. Use when context budget is tight.
 
 Parameters: `action`*, `targets`
 
 ## `ctx_load_tools`
 
-Load/unload specialized tool categories on demand. Categories: arch, debug, memory, metrics, session. Core is always loaded.
+Load/unload specialized tool categories on demand to reduce tool surface area.
+action=load|unload|list. Categories: arch, debug, memory, metrics, session.
+Core is always loaded and cannot be unloaded. Use when you only need
+a subset of tools for your current task.
 
 Parameters: `action`*, `category`
 
 ## `ctx_metrics`
 
-Session token stats, cache rates, per-tool savings.
+Session token statistics — cache hit rates, per-tool savings, pipeline metrics,
+and signature backend ratios. No parameters needed. Use to understand token
+efficiency and identify which tools cost the most. Complements ctx_radar
+for full context budget analysis.
 
 Parameters: _none_
 
@@ -295,15 +328,19 @@ Parameters: `fresh`, `mode`, `paths`*
 
 ## `ctx_multi_repo`
 
-Multi-repo management: add/remove roots, cross-repo search with Reciprocal Rank Fusion (RRF). Enables searching across multiple project directories simultaneously.
+Multi-repository management — add, remove, and search across project directories.
+action=add_root|remove_root|list_roots|search. Cross-repo search uses Reciprocal
+Rank Fusion (RRF) to merge results from multiple repos. query=search term;
+roots=filter to specific repos. max_results limits output (default 20).
 
 Parameters: `action`*, `alias`, `max_results`, `path`, `query`, `roots`
 
 ## `ctx_outline`
 
-File symbols: path='file.rs'->signatures; kind=fn|struct|class|all filter
-Lists all named symbols in a file with signatures and line numbers.
-Generated via tree-sitter extraction of fn/struct/class/trait declarations.
+List file symbols with signatures and line numbers — path='file.rs' returns fn, struct,
+class, and trait declarations via tree-sitter extraction. kind=fn|struct|class|all
+to filter. Use for a quick API overview of a file. For deeper understanding,
+use ctx_compose. For full file content, use ctx_read.
 
 Parameters: `kind`, `path`*
 
@@ -318,55 +355,82 @@ Parameters: `path`, `task`
 
 ## `ctx_pack`
 
-Context Package Manager. Actions: pr (PR context), create (build package from project), list, info, remove, install, export, import, auto_load, summary.
+Context Package Manager — create, install, and manage portable context packages.
+Actions: pr (PR context), create (build from project), list, info, remove,
+install, export, import, auto_load, summary. Use to bundle and share context
+state including knowledge, graph, session patterns, and gotchas.
 
 Parameters: `action`*, `apply`, `author`, `base`, `depth`, `description`, `diff`, `enable`, `file`, `format`, `layers`, `level`, `name`, `project_root`, `scope`, `tags`, `version`
 
 ## `ctx_package`
 
-Save or resume portable context packages — self-contained JSON bundles with session state, summaries, and knowledge. Use to hand off context between agents, persist session snapshots for later, or onboard a new agent into a previous session's context. Actions: save (export current session), resume (import from a package file), list (show saved packages), info (inspect a package without importing).
+Save or resume portable context packages — self-contained JSON bundles with session
+state, summaries, and knowledge. Use to hand off context between agents, persist
+session snapshots for later, or onboard a new agent into a previous session.
+Actions: save (export), resume (import), list, info (inspect without importing).
 
 Parameters: `action`, `description`, `path`
 
 ## `ctx_plan`
 
-Context planning (CFT). Computes optimal context plan with Phi scoring, budget allocation, and policy-driven view selection.
+Context planning (CFT) — selects WHICH files/modules to include in context via Phi scoring, budget
+allocation, and policy-driven view selection. Scans the project to pick the most relevant content.
+task=description (short English), budget=token limit (default 12000), profile=ultra_lean|balanced|forensic.
+For compressing already-chosen files to fit a budget, use ctx_fill instead.
 
 Parameters: `budget`, `profile`, `task`*
 
 ## `ctx_plugins`
 
-Plugin management. Actions: list (show installed plugins), enable (activate a plugin), disable (deactivate a plugin), info (show plugin details), hooks (list available hook points).
+Plugin management — list, enable, disable, and inspect plugins with their hooks.
+Actions: list (show installed), enable (activate), disable (deactivate),
+info (show details), hooks (list available hook points). name=plugin_name
+required for enable, disable, info. Use to extend tool functionality.
 
 Parameters: `action`*, `name`
 
 ## `ctx_prefetch`
 
-Predictive prefetch — prewarm cache for blast radius files (graph + task signals) within budgets.
+Predictive prefetch — prewarm the cache for blast radius files using graph and
+task signals. task=description for relevance scoring; changed_files=paths to
+compute blast radius; budget_tokens=soft budget (default 3000); max_files=limit
+(default 10). Use before context-heavy operations to minimize latency.
 
 Parameters: `budget_tokens`, `changed_files`, `max_files`, `root`, `task`
 
 ## `ctx_preload`
 
-Proactive context loader — caches task-relevant files, returns L-curve-optimized summary (~50-100 tokens vs ~5000 for individual reads).
+Proactive context loader — caches task-relevant files and returns L-curve-optimized
+summary (~50-100 tokens vs ~5000 for individual reads). task=short description;
+path=project root. Use at session start or when switching tasks to efficiently
+warm the context cache with the most relevant files.
 
 Parameters: `path`, `task`*
 
 ## `ctx_proof`
 
-Export a machine-readable ContextProofV1 (Verifier + SLO + Pipeline + Provenance). Writes to .lean-ctx/proofs/ by default.
+Export machine-readable ContextProofV1 with Verifier, SLO, Pipeline, and Provenance.
+Writes to .lean-ctx/proofs/ by default. action=export (required);
+format=json|summary|both; write=true|false; filename=custom path;
+max_evidence=max tool receipts (default 50). Use for audit trails.
 
 Parameters: `action`*, `filename`, `format`, `max_evidence`, `max_ledger_files`, `project_root`, `write`
 
 ## `ctx_provider`
 
-External context providers (GitHub, GitLab, Jira, Postgres, MCP, custom REST).
+External context providers — query data from GitHub, GitLab, Jira, Postgres, MCP
+bridges, and custom REST APIs. Actions: discover|list|status|refresh|configure|
+query|mcp_resources|gitlab_issues. provider=id (github|gitlab|jira|mcp:<name>);
+resource=issues|pull_requests. Data flows through consolidation pipeline.
 
 Parameters: `action`*, `iid`, `labels`, `limit`, `mode`, `provider`, `resource`, `state`, `status`
 
 ## `ctx_radar`
 
-Full context budget breakdown: system prompt, messages, tools, reads, shell — all tracked token usage.
+Full context budget breakdown — system prompt, messages, tools, reads, shell,
+all tracked token usage. format=display (human-readable) or json (structured).
+Complements ctx_metrics for comprehensive budget analysis. Use when context
+window is tight and you need to identify the biggest consumers.
 
 Parameters: `format`
 
@@ -383,47 +447,61 @@ Parameters: `aggressiveness`, `fresh`, `limit`, `mode`, `offset`, `path`*, `prot
 
 ## `ctx_refactor`
 
-LSP/IDE refactoring. action=one pipe-delimited value below. Reads (references/definition/implementations/declaration/type_hierarchy/symbols_overview/inspections) need a language server or the JetBrains backend. Symbol edits (replace/insert_before/insert_after_symbol) are name_path-addressed, IDE-first with a lossless headless fallback. Two-Phase ops (rename/move/safe_delete/inline _preview+_apply) need a JetBrains IDE (else BACKEND_REQUIRED) with a stateless plan_hash TOCTOU guard. rename/move/safe_delete block conflicts unless force=true; inline cannot be forced (→ UNSUPPORTED). reformat is Single-Phase, by name_path | path | path+line.
+LSP/IDE refactoring — rename, move, safe_delete, inline, and read-only analyses
+(references, definition, implementations, type_hierarchy, inspections).
+Single-Phase edits (replace_symbol_body, reformat) work headless via name_path.
+Two-Phase ops (rename/move/safe_delete/inline _preview+_apply) need JetBrains
+IDE (else BACKEND_REQUIRED) with plan_hash TOCTOU guard. Conflicts blocked
+unless force=true. See action enum for full list of pipe-delimited values.
 
 Parameters: `action`*, `column`, `direction`, `end_line`, `expected_hash`, `force`, `keep_definition`, `line`, `mode`, `name_path`, `new_body`, `new_name`, `optimize_imports`, `path`, `plan_hash`, `propagate`, `scope`, `search_comments`, `search_text_occurrences`, `target_parent`, `target_path`, `text`
 
 ## `ctx_repomap`
 
-PageRank symbol map: focus_files=['path/*.rs'] boosts areas; max_tokens controls size (default 2048)
-Shows structurally important symbols ranked by PageRank and session relevance.
+PageRank symbol map ranked by structural importance and session relevance.
+focus_files=['path/*.rs'] boosts specific areas; max_tokens controls size (default 2048).
 Use for codebase-wide orientation; for task-scoped view use ctx_overview.
 
 Parameters: `focus_files`, `max_tokens`, `path`
 
 ## `ctx_response`
 
-Compress LLM response text (structural de-duplication).
+Compress LLM response text via structural de-duplication.
+Pass response text to remove repetitive patterns while preserving key information.
+Use to reduce token waste before storing or forwarding responses.
 
 Parameters: `text`*
 
 ## `ctx_retrieve`
 
-Retrieve original uncompressed content from the session cache (CCR). Use when a compressed ctx_read output is insufficient.
+Retrieve original uncompressed content from the session cache (CCR).
+Use when a compressed ctx_read output is insufficient — restores full verbatim source.
+Supports query='search' to find matching lines within cached content.
+Requires path to a file previously read via ctx_read.
 
 Parameters: `path`*, `query`
 
 ## `ctx_review`
 
-Automated code review: combines impact analysis, caller tracking, and test discovery. Actions: review (single file), diff-review (from git diff), checklist (structured review questions).
+Automated code review with impact analysis, caller tracking, and test discovery.
+Actions: review (single file), diff-review (from git diff),
+checklist (structured review questions). depth=N controls analysis breadth (default 3).
 
 Parameters: `action`*, `depth`, `path`
 
 ## `ctx_routes`
 
-HTTP routes: method=GET|POST filter; path='/api' prefix; auto-detects frameworks
-Extracts endpoints from: Express, Flask, FastAPI, Actix, Spring, Rails, Next.js.
-Use to discover API surface without reading route definition files.
+Discover HTTP API endpoints without reading route definition files.
+Auto-detects: Express, Flask, FastAPI, Actix, Spring, Rails, Next.js.
+method=GET|POST filters by verb; path='/api' filters by prefix.
 
 Parameters: `method`, `path`
 
 ## `ctx_rules`
 
-Cross-agent rules governance (ContextOps). Actions: sync (distribute rules to agents), diff (show drift), lint (check consistency), status (show sync state), init (create central config).
+Cross-agent rules governance (ContextOps).
+Actions: sync (distribute rules to agents), diff (show drift),
+lint (check consistency), status (sync state), init (create central config).
 
 Parameters: `action`*, `agent`
 
@@ -448,15 +526,20 @@ Parameters: `action`, `file_path`, `languages`, `line`, `mode`, `path`, `path_gl
 
 ## `ctx_session`
 
-Cross-session memory: action=task/finding/decision persists; load session_id=X resumes
-Use at session end to persist progress; at start to restore previous work.
-action=status for current snapshot; action=save commits state; action=reset clears.
+Cross-session memory: action=task|finding|decision persists progress;
+load session_id=X resumes prior work. Use at session end to persist;
+at start to restore. action=status for snapshot; action=save commits state;
+action=reset clears. Supports profile|role|budget|slo|diff|verify|episodes|procedures.
 
 Parameters: `action`*, `session_id`, `value`
 
 ## `ctx_share`
 
-Share cached file contexts between agents. Actions: push (share files from your cache to another agent), pull (receive files shared by other agents), list (show all shared contexts), clear (remove your shared contexts).
+Share cached file contexts between agents for collaborative workflows.
+Actions: push (share files from your cache to another agent),
+pull (receive files shared by others), list (show shared contexts),
+clear (remove your shares). Omit to_agent for broadcast;
+set to_agent='agent-id' for targeted sharing.
 
 Parameters: `action`*, `message`, `paths`, `to_agent`
 
@@ -471,25 +554,38 @@ Parameters: `command`*, `cwd`, `env`, `raw`
 
 ## `ctx_skillify`
 
-Codify recurring patterns from this project's session diary + knowledge into versioned, git-committable .cursor/rules/skillify-*.mdc files. Actions: mine (distill & write/merge rules), list (show generated rules), status (config + counts), promote (copy a project rule to ~/.cursor/rules). Precision-biased; only acts when invoked; re-runs are idempotent.
+Codify recurring patterns from session diary + knowledge into versioned,
+git-committable .cursor/rules/skillify-*.mdc files.
+Actions: mine (distill & write/merge rules), list (show generated rules),
+status (config + counts), promote (copy to ~/.cursor/rules).
+Precision-biased; re-runs are idempotent.
 
 Parameters: `action`, `slug`
 
 ## `ctx_smart_read`
 
-Auto-select optimal read mode for a file.
+Auto-select optimal read mode (full|map|signatures|auto) based on file size,
+type, and compression history. Use when you want smart defaults without
+choosing a mode. For explicit control use ctx_read with mode= parameter directly.
 
 Parameters: `path`*
 
 ## `ctx_smells`
 
-Code smell detection. Actions: scan|summary|rules|file.
+Code smell detection engine.
+Actions: scan (run all rules on project), summary (aggregate counts),
+rules (list available rules with descriptions), file (scan a single file).
+Supports rule='name' and path='file' filters for targeted analysis.
 
 Parameters: `action`, `format`, `path`, `root`, `rule`
 
 ## `ctx_summary`
 
-Record and recall AI session summaries — compact, semantically-recallable digests of what was done (task, files, decisions, next steps). Actions: recall (find past summaries by query; semantic when embeddings are warm, else lexical), record (snapshot the current session now), list (recent summaries). Summaries are also captured automatically on the checkpoint cadence.
+Record and recall AI session summaries — compact, semantically-recallable
+digests of what was done (task, files, decisions, next steps).
+Actions: recall (find past summaries by query), record (snapshot session),
+list (recent summaries). Auto-captured on checkpoint cadence.
+Use with ctx_session for cross-session continuity.
 
 Parameters: `action`, `query`, `top_k`
 
@@ -505,21 +601,30 @@ Parameters: `file`, `kind`, `name`*
 
 ## `ctx_task`
 
-Multi-agent task orchestration. Actions: create|update|list|get|cancel|message|info.
+Multi-agent task orchestration.
+Actions: create (assign to agent), update (change state), list (active),
+get (details), cancel, message (add note), info (metadata).
+States: working|input-required|completed|failed|canceled.
 
 Parameters: `action`*, `description`, `message`, `state`, `task_id`, `to_agent`
 
 ## `ctx_tools`
 
 Gateway to downstream MCP servers — unlimited external tools at ~constant context cost.
-actions: find (query → top-N relevant tools as ChoiceCards) | call (proxy a `server::tool`) | list (servers+counts) | refresh.
-Use find to discover, then call the chosen `server::tool`. Off by default ([gateway] config).
+actions: find (query → top-N relevant tools as ChoiceCards) |
+call (proxy a server::tool) | list (servers+counts) | refresh.
+Use find to discover, then call the chosen server::tool.
+Off by default — enable via [gateway] config section.
 
 Parameters: `action`, `arguments`, `query`, `tool`
 
 ## `ctx_transcript_compact`
 
-Compact an OpenAI-format message array deterministically: keep system + a fresh tail verbatim, replace older turns with a recoverable summary, and offload the raw turns into lean-ctx session memory (indexed for ctx_search/ctx_knowledge recall). Built for the Hermes context-engine plugin. Returns JSON {messages, stats}; tool_call/tool_result pairs are never split.
+Compact an OpenAI-format message array deterministically:
+keep system + fresh tail verbatim, replace older turns with a recoverable
+summary, offload raw turns into session memory (indexed for recall).
+Built for the Hermes context-engine plugin. Returns JSON {messages, stats}.
+tool_call/tool_result pairs are never split.
 
 Parameters: `focus_topic`, `fresh_tail_tokens`, `messages`*, `protect_min_messages`
 
@@ -528,26 +633,34 @@ Parameters: `focus_topic`, `fresh_tail_tokens`, `messages`*, `protect_min_messag
 Directory tree with file counts per directory. depth=N (default 3);
 show_hidden for dotfiles; paths for multi-root.
 respect_gitignore filters ignored files (default true).
+Use for lightweight project orientation before ctx_repomap or ctx_compose.
 
 Parameters: `depth`, `path`, `paths`, `respect_gitignore`, `show_hidden`
 
 ## `ctx_url_read`
 
-Fetch URL: pages→Markdown; PDF→text; YouTube→transcript; mode=auto best per type
-mode=facts|quotes for research (claims+confidence). query='topic' to focus extraction.
-GitHub blob/raw URLs auto-resolve to raw file. SSRF-guarded (no private IPs). max_tokens=6000.
+Fetch URL: pages→Markdown; PDF→text; YouTube→transcript; mode=auto best per type.
+mode=facts|quotes for research (claims+confidence). query='topic' focuses extraction.
+GitHub blob/raw URLs auto-resolve to raw file. SSRF-guarded (no private IPs).
+max_tokens=6000; timeout_secs=20 (max 60).
 
 Parameters: `max_items`, `max_tokens`, `mode`, `query`, `timeout_secs`, `url`*
 
 ## `ctx_verify`
 
-Verification observability. Actions: stats (tool call statistics), proof|v2 (ContextProofV2 claim-based verification with Lean4 proofs).
+Verification observability — tool call statistics and claim-based verification.
+Actions: stats (tool call usage counts), proof|v2 (ContextProofV2 claim
+verification with Lean4 proofs). Use to audit tool usage or verify claims.
 
 Parameters: `action`, `format`
 
 ## `ctx_workflow`
 
-Workflow rails (state machine + evidence). Actions: start|status|transition|complete|evidence_add|evidence_list|stop.
+Workflow rails — state machine with evidence tracking.
+Actions: start|status|transition|complete|evidence_add|evidence_list|stop.
+spec=WorkflowSpec JSON to define custom states/transitions.
+Built-in plan_code_test workflow when spec omitted.
+Use with ctx_task for multi-agent orchestration.
 
 Parameters: `action`, `key`, `name`, `spec`, `to`, `value`
 
@@ -555,6 +668,8 @@ Parameters: `action`, `key`, `name`, `spec`, `to`, `value`
 
 Shell command with auto-compression (~95 patterns). Alias for ctx_shell.
 Output is compressed for token savings. For verbatim output pass raw=true.
+Use when your MCP client prefers shell/bash over ctx_shell — transparently
+delegates to ctx_shell internals.
 
 Parameters: `command`*, `cwd`
 

--- a/rust/src/core/rules_canonical.rs
+++ b/rust/src/core/rules_canonical.rs
@@ -22,6 +22,10 @@ pub const END_MARK: &str = "<!-- /lean-ctx -->";
 /// injection layer can parse it and decide whether a file is up-to-date.
 pub const RULES_VERSION: usize = 1;
 
+/// Banner placed at the top of dedicated rule files (non-shadow only).
+pub const CRITICAL: &str = "CRITICAL: ALWAYS use lean-ctx tools instead of native equivalents. \
+     This is NOT optional.";
+
 /// Compact bullet-list mapping (for both dedicated and shared contexts).
 pub const BULLETS: &str = "\
 MANDATORY MAPPING:\n\
@@ -63,11 +67,6 @@ One turn with 5 parallel ctx_read calls completes faster than 5 sequential turns
 ctx_compose bundles multiple lookups into one call; for anything it doesn't\n\
 cover, batch independent reads/searches together.";
 
-/// One-line reference for ctx_read modes (purpose: every session carries
-/// this, so it must stay terse — #579).
-pub const READ_MODES: &str = "ctx_read modes (required): full=verbatim(edit-ready) signatures=API map=structure \
-     auto=smart diff=git-delta lines:N-M=window. fresh=true forces disk re-read.";
-
 /// One-line automation reminder.
 pub const AUTO: &str = "Auto: preload/dedup/compress run in background. \
     ctx_session=memory, ctx_knowledge=facts, ctx_semantic_search=meaning search, \
@@ -85,37 +84,24 @@ pub const INTELLIGENCE: &str =
 pub const LITM_END: &str = "TOOL PREFERENCE (END): ctx_compose>chain ctx_read>Read ctx_shell>Shell \
      ctx_search>Grep ctx_glob>Glob ctx_tree>ls | Edit/Write/Delete=native";
 
-/// Banner placed at the top of dedicated rule files (non-shadow only).
-pub const CRITICAL: &str = "CRITICAL: ALWAYS use lean-ctx tools instead of native equivalents. \
-     This is NOT optional.";
-
 const FULL_NON_SHADOW: &[&str] = &[
+    CRITICAL,
     BULLETS,
     NEVER,
     INTENT,
     ANTI,
     PARALLEL,
-    READ_MODES,
     AUTO,
     CEP,
     INTELLIGENCE,
     LITM_END,
 ];
 
-const FULL_SHADOW: &[&str] = &[
-    INTENT,
-    ANTI,
-    PARALLEL,
-    READ_MODES,
-    AUTO,
-    CEP,
-    INTELLIGENCE,
-    LITM_END,
-];
+const FULL_SHADOW: &[&str] = &[INTENT, ANTI, PARALLEL, AUTO, CEP, INTELLIGENCE, LITM_END];
 
-const COMPACT_NON_SHADOW: &[&str] = &[BULLETS, NEVER, INTENT, ANTI, PARALLEL, READ_MODES];
+const COMPACT_NON_SHADOW: &[&str] = &[CRITICAL, BULLETS, NEVER, INTENT, ANTI, PARALLEL];
 
-const COMPACT_SHADOW: &[&str] = &[INTENT, ANTI, PARALLEL, READ_MODES];
+const COMPACT_SHADOW: &[&str] = &[INTENT, ANTI, PARALLEL];
 
 /// Selects the profile (FULL vs COMPACT) and the wrapping style (markers,
 /// headers, footers) for `render()`.
@@ -156,15 +142,9 @@ pub fn render(shadow: bool, wrapper: Wrapper) -> String {
         return body;
     }
 
-    let critical_section = if shadow {
-        String::new()
-    } else {
-        format!("{CRITICAL}\n\n")
-    };
-
     let version_line = format!("<!-- version: {RULES_VERSION} -->");
 
-    format!("{START_MARK}\n\n{version_line}\n\n{critical_section}{body}\n{END_MARK}")
+    format!("{START_MARK}\n{version_line}\n\n{body}\n{END_MARK}")
 }
 // ============================================================
 // RULES FILE — centralized interface for reading rule files
@@ -333,7 +313,6 @@ mod tests {
         assert!(!INTENT.is_empty());
         assert!(!ANTI.is_empty());
         assert!(!PARALLEL.is_empty());
-        assert!(!READ_MODES.is_empty());
         assert!(!AUTO.is_empty());
         assert!(!CEP.is_empty());
         assert!(!INTELLIGENCE.is_empty());
@@ -414,7 +393,6 @@ mod tests {
         assert!(out.contains(END_MARK));
         assert!(out.contains("MANDATORY MAPPING"));
         assert!(out.contains(BULLETS));
-        assert!(out.contains(READ_MODES));
     }
 
     #[test]
@@ -429,7 +407,6 @@ mod tests {
             !out.contains("MANDATORY MAPPING"),
             "shadow must not contain BULLETS"
         );
-        assert!(out.contains(READ_MODES), "shadow must keep READ_MODES");
     }
 
     // --- render() — Bare ---
@@ -442,7 +419,6 @@ mod tests {
         assert!(!out.contains("<!-- version:"), "Bare must not have version");
         assert!(out.contains(BULLETS));
         assert!(out.contains(NEVER));
-        assert!(out.contains(READ_MODES));
     }
 
     #[test]
@@ -453,7 +429,6 @@ mod tests {
             !out.contains("MANDATORY MAPPING"),
             "shadow Bare must not have BULLETS"
         );
-        assert!(out.contains(READ_MODES), "shadow Bare keeps READ_MODES");
     }
 
     // --- Wrapper round-trip ---

--- a/rust/src/hooks/support.rs
+++ b/rust/src/hooks/support.rs
@@ -190,7 +190,6 @@ fn codex_instruction_doc_content() -> String {
     let marker = crate::core::rules_canonical::START_MARK;
     let bullets = crate::core::rules_canonical::BULLETS;
     let never = crate::core::rules_canonical::NEVER;
-    let read_modes = crate::core::rules_canonical::READ_MODES;
     format!(
         r#"{marker} (Hybrid Mode)
 
@@ -217,8 +216,6 @@ those tokens.
 {bullets}
 
 {never}
-
-Read modes: {read_modes}
 
 ## CLI
 

--- a/rust/src/rules_inject/tests.rs
+++ b/rust/src/rules_inject/tests.rs
@@ -38,15 +38,6 @@ fn dedicated_rules_have_markers() {
     assert!(d.contains("intent"));
 }
 
-#[test]
-fn dedicated_rules_contain_read_modes() {
-    let d = dedicated_content_cached();
-    assert!(d.contains("full"));
-    assert!(d.contains("map"));
-    assert!(d.contains("signatures"));
-    assert!(d.contains("lines:N-M"));
-}
-
 // ── Shadow mode ──────────────────────────────────────────────
 
 #[test]

--- a/rust/src/tool_defs/granular.rs
+++ b/rust/src/tool_defs/granular.rs
@@ -24,7 +24,7 @@ pub fn unified_tool_defs() -> Vec<Tool> {
     vec![
         tool_def(
             "ctx_read",
-            "Read file (replaces native Read). Cached, re-reads ~13 tok. Omit mode to auto-select (recommended); full only right before editing. Modes: auto(default)|full|map|signatures|diff|aggressive|entropy|task|reference|lines:N-M. fresh=true re-reads.",
+            "Read file (replaces native Read). Cached, re-reads ~13 tok. Omit mode to auto-select; full only right before editing. Modes: auto|full|map|signatures|diff|aggressive|entropy|task|reference|lines:N-M. fresh=true re-reads.",
             json!({
                 "type": "object",
                 "properties": {
@@ -40,7 +40,7 @@ pub fn unified_tool_defs() -> Vec<Tool> {
         ),
         tool_def(
             "ctx_shell",
-            "Run shell (replaces native Shell). Compressed output. raw=true skips compression. cwd sets working directory.",
+            "Run shell (replaces native Shell). Compressed output (~95 patterns). raw=true for verbatim. cwd sets working dir (default: project root).",
             json!({
                 "type": "object",
                 "properties": {
@@ -53,7 +53,7 @@ pub fn unified_tool_defs() -> Vec<Tool> {
         ),
         tool_def(
             "ctx_search",
-            "Search code (replaces native Grep/rg). Regex, .gitignore aware, token-efficient.",
+            "Search code (replaces native Grep/rg) — use when you know the exact pattern. Regex, .gitignore aware, token-efficient. For understanding code, use ctx_compose FIRST.",
             json!({
                 "type": "object",
                 "properties": {
@@ -69,7 +69,7 @@ pub fn unified_tool_defs() -> Vec<Tool> {
         ),
         tool_def(
             "ctx_tree",
-            "Directory tree (replaces ls/find). Compact maps with file counts.",
+            "Directory tree (replaces ls/find) — compact maps with file counts per directory. depth=N (default 3); paths for multi-root. Use for orientation before ctx_repomap or ctx_compose.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_agent.rs
+++ b/rust/src/tools/registered/ctx_agent.rs
@@ -15,44 +15,44 @@ impl McpTool for CtxAgentTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_agent",
-            "Multi-agent coordination: shared message bus, persistent diaries, stigmergic scent field. Actions: register (agent_type+role), \
-post (message+category), read (poll), status (active|idle|finished), handoff (transfer task+summary), \
-sync (agents + messages + scent: claims/stuck/hot), claim/release (atomic file/task claim, message=target), \
-brief (sub-agent briefing pack: message=task, priority=budget), \
-return (distill sub-agent report into knowledge: message='category/key: value' lines), \
-diary (log discovery/decision/blocker/progress/insight), recall_diary, diaries, list, info.",
+            "Multi-agent coordination — shared message bus, persistent diaries, stigmergic scent field. \
+Actions: register (agent_type+role), post (message+category), read (poll), \
+status (active|idle|finished), handoff (task+summary), sync (agents+messages+scent), \
+claim/release (file/task claim), brief (sub-agent briefing), \
+return (distill report into knowledge), diary, recall_diary, list, info. \
+Use when orchestrating multiple LLM agents across a shared workspace.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["register", "list", "post", "read", "status", "info", "handoff", "sync", "claim", "release", "brief", "return", "diary", "recall_diary", "diaries", "share_knowledge", "receive_knowledge"],
-                        "description": "Agent operation."
+                        "description": "register|list|post|read|status|info|handoff|sync|claim|release|brief|return|diary|recall_diary|diaries|share_knowledge|receive_knowledge"
                     },
                     "agent_type": {
                         "type": "string",
-                        "description": "Agent type for register (cursor, claude, codex, gemini, crush, subagent)"
+                        "description": "cursor|claude|codex|gemini|crush|subagent"
                     },
                     "role": {
                         "type": "string",
-                        "description": "Agent role (dev, review, test, plan)"
+                        "description": "dev|review|test|plan"
                     },
                     "message": {
                         "type": "string",
-                        "description": "Message text for post action, or status detail for status action"
+                        "description": "Post text or status detail"
                     },
                     "category": {
                         "type": "string",
-                        "description": "Message category for post (finding, warning, request, status)"
+                        "description": "finding|warning|request|status"
                     },
                     "to_agent": {
                         "type": "string",
-                        "description": "Target agent ID for direct message (omit for broadcast)"
+                        "description": "Target agent ID"
                     },
                     "status": {
                         "type": "string",
                         "enum": ["active", "idle", "finished"],
-                        "description": "New status for status action"
+                        "description": "active|idle|finished"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_analyze.rs
+++ b/rust/src/tools/registered/ctx_analyze.rs
@@ -15,7 +15,7 @@ impl McpTool for CtxAnalyzeTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_analyze",
-            "Entropy analysis — recommends optimal compression mode for a file.",
+            "Entropy analysis — recommends optimal compression mode for a file path. Use before ctx_read to pick the best mode (full/signatures/auto) that balances size vs information retention.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_architecture.rs
+++ b/rust/src/tools/registered/ctx_architecture.rs
@@ -15,24 +15,25 @@ impl McpTool for CtxArchitectureTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_architecture",
-            "Architecture analysis: action=overview→high-level; clusters|communities→groupings\n\
-             layers|cycles→dependency violations; entrypoints|hotspots→risk areas; health→quality.\n\
-             Use to understand module structure without reading every file. action=module path='src/' to zoom.",
+            "Architecture analysis — understand module structure without reading every file.\n\
+action=overview→high-level; clusters|communities→groupings;\n\
+layers|cycles→dependency violations; entrypoints|hotspots→risk areas;\n\
+health→quality; module path='src/' to zoom into a specific module.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["overview", "clusters", "communities", "layers", "cycles", "entrypoints", "hotspots", "health", "module"],
-                        "description": "Architecture operation (default: overview)"
+                        "description": "overview|clusters|communities|layers|cycles|entrypoints|hotspots|health|module"
                     },
                     "path": {
                         "type": "string",
-                        "description": "Module/file path for action=module"
+                        "description": "Module/file path"
                     },
                     "root": {
                         "type": "string",
-                        "description": "Project root (default: .)"
+                        "description": "Project root"
                     },
                     "format": {
                         "type": "string",

--- a/rust/src/tools/registered/ctx_artifacts.rs
+++ b/rust/src/tools/registered/ctx_artifacts.rs
@@ -17,35 +17,35 @@ impl McpTool for CtxArtifactsTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_artifacts",
-            "Context artifact registry + BM25 index. Actions: list|status|index|reindex|search|remove.",
+            "Context artifact registry with BM25 search — manage and query indexed code artifacts. Actions: list|status|index|reindex|search|remove. Use search with query for semantic retrieval across artifacts.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["list", "status", "index", "reindex", "search", "remove"],
-                        "description": "Artifact action"
+                        "description": "list|status|index|reindex|search|remove"
                     },
                     "project_root": {
                         "type": "string",
-                        "description": "Project root (default: session project root)"
+                        "description": "Project root"
                     },
                     "query": {
                         "type": "string",
-                        "description": "Search query (required for action=search)"
+                        "description": "Search query"
                     },
                     "name": {
                         "type": "string",
-                        "description": "Artifact name (required for action=remove)"
+                        "description": "Artifact name"
                     },
                     "top_k": {
                         "type": "integer",
-                        "description": "Max results (default: 10, max: 50)"
+                        "description": "Max results"
                     },
                     "format": {
                         "type": "string",
                         "enum": ["json", "markdown"],
-                        "description": "Output format (default: json)"
+                        "description": "json|markdown"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_benchmark.rs
+++ b/rust/src/tools/registered/ctx_benchmark.rs
@@ -15,7 +15,7 @@ impl McpTool for CtxBenchmarkTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_benchmark",
-            "Benchmark compression modes for a file or project.",
+            "Benchmark compression modes — measures token savings across all available modes for a file or project. Provide a file path, or use action=project format=json|markdown for project-wide results.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_cache.rs
+++ b/rust/src/tools/registered/ctx_cache.rs
@@ -15,18 +15,18 @@ impl McpTool for CtxCacheTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_cache",
-            "Cache ops: status|clear|invalidate.",
+            "Cache operations — inspect, clear, or invalidate the read cache. Actions: status lists cached files; clear empties all; invalidate path=... refreshes a single entry. Use to diagnose stale content or recover budget.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["status", "clear", "invalidate"],
-                        "description": "Cache operation to perform"
+                        "description": "status|clear|invalidate"
                     },
                     "path": {
                         "type": "string",
-                        "description": "File path (required for 'invalidate' action)"
+                        "description": "Target path"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_call.rs
+++ b/rust/src/tools/registered/ctx_call.rs
@@ -15,14 +15,14 @@ impl McpTool for CtxCallTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_call",
-            "Invoke any non-core lean-ctx tool by name.\n\
-             Categories: arch, debug, memory, batch, agent, util. Find exact names \
-             with ctx_discover_tools (query=keyword; empty query lists all).",
+            "Invoke any non-core lean-ctx tool by name — for tools not exposed as standalone MCP tools.\n\
+Categories: arch, debug, memory, batch, agent, util. Find exact names with\n\
+ctx_discover_tools (query=keyword; empty query lists all). Cannot invoke itself.",
             json!({
                 "type": "object",
                 "properties": {
                     "name": { "type": "string", "description": "Tool name" },
-                    "arguments": { "type": "object", "description": "Arguments for the tool" }
+                    "arguments": { "type": "object",                         "description": "Tool arguments" }
                 },
                 "required": ["name"]
             }),

--- a/rust/src/tools/registered/ctx_callgraph.rs
+++ b/rust/src/tools/registered/ctx_callgraph.rs
@@ -26,12 +26,12 @@ impl McpTool for CtxCallgraphTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "description": "callers|callees|trace|risk (default: callers)",
+                        "description": "callers|callees|trace|risk",
                         "enum": ["callers", "callees", "trace", "risk"]
                     },
                     "symbol": {
                         "type": "string",
-                        "description": "Symbol name (required for callers/callees/risk)"
+                        "description": "Symbol name"
                     },
                     "file": {
                         "type": "string",
@@ -39,17 +39,17 @@ impl McpTool for CtxCallgraphTool {
                     },
                     "depth": {
                         "type": "integer",
-                        "description": "BFS depth for callers/callees (1–5, default 1)",
+                        "description": "BFS depth (1-5)",
                         "minimum": 1,
                         "maximum": 5
                     },
                     "from": {
                         "type": "string",
-                        "description": "Source symbol for trace action"
+                        "description": "Source symbol"
                     },
                     "to": {
                         "type": "string",
-                        "description": "Target symbol for trace action"
+                        "description": "Target symbol"
                     }
                 }
             }),

--- a/rust/src/tools/registered/ctx_checkpoint.rs
+++ b/rust/src/tools/registered/ctx_checkpoint.rs
@@ -24,24 +24,25 @@ impl McpTool for CtxCheckpointTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_checkpoint",
-            "Local shadow git history of the agent's changes (separate from the user's .git).\n\
-             actions: snapshot (record current state) | log (list checkpoints) | diff (vs a checkpoint) | restore (revert files).\n\
-             Snapshot before+after a change to capture exactly what the LLM modified; diff/restore to review or roll back.\n\
-             Never touches the user's repository.",
+            "Local shadow git history of the agent's changes — separate from the user's .git.\n\
+Actions: snapshot (record current state), log (list checkpoints),\n\
+diff (compare against a checkpoint), restore (revert files).\n\
+Snapshot before+after changes to capture exactly what was modified.\n\
+Never touches the user's repository.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["snapshot", "log", "diff", "restore"],
-                        "description": "Operation to perform (default: log)"
+                        "description": "snapshot|log|diff|restore"
                     },
-                    "message": { "type": "string", "description": "Snapshot label (snapshot)" },
-                    "from": { "type": "string", "description": "Base checkpoint sha (diff)" },
-                    "to": { "type": "string", "description": "Target checkpoint sha (diff; default: working tree)" },
-                    "ref": { "type": "string", "description": "Checkpoint sha to restore from (restore)" },
-                    "path": { "type": "string", "description": "Limit restore to this file/dir (restore)" },
-                    "limit": { "type": "integer", "description": "Max checkpoints to list (log, default: 20)" }
+                    "message": { "type": "string", "description": "Snapshot label" },
+                    "from": { "type": "string", "description": "Base checkpoint SHA" },
+                    "to": { "type": "string", "description": "Target checkpoint SHA" },
+                    "ref": { "type": "string", "description": "Checkpoint SHA" },
+                    "path": { "type": "string", "description": "File/dir to restore" },
+                    "limit": { "type": "integer", "description": "Max checkpoints" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_compile.rs
+++ b/rust/src/tools/registered/ctx_compile.rs
@@ -15,12 +15,12 @@ impl McpTool for CtxCompileTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_compile",
-            "Context compilation (CFT). Builds minimal context package via greedy knapsack + Boltzmann view selection. Modes: handles|compressed|full.",
+            "Context compilation (CFT) — builds minimal context package via greedy knapsack + Boltzmann view selection. Modes: handles|compressed|full. Use to produce focused context for handoff or subagent tasks.",
             json!({
                 "type": "object",
                 "properties": {
-                    "mode": { "type": "string", "description": "handles|compressed|full (default: handles)" },
-                    "budget": { "type": "integer", "description": "Token budget (default: 12000)" }
+                    "mode": { "type": "string", "description": "handles|compressed|full" },
+                    "budget": { "type": "integer", "description": "Token budget" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_compose.rs
+++ b/rust/src/tools/registered/ctx_compose.rs
@@ -25,7 +25,7 @@ impl McpTool for CtxComposeTool {
                 "type": "object",
                 "properties": {
                     "task": { "type": "string", "description": "Short English task/question or symbol names" },
-                    "path": { "type": "string", "description": "Project root (default: .)" }
+                    "path": { "type": "string", "description": "Project root" }
                 },
                 "required": ["task"]
             }),

--- a/rust/src/tools/registered/ctx_compress.rs
+++ b/rust/src/tools/registered/ctx_compress.rs
@@ -15,13 +15,14 @@ impl McpTool for CtxCompressTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_compress",
-            "Context checkpoint: compresses read cache to free budget in long sessions\n\
-             include_signatures=true (default) preserves API surface in compressed state.\n\
-             Does not affect session state or knowledge—only the read cache compaction.",
+            "Compress read cache to free token budget in long sessions.\n\
+include_signatures=true (default) preserves API surface in compressed state.\n\
+Does not affect session state or knowledge — only read cache compaction.\n\
+Use when nearing context limit to reclaim space for new content.",
             json!({
                 "type": "object",
                 "properties": {
-                    "include_signatures": { "type": "boolean", "description": "Include signatures (default: true)" }
+                    "include_signatures": { "type": "boolean", "description": "Include signatures" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_compress_memory.rs
+++ b/rust/src/tools/registered/ctx_compress_memory.rs
@@ -15,7 +15,7 @@ impl McpTool for CtxCompressMemoryTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_compress_memory",
-            "Compress a memory/config file (CLAUDE.md, .cursorrules) preserving code, URLs, paths. Creates .original.md backup.",
+            "Compress a memory/config file (CLAUDE.md, .cursorrules) preserving code, URLs, and paths. Creates .original.md backup. Use to reduce token overhead of persistent instruction files.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_context.rs
+++ b/rust/src/tools/registered/ctx_context.rs
@@ -15,7 +15,7 @@ impl McpTool for CtxContextTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_context",
-            "Session context overview — cached files, seen files, session state.",
+            "Session context overview — shows cached files, seen files, session state, and current CRP mode. No arguments needed. Call periodically to track what's in your context window and remaining budget.",
             json!({
                 "type": "object",
                 "properties": {}

--- a/rust/src/tools/registered/ctx_control.rs
+++ b/rust/src/tools/registered/ctx_control.rs
@@ -15,7 +15,7 @@ impl McpTool for CtxControlTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_control",
-            "Universal context manipulation (Context Field Theory). Actions: exclude|include|pin|unpin|set_view|set_priority|mark_outdated|reset|list|history. Overlay-based, reversible, scoped.",
+            "Universal context manipulation (CFT) — fine-tune what appears in context. Actions: exclude|include|pin|unpin|set_view|set_priority|mark_outdated|reset|list|history. Overlay-based, reversible, scoped to call/session/project.",
             json!({
                 "type": "object",
                 "properties": {
@@ -25,7 +25,7 @@ impl McpTool for CtxControlTool {
                     },
                     "target": { "type": "string", "description": "@F1 or path or item ID" },
                     "value": { "type": "string", "description": "New content, view name, or priority" },
-                    "scope": { "type": "string", "description": "call|session|project (default: session)" },
+                    "scope": { "type": "string", "description": "call|session|project" },
                     "reason": { "type": "string", "description": "Reason for the action" }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_cost.rs
+++ b/rust/src/tools/registered/ctx_cost.rs
@@ -15,22 +15,22 @@ impl McpTool for CtxCostTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_cost",
-            "Cost attribution (local-first). Actions: report|agent|tools|json|reset.",
+            "Cost attribution — track tokens and cost per agent and tool call. Actions: report (summary), agent (per-agent), tools (per-tool), json (machine-readable), reset (zero counters). Local-first, no external billing calls.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["report", "agent", "tools", "json", "reset", "status"],
-                        "description": "Operation to perform (default: report)"
+                        "description": "report|agent|tools|json|reset|status"
                     },
                     "agent_id": {
                         "type": "string",
-                        "description": "Agent ID for action=agent (optional)"
+                        "description": "Agent ID"
                     },
                     "limit": {
                         "type": "integer",
-                        "description": "Max rows (default: 10)"
+                        "description": "Max rows"
                     }
                 }
             }),

--- a/rust/src/tools/registered/ctx_dedup.rs
+++ b/rust/src/tools/registered/ctx_dedup.rs
@@ -15,13 +15,13 @@ impl McpTool for CtxDedupTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_dedup",
-            "Cross-file dedup: analyze or apply shared block references.",
+            "Cross-file deduplication — detect and eliminate repeated content across files. action=analyze (default) finds shared blocks; action=apply registers them for auto-dedup in ctx_read output.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "description": "analyze (default) or apply (register shared blocks for auto-dedup in ctx_read)",
+                        "description": "analyze (find shared) | apply (register dedup)",
                         "default": "analyze"
                     }
                 }

--- a/rust/src/tools/registered/ctx_delta.rs
+++ b/rust/src/tools/registered/ctx_delta.rs
@@ -22,7 +22,7 @@ impl McpTool for CtxDeltaTool {
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Absolute file path" }
+                    "path": { "type": "string", "description": "File path" }
                 },
                 "required": ["path"]
             }),

--- a/rust/src/tools/registered/ctx_discover.rs
+++ b/rust/src/tools/registered/ctx_discover.rs
@@ -15,7 +15,9 @@ impl McpTool for CtxDiscoverTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_discover",
-            "Find missed compression opportunities in shell history.",
+            "Identify compression misses in shell history — use when context feels bloated.\n\
+             Shows commands that would save tokens via lean-ctx patterns. limit=N caps results.\n\
+             No params needed for quick health check.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_discover_tools.rs
+++ b/rust/src/tools/registered/ctx_discover_tools.rs
@@ -15,11 +15,13 @@ impl McpTool for CtxDiscoverToolsTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_discover_tools",
-            "Search available lean-ctx tools by keyword. Returns matching tool names and descriptions.",
+            "Search available lean-ctx tools by keyword — use to find the right tool.\n\
+             Empty query lists all tools. query=\"keyword\" returns matching names and descriptions.\n\
+             Use before ctx_call or when unsure which tool fits your task.",
             json!({
                 "type": "object",
                 "properties": {
-                    "query": { "type": "string", "description": "Search keyword to filter tools (optional, empty returns all)" }
+                    "query": { "type": "string", "description": "Search keyword (empty returns all)" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_edit.rs
+++ b/rust/src/tools/registered/ctx_edit.rs
@@ -17,17 +17,18 @@ impl McpTool for CtxEditTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_edit",
-            "Search-and-replace edit: old_string must be unique unless replace_all=true\n\
-             create=true writes new files from new_string. TOCTOU-guarded with preimage hash verification.\n\
-             backup creates .bak before modifying. Supports MD5/size/mtime pre-guards for race-free edits.",
+            "Search-and-replace edit with TOCTOU safety — for simple text replacement in a single file.\n\
+             Use INSTEAD of native Edit when Read is unavailable. old_string must be unique unless replace_all=true.\n\
+             create=true writes new files. backup creates .bak. MD5/size/mtime pre-guards prevent race conditions.\n\
+             Do NOT loop on failures — switch to ctx_edit. For LSP-aware refactoring (rename, move, inline), use ctx_refactor.",
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Absolute path" },
-                    "old_string": { "type": "string", "description": "Text to replace (unique unless replace_all)" },
+                    "path": { "type": "string", "description": "Path" },
+                    "old_string": { "type": "string", "description": "Text to replace (unique unless replace_all=true)" },
                     "new_string": { "type": "string", "description": "Replacement text" },
                     "replace_all": { "type": "boolean", "default": false },
-                    "create": { "type": "boolean", "description": "Create file from new_string", "default": false }
+                    "create": { "type": "boolean", "description": "Create file", "default": false }
                 },
                 "required": ["path", "new_string"]
             }),

--- a/rust/src/tools/registered/ctx_execute.rs
+++ b/rust/src/tools/registered/ctx_execute.rs
@@ -18,42 +18,41 @@ impl McpTool for CtxExecuteTool {
         tool_def(
             "ctx_execute",
             "Run code in sandbox (11 languages) — use when compute beats shell glue.\n\
-             action=code (default) for one-shot transform/math/generation; action=batch for parallel\n\
-             multi-language scripts; action=file to process a project file (extension auto-detects\n\
-             language). Pass intent to focus large output and save tokens. Prefer over ctx_shell when\n\
-             logic, conditionals, multi-line scripts, or cross-language data munging — stdout-only,\n\
-             no argv escaping. Languages: javascript, typescript, python, shell, ruby, go, rust, php,\n\
-             perl, r, elixir.",
+             action=code (default) for one-shot scripts; action=batch for parallel multi-language;\n\
+             action=file to process a project file (extension auto-detects language).\n\
+             Pass intent to focus large output. Prefer over ctx_shell for conditionals,\n\
+             multi-line scripts, or cross-language data munging. Languages: javascript,\n\
+             typescript, python, shell, ruby, go, rust, php, perl, r, elixir.",
             json!({
                 "type": "object",
                 "properties": {
                     "language": {
                         "type": "string",
-                        "description": "REQUIRED for action=code. One of: javascript|typescript|python|shell|ruby|go|rust|php|perl|r|elixir. Omit for action=file (auto-detected)."
+                        "description": "javascript|typescript|python|shell|ruby|go|rust|php|perl|r|elixir (for action=code)"
                     },
                     "code": {
                         "type": "string",
-                        "description": "Source code string. REQUIRED for action=code. Set intent to focus large output on what you need."
+                        "description": "Source code for action=code. Set intent to filter large output."
                     },
                     "intent": {
                         "type": "string",
-                        "description": "What you need from output. Triggers intent-driven filtering when output is large — saves tokens by discarding irrelevant lines."
+                        "description": "Focus intent; triggers filtering when output is large."
                     },
                     "timeout": {
                         "type": "integer",
-                        "description": "Timeout in seconds (default: 30). Increase for long-running scripts (data processing, scraping)."
+                        "description": "Timeout in seconds (default: 30)"
                     },
                     "action": {
                         "type": "string",
-                        "description": "code (default) — run one script via language+code. batch — run multiple scripts in parallel via items. file — process a project file (language auto-detected from extension)."
+                        "description": "code (run script) | batch (parallel) | file (project file)"
                     },
                     "items": {
                         "type": "string",
-                        "description": "JSON array of [{\"language\": \"...\", \"code\": \"...\"}] for action=batch. All scripts run in parallel."
+                        "description": "JSON array of [{language, code}] for batch action."
                     },
                     "path": {
                         "type": "string",
-                        "description": "Project file path. REQUIRED for action=file. Language auto-detected from file extension (see detect_language_from_extension)."
+                        "description": "File path for action=file (language auto-detected)."
                     }
                 }
             }),

--- a/rust/src/tools/registered/ctx_expand.rs
+++ b/rust/src/tools/registered/ctx_expand.rs
@@ -16,21 +16,21 @@ impl McpTool for CtxExpandTool {
         tool_def(
             "ctx_expand",
             "Retrieve archived tool output by ID (e.g. id=@F1 from [Archived:ID] hints).\n\
-             Use when you see an [Archived:ID] reference in tool output and need the full\n\
-             content. Supports head/tail/search to filter lines. action=search_all across\n\
-             all archives. action=list shows available archives. Zero-loss: original preserved.\n\
+             Use when you see an [Archived:ID] reference and need the full content.\n\
+             Supports head/tail/search to filter lines. action=search_all across all archives.\n\
+             action=list shows available archives. Zero-loss: original preserved.\n\
              For reading files, use ctx_read or ctx_compose instead.",
             json!({
                 "type": "object",
                 "properties": {
-                    "id": { "type": "string", "description": "Archive ID or handle ref (@F1)" },
-                    "action": { "type": "string", "description": "retrieve (default)|list|search_all" },
-                    "start_line": { "type": "integer", "description": "1-based start line in archived output" },
-                    "end_line": { "type": "integer", "description": "1-based end line in archived output" },
+                    "id": { "type": "string", "description": "Archive ID or @F1 ref" },
+                    "action": { "type": "string", "description": "retrieve|list|search_all" },
+                    "start_line": { "type": "integer", "description": "1-based start line" },
+                    "end_line": { "type": "integer", "description": "1-based end line" },
                     "head": { "type": "integer", "description": "First N lines" },
                     "tail": { "type": "integer", "description": "Last N lines" },
-                    "search": { "type": "string", "description": "Only lines matching substring" },
-                    "json_keys": { "type": "boolean", "description": "Describe JSON structure" },
+                    "search": { "type": "string", "description": "Lines matching substring" },
+                    "json_keys": { "type": "boolean", "description": "List JSON keys" },
                     "json_path": { "type": "string", "description": "JSON path, e.g. data.items.0" },
                     "query": { "type": "string", "description": "search_all query" },
                     "session_id": { "type": "string", "description": "Filter by session ID" }

--- a/rust/src/tools/registered/ctx_feedback.rs
+++ b/rust/src/tools/registered/ctx_feedback.rs
@@ -15,23 +15,25 @@ impl McpTool for CtxFeedbackTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_feedback",
-            "Harness feedback for LLM output tokens/latency (local-first). Actions: record|report|json|reset|status.",
+            "Record and report LLM token/latency metrics (local-first) — use to track efficiency.\n\
+             Actions: record (log event), report (readable summary), json (machine-readable),\n\
+             reset (clear data), status (storage info). record requires llm_input_tokens + llm_output_tokens.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["record", "report", "json", "reset", "status"],
-                        "description": "Operation to perform (default: report)"
+                        "description": "record (log event) | report (summary) | json (data) | reset (clear) | status (storage)"
                     },
-                    "agent_id": { "type": "string", "description": "Agent ID (optional; defaults to current agent)" },
-                    "intent": { "type": "string", "description": "Intent/task string (optional)" },
-                    "model": { "type": "string", "description": "Model identifier (optional)" },
+                    "agent_id": { "type": "string", "description": "Agent ID (default: current agent)" },
+                    "intent": { "type": "string", "description": "Intent/task string" },
+                    "model": { "type": "string", "description": "Model identifier" },
                     "llm_input_tokens": { "type": "integer", "description": "Required for action=record" },
                     "llm_output_tokens": { "type": "integer", "description": "Required for action=record" },
-                    "latency_ms": { "type": "integer", "description": "Optional for action=record" },
-                    "note": { "type": "string", "description": "Optional note (no prompts/PII)" },
-                    "limit": { "type": "integer", "description": "For report/json: max recent events (default: 500)" }
+                    "latency_ms": { "type": "integer", "description": "Latency in ms (for record)" },
+                    "note": { "type": "string", "description": "Note (no prompts/PII)" },
+                    "limit": { "type": "integer", "description": "Max recent events (default: 500)" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_fill.rs
+++ b/rust/src/tools/registered/ctx_fill.rs
@@ -17,22 +17,25 @@ impl McpTool for CtxFillTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_fill",
-            "Budget-aware context fill — auto-selects compression per file within token limit.",
+            "Budget-aware context fill — given a list of paths, auto-compresses each to fit within a token budget.\n\
+             Pass paths array + budget=N. task=\"...\" enables intent-driven pruning for relevance.\n\
+             Does NOT decide what to include (use ctx_plan for project-wide selection).\n\
+             Use instead of reading each file individually when you have many files and a budget.",
             json!({
                 "type": "object",
                 "properties": {
                     "paths": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "File paths to consider"
+                        "description": "File paths"
                     },
                     "budget": {
                         "type": "integer",
-                        "description": "Maximum token budget to fill"
+                        "description": "Max token budget"
                     },
                     "task": {
                         "type": "string",
-                        "description": "Optional task (short English preferred) for intent-driven pruning"
+                        "description": "Intent-driven pruning target"
                     }
                 },
                 "required": ["paths", "budget"]

--- a/rust/src/tools/registered/ctx_gain.rs
+++ b/rust/src/tools/registered/ctx_gain.rs
@@ -15,7 +15,9 @@ impl McpTool for CtxGainTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_gain",
-            "Gain report (includes Wrapped via action=wrapped).",
+            "Gain report — shows token savings from lean-ctx compression. Use to measure efficiency.\n\
+             action=wrapped for periodic/annual summary. Other actions: status|report|score|cost|tasks|heatmap|agents|json.\n\
+             period=\"week\"|\"month\"|\"all\" scopes the report.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_git_read.rs
+++ b/rust/src/tools/registered/ctx_git_read.rs
@@ -27,24 +27,24 @@ impl McpTool for CtxGitReadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_git_read",
-            "Read a remote git repository via a cached shallow clone (not HTML scraping).\n\
-             modes: overview (tree + README) | tree (file list) | read (a file) | grep (search).\n\
-             Accepts repo URLs and GitHub/GitLab blob/tree links (ref + path auto-detected). https-only, SSRF-guarded, bounded.\n\
-             Use instead of ctx_url_read when you need a whole repo's files/structure.",
+            "Read remote git repos via cached shallow clone (not HTML scraping).\n\
+             modes: overview (tree + README) | tree (file list) | read (file content) | grep (search).\n\
+             Accepts repo URLs and GitHub/GitLab blob/tree links (ref+path auto-detected).\n\
+             https-only, SSRF-guarded. Use instead of ctx_url_read for a whole repo.",
             json!({
                 "type": "object",
                 "properties": {
-                    "url": { "type": "string", "description": "https repo URL, optionally a blob/tree link carrying ref + path" },
+                    "url": { "type": "string", "description": "https repo URL (blob/tree links auto-detect ref+path)" },
                     "mode": {
                         "type": "string",
                         "enum": ["overview", "tree", "read", "grep"],
-                        "description": "Default: read when a path is present, else overview"
+                        "description": "overview|tree|read|grep"
                     },
-                    "path": { "type": "string", "description": "File (read) or directory (tree/grep) within the repo" },
-                    "ref": { "type": "string", "description": "Branch/tag/commit (overrides any ref in the URL)" },
+                    "path": { "type": "string", "description": "Path within repo" },
+                    "ref": { "type": "string", "description": "Branch/tag/commit (overrides URL ref)" },
                     "query": { "type": "string", "description": "Search term for grep mode" },
-                    "max_tokens": { "type": "integer", "description": "Token budget for returned content (default: 6000)" },
-                    "timeout_secs": { "type": "integer", "description": "Clone/fetch timeout (default: 90, max: 300)" }
+                    "max_tokens": { "type": "integer", "description": "Token budget (default: 6000)" },
+                    "timeout_secs": { "type": "integer", "description": "Timeout seconds (default: 90, max: 300)" }
                 },
                 "required": ["url"]
             }),

--- a/rust/src/tools/registered/ctx_glob.rs
+++ b/rust/src/tools/registered/ctx_glob.rs
@@ -15,21 +15,21 @@ impl McpTool for CtxGlobTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_glob",
-            "Find files by glob pattern. Respects .gitignore;\n\
-             supports multi-root via `paths` array. max_results=N sets limit.\n\
+            "Find files by glob pattern — use to locate files by name or extension.\n\
+             Respects .gitignore. Supports multi-root via paths array. max_results=N sets limit.\n\
              For file content search, use ctx_search (pattern) or ctx_semantic_search (meaning).",
             json!({
                 "type": "object",
                 "properties": {
-                    "pattern": { "type": "string", "description": "Glob pattern (e.g. **/*.ts, *.rs)" },
-                    "path": { "type": "string", "description": "Directory to search (default: .)" },
+                    "pattern": { "type": "string", "description": "Glob pattern (e.g. **/*.ts)" },
+                    "path": { "type": "string", "description": "Directory to search" },
                     "paths": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Multiple directories to search (alternative to path)"
+                        "description": "Alternative to path: multi-root"
                     },
                     "max_results": { "type": "integer", "description": "Max results (default: 200)" },
-                    "ignore_gitignore": { "type": "boolean", "description": "Set true to scan ALL files including .gitignore'd paths (default: false). Requires role policy (e.g. admin)." }
+                    "ignore_gitignore": { "type": "boolean", "description": "Scan gitignored files (requires admin role)" }
                 },
                 "required": ["pattern"]
             }),

--- a/rust/src/tools/registered/ctx_graph.rs
+++ b/rust/src/tools/registered/ctx_graph.rs
@@ -16,7 +16,7 @@ impl McpTool for CtxGraphTool {
         tool_def(
             "ctx_graph",
             "Code graph queries — find usages, relationships, and dependency chains.\n\
-             action=symbol path='file.rs::fnName' finds all usages of a symbol.\n\
+             action=symbol path=\"file.rs::fnName\" finds all usages of a symbol.\n\
              action=neighbors shows adjacent nodes; action=path from→to shows dependency\n\
              chains between files. action=diff since=HEAD~1 for git change impact.\n\
              For understanding code end-to-end, use ctx_compose FIRST. Use ctx_graph for\n\
@@ -30,7 +30,7 @@ impl McpTool for CtxGraphTool {
                     },
                     "path": {
                         "type": "string",
-                        "description": "File path; file::symbol for action=symbol; FROM file for action=path"
+                        "description": "Path; file::symbol for symbol action"
                     },
                     "to": { "type": "string", "description": "Target file (action=path)" },
                     "depth": { "type": "integer", "description": "Traversal depth" },

--- a/rust/src/tools/registered/ctx_handoff.rs
+++ b/rust/src/tools/registered/ctx_handoff.rs
@@ -17,24 +17,26 @@ impl McpTool for CtxHandoffTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_handoff",
-            "Context Ledger Protocol (hashed, deterministic, local-first). Actions: create|show|list|pull|clear|export|import.",
+            "Context handoff protocol (hashed, deterministic, local-first).\n\
+             Actions: create|show|list|pull|clear|export|import. Stores curated file refs with hashes.\n\
+             Use before ending a session or when handing off work to another agent.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["create", "show", "list", "pull", "clear", "export", "import"],
-                        "description": "Operation to perform (default: list)"
+                        "description": "create|show|list|pull|clear|export|import"
                     },
                     "path": { "type": "string", "description": "Ledger file path (for show/pull/import)" },
-                    "paths": { "type": "array", "items": { "type": "string" }, "description": "Optional file paths for curated refs (for create/export)" },
-                    "format": { "type": "string", "description": "Output format (json|summary|a2a — a2a wraps the bundle in a spec-shaped A2A Task envelope)" },
+                    "paths": { "type": "array", "items": { "type": "string" }, "description": "File paths for curated refs" },
+                    "format": { "type": "string", "description": "json|summary|a2a" },
                     "write": { "type": "boolean", "description": "Write export to file" },
-                    "privacy": { "type": "string", "description": "Export privacy: redacted (default) | full (admin only)" },
+                    "privacy": { "type": "string", "description": "redacted|full (admin only)" },
                     "filename": { "type": "string", "description": "Custom filename for export" },
-                    "apply_workflow": { "type": "boolean", "description": "For pull/import: apply workflow state (default: true)" },
-                    "apply_session": { "type": "boolean", "description": "For pull/import: apply session snapshot (default: true)" },
-                    "apply_knowledge": { "type": "boolean", "description": "For pull/import: import knowledge facts (default: true)" }
+                    "apply_workflow": { "type": "boolean", "description": "Apply workflow state" },
+                    "apply_session": { "type": "boolean", "description": "Apply session snapshot" },
+                    "apply_knowledge": { "type": "boolean", "description": "Import knowledge facts" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_heatmap.rs
+++ b/rust/src/tools/registered/ctx_heatmap.rs
@@ -15,7 +15,9 @@ impl McpTool for CtxHeatmapTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_heatmap",
-            "File access heatmap — shows most frequently accessed files.",
+            "File access heatmap — shows most frequently accessed files per session.\n\
+             action=status (default) for summary, action=detail for per-file access counts.\n\
+             Use to identify hot files and optimize context usage.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_impact.rs
+++ b/rust/src/tools/registered/ctx_impact.rs
@@ -15,28 +15,29 @@ impl McpTool for CtxImpactTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_impact",
-            "Change impact: action=analyze path='file.rs'→blast radius; depth=N; action=diff→git refs\n\
-             action=chain from→to→dependency path. depth controls traversal (default 5).\n\
-             Use before refactoring to assess risk. path can be file path or type/class name.",
+            "Change impact analysis — assess blast radius before refactoring.\n\
+             action=analyze path=\"file.rs\" maps downstream dependents; action=diff compares git refs;\n\
+             action=chain traces from→to dependency paths. depth controls traversal (default 5).\n\
+             Use before any significant refactor to understand risk.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["analyze", "diff", "chain", "build", "update", "status"],
-                        "description": "Impact operation (default: analyze)"
+                        "description": "analyze|diff|chain|build|update|status"
                     },
                     "path": {
                         "type": "string",
-                        "description": "File path or type name (e.g. ArcPoint→defining file). For chain: from->to spec"
+                        "description": "File path or type name"
                     },
                     "root": {
                         "type": "string",
-                        "description": "Project root (default: .)"
+                        "description": "Project root"
                     },
                     "depth": {
                         "type": "integer",
-                        "description": "Max traversal depth (default: 5)"
+                        "description": "Max depth (default: 5)"
                     },
                     "format": {
                         "type": "string",

--- a/rust/src/tools/registered/ctx_index.rs
+++ b/rust/src/tools/registered/ctx_index.rs
@@ -17,18 +17,20 @@ impl McpTool for CtxIndexTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_index",
-            "Index orchestration. Actions: status|build|build-full.",
+            "Index orchestration — manage the code graph index.\n\
+             Actions: status (current state), build (incremental update), build-full (complete rebuild).\n\
+             Use when the graph index is stale and ctx_graph returns empty or outdated results.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["status", "build", "build-full"],
-                        "description": "Index action"
+                        "description": "status|build|build-full"
                     },
                     "project_root": {
                         "type": "string",
-                        "description": "Project root (default: session project root)"
+                        "description": "Project root"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_intent.rs
+++ b/rust/src/tools/registered/ctx_intent.rs
@@ -15,12 +15,14 @@ impl McpTool for CtxIntentTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_intent",
-            "Structured intent input (optional) — submit compact JSON or short text; server also infers intents automatically from tool calls.",
+            "Structured intent input (optional) — submit compact task goals as JSON or short text.\n\
+             Server also auto-infers intent from tool calls. Use to guide context prioritization,\n\
+             preloading, and cache optimization. query=task|JSON; project_root=scope.",
             json!({
                 "type": "object",
                 "properties": {
                     "query": { "type": "string", "description": "Compact JSON intent or short text" },
-                    "project_root": { "type": "string", "description": "Project root directory (default: .)" }
+                    "project_root": { "type": "string", "description": "Project root" }
                 },
                 "required": ["query"]
             }),

--- a/rust/src/tools/registered/ctx_knowledge.rs
+++ b/rust/src/tools/registered/ctx_knowledge.rs
@@ -17,9 +17,9 @@ impl McpTool for CtxKnowledgeTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_knowledge",
-            "Persistent memory across sessions — remember decisions, patterns, and facts.\n\
+            "Persistent memory across sessions — remember decisions, patterns, and facts for recall.\n\
              action=remember saves a fact; action=recall query='X' retrieves it.\n\
-             Use to persist architecture decisions, gotchas, and patterns for future sessions.\n\
+             Use to persist architecture decisions, gotchas, and patterns between sessions.\n\
              action=gotcha trigger='X' resolution='Y' for known pitfalls.\n\
              mode=semantic|exact for recall. category groups related facts.",
             json!({
@@ -36,11 +36,11 @@ impl McpTool for CtxKnowledgeTool {
                     "key": { "type": "string" },
                     "value": { "type": "string" },
                     "query": { "type": "string", "description": "Query for recall/search/relate" },
-                    "mode": { "type": "string", "description": "Recall mode: auto|exact|semantic|hybrid" },
-                    "as_of": { "type": "string", "description": "Recall facts valid at this date (YYYY-MM-DD)" },
+                    "mode": { "type": "string", "description": "auto|exact|semantic|hybrid" },
+                    "as_of": { "type": "string", "description": "YYYY-MM-DD date filter" },
                     "pattern_type": { "type": "string" },
                     "examples": { "type": "array", "items": { "type": "string" } },
-                    "confidence": { "type": "number", "description": "0.0-1.0 (default 0.8)" }
+                    "confidence": { "type": "number", "description": "0.0-1.0" }
                 },
                 "required": ["action"]
             }),

--- a/rust/src/tools/registered/ctx_ledger.rs
+++ b/rust/src/tools/registered/ctx_ledger.rs
@@ -19,18 +19,21 @@ impl McpTool for CtxLedgerTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_ledger",
-            "Context ledger ops: status|reset|evict. Manages persistent context pressure.",
+            "Context ledger operations — track and manage persistent context pressure.\n\
+             action=status shows pressure (%), top files by cost, and recommendations;\n\
+             action=reset clears all entries; action=evict targets=paths removes files\n\
+             and excludes them from re-accumulation. Use when context budget is tight.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["status", "reset", "evict"],
-                        "description": "Ledger operation: status (show pressure), reset (clear all), evict (remove specific files)"
+                        "description": "status|reset|evict"
                     },
                     "targets": {
                         "type": "string",
-                        "description": "Comma-separated file paths to evict (required for 'evict' action)"
+                        "description": "Paths to evict (comma-separated)"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_load_tools.rs
+++ b/rust/src/tools/registered/ctx_load_tools.rs
@@ -16,18 +16,21 @@ impl McpTool for CtxLoadToolsTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_load_tools",
-            "Load/unload specialized tool categories on demand. Categories: arch, debug, memory, metrics, session. Core is always loaded.",
+            "Load/unload specialized tool categories on demand to reduce tool surface area.\n\
+             action=load|unload|list. Categories: arch, debug, memory, metrics, session.\n\
+             Core is always loaded and cannot be unloaded. Use when you only need\n\
+             a subset of tools for your current task.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["load", "unload", "list"],
-                        "description": "load = activate category, unload = deactivate, list = show status"
+                        "description": "load|unload|list"
                     },
                     "category": {
                         "type": "string",
-                        "description": "Category name: arch|debug|memory|metrics|session"
+                        "description": "arch|debug|memory|metrics|session"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_metrics.rs
+++ b/rust/src/tools/registered/ctx_metrics.rs
@@ -15,7 +15,10 @@ impl McpTool for CtxMetricsTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_metrics",
-            "Session token stats, cache rates, per-tool savings.",
+            "Session token statistics — cache hit rates, per-tool savings, pipeline metrics,\n\
+             and signature backend ratios. No parameters needed. Use to understand token\n\
+             efficiency and identify which tools cost the most. Complements ctx_radar\n\
+             for full context budget analysis.",
             json!({
                 "type": "object",
                 "properties": {}

--- a/rust/src/tools/registered/ctx_multi_read.rs
+++ b/rust/src/tools/registered/ctx_multi_read.rs
@@ -35,11 +35,11 @@ impl McpTool for CtxMultiReadTool {
                     "mode": {
                         "type": "string",
                         "default": "auto",
-                        "description": "Same as ctx_read modes (default auto). full→edit; raw→zero-overhead. Omit for optimal per-file"
+                        "description": "auto|full|raw|signatures|map (same as ctx_read)"
                     },
                     "fresh": {
                         "type": "boolean",
-                        "description": "Bypass cache, full re-read all. Use in subagents with stale parent cache"
+                        "description": "Bypass cache, full re-read"
                     }
                 },
                 "required": ["paths"]

--- a/rust/src/tools/registered/ctx_multi_repo.rs
+++ b/rust/src/tools/registered/ctx_multi_repo.rs
@@ -17,22 +17,25 @@ impl McpTool for CtxMultiRepoTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_multi_repo",
-            "Multi-repo management: add/remove roots, cross-repo search with Reciprocal Rank Fusion (RRF). Enables searching across multiple project directories simultaneously.",
+            "Multi-repository management — add, remove, and search across project directories.\n\
+             action=add_root|remove_root|list_roots|search. Cross-repo search uses Reciprocal\n\
+             Rank Fusion (RRF) to merge results from multiple repos. query=search term;\n\
+             roots=filter to specific repos. max_results limits output (default 20).",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["add_root", "remove_root", "list_roots", "search", "status", "save_config"],
-                        "description": "Action to perform"
+                        "description": "add_root|remove_root|list_roots|search|status|save_config"
                     },
                     "path": {
                         "type": "string",
-                        "description": "Repository path (for add_root/remove_root)"
+                        "description": "Repo path"
                     },
                     "alias": {
                         "type": "string",
-                        "description": "Short alias for the repo (for add_root). Auto-derived from directory name if omitted."
+                        "description": "Short alias (auto-derived if omitted)"
                     },
                     "query": {
                         "type": "string",
@@ -41,11 +44,11 @@ impl McpTool for CtxMultiRepoTool {
                     "roots": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Filter search to specific roots by alias or path (for search). Omit to search all."
+                        "description": "Filter to specific repos by alias/path"
                     },
                     "max_results": {
                         "type": "integer",
-                        "description": "Maximum results to return (default: 20)"
+                        "description": "Max results"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_outline.rs
+++ b/rust/src/tools/registered/ctx_outline.rs
@@ -15,13 +15,14 @@ impl McpTool for CtxOutlineTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_outline",
-            "File symbols: path='file.rs'->signatures; kind=fn|struct|class|all filter\n\
-             Lists all named symbols in a file with signatures and line numbers.\n\
-             Generated via tree-sitter extraction of fn/struct/class/trait declarations.",
+            "List file symbols with signatures and line numbers — path='file.rs' returns fn, struct,\n\
+             class, and trait declarations via tree-sitter extraction. kind=fn|struct|class|all\n\
+             to filter. Use for a quick API overview of a file. For deeper understanding,\n\
+             use ctx_compose. For full file content, use ctx_read.",
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "File path" },
+                    "path": { "type": "string", "description": "Path" },
                     "kind": { "type": "string", "description": "fn|struct|class|all filter" }
                 },
                 "required": ["path"]

--- a/rust/src/tools/registered/ctx_overview.rs
+++ b/rust/src/tools/registered/ctx_overview.rs
@@ -28,7 +28,7 @@ impl McpTool for CtxOverviewTool {
                     },
                     "path": {
                         "type": "string",
-                        "description": "Project root directory (default: .)"
+                        "description": "Project root"
                     }
                 }
             }),

--- a/rust/src/tools/registered/ctx_pack.rs
+++ b/rust/src/tools/registered/ctx_pack.rs
@@ -17,7 +17,10 @@ impl McpTool for CtxPackTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_pack",
-            "Context Package Manager. Actions: pr (PR context), create (build package from project), list, info, remove, install, export, import, auto_load, summary.",
+            "Context Package Manager — create, install, and manage portable context packages.\n\
+             Actions: pr (PR context), create (build from project), list, info, remove,\n\
+             install, export, import, auto_load, summary. Use to bundle and share context\n\
+             state including knowledge, graph, session patterns, and gotchas.",
             json!({
                 "type": "object",
                 "properties": {
@@ -28,15 +31,15 @@ impl McpTool for CtxPackTool {
                     },
                     "project_root": {
                         "type": "string",
-                        "description": "Project root (default: session project root)"
+                        "description": "Project root"
                     },
                     "name": {
                         "type": "string",
-                        "description": "Package name (required for create, info, remove, install, export, auto_load)"
+                        "description": "Package name"
                     },
                     "version": {
                         "type": "string",
-                        "description": "Package version (default: latest or '1.0.0' for create)"
+                        "description": "Package version"
                     },
                     "description": {
                         "type": "string",
@@ -54,24 +57,24 @@ impl McpTool for CtxPackTool {
                     "layers": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Layers to include: knowledge, graph, session, patterns, gotchas (for create)"
+                        "description": "knowledge|graph|session|patterns|gotchas"
                     },
                     "level": {
                         "type": "integer",
-                        "description": "Conformance level 1-3 (for create, default: 1)"
+                        "description": "1-3"
                     },
                     "scope": {
                         "type": "string",
-                        "description": "Package scope like @org (for create)"
+                        "description": "@org style scope"
                     },
                     "base": {
                         "type": "string",
-                        "description": "Git base ref (for pr action, default: auto-detect)"
+                        "description": "Git base ref"
                     },
                     "format": {
                         "type": "string",
                         "enum": ["markdown", "json"],
-                        "description": "Output format (for pr action, default: markdown)"
+                        "description": "markdown|json"
                     },
                     "depth": {
                         "type": "integer",
@@ -79,7 +82,7 @@ impl McpTool for CtxPackTool {
                     },
                     "diff": {
                         "type": "string",
-                        "description": "Git diff --name-status text (for pr action; if omitted, computed via git)"
+                        "description": "Git diff --name-status text"
                     },
                     "file": {
                         "type": "string",
@@ -87,11 +90,11 @@ impl McpTool for CtxPackTool {
                     },
                     "apply": {
                         "type": "boolean",
-                        "description": "Apply package after import (for import action, default: false)"
+                        "description": "Apply after import"
                     },
                     "enable": {
                         "type": "boolean",
-                        "description": "Enable or disable auto-load (for auto_load action, default: true)"
+                        "description": "Enable auto-load"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_package.rs
+++ b/rust/src/tools/registered/ctx_package.rs
@@ -15,22 +15,25 @@ impl McpTool for CtxPackageTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_package",
-            "Save or resume portable context packages — self-contained JSON bundles with session state, summaries, and knowledge. Use to hand off context between agents, persist session snapshots for later, or onboard a new agent into a previous session's context. Actions: save (export current session), resume (import from a package file), list (show saved packages), info (inspect a package without importing).",
+            "Save or resume portable context packages — self-contained JSON bundles with session\n\
+             state, summaries, and knowledge. Use to hand off context between agents, persist\n\
+             session snapshots for later, or onboard a new agent into a previous session.\n\
+             Actions: save (export), resume (import), list, info (inspect without importing).",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["save", "resume", "list", "info"],
-                        "description": "Package action (default: save)"
+                        "description": "save|resume|list|info"
                     },
                     "path": {
                         "type": "string",
-                        "description": "File path for resume/info, or custom output path for save"
+                        "description": "File path"
                     },
                     "description": {
                         "type": "string",
-                        "description": "Human-readable description for the saved package"
+                        "description": "Package description"
                     }
                 },
                 "required": []

--- a/rust/src/tools/registered/ctx_plan.rs
+++ b/rust/src/tools/registered/ctx_plan.rs
@@ -15,7 +15,10 @@ impl McpTool for CtxPlanTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_plan",
-            "Context planning (CFT). Computes optimal context plan with Phi scoring, budget allocation, and policy-driven view selection.",
+            "Context planning (CFT) — selects WHICH files/modules to include in context via Phi scoring, budget\n\
+             allocation, and policy-driven view selection. Scans the project to pick the most relevant content.\n\
+             task=description (short English), budget=token limit (default 12000), profile=ultra_lean|balanced|forensic.\n\
+             For compressing already-chosen files to fit a budget, use ctx_fill instead.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_plugins.rs
+++ b/rust/src/tools/registered/ctx_plugins.rs
@@ -15,7 +15,10 @@ impl McpTool for CtxPluginsTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_plugins",
-            "Plugin management. Actions: list (show installed plugins), enable (activate a plugin), disable (deactivate a plugin), info (show plugin details), hooks (list available hook points).",
+            "Plugin management — list, enable, disable, and inspect plugins with their hooks.\n\
+             Actions: list (show installed), enable (activate), disable (deactivate),\n\
+             info (show details), hooks (list available hook points). name=plugin_name\n\
+             required for enable, disable, info. Use to extend tool functionality.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_prefetch.rs
+++ b/rust/src/tools/registered/ctx_prefetch.rs
@@ -17,15 +17,18 @@ impl McpTool for CtxPrefetchTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_prefetch",
-            "Predictive prefetch — prewarm cache for blast radius files (graph + task signals) within budgets.",
+            "Predictive prefetch — prewarm the cache for blast radius files using graph and\n\
+             task signals. task=description for relevance scoring; changed_files=paths to\n\
+             compute blast radius; budget_tokens=soft budget (default 3000); max_files=limit\n\
+             (default 10). Use before context-heavy operations to minimize latency.",
             json!({
                 "type": "object",
                 "properties": {
-                    "root": { "type": "string", "description": "Project root (default: .)" },
-                    "task": { "type": "string", "description": "Optional task (short English preferred) for relevance scoring" },
-                    "changed_files": { "type": "array", "items": { "type": "string" }, "description": "Optional changed files (paths) to compute blast radius" },
-                    "budget_tokens": { "type": "integer", "description": "Soft budget hint for mode selection (default: 3000)" },
-                    "max_files": { "type": "integer", "description": "Max files to prefetch (default: 10)" }
+                    "root": { "type": "string", "description": "Project root" },
+                    "task": { "type": "string", "description": "Task for relevance scoring" },
+                    "changed_files": { "type": "array", "items": { "type": "string" }, "description": "Changed files for blast radius" },
+                    "budget_tokens": { "type": "integer", "description": "Soft budget hint" },
+                    "max_files": { "type": "integer", "description": "Max files to prefetch" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_preload.rs
+++ b/rust/src/tools/registered/ctx_preload.rs
@@ -15,17 +15,20 @@ impl McpTool for CtxPreloadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_preload",
-            "Proactive context loader — caches task-relevant files, returns L-curve-optimized summary (~50-100 tokens vs ~5000 for individual reads).",
+            "Proactive context loader — caches task-relevant files and returns L-curve-optimized\n\
+             summary (~50-100 tokens vs ~5000 for individual reads). task=short description;\n\
+             path=project root. Use at session start or when switching tasks to efficiently\n\
+             warm the context cache with the most relevant files.",
             json!({
                 "type": "object",
                 "properties": {
                     "task": {
                         "type": "string",
-                        "description": "Task description, short English preferred (e.g. 'fix auth bug in validate_token')"
+                        "description": "Task description (short English)"
                     },
                     "path": {
                         "type": "string",
-                        "description": "Project root (default: .)"
+                        "description": "Project root"
                     }
                 },
                 "required": ["task"]

--- a/rust/src/tools/registered/ctx_proof.rs
+++ b/rust/src/tools/registered/ctx_proof.rs
@@ -15,17 +15,20 @@ impl McpTool for CtxProofTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_proof",
-            "Export a machine-readable ContextProofV1 (Verifier + SLO + Pipeline + Provenance). Writes to .lean-ctx/proofs/ by default.",
+            "Export machine-readable ContextProofV1 with Verifier, SLO, Pipeline, and Provenance.\n\
+             Writes to .lean-ctx/proofs/ by default. action=export (required);\n\
+             format=json|summary|both; write=true|false; filename=custom path;\n\
+             max_evidence=max tool receipts (default 50). Use for audit trails.",
             json!({
                 "type": "object",
                 "properties": {
-                    "action": { "type": "string", "description": "export (required)" },
-                    "project_root": { "type": "string", "description": "Project root for proof output (default: .)" },
-                    "format": { "type": "string", "description": "json|summary|both (default: json)" },
-                    "write": { "type": "boolean", "description": "Write proof file under .lean-ctx/proofs/ (default: true)" },
+                    "action": { "type": "string", "description": "export" },
+                    "project_root": { "type": "string", "description": "Project root" },
+                    "format": { "type": "string", "description": "json|summary|both" },
+                    "write": { "type": "boolean", "description": "Write to .lean-ctx/proofs/" },
                     "filename": { "type": "string", "description": "Optional output filename" },
-                    "max_evidence": { "type": "integer", "description": "Max tool receipts to include (default: 50)" },
-                    "max_ledger_files": { "type": "integer", "description": "Max context ledger top files to include (default: 10)" }
+                    "max_evidence": { "type": "integer", "description": "Max tool receipts" },
+                    "max_ledger_files": { "type": "integer", "description": "Max ledger files" }
                 },
                 "required": ["action"]
             }),

--- a/rust/src/tools/registered/ctx_provider.rs
+++ b/rust/src/tools/registered/ctx_provider.rs
@@ -15,7 +15,10 @@ impl McpTool for CtxProviderTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_provider",
-            "External context providers (GitHub, GitLab, Jira, Postgres, MCP, custom REST).",
+            "External context providers — query data from GitHub, GitLab, Jira, Postgres, MCP\n\
+             bridges, and custom REST APIs. Actions: discover|list|status|refresh|configure|\n\
+             query|mcp_resources|gitlab_issues. provider=id (github|gitlab|jira|mcp:<name>);\n\
+             resource=issues|pull_requests. Data flows through consolidation pipeline.",
             json!({
                 "type": "object",
                 "properties": {
@@ -25,18 +28,18 @@ impl McpTool for CtxProviderTool {
                     },
                     "provider": {
                         "type": "string",
-                        "description": "Provider ID (github|gitlab|jira|mcp:<name>). Required for query"
+                        "description": "github|gitlab|jira|mcp:<name>"
                     },
                     "resource": {
                         "type": "string",
-                        "description": "query: e.g. issues, pull_requests. configure: paths|template|show"
+                        "description": "issues|pull_requests|paths|template|show"
                     },
-                    "mode": { "type": "string", "description": "query output: compact|chunks" },
+                    "mode": { "type": "string", "description": "compact|chunks" },
                     "state": { "type": "string", "description": "open|closed|merged|all" },
-                    "labels": { "type": "string", "description": "Comma-separated label filter" },
+                    "labels": { "type": "string", "description": "Comma-separated labels" },
                     "iid": { "type": "integer", "description": "Issue/MR IID" },
                     "status": { "type": "string", "description": "Pipeline status filter" },
-                    "limit": { "type": "integer", "description": "Max results (default 20)" }
+                    "limit": { "type": "integer", "description": "Max results" }
                 },
                 "required": ["action"]
             }),

--- a/rust/src/tools/registered/ctx_radar.rs
+++ b/rust/src/tools/registered/ctx_radar.rs
@@ -15,13 +15,16 @@ impl McpTool for CtxRadarTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_radar",
-            "Full context budget breakdown: system prompt, messages, tools, reads, shell — all tracked token usage.",
+            "Full context budget breakdown — system prompt, messages, tools, reads, shell,\n\
+             all tracked token usage. format=display (human-readable) or json (structured).\n\
+             Complements ctx_metrics for comprehensive budget analysis. Use when context\n\
+             window is tight and you need to identify the biggest consumers.",
             json!({
                 "type": "object",
                 "properties": {
                     "format": {
                         "type": "string",
-                        "description": "Output format: 'display' (human-readable) or 'json' (structured)",
+                        "description": "display|json",
                         "enum": ["display", "json"],
                         "default": "display"
                     }

--- a/rust/src/tools/registered/ctx_refactor.rs
+++ b/rust/src/tools/registered/ctx_refactor.rs
@@ -15,58 +15,52 @@ impl McpTool for CtxRefactorTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_refactor",
-            "LSP/IDE refactoring. action=one pipe-delimited value below. \
-             Reads (references/definition/implementations/declaration/type_hierarchy/\
-             symbols_overview/inspections) need a language server or the JetBrains \
-             backend. Symbol edits (replace/insert_before/insert_after_symbol) are \
-             name_path-addressed, IDE-first with a lossless headless fallback. Two-Phase \
-             ops (rename/move/safe_delete/inline _preview+_apply) need a JetBrains IDE \
-             (else BACKEND_REQUIRED) with a stateless plan_hash TOCTOU guard. \
-             rename/move/safe_delete block conflicts unless force=true; inline cannot be \
-             forced (→ UNSUPPORTED). reformat is Single-Phase, by name_path | path | path+line.",
+            "LSP/IDE refactoring — rename, move, safe_delete, inline, and read-only analyses\n\
+             (references, definition, implementations, type_hierarchy, inspections).\n\
+             Single-Phase edits (replace_symbol_body, reformat) work headless via name_path.\n\
+             Two-Phase ops (rename/move/safe_delete/inline _preview+_apply) need JetBrains\n\
+             IDE (else BACKEND_REQUIRED) with plan_hash TOCTOU guard. Conflicts blocked\n\
+             unless force=true. See action enum for full list of pipe-delimited values.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "description": "rename|references|definition|implementations|declaration|type_hierarchy|\
-                            symbols_overview|inspections|replace_symbol_body|insert_before_symbol|\
-                            insert_after_symbol|rename_preview|rename_apply|move_preview|move_apply|\
-                            safe_delete_preview|safe_delete_apply|inline_preview|inline_apply|reformat"
+                        "description": "rename|references|definition|implementations|declaration|type_hierarchy|symbols_overview|inspections|replace_symbol_body|insert_before_symbol|insert_after_symbol|rename_preview|rename_apply|move_preview|move_apply|safe_delete_preview|safe_delete_apply|inline_preview|inline_apply|reformat"
                     },
-                    "path": { "type": "string", "description": "File path" },
-                    "line": { "type": "integer", "description": "1-indexed line number" },
-                    "column": { "type": "integer", "description": "0-indexed character offset" },
-                    "new_name": { "type": "string", "description": "New name (only for rename action)" },
+                    "path": { "type": "string", "description": "Path" },
+                    "line": { "type": "integer", "description": "1-indexed line" },
+                    "column": { "type": "integer", "description": "0-indexed column" },
+                    "new_name": { "type": "string", "description": "New symbol name" },
                     "scope": {
                         "type": "string",
                         "enum": ["project", "all"],
-                        "description": "Search scope for references/implementations/type_hierarchy (JetBrains backend). 'project' = project sources only (default); 'all' = include libraries/SDK."
+                        "description": "project|all"
                     },
                     "direction": {
                         "type": "string",
                         "enum": ["supertypes", "subtypes"],
-                        "description": "type_hierarchy direction (JetBrains backend). 'supertypes' (default) = parents; 'subtypes' = children/implementors."
+                        "description": "supertypes|subtypes"
                     },
                     "mode": {
                         "type": "string",
                         "enum": ["run", "list"],
-                        "description": "inspections mode (JetBrains backend). 'run' (default) = diagnostics for the given file; 'list' = enabled inspections of the current project profile."
+                        "description": "run|list"
                     },
-                    "name_path": { "type": "string", "description": "Symbol path for body edits: 'Class/method' (qualified) or bare 'name'. Resolved via the symbol index; ambiguous → AMBIGUOUS_SYMBOL with candidates." },
-                    "new_body": { "type": "string", "description": "Full replacement declaration text (replace_symbol_body)." },
-                    "text": { "type": "string", "description": "Sibling text to insert (insert_before_symbol/insert_after_symbol); indentation is applied automatically." },
-                    "end_line": { "type": "integer", "description": "1-based last line of the symbol (only for the path+line fallback when name_path is omitted)." },
-                    "expected_hash": { "type": "string", "description": "Optional BLAKE3-hex of the current range content; mismatch → CONFLICT (no blind overwrite)." },
-                    "plan_hash": { "type": "string", "description": "Required for rename_apply: the BLAKE3 plan hash returned by rename_preview (stateless TOCTOU guard; mismatch → CONFLICT)." },
-                    "force": { "type": "boolean", "description": "rename_apply only: override blocking refactoring conflicts (default false → CONFLICT when conflicts exist)." },
-                    "search_comments": { "type": "boolean", "description": "rename: also rename matches inside comments/strings (default false)." },
-                    "search_text_occurrences": { "type": "boolean", "description": "rename: also rename non-code text occurrences (default false)." },
-                    "target_path": { "type": "string", "description": "move only: destination directory/file (project-relative). Set EXACTLY ONE of target_path/target_parent. Out-of-jail or both/neither set → INVALID_TARGET." },
-                    "target_parent": { "type": "string", "description": "move only: destination parent symbol (name_path, e.g. 'OtherClass') for a member move. Set EXACTLY ONE of target_path/target_parent." },
-                    "propagate": { "type": "boolean", "description": "safe_delete_apply only: also delete dependencies that become unreferenced (Serena 'propagate', default false)." },
-                    "keep_definition": { "type": "boolean", "description": "inline only: inline at all call sites but keep the declaration (default false)." },
-                    "optimize_imports": { "type": "boolean", "description": "reformat only: also remove unused imports (default false)." }
+                    "name_path": { "type": "string", "description": "Symbol path for body edits (qualified or bare)" },
+                    "new_body": { "type": "string", "description": "Full replacement declaration text" },
+                    "text": { "type": "string", "description": "Sibling text to insert (auto-indented)" },
+                    "end_line": { "type": "integer", "description": "1-based last line (path+line fallback)" },
+                    "expected_hash": { "type": "string", "description": "BLAKE3 hex of current range (TOCTOU guard)" },
+                    "plan_hash": { "type": "string", "description": "BLAKE3 plan hash from rename_preview" },
+                    "force": { "type": "boolean", "description": "Override refactoring conflicts" },
+                    "search_comments": { "type": "boolean", "description": "Rename in comments/strings" },
+                    "search_text_occurrences": { "type": "boolean", "description": "Rename in non-code text" },
+                    "target_path": { "type": "string", "description": "Destination directory/file (project-relative)" },
+                    "target_parent": { "type": "string", "description": "Destination parent symbol for member move" },
+                    "propagate": { "type": "boolean", "description": "Delete unreferenced dependencies" },
+                    "keep_definition": { "type": "boolean", "description": "Keep declaration after inline" },
+                    "optimize_imports": { "type": "boolean", "description": "Remove unused imports" }
                 },
                 "required": ["action"]
             }),

--- a/rust/src/tools/registered/ctx_repomap.rs
+++ b/rust/src/tools/registered/ctx_repomap.rs
@@ -18,14 +18,14 @@ impl McpTool for CtxRepomapTool {
     fn tool_def(&self) -> rmcp::model::Tool {
         tool_def(
             "ctx_repomap",
-            "PageRank symbol map: focus_files=['path/*.rs'] boosts areas; max_tokens controls size (default 2048)\n\
-             Shows structurally important symbols ranked by PageRank and session relevance.\n\
+            "PageRank symbol map ranked by structural importance and session relevance.\n\
+             focus_files=['path/*.rs'] boosts specific areas; max_tokens controls size (default 2048).\n\
              Use for codebase-wide orientation; for task-scoped view use ctx_overview.",
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Project root (default: session)" },
-                    "max_tokens": { "type": "integer", "description": "Token budget (default 2048)", "default": 2048 },
+                    "path": { "type": "string", "description": "Project root" },
+                    "max_tokens": { "type": "integer", "description": "Token budget", "default": 2048 },
                     "focus_files": {
                         "type": "array",
                         "items": { "type": "string" },

--- a/rust/src/tools/registered/ctx_response.rs
+++ b/rust/src/tools/registered/ctx_response.rs
@@ -15,7 +15,9 @@ impl McpTool for CtxResponseTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_response",
-            "Compress LLM response text (structural de-duplication).",
+            "Compress LLM response text via structural de-duplication.\n\
+             Pass response text to remove repetitive patterns while preserving key information.\n\
+             Use to reduce token waste before storing or forwarding responses.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_retrieve.rs
+++ b/rust/src/tools/registered/ctx_retrieve.rs
@@ -15,18 +15,20 @@ impl McpTool for CtxRetrieveTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_retrieve",
-            "Retrieve original uncompressed content from the session cache (CCR). \
-             Use when a compressed ctx_read output is insufficient.",
+            "Retrieve original uncompressed content from the session cache (CCR).\n\
+             Use when a compressed ctx_read output is insufficient — restores full verbatim source.\n\
+             Supports query='search' to find matching lines within cached content.\n\
+             Requires path to a file previously read via ctx_read.",
             json!({
                 "type": "object",
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "File path whose original content to retrieve"
+                        "description": "Target path"
                     },
                     "query": {
                         "type": "string",
-                        "description": "Optional: search within cached content"
+                        "description": "Search within cached content"
                     }
                 },
                 "required": ["path"]

--- a/rust/src/tools/registered/ctx_review.rs
+++ b/rust/src/tools/registered/ctx_review.rs
@@ -15,23 +15,24 @@ impl McpTool for CtxReviewTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_review",
-            "Automated code review: combines impact analysis, caller tracking, and test discovery. \
-             Actions: review (single file), diff-review (from git diff), checklist (structured review questions).",
+            "Automated code review with impact analysis, caller tracking, and test discovery.\n\
+             Actions: review (single file), diff-review (from git diff),\n\
+             checklist (structured review questions). depth=N controls analysis breadth (default 3).",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["review", "diff-review", "checklist"],
-                        "description": "Review action"
+                        "description": "review|diff-review|checklist"
                     },
                     "path": {
                         "type": "string",
-                        "description": "File path to review (or git diff text for diff-review)"
+                        "description": "File path or git diff text"
                     },
                     "depth": {
                         "type": "integer",
-                        "description": "Impact analysis depth (default: 3)"
+                        "description": "Analysis depth"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_routes.rs
+++ b/rust/src/tools/registered/ctx_routes.rs
@@ -15,13 +15,13 @@ impl McpTool for CtxRoutesTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_routes",
-            "HTTP routes: method=GET|POST filter; path='/api' prefix; auto-detects frameworks\n\
-             Extracts endpoints from: Express, Flask, FastAPI, Actix, Spring, Rails, Next.js.\n\
-             Use to discover API surface without reading route definition files.",
+            "Discover HTTP API endpoints without reading route definition files.\n\
+             Auto-detects: Express, Flask, FastAPI, Actix, Spring, Rails, Next.js.\n\
+             method=GET|POST filters by verb; path='/api' filters by prefix.",
             json!({
                 "type": "object",
                 "properties": {
-                    "method": { "type": "string", "description": "GET|POST|PUT|DELETE filter" },
+                    "method": { "type": "string", "description": "GET|POST|PUT|DELETE" },
                     "path": { "type": "string", "description": "Path prefix, e.g. /api/users" }
                 }
             }),

--- a/rust/src/tools/registered/ctx_rules.rs
+++ b/rust/src/tools/registered/ctx_rules.rs
@@ -15,18 +15,20 @@ impl McpTool for CtxRulesTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_rules",
-            "Cross-agent rules governance (ContextOps). Actions: sync (distribute rules to agents), diff (show drift), lint (check consistency), status (show sync state), init (create central config).",
+            "Cross-agent rules governance (ContextOps).\n\
+             Actions: sync (distribute rules to agents), diff (show drift),\n\
+             lint (check consistency), status (sync state), init (create central config).",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["sync", "diff", "lint", "status", "init"],
-                        "description": "Rules action to perform"
+                        "description": "sync|diff|lint|status|init"
                     },
                     "agent": {
                         "type": "string",
-                        "description": "Target agent name (for sync action only, e.g. 'cursor', 'claude')"
+                        "description": "Target agent name (for sync)"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_search.rs
+++ b/rust/src/tools/registered/ctx_search.rs
@@ -30,7 +30,7 @@ impl McpTool for CtxSearchTool {
                         "description": "Multi-root (alternative to path)"
                     },
                     "include": { "type": "string", "description": "Glob filter: *.ts, src/**/*.rs" },
-                    "max_results": { "type": "integer", "description": "Default 20" },
+                    "max_results": { "type": "integer", "description": "Result limit" },
                     "ignore_gitignore": { "type": "boolean", "description": "Scan gitignored (needs role)" }
                 },
                 "required": ["pattern"]

--- a/rust/src/tools/registered/ctx_semantic_search.rs
+++ b/rust/src/tools/registered/ctx_semantic_search.rs
@@ -26,24 +26,24 @@ impl McpTool for CtxSemanticSearchTool {
                 "type": "object",
                 "properties": {
                     "query": { "type": "string", "description": "Natural language or symbol query" },
-                    "path": { "type": "string", "description": "Project root (default: .)" },
-                    "top_k": { "type": "integer", "description": "Result count (default 10)" },
+                    "path": { "type": "string", "description": "Project root" },
+                    "top_k": { "type": "integer", "description": "Result count" },
                     "action": {
                         "type": "string",
                         "enum": ["search", "reindex", "find_related"],
-                        "description": "search (default)|reindex|find_related"
+                        "description": "search|reindex|find_related"
                     },
                     "mode": {
                         "type": "string",
                         "enum": ["bm25", "dense", "hybrid"],
-                        "description": "bm25|dense|hybrid (default hybrid)"
+                        "description": "bm25|dense|hybrid"
                     },
-                    "file_path": { "type": "string", "description": "Source file for find_related (rel)" },
+                    "file_path": { "type": "string", "description": "Source file for find_related" },
                     "line": { "type": "integer", "description": "Line for find_related" },
                     "languages": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Restrict to exts: ['rust','ts']"
+                        "description": "Restrict to extensions"
                     },
                     "path_glob": { "type": "string", "description": "Glob over rel paths" }
                 },

--- a/rust/src/tools/registered/ctx_session.rs
+++ b/rust/src/tools/registered/ctx_session.rs
@@ -15,9 +15,10 @@ impl McpTool for CtxSessionTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_session",
-            "Cross-session memory: action=task/finding/decision persists; load session_id=X resumes\n\
-             Use at session end to persist progress; at start to restore previous work.\n\
-             action=status for current snapshot; action=save commits state; action=reset clears.",
+            "Cross-session memory: action=task|finding|decision persists progress;\n\
+             load session_id=X resumes prior work. Use at session end to persist;\n\
+             at start to restore. action=status for snapshot; action=save commits state;\n\
+             action=reset clears. Supports profile|role|budget|slo|diff|verify|episodes|procedures.",
             json!({
                 "type": "object",
                 "properties": {
@@ -26,7 +27,7 @@ impl McpTool for CtxSessionTool {
                         "description": "status|load|save|task|finding|decision|reset|list|cleanup|snapshot|restore|resume|profile|role|budget|slo|diff|verify|episodes|procedures"
                     },
                     "value": { "type": "string", "description": "Value for task/finding/decision actions" },
-                    "session_id": { "type": "string", "description": "Session ID to load (omitting loads latest)" }
+                    "session_id": { "type": "string", "description": "Session ID (omit for latest)" }
                 },
                 "required": ["action"]
             }),

--- a/rust/src/tools/registered/ctx_share.rs
+++ b/rust/src/tools/registered/ctx_share.rs
@@ -15,27 +15,30 @@ impl McpTool for CtxShareTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_share",
-            "Share cached file contexts between agents. Actions: push (share files from your cache to another agent), \
-pull (receive files shared by other agents), list (show all shared contexts), clear (remove your shared contexts).",
+            "Share cached file contexts between agents for collaborative workflows.\n\
+             Actions: push (share files from your cache to another agent),\n\
+             pull (receive files shared by others), list (show shared contexts),\n\
+             clear (remove your shares). Omit to_agent for broadcast;\n\
+             set to_agent='agent-id' for targeted sharing.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["push", "pull", "list", "clear"],
-                        "description": "Share operation to perform"
+                        "description": "push|pull|list|clear"
                     },
                     "paths": {
                         "type": "string",
-                        "description": "Comma-separated file paths to share (for push action)"
+                        "description": "Comma-separated paths (for push)"
                     },
                     "to_agent": {
                         "type": "string",
-                        "description": "Target agent ID (omit for broadcast to all agents)"
+                        "description": "Target agent ID (omit for broadcast)"
                     },
                     "message": {
                         "type": "string",
-                        "description": "Optional context message explaining what was shared"
+                        "description": "Context message about what was shared"
                     }
                 },
                 "required": ["action"]

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -26,7 +26,7 @@ impl McpTool for CtxShellTool {
                 "properties": {
                     "command": { "type": "string", "description": "Shell command" },
                     "raw": { "type": "boolean", "description": "Skip compression (verbatim)" },
-                    "cwd": { "type": "string", "description": "Working dir (default: last cd or project root)" },
+                    "cwd": { "type": "string", "description": "Working dir" },
                     "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } }
                 },
                 "required": ["command"]

--- a/rust/src/tools/registered/ctx_skillify.rs
+++ b/rust/src/tools/registered/ctx_skillify.rs
@@ -15,18 +15,22 @@ impl McpTool for CtxSkillifyTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_skillify",
-            "Codify recurring patterns from this project's session diary + knowledge into versioned, git-committable .cursor/rules/skillify-*.mdc files. Actions: mine (distill & write/merge rules), list (show generated rules), status (config + counts), promote (copy a project rule to ~/.cursor/rules). Precision-biased; only acts when invoked; re-runs are idempotent.",
+            "Codify recurring patterns from session diary + knowledge into versioned,\n\
+             git-committable .cursor/rules/skillify-*.mdc files.\n\
+             Actions: mine (distill & write/merge rules), list (show generated rules),\n\
+             status (config + counts), promote (copy to ~/.cursor/rules).\n\
+             Precision-biased; re-runs are idempotent.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["mine", "list", "status", "promote"],
-                        "description": "Skillify action (default: mine)"
+                        "description": "mine|list|status|promote"
                     },
                     "slug": {
                         "type": "string",
-                        "description": "Rule slug for the promote action (e.g. skillify-stop-before-build)"
+                        "description": "Rule slug (for promote)"
                     }
                 }
             }),

--- a/rust/src/tools/registered/ctx_smart_read.rs
+++ b/rust/src/tools/registered/ctx_smart_read.rs
@@ -15,11 +15,13 @@ impl McpTool for CtxSmartReadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_smart_read",
-            "Auto-select optimal read mode for a file.",
+            "Auto-select optimal read mode (full|map|signatures|auto) based on file size,\n\
+             type, and compression history. Use when you want smart defaults without\n\
+             choosing a mode. For explicit control use ctx_read with mode= parameter directly.",
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Absolute file path to read" }
+                    "path": { "type": "string", "description": "File path" }
                 },
                 "required": ["path"]
             }),

--- a/rust/src/tools/registered/ctx_smells.rs
+++ b/rust/src/tools/registered/ctx_smells.rs
@@ -15,14 +15,17 @@ impl McpTool for CtxSmellsTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_smells",
-            "Code smell detection. Actions: scan|summary|rules|file.",
+            "Code smell detection engine.\n\
+             Actions: scan (run all rules on project), summary (aggregate counts),\n\
+             rules (list available rules with descriptions), file (scan a single file).\n\
+             Supports rule='name' and path='file' filters for targeted analysis.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["scan", "summary", "rules", "file"],
-                        "description": "Smell operation (default: summary)"
+                        "description": "scan|summary|rules|file"
                     },
                     "rule": {
                         "type": "string",
@@ -34,7 +37,7 @@ impl McpTool for CtxSmellsTool {
                     },
                     "root": {
                         "type": "string",
-                        "description": "Project root (default: .)"
+                        "description": "Project root"
                     },
                     "format": {
                         "type": "string",

--- a/rust/src/tools/registered/ctx_summary.rs
+++ b/rust/src/tools/registered/ctx_summary.rs
@@ -15,22 +15,26 @@ impl McpTool for CtxSummaryTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_summary",
-            "Record and recall AI session summaries — compact, semantically-recallable digests of what was done (task, files, decisions, next steps). Actions: recall (find past summaries by query; semantic when embeddings are warm, else lexical), record (snapshot the current session now), list (recent summaries). Summaries are also captured automatically on the checkpoint cadence.",
+            "Record and recall AI session summaries — compact, semantically-recallable\n\
+             digests of what was done (task, files, decisions, next steps).\n\
+             Actions: recall (find past summaries by query), record (snapshot session),\n\
+             list (recent summaries). Auto-captured on checkpoint cadence.\n\
+             Use with ctx_session for cross-session continuity.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["recall", "record", "list"],
-                        "description": "Summary action (default: recall)"
+                        "description": "recall|record|list"
                     },
                     "query": {
                         "type": "string",
-                        "description": "Recall query, e.g. \"what did I change in the graph index?\""
+                        "description": "Recall query, e.g. \"what did I change?\""
                     },
                     "top_k": {
                         "type": "integer",
-                        "description": "Max summaries to return for recall (default 5, max 20)"
+                        "description": "Max summaries to return"
                     }
                 }
             }),

--- a/rust/src/tools/registered/ctx_task.rs
+++ b/rust/src/tools/registered/ctx_task.rs
@@ -15,20 +15,23 @@ impl McpTool for CtxTaskTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_task",
-            "Multi-agent task orchestration. Actions: create|update|list|get|cancel|message|info.",
+            "Multi-agent task orchestration.\n\
+             Actions: create (assign to agent), update (change state), list (active),\n\
+             get (details), cancel, message (add note), info (metadata).\n\
+             States: working|input-required|completed|failed|canceled.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["create", "update", "list", "get", "cancel", "message", "info"],
-                        "description": "Task operation"
+                        "description": "create|update|list|get|cancel|message|info"
                     },
-                    "task_id": { "type": "string", "description": "Task ID (required for update|get|cancel|message)" },
-                    "to_agent": { "type": "string", "description": "Target agent ID (required for create)" },
+                    "task_id": { "type": "string", "description": "Task ID (for update|get|cancel|message)" },
+                    "to_agent": { "type": "string", "description": "Target agent ID (for create)" },
                     "description": { "type": "string", "description": "Task description (for create)" },
-                    "state": { "type": "string", "description": "New state for update (working|input-required|completed|failed|canceled)" },
-                    "message": { "type": "string", "description": "Optional message / reason" }
+                    "state": { "type": "string", "description": "New state (working|input-required|completed|failed|canceled)" },
+                    "message": { "type": "string", "description": "Message or reason" }
                 },
                 "required": ["action"]
             }),

--- a/rust/src/tools/registered/ctx_tools.rs
+++ b/rust/src/tools/registered/ctx_tools.rs
@@ -19,19 +19,21 @@ impl McpTool for CtxToolsTool {
         tool_def(
             "ctx_tools",
             "Gateway to downstream MCP servers — unlimited external tools at ~constant context cost.\n\
-             actions: find (query → top-N relevant tools as ChoiceCards) | call (proxy a `server::tool`) | list (servers+counts) | refresh.\n\
-             Use find to discover, then call the chosen `server::tool`. Off by default ([gateway] config).",
+             actions: find (query → top-N relevant tools as ChoiceCards) |\n\
+             call (proxy a server::tool) | list (servers+counts) | refresh.\n\
+             Use find to discover, then call the chosen server::tool.\n\
+             Off by default — enable via [gateway] config section.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["find", "call", "list", "refresh"],
-                        "description": "Operation to perform (default: find)"
+                        "description": "find|call|list|refresh"
                     },
-                    "query": { "type": "string", "description": "What you want to do; ranks the catalog (find)" },
-                    "tool": { "type": "string", "description": "A `server::tool` handle from find (call)" },
-                    "arguments": { "type": "object", "description": "Arguments forwarded verbatim to the downstream tool (call)" }
+                    "query": { "type": "string", "description": "What you want to do (for find)" },
+                    "tool": { "type": "string", "description": "`server::tool` handle (for call)" },
+                    "arguments": { "type": "object", "description": "Arguments for downstream tool (call)" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_transcript_compact.rs
+++ b/rust/src/tools/registered/ctx_transcript_compact.rs
@@ -20,26 +20,30 @@ impl McpTool for CtxTranscriptCompactTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_transcript_compact",
-            "Compact an OpenAI-format message array deterministically: keep system + a fresh tail verbatim, replace older turns with a recoverable summary, and offload the raw turns into lean-ctx session memory (indexed for ctx_search/ctx_knowledge recall). Built for the Hermes context-engine plugin. Returns JSON {messages, stats}; tool_call/tool_result pairs are never split.",
+            "Compact an OpenAI-format message array deterministically:\n\
+             keep system + fresh tail verbatim, replace older turns with a recoverable\n\
+             summary, offload raw turns into session memory (indexed for recall).\n\
+             Built for the Hermes context-engine plugin. Returns JSON {messages, stats}.\n\
+             tool_call/tool_result pairs are never split.",
             json!({
                 "type": "object",
                 "properties": {
                     "messages": {
                         "type": "array",
                         "items": { "type": "object" },
-                        "description": "OpenAI-format message array to compact"
+                        "description": "OpenAI message array to compact"
                     },
                     "fresh_tail_tokens": {
                         "type": "integer",
-                        "description": "Recent tokens to keep verbatim (default 4000)"
+                        "description": "Recent tokens to keep verbatim"
                     },
                     "protect_min_messages": {
                         "type": "integer",
-                        "description": "Minimum recent messages to keep verbatim (default 6)"
+                        "description": "Minimum recent messages to keep"
                     },
                     "focus_topic": {
                         "type": "string",
-                        "description": "Optional topic to prioritise in the summary"
+                        "description": "Topic to prioritise in summary"
                     }
                 },
                 "required": ["messages"]

--- a/rust/src/tools/registered/ctx_tree.rs
+++ b/rust/src/tools/registered/ctx_tree.rs
@@ -17,19 +17,20 @@ impl McpTool for CtxTreeTool {
             "ctx_tree",
             "Directory tree with file counts per directory. depth=N (default 3);\n\
              show_hidden for dotfiles; paths for multi-root.\n\
-             respect_gitignore filters ignored files (default true).",
+             respect_gitignore filters ignored files (default true).\n\
+             Use for lightweight project orientation before ctx_repomap or ctx_compose.",
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Dir (default .)" },
+                    "path": { "type": "string", "description": "Dir" },
                     "paths": {
                         "type": "array",
                         "items": { "type": "string" },
                         "description": "Multi-root (alternative to path)"
                     },
-                    "depth": { "type": "integer", "description": "Max depth (default 3)" },
+                    "depth": { "type": "integer", "description": "Max depth" },
                     "show_hidden": { "type": "boolean", "description": "Include dotfiles" },
-                    "respect_gitignore": { "type": "boolean", "description": "Filter ignored (default true)" }
+                    "respect_gitignore": { "type": "boolean", "description": "Filter ignored" }
                 }
             }),
         )

--- a/rust/src/tools/registered/ctx_url_read.rs
+++ b/rust/src/tools/registered/ctx_url_read.rs
@@ -21,9 +21,10 @@ impl McpTool for CtxUrlReadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_url_read",
-            "Fetch URL: pages→Markdown; PDF→text; YouTube→transcript; mode=auto best per type\n\
-             mode=facts|quotes for research (claims+confidence). query='topic' to focus extraction.\n\
-             GitHub blob/raw URLs auto-resolve to raw file. SSRF-guarded (no private IPs). max_tokens=6000.",
+            "Fetch URL: pages→Markdown; PDF→text; YouTube→transcript; mode=auto best per type.\n\
+             mode=facts|quotes for research (claims+confidence). query='topic' focuses extraction.\n\
+             GitHub blob/raw URLs auto-resolve to raw file. SSRF-guarded (no private IPs).\n\
+             max_tokens=6000; timeout_secs=20 (max 60).",
             json!({
                 "type": "object",
                 "properties": {
@@ -31,12 +32,12 @@ impl McpTool for CtxUrlReadTool {
                     "mode": {
                         "type": "string",
                         "enum": ["auto", "markdown", "text", "links", "facts", "quotes", "transcript"],
-                        "description": "auto|markdown|text|links|facts|quotes|transcript (default auto)"
+                        "description": "auto|markdown|text|links|facts|quotes|transcript"
                     },
-                    "query": { "type": "string", "description": "Focus query; boosts facts/quotes relevance" },
-                    "max_tokens": { "type": "integer", "description": "Token budget (default 6000)" },
-                    "max_items": { "type": "integer", "description": "Max items for facts/quotes (default 12)" },
-                    "timeout_secs": { "type": "integer", "description": "Timeout seconds (default 20, max 60)" }
+                    "query": { "type": "string", "description": "Focus query (boosts facts/quotes)" },
+                    "max_tokens": { "type": "integer", "description": "Token budget" },
+                    "max_items": { "type": "integer", "description": "Max items for facts/quotes" },
+                    "timeout_secs": { "type": "integer", "description": "Timeout in seconds" }
                 },
                 "required": ["url"]
             }),

--- a/rust/src/tools/registered/ctx_verify.rs
+++ b/rust/src/tools/registered/ctx_verify.rs
@@ -15,11 +15,13 @@ impl McpTool for CtxVerifyTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_verify",
-            "Verification observability. Actions: stats (tool call statistics), proof|v2 (ContextProofV2 claim-based verification with Lean4 proofs).",
+            "Verification observability — tool call statistics and claim-based verification.\n\
+             Actions: stats (tool call usage counts), proof|v2 (ContextProofV2 claim\n\
+             verification with Lean4 proofs). Use to audit tool usage or verify claims.",
             json!({
                 "type": "object",
                 "properties": {
-                    "action": { "type": "string", "description": "stats" },
+                    "action": { "type": "string", "description": "stats|proof|v2" },
                     "format": { "type": "string" }
                 }
             }),

--- a/rust/src/tools/registered/ctx_workflow.rs
+++ b/rust/src/tools/registered/ctx_workflow.rs
@@ -15,20 +15,24 @@ impl McpTool for CtxWorkflowTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_workflow",
-            "Workflow rails (state machine + evidence). Actions: start|status|transition|complete|evidence_add|evidence_list|stop.",
+            "Workflow rails — state machine with evidence tracking.\n\
+             Actions: start|status|transition|complete|evidence_add|evidence_list|stop.\n\
+             spec=WorkflowSpec JSON to define custom states/transitions.\n\
+             Built-in plan_code_test workflow when spec omitted.\n\
+             Use with ctx_task for multi-agent orchestration.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
                         "enum": ["start", "status", "transition", "complete", "evidence_add", "evidence_list", "stop"],
-                        "description": "Workflow operation (default: status)"
+                        "description": "start|status|transition|complete|evidence_add|evidence_list|stop"
                     },
-                    "name": { "type": "string", "description": "Optional workflow name override (action=start)" },
-                    "spec": { "type": "string", "description": "WorkflowSpec JSON (action=start). If omitted, uses builtin plan_code_test." },
-                    "to": { "type": "string", "description": "Target state (action=transition)" },
-                    "key": { "type": "string", "description": "Evidence key (action=evidence_add)" },
-                    "value": { "type": "string", "description": "Optional evidence value / transition note" }
+                    "name": { "type": "string", "description": "Workflow name (for start)" },
+                    "spec": { "type": "string", "description": "WorkflowSpec JSON (for start; omit for builtin)" },
+                    "to": { "type": "string", "description": "Target state (for transition)" },
+                    "key": { "type": "string", "description": "Evidence key (for evidence_add)" },
+                    "value": { "type": "string", "description": "Evidence value or transition note" }
                 }
             }),
         )

--- a/rust/src/tools/registered/shell_alias.rs
+++ b/rust/src/tools/registered/shell_alias.rs
@@ -26,7 +26,9 @@ impl McpTool for ShellAliasTool {
         tool_def(
             "shell",
             "Shell command with auto-compression (~95 patterns). Alias for ctx_shell.\n\
-             Output is compressed for token savings. For verbatim output pass raw=true.",
+             Output is compressed for token savings. For verbatim output pass raw=true.\n\
+             Use when your MCP client prefers shell/bash over ctx_shell — transparently\n\
+             delegates to ctx_shell internals.",
             json!({
                 "type": "object",
                 "properties": {
@@ -36,7 +38,7 @@ impl McpTool for ShellAliasTool {
                     },
                     "cwd": {
                         "type": "string",
-                        "description": "Working dir (default: project root)"
+                        "description": "Working dir"
                     }
                 },
                 "required": ["command"]

--- a/rust/tests/hn_hardening_scenarios.rs
+++ b/rust/tests/hn_hardening_scenarios.rs
@@ -435,18 +435,21 @@ mod confidence_signal {
 
     #[test]
     fn scenario_high_compression_hint_format() {
-        // Verify the hint format exists in source
+        // Verify the hint format exists in source. The local var was renamed
+        // savings_pct -> pct in the shell-fidelity refactor (42a186a65c).
         let src = include_str!("../src/tools/registered/ctx_shell.rs");
         assert!(
-            src.contains("compressed {savings_pct:.0}%: full output at"),
+            src.contains("compressed {pct:.0}%: full output at"),
             "high compression hint must use correct format"
         );
     }
 
     #[test]
     fn scenario_threshold_is_70_percent() {
-        let src = include_str!("../src/tools/registered/ctx_shell.rs");
-        assert!(src.contains("savings_pct > 70.0"), "threshold must be 70%");
+        // The 70% tee threshold now lives in the shared tee_policy (single source
+        // of truth), not inline in ctx_shell.rs (refactor 42a186a65c).
+        let src = include_str!("../src/shell/tee_policy.rs");
+        assert!(src.contains("> 70.0"), "threshold must be 70%");
     }
 }
 

--- a/rust/tests/intensive_benchmarks.rs
+++ b/rust/tests/intensive_benchmarks.rs
@@ -133,9 +133,12 @@ fn bench_tool_descriptions_token_count() {
     // Raised 3000 -> 4000 for the #496 tool-profile reorg: a material jump that
     // enriches per-tool profile metadata on the full opt-in surface. The default
     // surface stays small (see `bench_lazy_default_vs_full_overhead`).
+    // Raised 4000 -> 5200 for #505 (@omar-mohamed-khallaf): the power tier now
+    // carries the same first-line-dense, workflow-first treatment as the other
+    // tiers (actual ~4872), with headroom for a tool or two per #290.
     assert!(
-        total < 4000,
-        "Total tool description tokens should be <4000, got {total}"
+        total < 5200,
+        "Total tool description tokens should be <5200, got {total}"
     );
 
     for (name, desc) in &descriptions {

--- a/rust/tests/setup_ci_smoke.rs
+++ b/rust/tests/setup_ci_smoke.rs
@@ -341,7 +341,7 @@ fn init_agent_preserves_agents_md_and_is_idempotent() {
     let lean_ctx_content = std::fs::read_to_string(&lean_ctx_md).expect("LEAN-CTX.md exists");
     assert!(
         lean_ctx_content.contains("<!-- lean-ctx-rules -->")
-            && lean_ctx_content.contains("ctx_read modes"),
+            && lean_ctx_content.contains("Tool selection by intent"),
         "LEAN-CTX.md must contain the canonical lean-ctx ruleset"
     );
 }


### PR DESCRIPTION
Closes #505. Direct follow-up to #496.

## What changed

This PR adopts **@omar-mohamed-khallaf's own completion** of the #496 tool-profile reorg for the `power` tier, which was not part of the #506 integration. It combines his three PR #496 commits onto current `main`:

- `7b43517` refactor(tools): clean up tool descriptions and parameter docs
- `b44fcf9` chore(rules): add CRITICAL section to profiles & drop duplicated read modes
- `451b547` fix(docs): update reference docs

plus a small integration reconciliation commit (test re-anchor).

### Power-tier descriptions (`7b43517`)
Every `power` tool now carries the same **first-line-dense, workflow-first** treatment (purpose + when-to-use up front) as `minimal`/`standard`/`core`, and the JSON **parameter** docs are densified (pipe-delimited enums, no redundant prose). Removes overlap/duplication in the wording per omar's design notes (intent-first, reference related tools, force explicit choices).

### Rules cleanup (`b44fcf9`)
`rules_canonical` folds `CRITICAL` into the profile body and **drops the duplicated `READ_MODES` line** from every session (the modes already live in the `ctx_read` tool description — #579). Net token saving per session.

### Reconciliation (mine)
- `intensive_benchmarks` tool-desc budget `4000 -> 5200` (actual ~4872) per the #290 material-jump policy.
- Re-anchored the `setup_ci_smoke` LEAN-CTX.md assertion on `"Tool selection by intent"` (INTENT) since `READ_MODES` is gone.
- Regenerated `docs/reference/generated/mcp-tools.md` + website manifest.

## Acceptance criteria (#505)
- [x] Power-only descriptions follow the #496 convention (first line = purpose + when-to-use; workflow body).
- [x] No confusingly overlapping power-tool descriptions; JSON param docs densified too.
- [ ] `Output-Quality Gate (eval A/B)` stays green — verified by CI.
- [x] `cargo test`, `clippy --all-targets --all-features -D warnings`, `fmt --check` pass; `mcp-tools.md` regenerated.

## Validation (local)
- 5724 lib tests, 43 `intensive_benchmarks` (total 4872 < 5200, every tool < 160, overhead < 13000), `setup_ci_smoke`, `reference_docs_drift`, `mcp_manifest_up_to_date`, `docs_tool_counts_up_to_date`, `rules_consistency`, `contracts_frozen`, `capabilities_contract_up_to_date`, `conformance_suite`, `claude_config_dir`, `pattern_snapshots` — all green.
- `fmt` + `clippy -D warnings` clean (pre-commit hook).

Credit: @omar-mohamed-khallaf. Tool-count/duplication reduction (his second suggestion) tracked separately in #509.
