### PR TITLE
feat(shell): configurable ctx_shell timeouts + opt-in shell writes (re-cut of #523)

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -65,11 +65,14 @@ Top-level configuration keys
 - `savings_footer` (enum: auto | always | never, default `always` — env `LEAN_CTX_SAVINGS_FOOTER`) — Controls visibility of token savings footers: always (default, show on every response), never, auto (context-dependent). Also: LEAN_CTX_SHOW_SAVINGS=1|0
 - `shadow_mode` (bool, default `false` — env `LEAN_CTX_SHADOW_MODE`) — Opt-in (default off): transparently route native Read/Grep/Edit/Shell through lean-ctx — via hooks for hook-based agents, via the interception plugin for OpenCode
 - `shell_activation` (enum: always | agents-only | off, default `always` — env `LEAN_CTX_SHELL_ACTIVATION`) — Controls when the shell hook auto-activates aliases
+- `shell_allow_writes` (bool, default `false` — env `LEAN_CTX_SHELL_ALLOW_WRITES`) — Allow ctx_shell file-write redirects (>, >>, tee, heredoc-to-file, curl -o, wget default mode). Default false — prefer the native Write/Edit tool. The real command gating (allowlist, dangerous-pattern, interpreter-eval) still applies
 - `shell_allowlist` (array, default `[]` — env `LEAN_CTX_SHELL_ALLOWLIST`) — Optional shell command allowlist. When non-empty, only listed binaries are permitted
 - `shell_allowlist_extra` (array, default `[]`) — Commands merged on top of shell_allowlist without replacing the defaults. Managed via `lean-ctx allow <cmd>`
+- `shell_heavy_timeout_secs` (u64?, default `null` — env `LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS`) — Shell command timeout (seconds) for heavy commands (cargo build/test, make, docker build, git commit/push). null = built-in 10-minute ceiling
 - `shell_hook_disabled` (bool, default `false` — env `LEAN_CTX_NO_HOOK`) — Disable shell hook injection
 - `shell_security` (string, default `enforce` — env `LEAN_CTX_SHELL_SECURITY`) — Shell command gating: enforce (default, secure), warn (log only, never block) or off (skip allowlist + hard blocks; compression stays active)
 - `shell_strict_mode` (bool, default `false`) — Block $(), backticks, <() in shell arguments. Default false = warn only.
+- `shell_timeout_secs` (u64?, default `null` — env `LEAN_CTX_SHELL_TIMEOUT_SECS`) — Shell command timeout (seconds) for normal commands. null = built-in 2-minute default. LEAN_CTX_SHELL_TIMEOUT_MS overrides both tiers (in ms)
 - `slow_command_threshold_ms` (u64, default `5000`) — Commands taking longer than this (ms) are recorded in the slow log. Set to 0 to disable
 - `structure_first` (bool, default `false` — env `LEAN_CTX_STRUCTURE_FIRST`) — Opt-in: bias `auto` toward structure-first reads (map) for medium code files on a cold read. Off by default — for phase-isolated harnesses with no warm-session cache payback. Override via LEAN_CTX_STRUCTURE_FIRST
 - `symbol_map_auto` (bool, default `false`) — Opt-in: α-code identifier substitution in aggressive reads (>50-file projects). Off by default — abbreviated symbols hinder editing/refactoring

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -505,6 +505,30 @@ pub struct Config {
     /// LEAN_CTX_SHELL_SECURITY. `None` resolves to `enforce`.
     #[serde(default)]
     pub shell_security: Option<String>,
+
+    /// Default shell-command timeout in seconds for *normal* commands. `None`
+    /// resolves to the built-in 2-minute default; heavy builds/tests use
+    /// [`Config::shell_heavy_timeout_secs`]. Override via
+    /// `LEAN_CTX_SHELL_TIMEOUT_SECS` (`LEAN_CTX_SHELL_TIMEOUT_MS` still wins over
+    /// both, in milliseconds).
+    #[serde(default)]
+    pub shell_timeout_secs: Option<u64>,
+
+    /// Shell-command timeout in seconds for *heavy* commands (cargo build/test,
+    /// make, docker build, git commit/push, …). `None` resolves to the built-in
+    /// 10-minute ceiling. Override via `LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS`.
+    #[serde(default)]
+    pub shell_heavy_timeout_secs: Option<u64>,
+
+    /// When true, `ctx_shell` accepts shell file-write redirects (`>`, `>>`,
+    /// `tee`, heredoc-to-file, `curl -o`, `wget` default mode). Default false —
+    /// the native Write/Edit tool is preferred. Opt-in for power users who want
+    /// classic shell syntax; the real command gating (allowlist,
+    /// dangerous-pattern and interpreter-eval blocks) still applies. Override
+    /// via `LEAN_CTX_SHELL_ALLOW_WRITES=1`.
+    #[serde(default)]
+    pub shell_allow_writes: bool,
+
     /// Setup behavior: controls what gets injected during setup and updates.
     #[serde(default)]
     pub setup: SetupConfig,
@@ -611,6 +635,9 @@ impl Default for Config {
             shell_allowlist_extra: Vec::new(),
             shell_strict_mode: false,
             shell_security: None,
+            shell_timeout_secs: None,
+            shell_heavy_timeout_secs: None,
+            shell_allow_writes: false,
             setup: SetupConfig::default(),
         }
     }
@@ -934,6 +961,19 @@ impl Config {
     /// Returns the effective shell activation mode (env var > config > default).
     pub fn shell_activation_effective(&self) -> ShellActivation {
         ShellActivation::effective(self)
+    }
+
+    /// Returns `true` if `ctx_shell` may accept shell file-write redirects.
+    /// `LEAN_CTX_SHELL_ALLOW_WRITES` (`1`/`true`/`yes`/`on`) overrides
+    /// `config.toml`. The real command gating still applies either way.
+    pub fn shell_allow_writes_effective(&self) -> bool {
+        match std::env::var("LEAN_CTX_SHELL_ALLOW_WRITES") {
+            Ok(raw) => matches!(
+                raw.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            ),
+            Err(_) => self.shell_allow_writes,
+        }
     }
 
     /// Returns `true` if the daily update check is disabled via env var or config.

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -625,6 +625,33 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             "LEAN_CTX_SHELL_SECURITY",
         ),
     );
+    root.insert(
+        "shell_timeout_secs".into(),
+        key_with_env(
+            "u64?",
+            serde_json::json!(null),
+            "Shell command timeout (seconds) for normal commands. null = built-in 2-minute default. LEAN_CTX_SHELL_TIMEOUT_MS overrides both tiers (in ms)",
+            "LEAN_CTX_SHELL_TIMEOUT_SECS",
+        ),
+    );
+    root.insert(
+        "shell_heavy_timeout_secs".into(),
+        key_with_env(
+            "u64?",
+            serde_json::json!(null),
+            "Shell command timeout (seconds) for heavy commands (cargo build/test, make, docker build, git commit/push). null = built-in 10-minute ceiling",
+            "LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS",
+        ),
+    );
+    root.insert(
+        "shell_allow_writes".into(),
+        key_with_env(
+            "bool",
+            serde_json::json!(false),
+            "Allow ctx_shell file-write redirects (>, >>, tee, heredoc-to-file, curl -o, wget default mode). Default false — prefer the native Write/Edit tool. The real command gating (allowlist, dangerous-pattern, interpreter-eval) still applies",
+            "LEAN_CTX_SHELL_ALLOW_WRITES",
+        ),
+    );
 
     sections.insert(
         "root".into(),

--- a/rust/src/core/config/tests.rs
+++ b/rust/src/core/config/tests.rs
@@ -1603,3 +1603,77 @@ mod max_index_threads_tests {
         assert_eq!(Config::default().max_index_threads_effective(), 0);
     }
 }
+
+#[cfg(test)]
+mod shell_timeout_and_writes_tests {
+    use super::super::*;
+
+    #[test]
+    fn timeout_overrides_default_to_none() {
+        let cfg = Config::default();
+        assert_eq!(cfg.shell_timeout_secs, None);
+        assert_eq!(cfg.shell_heavy_timeout_secs, None);
+    }
+
+    #[test]
+    fn timeout_overrides_parse_from_toml() {
+        let cfg: Config =
+            toml::from_str("shell_timeout_secs = 90\nshell_heavy_timeout_secs = 1800").unwrap();
+        assert_eq!(cfg.shell_timeout_secs, Some(90));
+        assert_eq!(cfg.shell_heavy_timeout_secs, Some(1800));
+    }
+
+    #[test]
+    fn allow_writes_default_is_false() {
+        assert!(!Config::default().shell_allow_writes);
+    }
+
+    #[test]
+    fn allow_writes_parses_from_toml() {
+        let cfg: Config = toml::from_str("shell_allow_writes = true").unwrap();
+        assert!(cfg.shell_allow_writes);
+        let absent: Config = toml::from_str("").unwrap();
+        assert!(!absent.shell_allow_writes);
+    }
+
+    #[test]
+    fn allow_writes_round_trips_through_toml() {
+        let cfg = Config {
+            shell_allow_writes: true,
+            ..Default::default()
+        };
+        let serialized = toml::to_string(&cfg).expect("Config must serialize to TOML");
+        let restored: Config = toml::from_str(&serialized).expect("Config must round-trip");
+        assert!(restored.shell_allow_writes);
+    }
+
+    #[test]
+    fn allow_writes_effective_env_overrides_config() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved = std::env::var("LEAN_CTX_SHELL_ALLOW_WRITES").ok();
+
+        // Env truthy wins even when config is false.
+        crate::test_env::set_var("LEAN_CTX_SHELL_ALLOW_WRITES", "1");
+        assert!(Config::default().shell_allow_writes_effective());
+
+        // Env falsey/unknown falls back to the config field.
+        crate::test_env::set_var("LEAN_CTX_SHELL_ALLOW_WRITES", "nope");
+        let cfg_true = Config {
+            shell_allow_writes: true,
+            ..Default::default()
+        };
+        assert!(!Config::default().shell_allow_writes_effective());
+        // ...but with the env var present-but-falsey, config is ignored (explicit
+        // operator intent), so a true config still reads false here.
+        assert!(!cfg_true.shell_allow_writes_effective());
+
+        // With no env var, the config field decides.
+        crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOW_WRITES");
+        assert!(cfg_true.shell_allow_writes_effective());
+        assert!(!Config::default().shell_allow_writes_effective());
+
+        if let Some(v) = saved {
+            crate::test_env::set_var("LEAN_CTX_SHELL_ALLOW_WRITES", v);
+        }
+    }
+}

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -3,7 +3,6 @@ use std::process::Stdio;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
-const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_mins(2);
 const READER_RESULT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[cfg(test)]
@@ -181,40 +180,34 @@ fn ensure_utf8_locale(
 }
 
 fn command_timeout(command: &str) -> Duration {
-    // Explicit env override always wins (operators can pin any value).
-    if let Some(ms) = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|millis| *millis > 0)
-    {
-        return Duration::from_millis(ms);
-    }
-    // Otherwise mirror the interactive shell-hook path: heavy builds/tests
-    // (cargo install/nextest/build, npm ci, …) get the long timeout instead of
-    // being killed at the 2-minute default. Keeps `ctx_shell` and the hook
-    // consistent — previously only the hook consulted `is_heavy_command`.
-    crate::shell::heavy_timeout(command).unwrap_or(DEFAULT_COMMAND_TIMEOUT)
+    // Single source of truth: env (MS / per-tier SECS) > config > built-in
+    // heavy/normal ceilings. Keeps this path identical to `ctx_shell` and the
+    // interactive hook (`shell::exec::shell_timeout`).
+    crate::shell::shell_timeout(command)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_COMMAND_TIMEOUT, command_timeout, ensure_utf8_locale, execute_command_in};
+    use super::{command_timeout, ensure_utf8_locale, execute_command_in};
 
     #[test]
-    fn command_timeout_uses_heavy_for_heavy_commands() {
+    fn command_timeout_delegates_to_shell_timeout() {
+        // `command_timeout` is a thin alias for `shell::exec::shell_timeout`
+        // (full precedence coverage lives there). Smoke-test the delegation:
+        // heavy beats normal, and the universal MS override pins both.
+        let _lock = crate::core::data_dir::test_env_lock();
         let saved = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
         crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
 
-        // Heavy build/test commands get the long timeout, not the 2-min default.
-        assert!(command_timeout("cargo install --path .") > DEFAULT_COMMAND_TIMEOUT);
-        assert!(command_timeout("cargo nextest run") > DEFAULT_COMMAND_TIMEOUT);
-        // Ordinary commands keep the default.
-        assert_eq!(command_timeout("git status"), DEFAULT_COMMAND_TIMEOUT);
+        assert!(command_timeout("cargo install --path .") > command_timeout("git status"));
 
-        // Explicit env override wins over heavy detection.
         crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", "5000");
         assert_eq!(
             command_timeout("cargo install --path ."),
+            std::time::Duration::from_secs(5)
+        );
+        assert_eq!(
+            command_timeout("git status"),
             std::time::Duration::from_secs(5)
         );
 

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -106,11 +106,55 @@ const HEAVY_MAX_BYTES: usize = 32 * 1024 * 1024; // 32 MB
 const HEAVY_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(10);
 
 fn exec_limits(command: &str) -> (usize, std::time::Duration) {
-    if is_heavy_command(command) {
-        (HEAVY_MAX_BYTES, HEAVY_TIMEOUT)
+    let max_bytes = if is_heavy_command(command) {
+        HEAVY_MAX_BYTES
     } else {
-        (DEFAULT_MAX_BYTES, DEFAULT_TIMEOUT)
+        DEFAULT_MAX_BYTES
+    };
+    (max_bytes, shell_timeout(command))
+}
+
+/// Resolve the timeout `ctx_shell` / the shell hook grants a command.
+///
+/// Heavy builds/tests (cargo install/nextest/build, npm ci, git commit/push, …)
+/// get the long ceiling instead of being killed at the 2-minute default, keeping
+/// the MCP path and the interactive hook consistent. The constants are
+/// overridable so operators can pin any value. Precedence (first match wins):
+///
+/// 1. `LEAN_CTX_SHELL_TIMEOUT_MS` — universal override, in milliseconds.
+/// 2. heavy command → `LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS` / config
+///    `shell_heavy_timeout_secs`, else [`HEAVY_TIMEOUT`].
+/// 3. normal command → `LEAN_CTX_SHELL_TIMEOUT_SECS` / config
+///    `shell_timeout_secs`, else [`DEFAULT_TIMEOUT`].
+#[must_use]
+pub(crate) fn shell_timeout(command: &str) -> std::time::Duration {
+    if let Some(ms) = env_u64("LEAN_CTX_SHELL_TIMEOUT_MS") {
+        return std::time::Duration::from_millis(ms);
     }
+    if is_heavy_command(command) {
+        if let Some(secs) = env_u64("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS")
+            .or_else(|| config::Config::load().shell_heavy_timeout_secs)
+        {
+            return std::time::Duration::from_secs(secs);
+        }
+        HEAVY_TIMEOUT
+    } else {
+        if let Some(secs) = env_u64("LEAN_CTX_SHELL_TIMEOUT_SECS")
+            .or_else(|| config::Config::load().shell_timeout_secs)
+        {
+            return std::time::Duration::from_secs(secs);
+        }
+        DEFAULT_TIMEOUT
+    }
+}
+
+/// Parse a positive `u64` from an env var, ignoring absent/empty/zero/invalid
+/// values so the caller falls through to the next precedence tier.
+fn env_u64(var: &str) -> Option<u64> {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|n| *n > 0)
 }
 
 fn is_heavy_command(command: &str) -> bool {
@@ -165,16 +209,6 @@ fn is_heavy_command(command: &str) -> bool {
         "git push",
     ];
     HEAVY_PREFIXES.iter().any(|p| lower.starts_with(p))
-}
-
-/// Timeout the MCP `ctx_shell` tool should grant a command, mirroring the
-/// interactive hook's heavy-command detection. Returns `None` for ordinary
-/// commands (caller applies its own default), `Some(HEAVY_TIMEOUT)` for heavy
-/// builds/tests so long-running `cargo install`/`nextest`/etc. aren't killed at
-/// the 2-minute default. Keeps the MCP path and the shell-hook path consistent.
-#[must_use]
-pub(crate) fn heavy_timeout(command: &str) -> Option<std::time::Duration> {
-    is_heavy_command(command).then_some(HEAVY_TIMEOUT)
 }
 
 /// Execute a command from pre-split argv without going through `sh -c`.
@@ -750,75 +784,114 @@ mod exec_tests {
     }
 
     #[test]
-    fn heavy_commands_get_higher_limits() {
-        let (bytes, timeout) = super::exec_limits("cargo build --release");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
-
-        let (bytes, timeout) = super::exec_limits("cargo test --lib");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
-
-        let (bytes, timeout) = super::exec_limits("cargo nextest run");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
-
-        let (bytes, timeout) = super::exec_limits("npm run build");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
-
-        let (bytes, timeout) = super::exec_limits("docker build -t myapp .");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
-
-        // Git commands that trigger build/test hooks (pre-commit clippy,
-        // pre-push preflight) must not be killed at the 2-minute default.
-        let (bytes, timeout) = super::exec_limits("git commit --amend --no-edit");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
-
-        let (bytes, timeout) = super::exec_limits("git push -u origin HEAD");
-        assert_eq!(bytes, super::HEAVY_MAX_BYTES);
-        assert_eq!(timeout, super::HEAVY_TIMEOUT);
+    fn heavy_commands_get_higher_byte_limits() {
+        // exec_limits owns the byte ceiling; timeout resolution is covered by
+        // `shell_timeout_resolves_heavy_normal_and_env_overrides` (which is
+        // env/config-isolated, so these stay deterministic regardless of the
+        // operator's config.toml).
+        for cmd in [
+            "cargo build --release",
+            "cargo test --lib",
+            "cargo nextest run",
+            "npm run build",
+            "docker build -t myapp .",
+            // Git verbs that fire build/test hooks (pre-commit clippy, pre-push
+            // preflight) must not be killed at the default ceiling (#854).
+            "git commit --amend --no-edit",
+            "git push -u origin HEAD",
+        ] {
+            let (bytes, _) = super::exec_limits(cmd);
+            assert_eq!(bytes, super::HEAVY_MAX_BYTES, "heavy byte limit for {cmd}");
+        }
     }
 
     #[test]
-    fn normal_commands_get_default_limits() {
-        let (bytes, timeout) = super::exec_limits("echo hello");
-        assert_eq!(bytes, super::DEFAULT_MAX_BYTES);
-        assert_eq!(timeout, super::DEFAULT_TIMEOUT);
-
+    fn normal_commands_get_default_byte_limits() {
         // Read-only git verbs stay on the default ceiling — only `commit`/`push`
         // (which fire the cargo-heavy hooks) are promoted.
-        let (bytes, timeout) = super::exec_limits("git status");
-        assert_eq!(bytes, super::DEFAULT_MAX_BYTES);
-        assert_eq!(timeout, super::DEFAULT_TIMEOUT);
-
-        let (bytes, timeout) = super::exec_limits("git log --oneline -5");
-        assert_eq!(bytes, super::DEFAULT_MAX_BYTES);
-        assert_eq!(timeout, super::DEFAULT_TIMEOUT);
+        for cmd in ["echo hello", "git status", "git log --oneline -5"] {
+            let (bytes, _) = super::exec_limits(cmd);
+            assert_eq!(
+                bytes,
+                super::DEFAULT_MAX_BYTES,
+                "default byte limit for {cmd}"
+            );
+        }
     }
 
     #[test]
-    fn heavy_timeout_some_for_heavy_none_otherwise() {
+    fn shell_timeout_resolves_heavy_normal_and_env_overrides() {
+        // Serialize env mutation so this never races other env-reading tests.
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved_ms = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
+        let saved_secs = std::env::var("LEAN_CTX_SHELL_TIMEOUT_SECS").ok();
+        let saved_heavy = std::env::var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS").ok();
+        for v in [
+            "LEAN_CTX_SHELL_TIMEOUT_MS",
+            "LEAN_CTX_SHELL_TIMEOUT_SECS",
+            "LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS",
+        ] {
+            crate::test_env::remove_var(v);
+        }
+
+        // Heavy builds/tests and hook-firing git verbs get the heavy ceiling;
+        // read-only verbs stay on the default. Preserves the #854 promotion.
         assert_eq!(
-            super::heavy_timeout("cargo install --path ."),
-            Some(super::HEAVY_TIMEOUT)
+            super::shell_timeout("cargo install --path ."),
+            super::HEAVY_TIMEOUT
         );
         assert_eq!(
-            super::heavy_timeout("cargo nextest run"),
-            Some(super::HEAVY_TIMEOUT)
+            super::shell_timeout("cargo nextest run"),
+            super::HEAVY_TIMEOUT
         );
         assert_eq!(
-            super::heavy_timeout("git commit -m 'wip'"),
-            Some(super::HEAVY_TIMEOUT)
+            super::shell_timeout("git commit -m 'wip'"),
+            super::HEAVY_TIMEOUT
         );
         assert_eq!(
-            super::heavy_timeout("git push origin main"),
-            Some(super::HEAVY_TIMEOUT)
+            super::shell_timeout("git push origin main"),
+            super::HEAVY_TIMEOUT
         );
-        assert_eq!(super::heavy_timeout("git status"), None);
-        assert_eq!(super::heavy_timeout("ls -la"), None);
+        assert_eq!(super::shell_timeout("git status"), super::DEFAULT_TIMEOUT);
+        assert_eq!(super::shell_timeout("ls -la"), super::DEFAULT_TIMEOUT);
+
+        // Per-tier env overrides win over the built-in constants. (Non-round
+        // second values keep the literals clippy-clean and unambiguous.)
+        crate::test_env::set_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS", "90");
+        assert_eq!(
+            super::shell_timeout("cargo build"),
+            std::time::Duration::from_secs(90)
+        );
+        crate::test_env::remove_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS");
+
+        crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_SECS", "30");
+        assert_eq!(
+            super::shell_timeout("git status"),
+            std::time::Duration::from_secs(30)
+        );
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_SECS");
+
+        // The universal millisecond override wins over everything.
+        crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", "5000");
+        assert_eq!(
+            super::shell_timeout("cargo build"),
+            std::time::Duration::from_secs(5)
+        );
+        assert_eq!(
+            super::shell_timeout("git status"),
+            std::time::Duration::from_secs(5)
+        );
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+
+        for (var, saved) in [
+            ("LEAN_CTX_SHELL_TIMEOUT_MS", saved_ms),
+            ("LEAN_CTX_SHELL_TIMEOUT_SECS", saved_secs),
+            ("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS", saved_heavy),
+        ] {
+            if let Some(v) = saved {
+                crate::test_env::set_var(var, v);
+            }
+        }
     }
 
     // P0-1 (#413): the CLI allowlist must enforce for agents, warn for humans.

--- a/rust/src/shell/mod.rs
+++ b/rust/src/shell/mod.rs
@@ -7,7 +7,7 @@ mod redact;
 pub(crate) mod tee_policy;
 
 pub use compress::compress_if_beneficial_pub;
-pub(crate) use exec::heavy_timeout;
+pub(crate) use exec::shell_timeout;
 pub(crate) use exec::{STDERR_LABEL, combine_streams};
 pub use exec::{exec, exec_argv};
 pub use interactive::interactive;

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -42,7 +42,13 @@ impl McpTool for CtxShellTool {
         let command = get_str(args, "command")
             .ok_or_else(|| ErrorData::invalid_params("command is required", None))?;
 
-        if let Some(rejection) = crate::tools::ctx_shell::validate_command(&command) {
+        // The write-doctrine check (no `>`, `tee`, heredoc-to-file, curl -o, …)
+        // is an MCP-payload-safety convention, not a security boundary, so it is
+        // opt-out via `shell_allow_writes` (#523). The real command gating
+        // (`check_shell_allowlist`, below) is NOT affected by this flag.
+        if !crate::core::config::Config::load().shell_allow_writes_effective()
+            && let Some(rejection) = crate::tools::ctx_shell::validate_command(&command)
+        {
             // The command never ran — report as a tool error so MCP clients
             // (guards, retry logic) can detect it programmatically (#389).
             return Ok(ToolOutput {


### PR DESCRIPTION
## Summary

Clean re-cut of #523 (@omar-mohamed-khallaf) — keeps the two sound, low-risk features, drops a regression, and reconciles with `main` (#854 + #527 landed in the meantime). Closes #523.

### Taken from #523
- **Configurable shell timeouts** — `shell_timeout_secs` / `shell_heavy_timeout_secs` (config + `LEAN_CTX_SHELL_TIMEOUT_SECS` / `LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS`). A single `shell::exec::shell_timeout()` resolves the deadline with a clear precedence — `LEAN_CTX_SHELL_TIMEOUT_MS` (universal) > per-tier `*_SECS` env > config > built-in ceiling — and is now shared by `ctx_shell`, `ctx_execute` and the interactive hook. This replaces the old `heavy_timeout() -> Option` shim and removes the duplicate `execute.rs::DEFAULT_COMMAND_TIMEOUT`.
- **Opt-in shell writes** — `shell_allow_writes` (default `false`, + `LEAN_CTX_SHELL_ALLOW_WRITES`). Lets power users opt out of the `ctx_shell` write-doctrine (`>`, `>>`, `tee`, heredoc-to-file, `curl -o`, `wget`). That doctrine is an MCP-payload-safety convention, **not** a security boundary, so it is the only thing relaxed — the real gating (`check_shell_allowlist`: allowlist, dangerous-pattern, interpreter-eval blocks) still runs unconditionally.

### Dropped vs the original #523 (and why)
- **The dispatch watchdog change.** #523 removed the existing `LEAN_CTX_TOOL_TIMEOUT_SECS` configurability and the `0`-disables-watchdog escape, hard-coding `300s` — a regression of #271 (and the source of the clippy failure). `main`'s watchdog is left untouched.
- **The aggressive default bump** (2→10 min normal, 10→60 min heavy). Defaults stay at `main`'s values (2 min / 10 min); only the override plumbing is added, so **no one's timeout silently changes** on upgrade. #854's `git commit`/`git push` → heavy promotion is preserved and re-asserted in the new tests.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (5842 passed)
- [x] `scripts/preflight.sh full` (fmt + clippy + rustdoc + gen_docs drift + Windows cross-compile + full tests)
- [x] generated `config-keys.md` regenerated
- [x] new unit tests: timeout precedence (env/config/constants), `shell_allow_writes` default/parse/round-trip/env-override, byte-limit promotion

Co-authored-by: omar-mohamed-khallaf <omar-mohamed-khallaf@users.noreply.github.com>
