### PR TITLE
fix(ctx_read): document & honor the verbatim raw escape hatch (#513)

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -437,13 +437,14 @@ Parameters: `format`
 ## `ctx_read`
 
 Read source files. mode is REQUIRED — choose by intent:
-full=verbatim (edit-ready, use before Edit), signatures=API surface only,
-map=structural overview of large files, auto=smart (learns from task and
-session context, use for orientation), diff=git delta, lines:N-M=window.
-fresh=true bypasses cache.
+full=verbatim (edit-ready, use before Edit), raw=exact bytes (no framing),
+signatures=API surface only, map=structural overview of large files,
+auto=smart (learns from task and session context, use for orientation),
+diff=git delta, lines:N-M=window.
+fresh=true bypasses cache; raw=true=verbatim+fresh.
 For understanding code or finding answers, use ctx_compose FIRST instead.
 
-Parameters: `aggressiveness`, `fresh`, `limit`, `mode`, `offset`, `path`*, `protect`, `start_line`
+Parameters: `aggressiveness`, `fresh`, `limit`, `mode`, `offset`, `path`*, `protect`, `raw`, `start_line`
 
 ## `ctx_refactor`
 

--- a/rust/src/core/tdd_schema.rs
+++ b/rust/src/core/tdd_schema.rs
@@ -52,7 +52,7 @@ pub fn tdd_schema_value() -> Value {
                 "api": "  API:\\n    <signature>"
             },
             "file_ref_format": "F<idx>=<short-path> <line-count>L",
-            "compressed_hint": "[compressed — use mode=\"full\" for complete source]"
+            "compressed_hint": "[lean-ctx: compact view — nothing lost, full source on request]"
         },
         "stability": {
             "determinism": [

--- a/rust/src/server/tool_visibility.rs
+++ b/rust/src/server/tool_visibility.rs
@@ -307,10 +307,17 @@ mod tests {
     /// Bumped to 2275 for #451: `ctx_shell` now states it runs the system shell
     /// profile-free (no rc/profile sourced), a deliberate +~13 tok so agents stop
     /// mistaking it for a config-loaded interactive bash. Kept to one terse clause.
+    ///
+    /// Bumped to per-tool 335 / total 2310 for #513: `ctx_read` now documents the
+    /// verbatim escape hatch (`raw=true` arg + `raw` mode) so agents — especially
+    /// non-Opus models that fought the compression — discover how to get exact
+    /// bytes for review/audit instead of guessing. `ctx_read` is the richest core
+    /// tool and is the only one that crosses 300; the per-tool cap still guards
+    /// every other tool from bloat. Kept to terse clauses (+~33 tok on ctx_read).
     #[test]
     fn core_tool_surface_stays_within_budget() {
-        const PER_TOOL_BUDGET: usize = 300;
-        const TOTAL_BUDGET: usize = 2275;
+        const PER_TOOL_BUDGET: usize = 335;
+        const TOTAL_BUDGET: usize = 2310;
 
         let _guard = crate::core::data_dir::isolated_data_dir();
         let core = crate::tool_defs::core_tool_names();

--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -27,7 +27,7 @@ pub struct ReadOutput {
     pub output_tokens: usize,
 }
 
-const COMPRESSED_HINT: &str = "[compressed — use mode=\"full\" for complete source]";
+const COMPRESSED_HINT: &str = "[lean-ctx: compact view — nothing lost, full source on request]";
 
 const CACHEABLE_MODES: &[&str] = &["map", "signatures"];
 
@@ -101,7 +101,7 @@ fn append_compressed_hint(output: &str, file_path: &str) -> String {
         return output.to_string();
     }
     format!(
-        "{output}\n{COMPRESSED_HINT}\n  ctx_read(\"{file_path}\", mode=\"full\") | ctx_retrieve(\"{file_path}\")"
+        "{output}\n{COMPRESSED_HINT}\n  full: ctx_read(\"{file_path}\", mode=\"full\")  ·  exact bytes: ctx_read(\"{file_path}\", raw=true)  ·  recover: ctx_retrieve(\"{file_path}\")"
     )
 }
 
@@ -502,9 +502,10 @@ pub fn try_stub_hit_readonly(cache: &SessionCache, path: &str) -> Option<ReadOut
     } else {
         // #498 determinism: the cache-hit stub is a pure function of (content,
         // path) so identical re-reads stay byte-stable and provider prompt
-        // caching applies. Rotating proof lines and read-count notes are
-        // intentionally omitted from the body.
-        format!("{file_ref}={short} [unchanged {line_count}L]")
+        // caching applies. The `fresh=true` escape is a *static* suffix (no
+        // rotating proof lines or read-count notes), so determinism holds while
+        // a re-reader in non-meta mode still sees how to force the content (#513).
+        format!("{file_ref}={short} [unchanged {line_count}L · fresh=true to re-read]")
     };
     let out = crate::core::redaction::redact_text_if_enabled(&out);
     let sent = count_tokens(&out);
@@ -1058,9 +1059,10 @@ fn handle_full_with_auto_delta(
                 )
             } else {
                 // #498 determinism: byte-stable cache-hit stub (see
-                // try_stub_hit_readonly).
+                // try_stub_hit_readonly). The `fresh=true` escape is a static
+                // suffix, so non-meta re-readers still see how to force content (#513).
                 format!(
-                    "{file_ref}={short} [unchanged {}L]",
+                    "{file_ref}={short} [unchanged {}L · fresh=true to re-read]",
                     store_result.line_count
                 )
             };

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -36,10 +36,11 @@ impl McpTool for CtxReadTool {
         tool_def(
             "ctx_read",
             "Read source files. mode is REQUIRED — choose by intent:\n\
-             full=verbatim (edit-ready, use before Edit), signatures=API surface only,\n\
-             map=structural overview of large files, auto=smart (learns from task and\n\
-             session context, use for orientation), diff=git delta, lines:N-M=window.\n\
-             fresh=true bypasses cache.\n\
+             full=verbatim (edit-ready, use before Edit), raw=exact bytes (no framing),\n\
+             signatures=API surface only, map=structural overview of large files,\n\
+             auto=smart (learns from task and session context, use for orientation),\n\
+             diff=git delta, lines:N-M=window.\n\
+             fresh=true bypasses cache; raw=true=verbatim+fresh.\n\
              For understanding code or finding answers, use ctx_compose FIRST instead.",
             json!({
                 "type": "object",
@@ -47,8 +48,9 @@ impl McpTool for CtxReadTool {
                     "path": { "type": "string", "description": "Absolute path" },
                     "mode": {
                         "type": "string",
-                        "description": "REQUIRED. full=verbatim(edit-ready) signatures=API map=structure auto=smart diff=git-delta lines:N-M=window reference=quotes task=focus"
+                        "description": "REQUIRED. full=verbatim(edit-ready) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window reference=quotes task=focus"
                     },
+                    "raw": { "type": "boolean", "description": "Verbatim, no compression (= mode=\"raw\" + fresh)" },
                     "start_line": { "type": "integer", "description": "1-based first line (offset alias)" },
                     "offset": { "type": "integer", "description": "start_line alias" },
                     "limit": { "type": "integer", "description": "Max lines" },
@@ -128,7 +130,12 @@ impl CtxReadTool {
         let task_ref = current_task.as_deref();
 
         let profile = crate::core::profiles::active_profile();
-        let explicit_mode_arg = get_str(args, "mode");
+        // #513: `raw=true` is the intuitive "give me the exact bytes" escape an
+        // agent reaches for. Alias it to mode="raw" (verbatim, unframed) and
+        // force a fresh disk read below so a re-read never collapses to an
+        // `[unchanged]`/auto-delta stub. An explicit raw flag wins over `mode`.
+        let arg_raw = get_bool(args, "raw").unwrap_or(false);
+        let explicit_mode_arg = resolve_raw_alias(arg_raw, get_str(args, "mode"));
         let explicit_mode = explicit_mode_arg.is_some();
         // #673 — when the caller omits `mode`, a context policy pack's
         // `default_read_mode` (if set) takes precedence over the profile/auto
@@ -158,6 +165,11 @@ impl CtxReadTool {
             profile.read.default_mode_effective().to_string()
         };
         let mut fresh = get_bool(args, "fresh").unwrap_or(false);
+        // #513: a raw/verbatim request always reads from disk — the whole point
+        // is exact current bytes, never a cached stub or delta.
+        if arg_raw {
+            fresh = true;
+        }
         let cache_policy = crate::server::compaction_sync::effective_cache_policy();
         if cache_policy == "off" {
             fresh = true;
@@ -207,12 +219,21 @@ impl CtxReadTool {
             return Err(ErrorData::invalid_params(msg, None));
         }
         let budget_warning = gate_result.budget_warning.clone();
-        if let Some(overridden) = gate_result.overridden_mode {
+        // #513: an explicit raw/verbatim request is never silently downgraded by
+        // the budget gate — the caller asked for exact bytes.
+        if mode != "raw"
+            && let Some(overridden) = gate_result.overridden_mode
+        {
             mode = overridden;
         }
 
         let (mut mode, degrade_warning) = if crate::tools::ctx_read::is_instruction_file(path) {
             ("full".to_string(), None)
+        } else if mode == "raw" {
+            // #513: raw bypasses context-pressure degradation (which would
+            // otherwise downgrade to signatures under Block), exactly like
+            // instruction files — verbatim means verbatim.
+            ("raw".to_string(), None)
         } else {
             auto_degrade_read_mode(&mode)
         };
@@ -772,6 +793,20 @@ fn apply_line_window(
     }
 }
 
+/// #513: resolve the `raw=true` convenience flag into the effective explicit
+/// `mode` argument. Agents reach for `raw:true` to get exact bytes; it aliases
+/// to `mode="raw"` (verbatim, unframed) and wins over any caller-supplied
+/// `mode`. When `raw` is unset, the caller's `mode` (if any) passes through
+/// unchanged. The caller separately forces `fresh=true` for raw so a re-read
+/// never collapses to an `[unchanged]`/auto-delta stub.
+fn resolve_raw_alias(arg_raw: bool, mode_arg: Option<String>) -> Option<String> {
+    if arg_raw {
+        Some("raw".to_string())
+    } else {
+        mode_arg
+    }
+}
+
 fn apply_verdict(
     mode: &str,
     verdict: crate::core::degradation_policy::DegradationVerdictV1,
@@ -840,6 +875,28 @@ fn extract_file_summary(output: &str, path: &str) -> String {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn raw_alias_forces_raw_mode_over_explicit_mode() {
+        // #513: raw=true is the verbatim escape hatch and must win over any
+        // mode arg an agent also happened to pass.
+        assert_eq!(
+            resolve_raw_alias(true, Some("signatures".to_string())),
+            Some("raw".to_string())
+        );
+        assert_eq!(resolve_raw_alias(true, None), Some("raw".to_string()));
+    }
+
+    #[test]
+    fn raw_alias_absent_passes_mode_through() {
+        // Without raw=true the caller's mode is untouched (including None, which
+        // lets the auto/policy/profile resolution downstream pick the mode).
+        assert_eq!(
+            resolve_raw_alias(false, Some("full".to_string())),
+            Some("full".to_string())
+        );
+        assert_eq!(resolve_raw_alias(false, None), None);
+    }
 
     #[test]
     fn per_file_lock_same_path_returns_same_mutex() {


### PR DESCRIPTION
## Summary

Fixes #513. A community report (GLM 5.2 via Claude Code, during a security review) showed agents fighting lean-ctx's read compression and never finding the verbatim escape — `raw:true` was silently swallowed, the verbatim `mode="raw"` was undocumented, and full re-reads collapsed to `[unchanged]` stubs whose `fresh=true` hint only appeared in meta mode.

This is a **DX / discoverability** fix: the verbatim capability already existed and was correctly excluded from the terse layer (`post_process::skip_terse`) — it just wasn't reachable for an agent that hadn't memorised the conventions.

## Changes

- **`raw=true` now works on `ctx_read`** — alias for `mode="raw"` (exact, unframed bytes) + `fresh=true`. It wins over any `mode` arg and is exempt from the cache stub, the budget-gate override, and context-pressure degradation, so verbatim stays verbatim even under `Block`.
- **Documented `raw`** (both the `raw` mode and the `raw` argument) in the schema + tool description.
- **Non-meta `[unchanged]` stub** now names the `fresh=true` escape — a *static*, byte-stable suffix, so #498 determinism is preserved.
- **Softened the compressed-read hint** and pointed it at both `mode="full"` and `raw=true`.
- Per-tool description budget 300 → 335 / total 2275 → 2310 (`ctx_read` is the richest core tool; +~33 tok for the escape-hatch docs).
- Regenerated MCP manifest + reference docs + tdd-schema. Added unit tests for `resolve_raw_alias`.

Note: "native Read elided" in the report is Claude Code's own context manager, not lean-ctx; "native Bash intercepted" is the shell hook (bypass: `LEAN_CTX_RAW=1` / `lean-ctx-off`). Those are unchanged here.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (0 warnings)
- [x] `cargo test --lib` — 5727 passed, 0 failed
- [x] `cargo test --tests` — all integration binaries green
- [x] Token budgets: per-tool ctx_read 329≤335, core total 2229≤2310, descriptions 4894<5200, input overhead 12698<13000
- [x] `gen_docs` / `gen_mcp_manifest` / `gen_tdd_schema` `--check` all pass
- [ ] CI eval A/B gate on the `ctx_read` description change
