### PR TITLE
fix(shell): stop inherited LEAN_CTX_ACTIVE from disabling compression (#533)

### DIFF
--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -54,9 +54,7 @@ pub fn run() {
                 // carries runtime/session vars the MCP server never sees. Bridge
                 // them so ctx_shell can forward them too (#370).
                 core::agent_runtime_env::capture();
-                if std::env::var("LEAN_CTX_ACTIVE").is_ok()
-                    || std::env::var("LEAN_CTX_DISABLED").is_ok()
-                {
+                if crate::shell::reentry::should_pass_through() {
                     passthrough(&command);
                 }
                 if raw {
@@ -81,9 +79,7 @@ pub fn run() {
                     shell::exec_argv(cmd_args)
                 } else {
                     let command = cmd_args[0].clone();
-                    if std::env::var("LEAN_CTX_ACTIVE").is_ok()
-                        || std::env::var("LEAN_CTX_DISABLED").is_ok()
-                    {
+                    if crate::shell::reentry::should_pass_through() {
                         passthrough(&command);
                     }
                     shell::exec(&command)
@@ -822,7 +818,8 @@ fn restore_sigpipe_default() {}
 fn passthrough(command: &str) -> ! {
     let (shell, flag) = shell::shell_and_flag();
     let mut cmd = std::process::Command::new(&shell);
-    cmd.arg(&flag).arg(command).env("LEAN_CTX_ACTIVE", "1");
+    cmd.arg(&flag).arg(command);
+    shell::reentry::mark_child(&mut cmd);
     shell::platform::apply_utf8_locale(&mut cmd);
     let status = cmd.status().map_or(127, |s| s.code().unwrap_or(1));
     std::process::exit(status);

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -24,9 +24,9 @@ pub(crate) fn execute_command_with_env(
     }
     cmd.arg(&flag)
         .arg(&normalized_cmd)
-        .env("LEAN_CTX_ACTIVE", "1")
         .env("GIT_TERMINAL_PROMPT", "0")
         .stdin(Stdio::null());
+    crate::shell::reentry::mark_child(&mut cmd);
 
     if !extra_env.contains_key("GIT_PAGER") {
         cmd.env("GIT_PAGER", "cat");

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -236,7 +236,7 @@ pub fn exec_argv(args: &[String]) -> i32 {
         return code;
     }
 
-    if std::env::var("LEAN_CTX_DISABLED").is_ok() || std::env::var("LEAN_CTX_ACTIVE").is_ok() {
+    if super::reentry::should_pass_through() {
         return exec_direct(args);
     }
 
@@ -257,10 +257,10 @@ pub fn exec_argv(args: &[String]) -> i32 {
 fn exec_direct(args: &[String]) -> i32 {
     let mut cmd = Command::new(&args[0]);
     cmd.args(&args[1..])
-        .env("LEAN_CTX_ACTIVE", "1")
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
+    super::reentry::mark_child(&mut cmd);
     super::platform::apply_utf8_locale(&mut cmd);
     let status = cmd.status();
 
@@ -373,7 +373,7 @@ pub fn exec(command: &str) -> i32 {
     let command = crate::tools::ctx_shell::normalize_command_for_shell(command);
     let command = command.as_str();
 
-    if std::env::var("LEAN_CTX_DISABLED").is_ok() || std::env::var("LEAN_CTX_ACTIVE").is_ok() {
+    if super::reentry::should_pass_through() {
         return exec_inherit(command, &shell, &shell_flag);
     }
 
@@ -427,10 +427,10 @@ fn exec_inherit(command: &str, shell: &str, shell_flag: &str) -> i32 {
     let mut cmd = Command::new(shell);
     cmd.arg(shell_flag)
         .arg(command)
-        .env("LEAN_CTX_ACTIVE", "1")
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
+    super::reentry::mark_child(&mut cmd);
     super::platform::apply_utf8_locale(&mut cmd);
     super::platform::apply_profile_free_env(&mut cmd);
     let status = cmd.status();
@@ -525,9 +525,8 @@ fn exec_buffered(command: &str, shell: &str, shell_flag: &str, cfg: &config::Con
         cmd.arg(command);
     }
 
-    cmd.env("LEAN_CTX_ACTIVE", "1")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    super::reentry::mark_child(&mut cmd);
     super::platform::apply_utf8_locale(&mut cmd);
     super::platform::apply_profile_free_env(&mut cmd);
     let child = cmd.spawn();

--- a/rust/src/shell/mod.rs
+++ b/rust/src/shell/mod.rs
@@ -4,6 +4,7 @@ mod interactive;
 pub mod output_policy;
 pub(crate) mod platform;
 mod redact;
+pub(crate) mod reentry;
 pub(crate) mod tee_policy;
 
 pub use compress::compress_if_beneficial_pub;

--- a/rust/src/shell/reentry.rs
+++ b/rust/src/shell/reentry.rs
@@ -1,0 +1,97 @@
+//! Re-entrancy markers that stop nested `lean-ctx` invocations from
+//! double-compressing — decoupled from the user-facing activation flag.
+//!
+//! Two distinct signals were historically conflated in `LEAN_CTX_ACTIVE`
+//! (GH #533), which silently disabled compression for any agent that
+//! *inherited* it:
+//!
+//! - `LEAN_CTX_ACTIVE`: shell-hook re-entry guard. Stops the *shell* hook from
+//!   re-firing inside a command lean-ctx already spawned. It is a plain env var
+//!   an agent's top-level process can legitimately inherit.
+//! - [`WRAP_MARKER`] (`LEAN_CTX_WRAPPED`): process-level ownership. Set ONLY by
+//!   lean-ctx on the children it spawns, so its presence reliably means "a
+//!   parent lean-ctx already owns compression of this command tree" and a
+//!   nested `lean-ctx -c` must pass through. Because lean-ctx is the only
+//!   writer, an agent cannot trigger it by leaking an env var.
+
+use std::process::Command;
+
+/// Env var lean-ctx stamps on every child it spawns to mark the command tree as
+/// already owned (compression handled by the parent lean-ctx).
+pub(crate) const WRAP_MARKER: &str = "LEAN_CTX_WRAPPED";
+
+/// Legacy shell-hook re-entry guard. Still stamped on children so the shell
+/// hook (which tests `-z "$LEAN_CTX_ACTIVE"`) does not re-fire inside a wrapped
+/// command, but it no longer gates compression on its own.
+pub(crate) const ACTIVE_MARKER: &str = "LEAN_CTX_ACTIVE";
+
+/// True when `lean-ctx -c` / `-t` must run the command **raw** instead of
+/// compressing it again: either a parent lean-ctx already owns this command
+/// tree ([`WRAP_MARKER`]) or compression is globally disabled
+/// (`LEAN_CTX_DISABLED`).
+///
+/// Deliberately does **not** consult `LEAN_CTX_ACTIVE`: that flag is only a
+/// shell-hook re-entry guard, and an agent's top-level process can inherit it,
+/// which previously suppressed compression for every command it ran (#533).
+#[must_use]
+pub(crate) fn should_pass_through() -> bool {
+    std::env::var(WRAP_MARKER).is_ok() || std::env::var("LEAN_CTX_DISABLED").is_ok()
+}
+
+/// Stamp a child command so nested lean-ctx invocations pass through and the
+/// shell hook does not re-fire: sets both the ownership marker
+/// ([`WRAP_MARKER`]) and the legacy hook guard (`LEAN_CTX_ACTIVE`).
+pub(crate) fn mark_child(cmd: &mut Command) {
+    cmd.env(ACTIVE_MARKER, "1").env(WRAP_MARKER, "1");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ACTIVE_MARKER, WRAP_MARKER, mark_child, should_pass_through};
+
+    #[test]
+    fn wrap_marker_triggers_passthrough() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::remove_var("LEAN_CTX_DISABLED");
+        crate::test_env::remove_var(ACTIVE_MARKER);
+        crate::test_env::set_var(WRAP_MARKER, "1");
+        assert!(should_pass_through());
+        crate::test_env::remove_var(WRAP_MARKER);
+    }
+
+    #[test]
+    fn disabled_triggers_passthrough() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::remove_var(WRAP_MARKER);
+        crate::test_env::remove_var(ACTIVE_MARKER);
+        crate::test_env::set_var("LEAN_CTX_DISABLED", "1");
+        assert!(should_pass_through());
+        crate::test_env::remove_var("LEAN_CTX_DISABLED");
+    }
+
+    /// #533: an inherited/leaked `LEAN_CTX_ACTIVE` must NOT suppress compression.
+    #[test]
+    fn inherited_active_does_not_trigger_passthrough() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::remove_var(WRAP_MARKER);
+        crate::test_env::remove_var("LEAN_CTX_DISABLED");
+        crate::test_env::set_var(ACTIVE_MARKER, "1");
+        assert!(
+            !should_pass_through(),
+            "inherited LEAN_CTX_ACTIVE must not disable compression (#533)"
+        );
+        crate::test_env::remove_var(ACTIVE_MARKER);
+    }
+
+    #[test]
+    fn mark_child_sets_both_markers() {
+        let mut cmd = std::process::Command::new("true");
+        mark_child(&mut cmd);
+        let envs: std::collections::HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| Some((k.to_str()?.to_string(), v?.to_str()?.to_string())))
+            .collect();
+        assert_eq!(envs.get(WRAP_MARKER).map(String::as_str), Some("1"));
+        assert_eq!(envs.get(ACTIVE_MARKER).map(String::as_str), Some("1"));
+    }
+}


### PR DESCRIPTION
## Summary

`lean-ctx -c` silently ran commands **uncompressed** whenever `LEAN_CTX_ACTIVE` was present in the environment, defeating the core value prop for any agent that inherited it (reported on Codex). This decouples the overloaded flag so a leaked/inherited `LEAN_CTX_ACTIVE` no longer disables compression, while keeping recursion protection and the `LEAN_CTX_DISABLED` kill-switch intact.

Fixes the bug reported in #533 (root-cause analysis: [comment](https://github.com/yvgude/lean-ctx/issues/533#issuecomment-4788249926)).

## Root cause

`cli/dispatch/mod.rs` (and the second guard layer in `shell/exec.rs`) short-circuited the `-c`/`-t` path to a raw passthrough on `LEAN_CTX_ACTIVE`. That flag is lean-ctx's internal **re-entrancy guard** — set on every child it spawns so a nested hooked command does not double-compress — but it is a plain env var an agent's top-level process can inherit. The shell hook even did `export LEAN_CTX_ACTIVE=1; exec lean-ctx -c …`, making the non-interactive path self-defeating.

Deterministic repro on `main`:

```
$ lean-ctx -c "git status"                     # -> COMPRESSED
$ LEAN_CTX_ACTIVE=1 lean-ctx -c "git status"   # -> RAW passthrough (the bug)
```

## Fix

Split the two meanings that were both crammed into `LEAN_CTX_ACTIVE`:

- **`LEAN_CTX_WRAPPED` (new)** — process-level ownership marker, set **only** by lean-ctx on the children it spawns. Its presence reliably means "a parent lean-ctx already owns compression of this command tree", so a nested `lean-ctx -c` passes through. An agent cannot trigger it by leaking an env var.
- **`LEAN_CTX_ACTIVE`** — stays the shell-hook re-entry guard (still stamped on children so the hook does not re-fire), but no longer gates compression.

`-c`/`-t` passthrough now keys on `shell::reentry::should_pass_through()` (`LEAN_CTX_WRAPPED` or the documented `LEAN_CTX_DISABLED`), never on a merely-inherited `LEAN_CTX_ACTIVE`. A new `shell::reentry` module is the single source of truth for both markers and child stamping across the CLI dispatch, the shell executor, and the daemon executor.

Invariants preserved: no infinite recursion (lean-ctx still marks its own children with both vars), `LEAN_CTX_DISABLED` still fully bypasses, and no documented behavior changes (`LEAN_CTX_ACTIVE` was never a documented user toggle).

## Behavior matrix (verified e2e with the built binary)

| Env | Before | After |
|---|---|---|
| clean | compress | compress |
| `LEAN_CTX_ACTIVE=1` (inherited) | **raw (bug)** | **compress (fixed)** |
| `LEAN_CTX_WRAPPED=1` (lean-ctx child) | — | raw (recursion guard) |
| `LEAN_CTX_DISABLED=1` | raw | raw (kill-switch) |

## Test plan

- [x] New `shell::reentry` unit tests (4): wrap-marker / disabled → passthrough; **inherited ACTIVE must NOT passthrough** (#533 regression guard); `mark_child` stamps both vars.
- [x] `cargo test --lib` — 5832 pass (default), 5867 pass (`--all-features`), 0 failed.
- [x] `cargo clippy --all-targets --all-features -D warnings` — clean.
- [x] `preflight.sh full` — fmt, clippy, rustdoc, gen_docs drift, Windows cross-compile, tests — all green.
- [x] Output-Quality Gate (eval A/B replay) — **NO REGRESSION** (Δ=+0.039).
- [x] End-to-end repro: leaked `LEAN_CTX_ACTIVE=1 lean-ctx -c "git status"` now compresses; `LEAN_CTX_WRAPPED`/`LEAN_CTX_DISABLED` stay raw.

Refs #533.
