### PR TITLE
fix(embeddings): skip detached ORT model load in short-lived processes (#519)

### DIFF
--- a/rust/src/core/embeddings/mod.rs
+++ b/rust/src/core/embeddings/mod.rs
@@ -651,6 +651,56 @@ pub fn try_shared_engine() -> Option<&'static EmbeddingEngine> {
     SHARED_ENGINE.get()?.as_ref().ok()
 }
 
+/// Whether this process may load the ONNX model on a **detached background
+/// thread** (#519).
+///
+/// ONNX Runtime registers its op schemas in global C++ static state while a
+/// model is loading. If a detached loader thread is still mid-load when the
+/// process returns from `main`, it races `libonnxruntime`'s static-destructor
+/// teardown — a use-after-free SIGSEGV inside `onnx::OpSchema` on an ORT worker
+/// thread. The shipped `lean-ctx` daemon/MCP server is long-lived, so its
+/// warmup always finishes well before exit; short-lived processes (`cargo test`/
+/// bench/doctest binaries, build-time generators) can exit mid-load, so we
+/// refuse the background spawn for them. Their semantic features simply stay
+/// cold — blocking, on-thread loads still work and always complete before exit,
+/// which is race-free.
+///
+/// Note: blocking [`shared_engine`] loads are intentionally NOT gated — they
+/// finish on the caller's thread before the process exits, so no worker is ever
+/// active during teardown.
+#[cfg(feature = "embeddings")]
+pub fn background_load_allowed() -> bool {
+    // Unit tests compile with cfg(test): a cheap, unambiguous short-circuit.
+    // Integration/bench/doctest binaries link the lib in its normal config
+    // (cfg(test) is false), so they are caught by the executable-path probe.
+    if cfg!(test) {
+        return false;
+    }
+    !current_exe_is_test_artifact()
+}
+
+/// `true` when the running executable is a Cargo test/bench/doctest artifact.
+#[cfg(feature = "embeddings")]
+fn current_exe_is_test_artifact() -> bool {
+    std::env::current_exe()
+        .ok()
+        .as_deref()
+        .is_some_and(exe_path_is_test_artifact)
+}
+
+/// Pure predicate (unit-testable): Cargo places test, bench and doctest binaries
+/// directly inside `…/target/<profile>/deps/`. The shipped binary lives in a
+/// package `bin` directory (`/usr/bin`, `~/.local/bin`, `…/Homebrew/bin`, …) and
+/// is never a direct child of a `deps/` directory, so the parent-dir name is an
+/// install-location-independent signal (survives renames of the binary). (#519)
+#[cfg(feature = "embeddings")]
+fn exe_path_is_test_artifact(path: &Path) -> bool {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "deps")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -698,6 +748,44 @@ mod tests {
         assert_eq!(dir.to_string_lossy(), unique);
         assert!(!EmbeddingEngine::is_available());
         crate::test_env::remove_var("LEAN_CTX_MODELS_DIR");
+    }
+
+    /// #519: Cargo test/bench/doctest binaries live under `…/deps/`; the shipped
+    /// binary lives in a `bin` directory. The parent-dir probe must distinguish
+    /// them so background ORT loads are refused only in short-lived processes.
+    #[test]
+    #[cfg(feature = "embeddings")]
+    fn exe_path_test_artifact_detection() {
+        // Cargo test/bench/doctest artifacts: parent dir is `deps`.
+        assert!(exe_path_is_test_artifact(Path::new(
+            "/repo/rust/target/debug/deps/conformance_suite-0a1b2c3d4e5f6789"
+        )));
+        assert!(exe_path_is_test_artifact(Path::new(
+            "/repo/rust/target/release/deps/lean_ctx-deadbeefcafef00d"
+        )));
+        // Shipped/installed binary: never a direct child of `deps`.
+        assert!(!exe_path_is_test_artifact(Path::new(
+            "/usr/local/bin/lean-ctx"
+        )));
+        assert!(!exe_path_is_test_artifact(Path::new(
+            "/Users/x/.local/bin/lean-ctx"
+        )));
+        // A renamed shipped binary is still allowed (rename-independent signal).
+        assert!(!exe_path_is_test_artifact(Path::new("/opt/tools/ctx")));
+        // The plain target dir build (e.g. `target/debug/lean-ctx`) is not under
+        // `deps/` — treated as a product binary, not a test artifact.
+        assert!(!exe_path_is_test_artifact(Path::new(
+            "/repo/rust/target/debug/lean-ctx"
+        )));
+    }
+
+    /// In the unit-test binary `background_load_allowed` must be false via the
+    /// `cfg!(test)` short-circuit — no detached ORT load may ever be spawned
+    /// from a test process (the #519 teardown race).
+    #[test]
+    #[cfg(feature = "embeddings")]
+    fn background_load_disallowed_in_tests() {
+        assert!(!background_load_allowed());
     }
 
     /// GL #452: the EmbeddingBag detection is purely name-based — exactly two

--- a/rust/src/tools/ctx_knowledge/embeddings.rs
+++ b/rust/src/tools/ctx_knowledge/embeddings.rs
@@ -64,10 +64,14 @@ pub(crate) fn embedding_engine_impl(nonblocking: bool) -> Option<&'static Embedd
 #[cfg(feature = "embeddings")]
 fn ensure_engine_background() {
     use std::sync::atomic::{AtomicBool, Ordering};
-    // Unit tests must never spawn a background model load: the shared engine
-    // is process-global state (races tests asserting on it) and the load may
-    // download the model — network I/O that CI sandboxes must not perform.
-    if cfg!(test) {
+    // Never spawn a detached model load in a short-lived process (#519): a
+    // loader thread still running when the process returns from `main` races
+    // libonnxruntime's static-destructor teardown → SIGSEGV in onnx::OpSchema.
+    // This also keeps the process-global shared engine untouched in tests
+    // (races assertions) and avoids model-download network I/O in CI sandboxes.
+    // `background_load_allowed` covers unit tests (cfg!(test)) AND integration/
+    // bench/doctest binaries (which link the lib with cfg(test) = false).
+    if !crate::core::embeddings::background_load_allowed() {
         return;
     }
     static STARTED: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
## Summary

Fixes the flaky `SIGSEGV` / `EXC_BAD_ACCESS` during process teardown in
`embeddings`-linked test binaries (e.g. `conformance_suite`) on arm64 macOS
(#519). The fault is post-success (after all tests pass), on a worker thread
of ONNX Runtime, so it has no functional impact — but it exits via signal and
risks flaky red CI.

## Root cause

The #551 background-activation thread (`ensure_engine_background`) ran
`shared_engine()` — and thus the ONNX model load — on a **detached** thread.
ONNX Runtime registers its op schemas in global C++ static state while a model
loads. In a short-lived process that loader thread can still be mid-load when
the process returns from `main`, racing `libonnxruntime`'s static-destructor
teardown → use-after-free SIGSEGV in `onnx::OpSchema::FormalParameter` on an
ORT worker thread.

The previous guard was `cfg!(test)`, which is **false** for integration / bench
/ doctest binaries (they link the lib in its normal config). So `conformance_suite`
still spawned the detached loader and flaked.

## Fix

Add a central `embeddings::background_load_allowed()` gate that refuses the
detached spawn in every short-lived process:

- **unit tests** → `cfg!(test)` short-circuit;
- **integration / bench / doctest / generator binaries** → an executable-path
  probe (Cargo places those directly under `…/target/<profile>/deps/`; the
  shipped binary never is — a rename- and install-location-independent signal).

Blocking on-thread `shared_engine()` loads are intentionally **not** gated: they
complete on the caller's thread before the process exits, so no ORT worker is
ever active during static teardown. Long-lived processes (the shipped daemon /
MCP server) are unaffected — their warmup always finishes well before exit.

## Verification (arm64 macOS, `conformance_suite`, 30 runs each, `--test-threads=1`)

| build | result |
|---|---|
| **pre-fix** (`HEAD~1`) | **12/30 SIGSEGV** (exit 139) — ~40% |
| **with fix** | **0/30** crashes |

Plus deterministic unit tests for the gate (`exe_path_test_artifact_detection`,
`background_load_disallowed_in_tests`) and the existing `try_shared_engine`
invariant test. `cargo fmt` / `clippy --all-targets -D warnings` / `gen_docs
--check` / preflight all green.

Refs #519
