### PR TITLE
fix(security): surface the workspace-trust gate in blocked allowlist/path errors (#540)

### DIFF
--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -406,7 +406,7 @@ pub fn jail_path_with_roots(
                 candidate.display(),
                 root.display(),
             );
-            let hint = if crate::core::protocol::meta_visible() {
+            let mut hint = if crate::core::protocol::meta_visible() {
                 format!(
                     ". Hint: set LEAN_CTX_ALLOW_PATH={} or add it to allow_paths in ~/.lean-ctx/config.toml",
                     candidate.parent().unwrap_or(candidate).display()
@@ -414,6 +414,13 @@ pub fn jail_path_with_roots(
             } else {
                 String::new()
             };
+            // An untrusted workspace's project-local `allow_paths` is silently
+            // withheld; always surface that reason (the stderr warning is
+            // invisible over MCP, and the hint above is meta-gated off) (#540).
+            if let Some(notice) = crate::core::workspace_trust::untrusted_override_notice() {
+                hint.push_str(". ");
+                hint.push_str(&notice);
+            }
             return Err(format!("{base_msg}{hint}"));
         }
 

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -1126,6 +1126,14 @@ fn allowlist_block_message(base: &str) -> String {
         ));
     }
 
+    // A project-local `shell_allowlist`/`shell_allowlist_extra` is silently
+    // withheld for an untrusted workspace; surface that here so the edit's
+    // no-op reason isn't buried in an MCP-invisible stderr warning (#540).
+    if let Some(notice) = crate::core::workspace_trust::untrusted_override_notice() {
+        msg.push_str("\n\n⚠ ");
+        msg.push_str(&notice);
+    }
+
     msg
 }
 

--- a/rust/src/core/workspace_trust.rs
+++ b/rust/src/core/workspace_trust.rs
@@ -215,6 +215,47 @@ pub fn list() -> Vec<TrustedWorkspace> {
     load().map(|s| s.workspaces).unwrap_or_default()
 }
 
+/// Actionable, single-paragraph explanation for the MCP tool surfaces (#540):
+/// when the active project's `.lean-ctx.toml` carries SECURITY-sensitive
+/// overrides that are being withheld because the workspace is untrusted, name the
+/// ignored keys and the two ways to make them take effect. `None` when the
+/// workspace is trusted, has no project root, has no local config, or its local
+/// config carries no sensitive overrides.
+///
+/// `Config::merge_local` already logs the identical fact via `tracing::warn`, but
+/// that goes to stderr — invisible over an MCP/stdio transport. So a blocked
+/// command (`shell_allowlist*`) or read (`allow_paths`) otherwise gives the agent
+/// no clue why an edit "did nothing"; this surfaces it inside the error itself.
+#[must_use]
+pub fn untrusted_override_notice() -> Option<String> {
+    let root = crate::core::config::Config::find_project_root()?;
+    untrusted_override_notice_for(Path::new(&root))
+}
+
+/// Root-parameterized core of [`untrusted_override_notice`] (the public wrapper
+/// resolves the active project root; this stays testable with an explicit path).
+fn untrusted_override_notice_for(root: &Path) -> Option<String> {
+    let local = crate::core::config::Config::local_path(&root.to_string_lossy());
+    let toml = std::fs::read_to_string(&local).ok()?;
+    let withheld = crate::core::config::local_sensitive_overrides(&toml);
+    if withheld.is_empty() || is_trusted(root) {
+        return None;
+    }
+    let cfg_path = crate::core::config::Config::path().map_or_else(
+        || "the global config".to_string(),
+        |p| p.display().to_string(),
+    );
+    Some(format!(
+        "This workspace's .lean-ctx.toml sets security-sensitive override(s) [{keys}] that \
+         lean-ctx IGNORES because the workspace is untrusted — the usual reason such an edit \
+         appears to do nothing. To apply them, review the file then run `lean-ctx trust` in \
+         {root}, or move the key(s) into the global config ({cfg_path}), which is never \
+         trust-gated.",
+        keys = withheld.join(", "),
+        root = root.display(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,5 +323,52 @@ mod tests {
         assert!(!is_trusted(dir.path()));
         trust(dir.path()).unwrap();
         assert!(is_trusted(dir.path()));
+    }
+
+    // #540: the notice is the visible counterpart to the stderr-only merge_local
+    // warning — an untrusted workspace with sensitive overrides must explain the
+    // gate (and the `lean-ctx trust` remedy) right where the tool blocks.
+    #[test]
+    fn untrusted_sensitive_override_yields_actionable_notice() {
+        let _iso = isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".lean-ctx.toml"),
+            "allow_paths = [\"/srv/data\"]\nshell_allowlist_extra = [\"glab\"]\n",
+        )
+        .unwrap();
+        let notice = untrusted_override_notice_for(dir.path()).expect("untrusted → notice");
+        assert!(notice.contains("allow_paths"), "{notice}");
+        assert!(notice.contains("shell_allowlist_extra"), "{notice}");
+        assert!(notice.contains("lean-ctx trust"), "{notice}");
+    }
+
+    #[test]
+    fn trusted_workspace_yields_no_notice() {
+        let _iso = isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".lean-ctx.toml"),
+            "allow_paths = [\"/srv/data\"]\n",
+        )
+        .unwrap();
+        trust(dir.path()).unwrap();
+        assert!(untrusted_override_notice_for(dir.path()).is_none());
+    }
+
+    #[test]
+    fn no_local_config_yields_no_notice() {
+        let _iso = isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        assert!(untrusted_override_notice_for(dir.path()).is_none());
+    }
+
+    #[test]
+    fn comfort_only_override_yields_no_notice() {
+        let _iso = isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        // Comfort knobs are never gated, so they never trigger the trust notice.
+        std::fs::write(dir.path().join(".lean-ctx.toml"), "theme = \"dark\"\n").unwrap();
+        assert!(untrusted_override_notice_for(dir.path()).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes #540. `shell_allowlist_extra` and `allow_paths` *do* work — but when they
live in a **project-local `.lean-ctx.toml`** of an **untrusted** workspace,
`Config::merge_local` strips every security-sensitive override and only logs a
`tracing::warn`. Over an MCP/stdio transport (OpenCode, Claude Code, …) that
stderr line is invisible, so the agent sees a `glab` command stay blocked or an
`allow_paths` read keep failing **with no clue why** — the edit appears to "do
nothing", even after a restart.

This is the documented Workspace-Trust gate (security audit #4), not a loader
bug — confirmed by reproduction: the identical config in the **global**
`config.toml` applies fine; only the untrusted project-local copy is withheld.

## Root cause

The withheld-overrides signal existed in exactly one place the MCP user never
sees (stderr). `lean-ctx doctor` reports it, but nothing surfaces it at the
point of failure — the blocked tool call itself.

## Fix

- New `workspace_trust::untrusted_override_notice()`: when the active project
  ships sensitive overrides that are withheld because the workspace is
  untrusted, it returns a one-line, actionable explanation naming the ignored
  keys and the two remedies — run `lean-ctx trust`, or move the keys into the
  never-gated global config. `None` when trusted / no local file / no sensitive
  keys (root-parameterized inner fn keeps it unit-testable).
- Appended to the **shell-allowlist** block message and the **path-jail**
  "escapes project root" error — the exact moments the agent hits the wall.
- **Not** auto-trust: the gate is a deliberate security control, so the fix is
  *visibility + remedy*, never silently widening the boundary.

### Before → After (untrusted project-local `allow_paths` + `shell_allowlist_extra`)

`ctx_shell "glab --version"` now ends with:

```
[BLOCKED — DO NOT RETRY] 'glab' is not in the shell allowlist. …

⚠ This workspace's .lean-ctx.toml sets security-sensitive override(s)
[shell_allowlist_extra, allow_paths] that lean-ctx IGNORES because the workspace
is untrusted — the usual reason such an edit appears to do nothing. To apply
them, review the file then run `lean-ctx trust` in <root>, or move the key(s)
into the global config (<path>), which is never trust-gated.
```

`ctx_read` of a path outside the jail now appends the same notice to
`path escapes project root: …`.

## Test plan

- [x] 4 new unit tests in `workspace_trust` (untrusted→notice, trusted→none,
      no-local→none, comfort-only→none); 10/10 module tests pass.
- [x] `shell_allowlist` (136) + `pathjail` (20) tests green — no message
      regressions.
- [x] End-to-end over the **real MCP stdio path**: untrusted → notice on both
      `ctx_shell` and `ctx_read`; after `lean-ctx trust` both overrides apply;
      trusted + in-project reads carry no notice.
- [x] `scripts/preflight.sh full` green (fmt, clippy `--all-features`, rustdoc,
      `gen_docs --check`, Windows cross-compile, 5871 lib tests).
