### PR TITLE
fix(search): bound hybrid/dense cold-start embed; degrade instead of runaway (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   `raw` and state that the allowlist still holds.
 
 ### Fixed
+- **Hybrid/dense cold-start no longer re-embeds the whole corpus inline (#512).**
+  On a large repo, the *first* `ctx_semantic_search mode=hybrid` (or `dense`) call on
+  an MCP server that started *before* the on-disk dense index existed would embed the
+  entire corpus under the 120s per-request watchdog. The watchdog abandons the response
+  but cannot cancel the spawned compute, so the embed kept running — observed as a 500%+
+  CPU child for >10 min after the call "returned". A new cold-start guard counts the
+  chunks a re-embed would touch (`EmbeddingIndex::pending_chunk_count`) and, above a
+  budget (default 2000 chunks, tunable via `LEAN_CTX_HYBRID_INLINE_EMBED_MAX`; `0`
+  disables — the pre-#512 behavior), refuses the inline embed: **hybrid** degrades to the
+  coherent BM25+graph ranking (the same fallback used when dense is disabled) and
+  **dense** fails fast — both with a one-line hint to build the index once, out of band
+  (`lean-ctx index build-semantic`). Warm and incremental paths (a few changed chunks on
+  an existing index) are untouched and still embed inline.
 - **Shell-output compression can no longer inflate token counts (Windows CI
   flake).** The VCS branch of `compress_output` (git/jj/gh/glab/hg) returned its
   authoritative compressor's result even when it was not strictly shorter — so a

--- a/rust/src/core/embedding_index.rs
+++ b/rust/src/core/embedding_index.rs
@@ -323,6 +323,26 @@ impl EmbeddingIndex {
         needs_update
     }
 
+    /// Number of `chunks` a re-embed pass would have to embed right now — i.e.
+    /// the chunks belonging to files flagged by [`Self::files_needing_update`].
+    ///
+    /// Used by the hybrid/dense cold-start guard (#512): on a server that came
+    /// up before the on-disk index existed, the first query would otherwise embed
+    /// the *entire* corpus inline under the request watchdog, producing a runaway
+    /// the watchdog abandons but cannot cancel. Counting the pending chunks up
+    /// front lets the caller fall back instead of starting that embed.
+    pub fn pending_chunk_count(&self, chunks: &[CodeChunk]) -> usize {
+        let changed = self.files_needing_update(chunks);
+        if changed.is_empty() {
+            return 0;
+        }
+        let changed: std::collections::HashSet<&str> = changed.iter().map(String::as_str).collect();
+        chunks
+            .iter()
+            .filter(|c| changed.contains(c.file_path.as_str()))
+            .count()
+    }
+
     /// Update the index with new embeddings for changed files.
     /// Preserves existing embeddings for unchanged files.
     ///
@@ -623,6 +643,73 @@ mod tests {
         assert!(
             needs.contains(&"b.rs".to_string()),
             "deleted file should trigger update"
+        );
+    }
+
+    #[test]
+    fn pending_chunk_count_cold_start_counts_every_chunk() {
+        let idx = EmbeddingIndex::new(384);
+        let chunks = vec![
+            make_chunk("a.rs", "fn_a", "fn a() {}", 1, 3),
+            make_chunk("a.rs", "fn_b", "fn b() {}", 10, 12),
+            make_chunk("b.rs", "fn_c", "fn c() {}", 1, 3),
+        ];
+        assert_eq!(
+            idx.pending_chunk_count(&chunks),
+            3,
+            "an empty index must report every chunk as pending (cold start)"
+        );
+    }
+
+    #[test]
+    fn pending_chunk_count_zero_when_fully_embedded() {
+        let mut idx = EmbeddingIndex::new(384);
+        let chunks = vec![
+            make_chunk("a.rs", "fn_a", "fn a() {}", 1, 3),
+            make_chunk("b.rs", "fn_b", "fn b() {}", 1, 3),
+        ];
+        idx.update(
+            &chunks,
+            &[(0, dummy_embedding(384)), (1, dummy_embedding(384))],
+            &["a.rs".to_string(), "b.rs".to_string()],
+            None,
+        );
+        assert_eq!(
+            idx.pending_chunk_count(&chunks),
+            0,
+            "a fully-embedded index has no pending chunks (warm path stays inline)"
+        );
+    }
+
+    #[test]
+    fn pending_chunk_count_only_counts_changed_files_chunks() {
+        let mut idx = EmbeddingIndex::new(384);
+        let chunks_v1 = vec![
+            make_chunk("a.rs", "fn_a", "fn a() {}", 1, 3),
+            make_chunk("a.rs", "fn_b", "fn b() {}", 10, 12),
+            make_chunk("b.rs", "fn_c", "fn c() {}", 1, 3),
+        ];
+        idx.update(
+            &chunks_v1,
+            &[
+                (0, dummy_embedding(384)),
+                (1, dummy_embedding(384)),
+                (2, dummy_embedding(384)),
+            ],
+            &["a.rs".to_string(), "b.rs".to_string()],
+            None,
+        );
+
+        // Only b.rs changed → its single chunk is pending, a.rs's two are not.
+        let chunks_v2 = vec![
+            make_chunk("a.rs", "fn_a", "fn a() {}", 1, 3),
+            make_chunk("a.rs", "fn_b", "fn b() {}", 10, 12),
+            make_chunk("b.rs", "fn_c", "fn c() { changed }", 1, 3),
+        ];
+        assert_eq!(
+            idx.pending_chunk_count(&chunks_v2),
+            1,
+            "incremental update must only count the changed file's chunks"
         );
     }
 

--- a/rust/src/tools/ctx_semantic_search.rs
+++ b/rust/src/tools/ctx_semantic_search.rs
@@ -1038,6 +1038,54 @@ fn bm25_graph_search(
     format!("{header}{}", format_hybrid_results(&results, compact))
 }
 
+/// #512: max chunks the hybrid/dense path will embed *inline* (under the
+/// per-request watchdog) before degrading instead of embedding. A server that
+/// started before the on-disk dense index existed would otherwise embed the
+/// whole corpus on the first query — observed as a runaway 500%+ CPU child the
+/// 120s watchdog abandons but cannot cancel. Tunable via
+/// `LEAN_CTX_HYBRID_INLINE_EMBED_MAX`; `0` disables the guard (always embed
+/// inline — the pre-#512 behavior).
+#[cfg(feature = "embeddings")]
+fn inline_embed_max_chunks() -> usize {
+    const DEFAULT_MAX: usize = 2000;
+    std::env::var("LEAN_CTX_HYBRID_INLINE_EMBED_MAX")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX)
+}
+
+/// Pure budget check for the cold-start guard (#512): `max == 0` disables it,
+/// and the budget is inclusive (`pending == max` still embeds inline).
+#[cfg(feature = "embeddings")]
+fn exceeds_inline_embed_budget(pending: usize, max: usize) -> bool {
+    max > 0 && pending > max
+}
+
+/// Decide whether this call would trigger a large inline embed the watchdog
+/// cannot safely bound (#512). Returns the pending-chunk count when the call
+/// should degrade instead of embedding inline; `None` keeps the normal path
+/// (warm index, or an incremental embed of only a few changed chunks).
+#[cfg(feature = "embeddings")]
+fn cold_start_embed_guard(embed_idx: &EmbeddingIndex, index: &BM25Index) -> Option<usize> {
+    let pending = embed_idx.pending_chunk_count(&index.chunks);
+    exceeds_inline_embed_budget(pending, inline_embed_max_chunks()).then_some(pending)
+}
+
+/// One-line, deterministic hint pointing at the out-of-band dense build. Shared
+/// by the hybrid fallback and the dense fail-fast so the guidance never drifts.
+#[cfg(feature = "embeddings")]
+fn dense_build_hint(pending: usize, compact: bool) -> String {
+    if compact {
+        format!("[dense not built: {pending} chunks pending — run: lean-ctx index build-semantic]")
+    } else {
+        format!(
+            "[lean-ctx: dense index not built ({pending} chunks would embed inline). \
+             Build it once — no per-query embed, no cold-start hang: \
+             lean-ctx index build-semantic]"
+        )
+    }
+}
+
 fn hybrid_search_mode(
     query: &str,
     root: &Path,
@@ -1062,6 +1110,17 @@ fn hybrid_search_mode(
             Ok(v) => v,
             Err(e) => return format!("ERR: {e}"),
         };
+
+        // #512: cold-start guard. Never embed a large corpus inline under the
+        // request watchdog (it produces a runaway the watchdog abandons but
+        // cannot cancel). Degrade to the BM25+graph path — the same coherent
+        // fallback used when dense is disabled — and tell the user to build the
+        // dense index once, out of band. Incremental embeds (few changed chunks
+        // on a warm index) stay inline and fast.
+        if let Some(pending) = cold_start_embed_guard(&embed_idx, index) {
+            let base = bm25_graph_search(query, root, index, top_k, compact, filter, &cfg);
+            return format!("{base}\n{}", dense_build_hint(pending, compact));
+        }
 
         let (aligned, coverage, changed_files) =
             match ensure_embeddings(root, index, engine, &mut embed_idx) {
@@ -1180,6 +1239,14 @@ fn dense_search_mode(
             Ok(v) => v,
             Err(e) => return format!("ERR: {e}"),
         };
+
+        // #512: explicit dense has no BM25 fallback to degrade into, so fail fast
+        // with the same actionable hint rather than embed the whole corpus inline
+        // under the watchdog (the cold-start runaway). A warm/incremental index
+        // passes through untouched.
+        if let Some(pending) = cold_start_embed_guard(&embed_idx, index) {
+            return dense_build_hint(pending, compact);
+        }
 
         let (aligned, coverage, changed_files) =
             match ensure_embeddings(root, index, engine, &mut embed_idx) {
@@ -1528,6 +1595,48 @@ mod filter_tests {
         let f = SearchFilter::new(None, Some("rust/src/**")).unwrap();
         assert!(f.matches("rust/src/core/mod.rs"));
         assert!(!f.matches("website/src/pages/index.astro"));
+    }
+}
+
+#[cfg(all(test, feature = "embeddings"))]
+mod cold_start_guard_tests {
+    use super::*;
+
+    #[test]
+    fn budget_zero_disables_guard() {
+        // 0 = "always embed inline" (pre-#512 behavior), regardless of size.
+        assert!(!exceeds_inline_embed_budget(1_000_000, 0));
+    }
+
+    #[test]
+    fn budget_is_inclusive_and_triggers_above_threshold() {
+        assert!(!exceeds_inline_embed_budget(0, 2000), "warm index: inline");
+        assert!(
+            !exceeds_inline_embed_budget(2000, 2000),
+            "at the budget: still inline"
+        );
+        assert!(
+            exceeds_inline_embed_budget(2001, 2000),
+            "over the budget: degrade"
+        );
+    }
+
+    #[test]
+    fn default_threshold_positive_when_env_unset() {
+        // With the env override unset the default must be a real, positive guard.
+        if std::env::var_os("LEAN_CTX_HYBRID_INLINE_EMBED_MAX").is_none() {
+            assert!(inline_embed_max_chunks() >= 1);
+        }
+    }
+
+    #[test]
+    fn dense_build_hint_always_points_at_the_cli_build() {
+        let full = dense_build_hint(22_741, false);
+        assert!(full.contains("lean-ctx index build-semantic"));
+        assert!(full.contains("22741"));
+        let compact = dense_build_hint(22_741, true);
+        assert!(compact.contains("lean-ctx index build-semantic"));
+        assert!(compact.contains("22741"));
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #512.

On a large repo the **first** `ctx_semantic_search mode=hybrid` (or `dense`) call on an MCP server that started **before** the on-disk dense index existed embedded the *entire corpus inline* under the 120s per-request watchdog. The watchdog abandons the response but cannot cancel the spawned compute, so the embed kept running — a 500%+ CPU child for >10 min after the call "returned".

### Fix — cold-start guard
- `EmbeddingIndex::pending_chunk_count(chunks)` counts the chunks a re-embed would actually touch (cold start = all; warm = a few; fully embedded = 0).
- Above a budget (default **2000** chunks, tunable via `LEAN_CTX_HYBRID_INLINE_EMBED_MAX`; `0` disables → pre-#512 behavior) the inline embed is refused:
  - **hybrid** degrades to the coherent **BM25+graph** ranking (the exact fallback used when dense is disabled),
  - **dense** fails fast,
  - both emit a one-line, deterministic hint to build the index once out of band: `lean-ctx index build-semantic`.
- Warm / incremental paths (a few changed chunks on an existing index) are **untouched** and still embed inline.

This eliminates the runaway at the root (no unbounded inline embed is ever started), rather than relying on the watchdog to cancel CPU-bound work it cannot interrupt.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (0 warnings)
- [x] `cargo test --lib embedding_index::` (18) + `ctx_semantic_search::` (10) — incl. 7 new tests
- [x] generated-artifact drift checks (gen_docs / gen_mcp_manifest / gen_tdd_schema `--check`) green — no schema change
- [ ] CI green