### PR TITLE
fix(hooks): use native binary path on Windows PowerShell/cmd (#518)

### DIFF
--- a/rust/src/cli/shell_init.rs
+++ b/rust/src/cli/shell_init.rs
@@ -8,7 +8,7 @@ macro_rules! qprintln {
 
 pub fn print_hook_stdout(shell: &str) {
     let binary = crate::core::portable_binary::resolve_portable_binary();
-    let binary = crate::hooks::to_bash_compatible_path(&binary);
+    let binary = hook_binary_for_shell(shell, &binary);
 
     let code = match shell {
         "bash" | "zsh" => generate_hook_posix(&binary),
@@ -21,6 +21,20 @@ pub fn print_hook_stdout(shell: &str) {
         }
     };
     print!("{code}");
+}
+
+/// Pick the executable-path form to embed in a generated shell hook.
+///
+/// bash/zsh/fish (incl. Git Bash / MSYS on Windows) source the hook and invoke
+/// the binary from a POSIX shell, so on Windows they need the MSYS `/c/...`
+/// form. PowerShell and `pwsh` execute the path via the `&` call operator and
+/// cannot run an MSYS `/c/...` path (#518); they get the native path unchanged.
+/// On Unix `to_bash_compatible_path` is a no-op, so all shells are unaffected.
+fn hook_binary_for_shell(shell: &str, binary: &str) -> String {
+    match shell {
+        "powershell" | "pwsh" => binary.to_string(),
+        _ => crate::hooks::to_bash_compatible_path(binary),
+    }
 }
 
 fn backup_shell_config(path: &std::path::Path) {
@@ -979,6 +993,27 @@ lean-ctx-mode() {{
             hook.contains("IsOutputRedirected"),
             "PowerShell hook must contain pipe guard ([Console]::IsOutputRedirected)"
         );
+    }
+
+    #[test]
+    fn powershell_hook_binary_is_native_not_msys() {
+        // #518: PowerShell/pwsh execute the path via the `&` call operator and
+        // cannot run an MSYS `/c/...` path — they must get the native binary.
+        let win = "C:/Users/Dawid/.cargo/bin/lean-ctx.exe";
+        assert_eq!(hook_binary_for_shell("powershell", win), win);
+        assert_eq!(hook_binary_for_shell("pwsh", win), win);
+        assert!(!hook_binary_for_shell("powershell", win).contains("/c/"));
+    }
+
+    #[test]
+    fn posix_hook_binary_keeps_msys_form_on_windows_drive() {
+        // bash/zsh/fish source the hook from a POSIX shell, so a Windows drive
+        // path is converted to the MSYS `/c/...` form for them.
+        let win = "C:/Users/Dawid/.cargo/bin/lean-ctx.exe";
+        let msys = "/c/Users/Dawid/.cargo/bin/lean-ctx.exe";
+        assert_eq!(hook_binary_for_shell("bash", win), msys);
+        assert_eq!(hook_binary_for_shell("zsh", win), msys);
+        assert_eq!(hook_binary_for_shell("fish", win), msys);
     }
 
     #[test]

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -799,13 +799,11 @@ pub fn handle_copilot() {
 
 /// Inline rewrite: takes a command as CLI args, prints the rewritten command to stdout.
 /// The command is passed as positional arguments, not via stdin JSON.
-/// Uses native OS paths (not MSYS) because the calling shell may be
-/// PowerShell or cmd on Windows.
 pub fn handle_rewrite_inline() {
     if is_disabled() {
         return;
     }
-    let binary = resolve_binary_native();
+    let binary = resolve_binary();
     let args: Vec<String> = std::env::args().collect();
     // args: [binary, "hook", "rewrite-inline", ...command parts]
     if args.len() < 4 {
@@ -826,12 +824,13 @@ pub fn handle_rewrite_inline() {
     print!("{cmd}");
 }
 
+/// Resolve the lean-ctx executable path for hook command emission and
+/// subprocess spawning. Always the **native** OS path: the MSYS/Git-Bash
+/// `/c/...` form breaks `CreateProcess` on Windows and cannot be run by
+/// PowerShell or cmd (#518). Native `C:/...` runs in PowerShell, cmd *and*
+/// Git Bash, so it is the correct universal form for executed commands.
+/// (MSYS `/c/...` is only needed for bash *source* lines — see `cli::shell_init`.)
 fn resolve_binary() -> String {
-    let path = crate::core::portable_binary::resolve_portable_binary();
-    crate::hooks::to_bash_compatible_path(&path)
-}
-
-fn resolve_binary_native() -> String {
     crate::core::portable_binary::resolve_portable_binary()
 }
 

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -422,6 +422,32 @@ fn to_bash_compatible_path_msys2_unchanged() {
 }
 
 #[test]
+fn resolve_binary_is_native_not_msys() {
+    // #518: hook handlers spawn the binary (CreateProcess) and embed it into
+    // rewritten commands; both require the native path, never the MSYS `/c/...`
+    // form (unrunnable by PowerShell/cmd and invalid for CreateProcess).
+    assert_eq!(
+        resolve_binary(),
+        crate::core::portable_binary::resolve_portable_binary()
+    );
+}
+
+#[test]
+fn rewrite_preserves_native_windows_binary_path() {
+    // #518: a Windows native binary path must survive into the rewritten
+    // command verbatim — no `/c/...` MSYS rewrite, which PowerShell/cmd
+    // cannot execute.
+    let win_binary = "C:/Users/Dawid/.cargo/bin/lean-ctx.exe";
+    let rewritten =
+        rewrite_candidate("git status", win_binary).expect("git status is a rewrite candidate");
+    assert!(rewritten.contains(win_binary), "rewritten: {rewritten}");
+    assert!(
+        !rewritten.contains("/c/"),
+        "must not emit MSYS path: {rewritten}"
+    );
+}
+
+#[test]
 fn wrap_command_with_bash_path() {
     let binary = crate::hooks::to_bash_compatible_path(r"E:\packages\lean-ctx.exe");
     let result = wrap_single_command("git status", &binary);


### PR DESCRIPTION
## Summary

On Windows, lean-ctx embedded the MSYS/Git-Bash `/c/...` form of its own
executable into hook output **regardless of the target shell**. PowerShell and
cmd cannot run `/c/...` paths, so under Copilot/VSCode every rewritten terminal
command failed with `the term '/c/Users/.../lean-ctx.exe' is not recognized`
(reported in #518).

## Root cause

Two paths converted the binary to `/c/...` unconditionally:

- `hook_handlers::resolve_binary()` — used both to **spawn** the binary as a
  subprocess (`CreateProcess` rejects `/c/...`) and to build the **rewritten
  command** the agent shell executes.
- `cli::shell_init::print_hook_stdout()` — fed `/c/...` to the PowerShell hook
  generator, which is built for native paths.

The interactive installer (`init_cmd`) and the OpenCode inline path
(`handle_rewrite_inline`) already did the right thing; the JSON/stdout paths
did not.

## Fix

- `resolve_binary()` now returns the **native** path (used for spawns *and*
  emitted commands); the redundant `resolve_binary_native()` is folded in.
  Native `C:/...` runs in PowerShell, cmd **and** Git Bash.
- `print_hook_stdout()` selects the path form per shell via a new, testable
  `hook_binary_for_shell()` — native for `powershell`/`pwsh`, MSYS `/c/...` for
  `bash`/`zsh`/`fish`. The `/c/...` form now lives only in bash *source* lines.

No behavior change on Unix (`to_bash_compatible_path` is a no-op there) or for
Git Bash command execution.

## Test plan

- [x] `cargo test --lib` — new regression tests:
  - `hook_handlers`: `resolve_binary_is_native_not_msys`, `rewrite_preserves_native_windows_binary_path`
  - `cli::shell_init`: `powershell_hook_binary_is_native_not_msys`, `posix_hook_binary_keeps_msys_form_on_windows_drive`
- [x] `cargo clippy --all-targets -- -D warnings` (pre-commit gate) — clean
- [x] preflight incl. **Windows cross-compile** (`x86_64-pc-windows-gnu`) — green
- [ ] Manual on a Windows PowerShell host: confirm rewritten commands invoke `C:\...\lean-ctx.exe` (cannot be exercised on macOS CI hosts)

Closes #518
