### PR TITLE
feat(tools): fold read-cluster into ctx_read; deprecate aliases (#509 Phase 1)

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -360,11 +360,8 @@ Parameters: _none_
 
 ## `ctx_multi_read`
 
-Batch-read multiple files in one call — more efficient than N sequential
-ctx_read calls. paths=['a.rs','b.rs'] reads all at once.
-WORKFLOW: ctx_compose FIRST → ctx_multi_read for content.
-ANTI-PATTERN: not for understanding code logic — use ctx_compose.
-mode=full for edit; mode=auto for reading.
+DEPRECATED → use ctx_read with paths=['a.rs','b.rs']. Folded into ctx_read
+(#509); hidden from tools/list, still callable for one release.
 
 Parameters: `fresh`, `mode`, `paths`*
 
@@ -496,7 +493,7 @@ full=verbatim (edit-ready), raw=exact bytes (no framing), signatures=API,
 map=structure, auto=smart (learns from task context), diff=git delta,
 lines:N-M=window. fresh=true bypasses cache; raw=true=verbatim+fresh.
 
-Parameters: `aggressiveness`, `fresh`, `limit`, `mode`, `offset`, `path`*, `protect`, `raw`, `start_line`
+Parameters: `aggressiveness`, `fresh`, `limit`, `mode`, `offset`, `path`, `paths`, `protect`, `raw`, `start_line`
 
 ## `ctx_refactor`
 
@@ -623,9 +620,8 @@ Parameters: `action`, `slug`
 
 ## `ctx_smart_read`
 
-WORKFLOW: orientation — auto-selects mode (full|map|signatures) by file size.
-ANTIPATTERN: edit-target files → ctx_read mode=full for precision.
-Explicit mode control → ctx_read mode=...
+DEPRECATED → use ctx_read (it auto-selects the mode; omit `mode`). Folded
+into ctx_read (#509); hidden from tools/list, still callable for one release.
 
 Parameters: `path`*
 

--- a/rust/src/core/tool_profiles.rs
+++ b/rust/src/core/tool_profiles.rs
@@ -165,7 +165,6 @@ const STANDARD_TOOLS: &[&str] = &[
     "ctx_execute",
     "ctx_expand",
     "ctx_overview",
-    "ctx_multi_read",
     "ctx_url_read",
 ];
 
@@ -187,7 +186,7 @@ pub fn list_profiles() -> Vec<ProfileInfo> {
         },
         ProfileInfo {
             name: "standard",
-            tool_count: "17",
+            tool_count: "16",
             description: "Balanced set — adds callgraph, execute, semantics, delta, more",
         },
         ProfileInfo {
@@ -326,7 +325,9 @@ mod tests {
         assert!(profile.is_tool_enabled("ctx_expand"));
         assert!(profile.is_tool_enabled("ctx_execute"));
         assert!(profile.is_tool_enabled("ctx_overview"));
-        assert!(profile.is_tool_enabled("ctx_multi_read"));
+        // #509: ctx_multi_read is a deprecated alias folded into ctx_read (paths=…)
+        // and was removed from the Standard set.
+        assert!(!profile.is_tool_enabled("ctx_multi_read"));
         assert!(profile.is_tool_enabled("ctx_url_read"));
         assert!(!profile.is_tool_enabled("ctx_benchmark"));
         assert!(!profile.is_tool_enabled("ctx_analyze"));

--- a/rust/src/server/call_tool.rs
+++ b/rust/src/server/call_tool.rs
@@ -911,6 +911,12 @@ impl LeanCtxServer {
             }
         }
 
+        // #509: a folded read-cluster alias (ctx_smart_read / ctx_multi_read) stays
+        // callable but warns — prepend a one-line notice steering to the primary.
+        if let Some(notice) = crate::server::dynamic_tools::deprecation_notice(name) {
+            result_text = format!("{notice}\n{result_text}");
+        }
+
         Ok(finalize_call_result(result_text, shell_outcome))
     }
 

--- a/rust/src/server/dynamic_tools.rs
+++ b/rust/src/server/dynamic_tools.rs
@@ -107,6 +107,61 @@ pub fn categorize_tool(name: &str) -> ToolCategory {
     }
 }
 
+/// A deprecated tool that has been folded into a primary tool (#509 Phase 1).
+///
+/// The alias stays **registered and callable** (directly and via `ctx_call`) for
+/// one release so nothing breaks, but it is hidden from `tools/list` and warns on
+/// use, steering agents to the consolidated primary. Removal happens in Phase 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeprecatedAlias {
+    /// The primary tool that supersedes this alias (e.g. `"ctx_read"`).
+    pub replacement: &'static str,
+    /// One-line migration hint (e.g. how the primary covers this use case).
+    pub hint: &'static str,
+}
+
+/// Single source of truth for read-cluster deprecations (#509). Returns the
+/// replacement + migration hint when `name` is a deprecated alias, else `None`.
+///
+/// Used by [`crate::server::tool_visibility::is_tool_visible`] to hide the alias
+/// from `tools/list`, and by the dispatch layer to prepend a one-line
+/// deprecation notice to the alias's output. Keeping both behaviours keyed off
+/// this one function guarantees "hidden" and "warned" can never drift apart.
+#[must_use]
+pub fn deprecated_alias(name: &str) -> Option<DeprecatedAlias> {
+    match name {
+        "ctx_smart_read" => Some(DeprecatedAlias {
+            replacement: "ctx_read",
+            hint: "ctx_read auto-selects the mode (omit `mode`, or pass mode=\"auto\")",
+        }),
+        "ctx_multi_read" => Some(DeprecatedAlias {
+            replacement: "ctx_read",
+            hint: "ctx_read now batch-reads via paths=[\"a.rs\",\"b.rs\"]",
+        }),
+        _ => None,
+    }
+}
+
+/// Whether `name` is a deprecated alias hidden from `tools/list` (#509).
+#[must_use]
+pub fn is_deprecated_alias(name: &str) -> bool {
+    deprecated_alias(name).is_some()
+}
+
+/// The one-line deprecation notice prepended to a deprecated alias's output.
+/// Stable per tool (no timestamps/counters) so provider-side prompt caching
+/// stays byte-stable (#498).
+#[must_use]
+pub fn deprecation_notice(name: &str) -> Option<String> {
+    deprecated_alias(name).map(|d| {
+        format!(
+            "[DEPRECATED] {name} is superseded by {} — {}. This alias is hidden from \
+             tools/list and will be removed in a future release.",
+            d.replacement, d.hint
+        )
+    })
+}
+
 pub fn is_readonly_tool(name: &str) -> bool {
     matches!(
         name,
@@ -276,6 +331,35 @@ mod tests {
         let state = DynamicToolState::new();
         assert!(state.is_tool_active("ctx_read"));
         assert!(state.is_tool_active("ctx_search"));
+    }
+
+    #[test]
+    fn deprecated_alias_maps_read_cluster_to_ctx_read() {
+        // #509: only the folded read-cluster tools are deprecated; everything
+        // else (incl. the primary) returns None.
+        assert_eq!(
+            deprecated_alias("ctx_smart_read").unwrap().replacement,
+            "ctx_read"
+        );
+        assert_eq!(
+            deprecated_alias("ctx_multi_read").unwrap().replacement,
+            "ctx_read"
+        );
+        assert!(deprecated_alias("ctx_read").is_none());
+        assert!(deprecated_alias("ctx_search").is_none());
+        assert!(is_deprecated_alias("ctx_multi_read"));
+        assert!(!is_deprecated_alias("ctx_read"));
+    }
+
+    #[test]
+    fn deprecation_notice_is_stable_and_names_replacement() {
+        // Stable text (no timestamps/counters) for cache-byte-stability (#498),
+        // and it must point at the primary so agents know where to go.
+        let notice = deprecation_notice("ctx_multi_read").unwrap();
+        assert!(notice.starts_with("[DEPRECATED] ctx_multi_read is superseded by ctx_read"));
+        assert!(notice.contains("paths="));
+        assert_eq!(notice, deprecation_notice("ctx_multi_read").unwrap());
+        assert!(deprecation_notice("ctx_read").is_none());
     }
 
     #[test]

--- a/rust/src/server/tool_visibility.rs
+++ b/rust/src/server/tool_visibility.rs
@@ -73,6 +73,11 @@ pub fn is_tool_visible(
     if categorize_tool(name) == ToolCategory::Internal {
         return false;
     }
+    // #509: deprecated read-cluster aliases (ctx_smart_read, ctx_multi_read) are
+    // hidden from the advertised surface but stay callable for one release.
+    if super::dynamic_tools::is_deprecated_alias(name) {
+        return false;
+    }
     if !profile.is_tool_enabled(name) {
         return false;
     }
@@ -190,6 +195,34 @@ mod tests {
         assert!(!is_tool_visible("ctx_metrics", &p, &[], false, true));
         assert!(!is_tool_visible("ctx_cost", &p, &[], false, true));
         assert!(!is_tool_visible("ctx_discover_tools", &p, &[], false, true));
+    }
+
+    #[test]
+    fn deprecated_aliases_never_visible_even_in_power() {
+        // #509: folded read-cluster aliases are hidden from tools/list in every
+        // mode (Power enables everything) — but stay registered + callable.
+        let p = ToolProfile::Power;
+        assert!(!is_tool_visible("ctx_smart_read", &p, &[], false, true));
+        assert!(!is_tool_visible("ctx_multi_read", &p, &[], false, true));
+    }
+
+    #[test]
+    fn deprecated_aliases_stay_registered_and_callable() {
+        // The non-breaking contract (#509): hidden from the advertised surface,
+        // but still in the registry so direct calls and ctx_call keep working
+        // for one release. Removal is Phase 2.
+        let _guard = crate::core::data_dir::isolated_data_dir();
+        let defs = crate::server::registry::build_registry().tool_defs();
+        for name in ["ctx_smart_read", "ctx_multi_read"] {
+            assert!(
+                defs.iter().any(|t| t.name.as_ref() == name),
+                "{name} must stay registered (callable) even though hidden"
+            );
+            assert!(
+                !is_tool_visible(name, &ToolProfile::Power, &[], false, true),
+                "{name} must be hidden from tools/list"
+            );
+        }
     }
 
     #[test]
@@ -314,10 +347,16 @@ mod tests {
     /// bytes for review/audit instead of guessing. `ctx_read` is the richest core
     /// tool and is the only one that crosses 300; the per-tool cap still guards
     /// every other tool from bloat. Kept to terse clauses (+~33 tok on ctx_read).
+    ///
+    /// Bumped to per-tool 360 / total 2340 for #509: `ctx_read` absorbs the
+    /// `ctx_multi_read` batch capability via a `paths` array, so two tools collapse
+    /// into one (`ctx_smart_read` + `ctx_multi_read` are now deprecated aliases
+    /// hidden from the surface). The net effect REDUCES the advertised surface; the
+    /// only local cost is +~18 tok on `ctx_read`'s schema for the new `paths` arg.
     #[test]
     fn core_tool_surface_stays_within_budget() {
-        const PER_TOOL_BUDGET: usize = 335;
-        const TOTAL_BUDGET: usize = 2310;
+        const PER_TOOL_BUDGET: usize = 360;
+        const TOTAL_BUDGET: usize = 2340;
 
         let _guard = crate::core::data_dir::isolated_data_dir();
         let core = crate::tool_defs::core_tool_names();

--- a/rust/src/tools/registered/ctx_multi_read.rs
+++ b/rust/src/tools/registered/ctx_multi_read.rs
@@ -19,11 +19,8 @@ impl McpTool for CtxMultiReadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_multi_read",
-            "Batch-read multiple files in one call — more efficient than N sequential\n\
-             ctx_read calls. paths=['a.rs','b.rs'] reads all at once.\n\
-             WORKFLOW: ctx_compose FIRST → ctx_multi_read for content.\n\
-             ANTI-PATTERN: not for understanding code logic — use ctx_compose.\n\
-             mode=full for edit; mode=auto for reading.",
+            "DEPRECATED → use ctx_read with paths=['a.rs','b.rs']. Folded into ctx_read\n\
+             (#509); hidden from tools/list, still callable for one release.",
             json!({
                 "type": "object",
                 "properties": {
@@ -52,129 +49,130 @@ impl McpTool for CtxMultiReadTool {
         args: &Map<String, Value>,
         ctx: &ToolContext,
     ) -> Result<ToolOutput, ErrorData> {
-        // Panic guard (mirrors ctx_read): a panic in tree-sitter / compression must
-        // never unwind through the dispatch `block_in_place` and kill the MCP server.
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.handle_inner(args, ctx)
-        })) {
-            Ok(result) => result,
-            Err(_) => Err(ErrorData::internal_error(
-                "ctx_multi_read panicked while processing the batch. This is a bug — please report it.",
-                None,
-            )),
-        }
+        batch_read(args, ctx)
     }
 }
 
-impl CtxMultiReadTool {
-    #[allow(clippy::unused_self)]
-    fn handle_inner(
-        &self,
-        args: &Map<String, Value>,
-        ctx: &ToolContext,
-    ) -> Result<ToolOutput, ErrorData> {
-        let raw_paths = get_str_array(args, "paths")
-            .ok_or_else(|| ErrorData::invalid_params("paths array is required", None))?;
+/// Batch-read multiple files in one call. The single implementation shared by
+/// the (deprecated) `ctx_multi_read` tool and by `ctx_read` when it is called
+/// with a `paths` array (#509) — no duplicated batch logic across the two.
+///
+/// Panic guard (mirrors ctx_read): a panic in tree-sitter / compression must
+/// never unwind through the dispatch `block_in_place` and kill the MCP server.
+pub(crate) fn batch_read(
+    args: &Map<String, Value>,
+    ctx: &ToolContext,
+) -> Result<ToolOutput, ErrorData> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| handle_inner(args, ctx))) {
+        Ok(result) => result,
+        Err(_) => Err(ErrorData::internal_error(
+            "ctx_multi_read panicked while processing the batch. This is a bug — please report it.",
+            None,
+        )),
+    }
+}
 
-        let session_lock = ctx
-            .session
-            .as_ref()
-            .ok_or_else(|| ErrorData::internal_error("session not available", None))?;
-        let cache_lock = ctx
-            .cache
-            .as_ref()
-            .ok_or_else(|| ErrorData::internal_error("cache not available", None))?;
+fn handle_inner(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOutput, ErrorData> {
+    let raw_paths = get_str_array(args, "paths")
+        .ok_or_else(|| ErrorData::invalid_params("paths array is required", None))?;
 
-        let cap = crate::core::limits::max_read_bytes() as u64;
+    let session_lock = ctx
+        .session
+        .as_ref()
+        .ok_or_else(|| ErrorData::internal_error("session not available", None))?;
+    let cache_lock = ctx
+        .cache
+        .as_ref()
+        .ok_or_else(|| ErrorData::internal_error("cache not available", None))?;
 
-        // Resolve + filter paths and capture the active task under one short read lock.
-        // `bounded_lock` uses `Handle::block_on` directly — NOT a nested
-        // `block_in_place` — because the dispatch layer already wraps this handler in
-        // `block_in_place`. The previous nested `block_in_place` calls could exhaust the
-        // 32-thread blocking pool under concurrent reads and freeze the server (#271).
-        let (paths, current_task) = {
-            let Some(session) =
-                crate::server::bounded_lock::read(session_lock, "ctx_multi_read:session")
-            else {
-                return Err(ErrorData::internal_error(
-                    "session read-lock timeout in ctx_multi_read — another tool may be holding it. Retry in a moment.",
-                    None,
-                ));
-            };
-            let mut paths = Vec::with_capacity(raw_paths.len());
-            for p in &raw_paths {
-                let resolved = super::resolve_path_sync(&session, p)
-                    .map_err(|e| ErrorData::invalid_params(e, None))?;
-                if crate::core::binary_detect::is_binary_file(&resolved) {
-                    continue;
-                }
-                if let Ok(meta) = std::fs::metadata(&resolved)
-                    && meta.len() > cap
-                {
-                    continue;
-                }
-                paths.push(resolved);
-            }
-            let current_task = session.task.as_ref().map(|t| t.description.clone());
-            (paths, current_task)
-        };
+    let cap = crate::core::limits::max_read_bytes() as u64;
 
-        if paths.is_empty() {
-            return Err(ErrorData::invalid_params(
-                "all paths are binary or exceed the size limit",
-                None,
-            ));
-        }
-
-        // Default to the profile's read mode (auto) and let ctx_read resolve the
-        // optimal mode per file. Previously this forced auto→full, which is exactly
-        // the "everything comes back as full" complaint (#421): batch reads must
-        // honour auto like single ctx_read does.
-        let mode = get_str(args, "mode").unwrap_or_else(|| {
-            crate::core::profiles::active_profile()
-                .read
-                .default_mode_effective()
-                .to_string()
-        });
-        let fresh = get_bool(args, "fresh").unwrap_or(false);
-
-        // Batch read under one bounded write lock. `bounded_lock` guarantees we never
-        // block the runtime indefinitely and degrade gracefully on contention instead
-        // of hanging; ctx_read's own fast/slow path tolerates this lock being held.
-        let Some(mut cache) =
-            crate::server::bounded_lock::write(cache_lock, "ctx_multi_read:cache")
+    // Resolve + filter paths and capture the active task under one short read lock.
+    // `bounded_lock` uses `Handle::block_on` directly — NOT a nested
+    // `block_in_place` — because the dispatch layer already wraps this handler in
+    // `block_in_place`. The previous nested `block_in_place` calls could exhaust the
+    // 32-thread blocking pool under concurrent reads and freeze the server (#271).
+    let (paths, current_task) = {
+        let Some(session) =
+            crate::server::bounded_lock::read(session_lock, "ctx_multi_read:session")
         else {
             return Err(ErrorData::internal_error(
-                "cache write-lock timeout in ctx_multi_read — another tool may be holding it. Retry in a moment.",
+                "session read-lock timeout in ctx_multi_read — another tool may be holding it. Retry in a moment.",
                 None,
             ));
         };
-        let output = crate::tools::ctx_multi_read::handle_with_task_fresh(
-            &mut cache,
-            &paths,
-            &mode,
-            fresh,
-            ctx.crp_mode,
-            current_task.as_deref(),
-        );
-        let mut total_original: usize = 0;
-        for path in &paths {
-            total_original =
-                total_original.saturating_add(cache.get(path).map_or(0, |e| e.original_tokens));
+        let mut paths = Vec::with_capacity(raw_paths.len());
+        for p in &raw_paths {
+            let resolved = super::resolve_path_sync(&session, p)
+                .map_err(|e| ErrorData::invalid_params(e, None))?;
+            if crate::core::binary_detect::is_binary_file(&resolved) {
+                continue;
+            }
+            if let Ok(meta) = std::fs::metadata(&resolved)
+                && meta.len() > cap
+            {
+                continue;
+            }
+            paths.push(resolved);
         }
-        let tokens = crate::core::tokens::count_tokens(&output);
-        drop(cache);
+        let current_task = session.task.as_ref().map(|t| t.description.clone());
+        (paths, current_task)
+    };
 
-        Ok(ToolOutput {
-            text: output,
-            original_tokens: total_original,
-            saved_tokens: total_original.saturating_sub(tokens),
-            mode: Some(mode),
-            path: None,
-            changed: false,
-            shell_outcome: None,
-        })
+    if paths.is_empty() {
+        return Err(ErrorData::invalid_params(
+            "all paths are binary or exceed the size limit",
+            None,
+        ));
     }
+
+    // Default to the profile's read mode (auto) and let ctx_read resolve the
+    // optimal mode per file. Previously this forced auto→full, which is exactly
+    // the "everything comes back as full" complaint (#421): batch reads must
+    // honour auto like single ctx_read does.
+    let mode = get_str(args, "mode").unwrap_or_else(|| {
+        crate::core::profiles::active_profile()
+            .read
+            .default_mode_effective()
+            .to_string()
+    });
+    let fresh = get_bool(args, "fresh").unwrap_or(false);
+
+    // Batch read under one bounded write lock. `bounded_lock` guarantees we never
+    // block the runtime indefinitely and degrade gracefully on contention instead
+    // of hanging; ctx_read's own fast/slow path tolerates this lock being held.
+    let Some(mut cache) = crate::server::bounded_lock::write(cache_lock, "ctx_multi_read:cache")
+    else {
+        return Err(ErrorData::internal_error(
+            "cache write-lock timeout in ctx_multi_read — another tool may be holding it. Retry in a moment.",
+            None,
+        ));
+    };
+    let output = crate::tools::ctx_multi_read::handle_with_task_fresh(
+        &mut cache,
+        &paths,
+        &mode,
+        fresh,
+        ctx.crp_mode,
+        current_task.as_deref(),
+    );
+    let mut total_original: usize = 0;
+    for path in &paths {
+        total_original =
+            total_original.saturating_add(cache.get(path).map_or(0, |e| e.original_tokens));
+    }
+    let tokens = crate::core::tokens::count_tokens(&output);
+    drop(cache);
+
+    Ok(ToolOutput {
+        text: output,
+        original_tokens: total_original,
+        saved_tokens: total_original.saturating_sub(tokens),
+        mode: Some(mode),
+        path: None,
+        changed: false,
+        shell_outcome: None,
+    })
 }
 
 #[cfg(test)]
@@ -273,6 +271,43 @@ mod tests {
                 out.text
             );
         }
+    }
+
+    /// #509: `ctx_read` with a `paths` array must route to the shared
+    /// `batch_read` (folding `ctx_multi_read` into `ctx_read`), producing the
+    /// same multi-file batch output as calling `ctx_multi_read` directly.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctx_read_with_paths_delegates_to_batch_read() {
+        use crate::tools::registered::ctx_read::CtxReadTool;
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut paths = Vec::new();
+        for i in 0..3 {
+            let p = dir.path().join(format!("f{i}.rs"));
+            std::fs::write(&p, format!("fn f{i}() {{ let _ = {i}; }}\n")).unwrap();
+            paths.push(p.to_string_lossy().to_string());
+        }
+        let root = dir.path().to_string_lossy().to_string();
+
+        let cache: Arc<RwLock<SessionCache>> = Arc::new(RwLock::new(SessionCache::new()));
+        let session = {
+            let mut s = SessionState::new();
+            s.project_root = Some(root.clone());
+            Arc::new(RwLock::new(s))
+        };
+        let ctx = ctx_with(cache, session, &root);
+        let args = json!({ "paths": paths, "mode": "full" })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let out = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx))
+            .expect("ctx_read(paths) returned an error");
+        assert!(
+            out.text.contains("Read 3 files"),
+            "ctx_read(paths) must batch-read like ctx_multi_read, got: {}",
+            out.text
+        );
     }
 
     /// #421: `ctx_multi_read` used to force `auto`→`full`, so omitting `mode`

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -45,6 +45,7 @@ impl McpTool for CtxReadTool {
                 "type": "object",
                 "properties": {
                     "path": { "type": "string", "description": "Absolute path" },
+                    "paths": { "type": "array", "items": { "type": "string" }, "description": "Batch-read many files (replaces ctx_multi_read)" },
                     "mode": {
                         "type": "string",
                         "description": "REQUIRED. full=verbatim(edit-ready) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window reference=quotes task=focus"
@@ -57,7 +58,7 @@ impl McpTool for CtxReadTool {
                     "aggressiveness": { "type": "number", "description": "0.0(lossless)–1.0(max). Without explicit mode→density; also tunes entropy/task. Omit for defaults" },
                     "protect": { "type": "array", "items": { "type": "string" }, "description": "Symbols/strings force-kept verbatim in entropy/task modes" }
                 },
-                "required": ["path"]
+                "required": []
             }),
         )
     }
@@ -67,6 +68,16 @@ impl McpTool for CtxReadTool {
         args: &Map<String, Value>,
         ctx: &ToolContext,
     ) -> Result<ToolOutput, ErrorData> {
+        // #509: ctx_read absorbs multi-file batch reads (supersedes ctx_multi_read).
+        // A non-empty `paths` array routes to the one shared batch implementation.
+        if args
+            .get("paths")
+            .and_then(|v| v.as_array())
+            .is_some_and(|a| !a.is_empty())
+        {
+            return super::ctx_multi_read::batch_read(args, ctx);
+        }
+
         let path = require_resolved_path(ctx, args, "path")?;
 
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/rust/src/tools/registered/ctx_smart_read.rs
+++ b/rust/src/tools/registered/ctx_smart_read.rs
@@ -15,9 +15,8 @@ impl McpTool for CtxSmartReadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_smart_read",
-            "WORKFLOW: orientation — auto-selects mode (full|map|signatures) by file size.\n\
-             ANTIPATTERN: edit-target files → ctx_read mode=full for precision.\n\
-             Explicit mode control → ctx_read mode=...",
+            "DEPRECATED → use ctx_read (it auto-selects the mode; omit `mode`). Folded\n\
+             into ctx_read (#509); hidden from tools/list, still callable for one release.",
             json!({
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Summary

**#509 Phase 1 — read-variant cluster.** Collapses the three read tools into one discoverable primary, non-breaking and eval-gated, establishing the deprecation mechanism the remaining clusters will reuse.

The issue's premise: `ctx_smart_read` is just `ctx_read` with `mode=auto`, and `ctx_multi_read` is just `ctx_read` over N paths. This PR makes that real:

- **`ctx_read` gains a `paths` array** → batch-reads many files in one call, superseding `ctx_multi_read`. `ctx_read(paths)` and `ctx_multi_read` now share **one** `batch_read` implementation (no duplicated batch logic).
- **`ctx_smart_read` + `ctx_multi_read` become deprecated aliases**: hidden from `tools/list`, but still **registered + callable** (directly and via `ctx_call`) for one release, and they **warn on use** with a one-line notice pointing at `ctx_read`. Removal is Phase 2.
- **One SSOT** — `dynamic_tools::deprecated_alias()` — keys both the visibility gate and the deprecation notice, so "hidden" and "warned" can never drift. Reusable for the next clusters.
- `ctx_multi_read` dropped from the **Standard** profile (superseded by `ctx_read paths`).

## Why hidden-not-removed (non-breaking)

The registry stays **77** for the deprecation window; the *advertised* surface shrinks by 2. Phase 2 removes the aliases at the next major (→ 75). Anything still calling the old names keeps working and gets nudged to the primary. This matches the phased plan in #509.

## Token budget

Net description-token load **drops** — the deprecated one-liners save more than `ctx_read`'s `+18`-tok `paths` arg. The core per-tool / total budgets were bumped `335→360` / `2310→2340` with rationale in the test (same pattern as #432 / #451 / #513), because `ctx_read` is the one core tool that legitimately grows when it absorbs a capability.

## Test plan

- [x] `ctx_read(paths=[…])` delegates to the shared `batch_read` and produces the same multi-file output as `ctx_multi_read`.
- [x] Deprecated aliases are hidden from `tools/list` in every mode (incl. Power) **and** stay in the registry (callable).
- [x] Deprecation notice is stable (no timestamps/counters, #498) and names the replacement.
- [x] Drift: manifest + reference docs regenerated; `docs_tool_counts` / `mcp_manifest` / `reference_docs_drift` green.
- [x] Budgets: `bench_tool_descriptions_token_count` (5451 < 5600), `bench_total_input_overhead` (13686 < 14000), lazy reduction 82.3%.
- [x] `preflight full` green: fmt, clippy `--all-features -D warnings`, rustdoc, gen_docs, Windows cross-compile, `cargo test --lib --all-features` (5836 passed).
- [ ] CI **Output-Quality Gate (eval A/B)** — expected non-inferior (folds redundant tools; `ctx_read` still does everything).

Refs #509
