### PR TITLE
fix(config): flag a missing/elsewhere config file in blocked allowlist & path-jail errors (#540)

### DIFF
--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -1131,6 +1131,24 @@ impl Config {
             .map(|d| d.join("config.toml"))
     }
 
+    /// `Some(path)` when the global config the runtime *resolves* does not exist,
+    /// so lean-ctx is silently on built-in defaults. `None` when a config file is
+    /// present (or HOME is unresolvable).
+    ///
+    /// The directory is layout-dependent (XDG `~/.config/lean-ctx` vs legacy
+    /// `~/.lean-ctx` vs `$LEAN_CTX_DATA_DIR`) and an MCP client may launch the
+    /// server in a sandbox/container with a different `$HOME`. An edit made to a
+    /// *different* `config.toml` than this one is silently ignored; the block
+    /// messages use this to say so out loud over MCP, where the stderr path is
+    /// invisible (#540).
+    #[must_use]
+    pub fn missing_config_path() -> Option<PathBuf> {
+        match Self::path() {
+            Some(p) if !p.exists() => Some(p),
+            _ => None,
+        }
+    }
+
     /// Returns the path to the project-local config override file.
     pub fn local_path(project_root: &str) -> PathBuf {
         PathBuf::from(project_root).join(".lean-ctx.toml")

--- a/rust/src/core/config/tests.rs
+++ b/rust/src/core/config/tests.rs
@@ -1677,3 +1677,35 @@ mod shell_timeout_and_writes_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod config_path_visibility_tests {
+    use super::super::*;
+
+    // #540: `missing_config_path()` is the visible signal that the runtime
+    // resolved a `config.toml` that doesn't exist — i.e. an edit landed in a
+    // different file (XDG vs legacy dir, or a sandboxed HOME). The block messages
+    // turn this into an over-MCP-visible note.
+    #[test]
+    fn missing_config_path_flags_absent_then_clears_when_present() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved = std::env::var("LEAN_CTX_CONFIG_DIR").ok();
+        let dir = tempfile::tempdir().unwrap();
+        crate::test_env::set_var("LEAN_CTX_CONFIG_DIR", dir.path());
+
+        // No config.toml in the resolved dir → flagged as missing (on defaults).
+        assert_eq!(
+            Config::missing_config_path(),
+            Some(dir.path().join("config.toml"))
+        );
+
+        // Create the file → the runtime now has a real config, so no flag.
+        std::fs::write(dir.path().join("config.toml"), "ultra_compact = true\n").unwrap();
+        assert!(Config::missing_config_path().is_none());
+
+        crate::test_env::remove_var("LEAN_CTX_CONFIG_DIR");
+        if let Some(v) = saved {
+            crate::test_env::set_var("LEAN_CTX_CONFIG_DIR", v);
+        }
+    }
+}

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -421,6 +421,17 @@ pub fn jail_path_with_roots(
                 hint.push_str(". ");
                 hint.push_str(&notice);
             }
+            // The global config the runtime reads doesn't exist → on defaults, so
+            // an `allow_paths` edit made to a config.toml elsewhere (XDG vs legacy
+            // dir, or a sandboxed/container HOME) is never seen (#540).
+            if let Some(missing) = crate::core::config::Config::missing_config_path() {
+                hint.push_str(&format!(
+                    ". ⚠ lean-ctx reads no config file at {} (running on defaults) — an \
+                     allow_paths edit in a config.toml elsewhere is not read; \
+                     `lean-ctx doctor` shows the path in effect",
+                    missing.display()
+                ));
+            }
             return Err(format!("{base_msg}{hint}"));
         }
 

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -1124,6 +1124,19 @@ fn allowlist_block_message(base: &str) -> String {
              built-in defaults — this is almost certainly why editing the allowlist had no \
              effect. Fix the TOML error below, then retry:\n  {parse_err}\n  File: {cfg_path}"
         ));
+    } else if let Some(missing) = crate::core::config::Config::missing_config_path() {
+        // The resolved config doesn't exist → lean-ctx is on defaults. An edit
+        // made to a config.toml in a different dir (XDG vs legacy ~/.lean-ctx) or
+        // under a sandboxed/container HOME is never read — say so over MCP (#540).
+        msg.push_str(&format!(
+            "\n\n⚠ No config file exists at {} — lean-ctx is running on built-in defaults. \
+             If you added the command to a config.toml in a DIFFERENT location (XDG \
+             ~/.config/lean-ctx vs legacy ~/.lean-ctx, or your MCP client launches lean-ctx \
+             in a sandbox/container with a different HOME), the runtime never reads it. \
+             `lean-ctx doctor` prints the path actually in effect; pin it with \
+             LEAN_CTX_CONFIG_DIR.",
+            missing.display()
+        ));
     }
 
     // A project-local `shell_allowlist`/`shell_allowlist_extra` is silently


### PR DESCRIPTION
## Summary

Follow-up to #541 for issue #540. The reporter clarified the keys were in the
**global** config (not a project-local `.lean-ctx.toml`), so the workspace-trust
gate #541 surfaced does not explain their case. The remaining failure mode is a
**config-path mismatch**: `shell_allowlist_extra` / `allow_paths` live in the
global config, but the runtime resolves a **different `config.toml`** than the
file the user edited, so the setting is silently ignored and lean-ctx runs on
built-in defaults.

That happens when the resolved config dir differs from where the edit landed:

- XDG `~/.config/lean-ctx/config.toml` vs legacy `~/.lean-ctx/config.toml`,
- a `$LEAN_CTX_DATA_DIR` single-dir collapse, or
- an MCP client (OpenCode, …) launching lean-ctx in a **sandbox/container with a
  different `$HOME`**.

Over MCP/stdio the existing signals are easy to miss: the allowlist block already
printed `Config in effect:` but the **path-jail block printed nothing**, and
neither said the file simply **isn't there**.

## Changes

- `Config::missing_config_path() -> Option<PathBuf>` — `Some(path)` when the
  resolved global `config.toml` does not exist (on defaults), else `None`.
- **allowlist block** (`ctx_shell`): explicit *"No config file exists at `<path>`
  — running on built-in defaults"* note, mutually exclusive with the existing
  parse-error branch.
- **path-jail block** (`ctx_read`/`ctx_search`): same marker so a blocked
  `allow_paths` read explains itself.

Both name the path the runtime actually reads and point at `lean-ctx doctor` /
`LEAN_CTX_CONFIG_DIR`. Error-path only — no change to normal tool output bodies
(determinism doctrine #498 preserved).

## Test plan

- [x] New config unit test: absent → `Some(path)`, present → `None`.
- [x] `cargo test --lib` — 5837 passing; existing allowlist/path-jail assertions
      use `contains()` and stay green.
- [x] `cargo fmt --check`, `cargo clippy --all-targets` clean.
- [x] `scripts/preflight.sh full` — 7/7 (incl. Windows cross-compile, rustdoc).
- [x] E2E over MCP stdio: global config edited at the XDG path while the runtime
      resolves an empty dir → both the `glab` allowlist block and the
      `allow_paths` read block now name the missing path the runtime reads.

Closes #540 once verified by the reporter.
