### PR TITLE
feat(ctx_read): type-safe ReadMode vocabulary (#528 / #509 Phase 2)

### DIFF
--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -14,6 +14,10 @@ use crate::tools::CrpMode;
 // accuracy invariants (GL#441).
 pub(crate) mod render;
 pub(crate) use render::*;
+/// Type-safe read-mode vocabulary (#528): single source of truth for which
+/// modes exist and how each is classified.
+pub(crate) mod mode;
+pub(crate) use mode::ReadMode;
 #[cfg(test)]
 mod tests;
 
@@ -29,10 +33,12 @@ pub struct ReadOutput {
 
 const COMPRESSED_HINT: &str = "[lean-ctx: compact view — nothing lost, full source on request]";
 
-const CACHEABLE_MODES: &[&str] = &["map", "signatures"];
-
+/// SSOT via [`ReadMode`] (#528): the `map`/`signatures` summaries whose rendered
+/// body is stored per-file in `compressed_outputs`. Unknown modes are not
+/// cacheable, matching the prior `["map","signatures"].contains(mode)`.
 fn is_cacheable_mode(mode: &str) -> bool {
-    CACHEABLE_MODES.contains(&mode)
+    mode.parse::<ReadMode>()
+        .is_ok_and(|m| m.is_compressed_cacheable())
 }
 
 /// `#361` anti-inflation capping applies to whole-file views (`full` and the
@@ -45,7 +51,10 @@ fn is_cacheable_mode(mode: &str) -> bool {
 /// `diff` a delta, `raw` the bytes — so replacing them with the whole file would
 /// be wrong, not cheaper, and they are never capped.
 fn mode_allows_raw_cap(mode: &str) -> bool {
-    !(mode.starts_with("lines:") || matches!(mode, "reference" | "diff" | "raw"))
+    // SSOT via [`ReadMode`] (#528). Unknown modes keep the prior default of
+    // `true` (only `lines:`/`reference`/`diff`/`raw` opt out of the #361 cap).
+    mode.parse::<ReadMode>()
+        .map_or(true, |m| m.allows_raw_cap())
 }
 
 fn compressed_cache_key(
@@ -388,10 +397,11 @@ fn handle_with_options_resolved(
         entry.last_mode.clone_from(&result.resolved_mode);
     }
 
-    let dedup_allowed = matches!(
-        result.resolved_mode.as_str(),
-        "map" | "signatures" | "aggressive" | "entropy" | "task"
-    );
+    // SSOT via [`ReadMode`] (#528): lossy summaries may elide shared blocks.
+    let dedup_allowed = result
+        .resolved_mode
+        .parse::<ReadMode>()
+        .is_ok_and(|m| m.is_lossy_summary());
     if dedup_allowed && let Some(deduped) = cache.apply_dedup(path, &result.content) {
         let new_tokens = count_tokens(&deduped);
         if new_tokens < result.output_tokens {
@@ -413,7 +423,15 @@ fn handle_with_options_resolved(
         // bounce proves otherwise (the bounce signal outweighs 6:1); large
         // full reads of never-bouncing extensions are wasted compression
         // opportunities and push the learned threshold up.
-        let compressed = !matches!(result.resolved_mode.as_str(), "full" | "diff" | "lines");
+        // SSOT via [`ReadMode`] (#528): only verbatim `full` and the `diff`
+        // delta are uncompressed. A resolved window is always the canonical
+        // `lines:N-M` (parses to `Lines` ⇒ compressed); the default of `true`
+        // for the unreachable bare `"lines"` keeps prior behaviour everywhere a
+        // real resolved mode can occur.
+        let compressed = result
+            .resolved_mode
+            .parse::<ReadMode>()
+            .map_or(true, |m| m.counts_as_compressed());
         if compressed {
             crate::core::adaptive_thresholds::record_quality_signal(
                 path,

--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -1,0 +1,365 @@
+//! Type-safe `ctx_read` modes (#528 / #509 Phase 2).
+//!
+//! Historically the read mode travelled through the whole pipeline as a bare
+//! `&str` (`"full"`, `"map"`, `"lines:5-10"`, `"density:0.40"`, …) and the
+//! knowledge of *which* modes exist — and how each one is classified (cacheable?
+//! lossy summary? counts as compressed?) — was duplicated across the registered
+//! handler, the read core and `render.rs`. That stringly-typed design let invalid
+//! states slip through (silently falling back to `full`) and let the duplicated
+//! classifications drift.
+//!
+//! [`ReadMode`] is the single source of truth for the mode vocabulary:
+//!
+//! * [`ReadMode::from_str`] parses (and *validates*) the canonical strings.
+//! * [`Display`](std::fmt::Display) round-trips **byte-identically** to those
+//!   same strings, so the type can be threaded through the typed decision points
+//!   without touching the string-mode MCP boundary or `render.rs` (back-compat).
+//! * the classification methods ([`ReadMode::is_compressed_cacheable`],
+//!   [`ReadMode::allows_raw_cap`], [`ReadMode::is_lossy_summary`],
+//!   [`ReadMode::counts_as_compressed`]) replace the scattered `matches!(mode,
+//!   …)` predicates, and the test module locks each one to the legacy predicate
+//!   it replaces so behaviour can never silently change.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Sentinel `end` meaning "to end of file" — preserved from the historical
+/// `lines:N-999999` form so [`Display`](std::fmt::Display) stays byte-stable.
+pub(crate) const LINE_RANGE_EOF: u32 = 999_999;
+
+/// A 1-based, inclusive line window (`lines:start-end`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LineRange {
+    pub(crate) start: u32,
+    pub(crate) end: u32,
+}
+
+impl LineRange {
+    /// Window `start..=end`. `start` is clamped to ≥ 1 to mirror the handler's
+    /// historical `start.max(1)` behaviour (#253).
+    #[must_use]
+    pub(crate) fn new(start: u32, end: u32) -> Self {
+        Self {
+            start: start.max(1),
+            end,
+        }
+    }
+
+    /// Window from `start` to end of file (the `lines:N-999999` form).
+    #[must_use]
+    pub(crate) fn to_eof(start: u32) -> Self {
+        Self::new(start, LINE_RANGE_EOF)
+    }
+}
+
+impl fmt::Display for LineRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.start, self.end)
+    }
+}
+
+/// The mode a `ctx_read` call resolves to.
+///
+/// `Density` carries an `f64`, so the enum is `PartialEq` but not `Eq`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ReadMode {
+    /// Verbatim, edit-ready (framed) — `"full"`.
+    Full,
+    /// Exact bytes, no framing — `"raw"`.
+    Raw,
+    /// API surface — `"signatures"`.
+    Signatures,
+    /// Structural outline — `"map"`.
+    Map,
+    /// Aggressive lossy summary — `"aggressive"`.
+    Aggressive,
+    /// Entropy-pruned summary — `"entropy"`.
+    Entropy,
+    /// Task-focused summary — `"task"`.
+    Task,
+    /// One-line pointer/quote — `"reference"`.
+    Reference,
+    /// Learned/auto mode selection — `"auto"`.
+    Auto,
+    /// Git delta vs the cached copy — `"diff"`.
+    Diff,
+    /// Line window — `"lines:start-end"`.
+    Lines(LineRange),
+    /// Target-density compression — `"density:0.NN"`.
+    Density(f64),
+}
+
+/// Error returned when a string is not a recognised [`ReadMode`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ParseModeError {
+    /// The string is not any known mode keyword or prefix.
+    Unknown(String),
+    /// A known prefix (`lines:` / `density:`) with an unparseable payload.
+    Malformed(String),
+}
+
+impl fmt::Display for ParseModeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseModeError::Unknown(s) => write!(f, "unknown read mode '{s}'"),
+            ParseModeError::Malformed(s) => write!(f, "malformed read mode '{s}'"),
+        }
+    }
+}
+
+impl std::error::Error for ParseModeError {}
+
+/// Parse the payload of a `lines:` mode (`"5-10"`, `"5-999999"`, or a bare
+/// `"5"` meaning "from line 5 to EOF").
+fn parse_line_range(payload: &str) -> Result<LineRange, ParseModeError> {
+    let malformed = || ParseModeError::Malformed(format!("lines:{payload}"));
+    if let Some((a, b)) = payload.split_once('-') {
+        let start = a.trim().parse::<u32>().map_err(|_| malformed())?;
+        let end = b.trim().parse::<u32>().map_err(|_| malformed())?;
+        Ok(LineRange::new(start, end))
+    } else {
+        // A bare `lines:N` means "from line N to EOF".
+        let start = payload.trim().parse::<u32>().map_err(|_| malformed())?;
+        Ok(LineRange::to_eof(start))
+    }
+}
+
+impl FromStr for ReadMode {
+    type Err = ParseModeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "full" => ReadMode::Full,
+            "raw" => ReadMode::Raw,
+            "signatures" => ReadMode::Signatures,
+            "map" => ReadMode::Map,
+            "aggressive" => ReadMode::Aggressive,
+            "entropy" => ReadMode::Entropy,
+            "task" => ReadMode::Task,
+            "reference" => ReadMode::Reference,
+            "auto" => ReadMode::Auto,
+            "diff" => ReadMode::Diff,
+            other => {
+                if let Some(payload) = other.strip_prefix("lines:") {
+                    ReadMode::Lines(parse_line_range(payload)?)
+                } else if let Some(payload) = other.strip_prefix("density:") {
+                    let target = payload
+                        .trim()
+                        .parse::<f64>()
+                        .map_err(|_| ParseModeError::Malformed(other.to_string()))?;
+                    ReadMode::Density(target)
+                } else {
+                    return Err(ParseModeError::Unknown(other.to_string()));
+                }
+            }
+        })
+    }
+}
+
+impl fmt::Display for ReadMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let keyword = match self {
+            ReadMode::Full => "full",
+            ReadMode::Raw => "raw",
+            ReadMode::Signatures => "signatures",
+            ReadMode::Map => "map",
+            ReadMode::Aggressive => "aggressive",
+            ReadMode::Entropy => "entropy",
+            ReadMode::Task => "task",
+            ReadMode::Reference => "reference",
+            ReadMode::Auto => "auto",
+            ReadMode::Diff => "diff",
+            ReadMode::Lines(range) => return write!(f, "lines:{range}"),
+            // Matches the handler's historical `format!("density:{:.2}", …)`.
+            ReadMode::Density(target) => return write!(f, "density:{target:.2}"),
+        };
+        f.write_str(keyword)
+    }
+}
+
+impl ReadMode {
+    /// `map`/`signatures` — the lossy summaries whose rendered body is stored in
+    /// the per-file `compressed_outputs` cache. Replaces `is_cacheable_mode`.
+    #[must_use]
+    pub(crate) fn is_compressed_cacheable(&self) -> bool {
+        matches!(self, ReadMode::Map | ReadMode::Signatures)
+    }
+
+    /// Whole-file views the `#361` anti-inflation raw cap applies to. Selection
+    /// and delta views (`lines:`, `reference`, `diff`, `raw`) have view-specific
+    /// semantics and are never capped. Replaces `mode_allows_raw_cap`.
+    #[must_use]
+    pub(crate) fn allows_raw_cap(&self) -> bool {
+        !matches!(
+            self,
+            ReadMode::Lines(_) | ReadMode::Reference | ReadMode::Diff | ReadMode::Raw
+        )
+    }
+
+    /// Lossy summaries eligible for cross-file block dedup (#…): the body is a
+    /// summary, so shared blocks can be elided. Replaces the inline
+    /// `dedup_allowed` match.
+    #[must_use]
+    pub(crate) fn is_lossy_summary(&self) -> bool {
+        matches!(
+            self,
+            ReadMode::Map
+                | ReadMode::Signatures
+                | ReadMode::Aggressive
+                | ReadMode::Entropy
+                | ReadMode::Task
+        )
+    }
+
+    /// Whether a read in this mode counts as "compressed" for bounce/quality
+    /// tracking (#538). Only verbatim `full` and the `diff` delta are *not*
+    /// compressed. Replaces the inline `!matches!(mode, "full"|"diff"|"lines")`
+    /// predicate — a resolved line window is the string `"lines:N-M"`, never the
+    /// bare `"lines"`, so that arm was dead and `Lines` stays compressed here.
+    #[must_use]
+    pub(crate) fn counts_as_compressed(&self) -> bool {
+        !matches!(self, ReadMode::Full | ReadMode::Diff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every canonical mode string the handler/`render.rs` produce or accept.
+    const CANONICAL: &[&str] = &[
+        "full",
+        "raw",
+        "signatures",
+        "map",
+        "aggressive",
+        "entropy",
+        "task",
+        "reference",
+        "auto",
+        "diff",
+        "lines:5-10",
+        "lines:5-999999",
+        "density:0.40",
+    ];
+
+    // --- Legacy predicates being replaced (kept verbatim so the equivalence
+    // tests below pin behaviour to the exact prior semantics). ---
+
+    fn legacy_is_cacheable(mode: &str) -> bool {
+        ["map", "signatures"].contains(&mode)
+    }
+
+    fn legacy_allows_raw_cap(mode: &str) -> bool {
+        !(mode.starts_with("lines:") || matches!(mode, "reference" | "diff" | "raw"))
+    }
+
+    fn legacy_is_lossy_summary(mode: &str) -> bool {
+        matches!(
+            mode,
+            "map" | "signatures" | "aggressive" | "entropy" | "task"
+        )
+    }
+
+    fn legacy_counts_as_compressed(mode: &str) -> bool {
+        !matches!(mode, "full" | "diff" | "lines")
+    }
+
+    #[test]
+    fn round_trips_every_canonical_mode() {
+        for mode in CANONICAL {
+            let parsed: ReadMode = mode.parse().expect("canonical mode parses");
+            assert_eq!(
+                parsed.to_string(),
+                *mode,
+                "Display must round-trip '{mode}' byte-identically"
+            );
+        }
+    }
+
+    #[test]
+    fn classification_matches_legacy_predicates() {
+        for mode in CANONICAL {
+            let parsed: ReadMode = mode.parse().expect("canonical mode parses");
+            assert_eq!(
+                parsed.is_compressed_cacheable(),
+                legacy_is_cacheable(mode),
+                "is_compressed_cacheable diverged for '{mode}'"
+            );
+            assert_eq!(
+                parsed.allows_raw_cap(),
+                legacy_allows_raw_cap(mode),
+                "allows_raw_cap diverged for '{mode}'"
+            );
+            assert_eq!(
+                parsed.is_lossy_summary(),
+                legacy_is_lossy_summary(mode),
+                "is_lossy_summary diverged for '{mode}'"
+            );
+            assert_eq!(
+                parsed.counts_as_compressed(),
+                legacy_counts_as_compressed(mode),
+                "counts_as_compressed diverged for '{mode}'"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_mode_is_rejected_by_from_str() {
+        assert_eq!(
+            "wat".parse::<ReadMode>(),
+            Err(ParseModeError::Unknown("wat".to_string()))
+        );
+        assert_eq!(
+            "".parse::<ReadMode>(),
+            Err(ParseModeError::Unknown(String::new()))
+        );
+    }
+
+    #[test]
+    fn malformed_parameterized_modes_are_rejected() {
+        assert_eq!(
+            "lines:abc".parse::<ReadMode>(),
+            Err(ParseModeError::Malformed("lines:abc".to_string()))
+        );
+        assert_eq!(
+            "lines:5-x".parse::<ReadMode>(),
+            Err(ParseModeError::Malformed("lines:5-x".to_string()))
+        );
+        assert_eq!(
+            "density:nope".parse::<ReadMode>(),
+            Err(ParseModeError::Malformed("density:nope".to_string()))
+        );
+    }
+
+    #[test]
+    fn line_range_parses_bounded_unbounded_and_bare() {
+        assert_eq!(
+            "lines:5-10".parse::<ReadMode>().unwrap(),
+            ReadMode::Lines(LineRange::new(5, 10))
+        );
+        assert_eq!(
+            "lines:5-999999".parse::<ReadMode>().unwrap(),
+            ReadMode::Lines(LineRange::to_eof(5))
+        );
+        // A bare `lines:5` means "from line 5 to EOF".
+        assert_eq!(
+            "lines:5".parse::<ReadMode>().unwrap(),
+            ReadMode::Lines(LineRange::to_eof(5))
+        );
+    }
+
+    #[test]
+    fn line_range_clamps_start_to_one() {
+        assert_eq!(LineRange::new(0, 10).start, 1);
+    }
+
+    #[test]
+    fn density_display_normalizes_to_two_decimals() {
+        // Parsing is lenient; Display normalizes to the handler's `{:.2}` form so
+        // identical reads stay byte-stable (#498 determinism).
+        let parsed: ReadMode = "density:0.5".parse().unwrap();
+        assert_eq!(parsed, ReadMode::Density(0.5));
+        assert_eq!(parsed.to_string(), "density:0.50");
+    }
+}

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -191,10 +191,12 @@ impl CtxReadTool {
         // route through the proven density path at the mapped target. An explicit
         // mode (incl. entropy/task) instead has the knob tune it via ReadTuning.
         if !explicit_mode && let Some(a) = aggressiveness {
-            mode = format!(
-                "density:{:.2}",
-                crate::core::aggressiveness::AggressivenessProfile::from_level(a).density_target
-            );
+            // SSOT mode construction via the typed `ReadMode` (#528): the typed
+            // `Density` Display emits the same `density:0.NN` the pipeline parses.
+            mode = crate::tools::ctx_read::ReadMode::Density(
+                crate::core::aggressiveness::AggressivenessProfile::from_level(a).density_target,
+            )
+            .to_string();
         }
         // `start_line` (and its `offset`/`limit` aliases) can pin a line window.
         // The resolution lives in `apply_line_window`/`resolve_line_window` so


### PR DESCRIPTION
## Summary

Phase 2 of #509. This lands the **type-safe `ReadMode` vocabulary** half of #528 and records the evaluation of the `SessionCache`-decoupling thesis.

`ctx_read`'s mode travelled through the whole pipeline as a bare `&str`, and the knowledge of *which* modes exist + how each is classified was duplicated across the registered handler, the read core and `render.rs`. That let invalid modes fall through to a silent `full` fallback and let the classifications drift apart.

### What changed
- **New `ReadMode` enum (+ `LineRange`)** — single source of truth for the mode vocabulary.
  - `FromStr` parses **and validates** the canonical modes (`full`, `raw`, `signatures`, `map`, `aggressive`, `entropy`, `task`, `reference`, `auto`, `diff`, `lines:N-M`, `density:0.NN`).
  - `Display` round-trips **byte-identically**, so the type threads through the typed decision points **without touching the string-mode MCP boundary or `render.rs`** — full back-compat, #498 determinism preserved.
- **Classification methods** (`is_compressed_cacheable` / `allows_raw_cap` / `is_lossy_summary` / `counts_as_compressed`) replace the scattered `matches!(mode, …)` predicates in the read core + handler. An **equivalence test locks each method to the exact legacy predicate** it replaces, so behaviour can't silently change.

### Decoupling evaluation (the other half of #528)
The thesis (from @omar-mohamed-khallaf, #525) was to make `ctx_read` *pure* by removing the `SessionCache`. Evaluated against the acceptance gate (“savings net-neutral or better”):
- The stub (`[unchanged …]`) + compressed-output cache is a **re-read savings optimization**; removing it can only be **net-neutral at best, net-negative in multi-read sessions** — it cannot pass the savings gate by construction.
- The determinism win the thesis sought (#498) is **already in place** (stubs are pure functions of content; the byte-stability test passes).
- The cross-context “lying stub” concern is **already mitigated** (`is_subagent_context()` force-fresh + `compaction_sync` delivery-flag reset).

→ **Keep `SessionCache` intact** (criterion 5). Ship the type-safety + SSOT now; the residual cross-context gap is captured for follow-up. Full writeup on #528.

### Acceptance criteria
- [x] eval A/B output-quality gate green — replay gate: **NO REGRESSION** (Δ=+0.039)
- [x] savings net-neutral — behaviour-preserving (Display round-trips byte-identically; no `render.rs` change)
- [x] determinism (#498) holds — byte-stable test + equivalence locks green
- [x] `ReadMode` type-safety without breaking the string-mode MCP boundary
- [x] `SessionCache` intact for all consumers

## Test plan
- [x] 7 new `ReadMode` tests (round-trip, classification-equivalence, validation) + 104 `ctx_read` tests green
- [x] full lib suite green (one unrelated pre-existing `proxy::cold_prefix` flake, passes isolated)
- [x] preflight: fmt · clippy `--all-features -Dwarnings` · rustdoc `-Dwarnings` · gen_docs · Windows cross-compile

Closes #528.
