### PR TITLE
fix(contracts): classify addon-manifest-v1 contract doc (#858 follow-up)

### DIFF
--- a/rust/src/core/contracts.rs
+++ b/rust/src/core/contracts.rs
@@ -187,6 +187,9 @@ pub fn contract_docs() -> Vec<ContractDoc> {
             Stable,
         ),
         doc("wrapped-permalink", "wrapped-permalink-v1.md", 1, Stable),
+        // Community addon manifest (#858): self-declared stable (v1); the format
+        // evolves additively (new optional fields), so Stable, not Frozen.
+        doc("addon-manifest", "addon-manifest-v1.md", 1, Stable),
         // ── Experimental: may change without notice ─────────────────────────
         doc(
             "hosted-personal-index",


### PR DESCRIPTION
## Summary

main (and every open PR) is CI-red on the **Test** job: #858 added `docs/contracts/addon-manifest-v1.md` but never classified it in `core::contracts::contract_docs()`, so the contract-freeze gate (`tests/contracts_frozen.rs::every_contract_doc_is_classified`) panics with `unclassified contract docs: ["addon-manifest-v1.md"]`.

Classify it as **Stable**, matching the doc's own self-declared `Status: stable (v1)`. The manifest format evolves additively (new optional fields), so Stable — not Frozen (no `frozen-hashes.json` entry needed).

## Test plan

- [x] `cargo test --test contracts_frozen` — 2 passed (was 1 failed).
- [x] preflight fast (fmt / clippy / docs / gen_docs / Windows cross-compile) green on push.

Unblocks main, #537, and #530.

Refs #858.
