### PR TITLE
fix(search): extend #512 cold-start guard to the CLI/editor search_hits path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,11 +168,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   CPU child for >10 min after the call "returned". A new cold-start guard counts the
   chunks a re-embed would touch (`EmbeddingIndex::pending_chunk_count`) and, above a
   budget (default 2000 chunks, tunable via `LEAN_CTX_HYBRID_INLINE_EMBED_MAX`; `0`
-  disables — the pre-#512 behavior), refuses the inline embed: **hybrid** degrades to the
-  coherent BM25+graph ranking (the same fallback used when dense is disabled) and
-  **dense** fails fast — both with a one-line hint to build the index once, out of band
-  (`lean-ctx index build-semantic`). Warm and incremental paths (a few changed chunks on
-  an existing index) are untouched and still embed inline.
+  disables — the pre-#512 behavior), refuses the inline embed across **all four search
+  entry points** (hybrid/dense × the MCP tool and the CLI/editor `search_hits` path):
+  **hybrid** degrades to the coherent BM25(+graph) ranking (the same fallback used when
+  dense is disabled) and **dense** fails fast — both with a one-line hint to build the
+  index once, out of band (`lean-ctx index build-semantic`). Warm and incremental paths
+  (a few changed chunks on an existing index) are untouched and still embed inline.
 - **Shell-output compression can no longer inflate token counts (Windows CI
   flake).** The VCS branch of `compress_output` (git/jj/gh/glab/hg) returned its
   authoritative compressor's result even when it was not strictly shorter — so a

--- a/rust/src/tools/ctx_semantic_search.rs
+++ b/rust/src/tools/ctx_semantic_search.rs
@@ -833,6 +833,12 @@ fn dense_results_for_root(
     filter: &SearchFilter,
 ) -> Result<(Vec<HybridResult>, f64), String> {
     let (engine, mut embed_idx) = load_engine_and_index(root)?;
+    // #512: cold-start guard for the CLI/editor (`search_hits`) path — the twin of
+    // the MCP `dense_search_mode` guard. Explicit dense fails fast on a cold index
+    // rather than embed the whole corpus inline under the request.
+    if let Some(pending) = cold_start_embed_guard(&embed_idx, index) {
+        return Err(dense_build_hint(pending, true));
+    }
     let (aligned, coverage, changed_files) =
         ensure_embeddings(root, index, engine, &mut embed_idx)?;
 
@@ -868,6 +874,17 @@ fn hybrid_results_for_root(
     filter: &SearchFilter,
 ) -> Result<(Vec<HybridResult>, f64), String> {
     let (engine, mut embed_idx) = load_engine_and_index(root)?;
+    // #512: cold-start guard for the CLI/editor (`search_hits`) path — the twin of
+    // the MCP `hybrid_search_mode` guard. Degrade to BM25 on a cold index rather
+    // than embed the whole corpus inline under the request.
+    if let Some(pending) = cold_start_embed_guard(&embed_idx, index) {
+        tracing::info!(
+            pending,
+            "hybrid cold-start guard: dense index not built — degrading to BM25 \
+             (build once: lean-ctx index build-semantic)"
+        );
+        return Ok((bm25_hits(index, query, top_k, filter), 0.0));
+    }
     let (aligned, coverage, changed_files) =
         ensure_embeddings(root, index, engine, &mut embed_idx)?;
 


### PR DESCRIPTION
## Summary

Follow-up to #515 (which fixes #512). #515 added the cold-start guard only on the **MCP handler** path (`hybrid_search_mode` / `dense_search_mode`).

The structured `search_hits` path used by the **CLI** (`lean-ctx semantic-search`) and **editor extensions** goes through `hybrid_results_for_root` / `dense_results_for_root`, which call the same `load_engine_and_index` + `ensure_embeddings` inline — so a cold start on a large repo had the **identical runaway** there.

This applies the same `cold_start_embed_guard` to both:
- **hybrid** → degrades to BM25 (logged via `tracing::info!`),
- **dense** → fails fast with the `lean-ctx index build-semantic` hint.

Warm / incremental paths are untouched. Completes #512 — all four search entry points (hybrid/dense x MCP/CLI) are now guarded.

## Test plan

- [x] `cargo fmt --all --check` (my files)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (0 warnings)
- [x] `cargo test --lib ctx_semantic_search::` (10) — incl. cold-start guard tests
- [ ] CI green