### PR TITLE
feat(build): Add Windows installer script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,102 @@
+<#
+install.ps1 - Build lean-ctx locally on Windows and install it into Cargo's bin directory.
+
+Usage:
+    .\install.ps1
+    .\install.ps1 -BuildOnly
+#>
+
+param(
+    [switch]$BuildOnly,
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Host 'Usage: .\install.ps1 [-BuildOnly] [-Help]'
+    Write-Host ''
+    Write-Host '  (no args)    Build lean-ctx locally and install it into Cargo''s bin directory'
+    Write-Host '  -BuildOnly   Build only, do not install'
+    Write-Host '  -Help        Show this help message'
+    exit 0
+}
+
+function Get-CargoBinDir {
+    if ($env:CARGO_HOME) {
+        return Join-Path $env:CARGO_HOME 'bin'
+    }
+
+    return Join-Path $HOME '.cargo\bin'
+}
+
+function Stop-RunningLeanCtx {
+    $existing = Get-Command lean-ctx -ErrorAction SilentlyContinue
+    if ($null -ne $existing) {
+        Write-Host 'Stopping running lean-ctx (if any)...'
+        try {
+            & $existing.Source stop | Out-Null
+        }
+        catch {
+        }
+    }
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$rustDir = Join-Path $scriptDir 'rust'
+
+if (-not (Test-Path $rustDir -PathType Container)) {
+    throw "Rust project not found at $rustDir"
+}
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    throw 'cargo not found. Install Rust from https://rustup.rs/'
+}
+
+$cargoBinDir = Get-CargoBinDir
+$builtBinary = Join-Path $rustDir 'target\release\lean-ctx.exe'
+$installedBinary = Join-Path $cargoBinDir 'lean-ctx.exe'
+
+Write-Host 'lean-ctx Windows installer'
+Write-Host '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+Write-Host 'Mode: build from source'
+Write-Host ''
+Write-Host 'Building lean-ctx (release)...'
+
+Push-Location $rustDir
+try {
+    & cargo build --release
+}
+finally {
+    Pop-Location
+}
+
+if (-not (Test-Path $builtBinary -PathType Leaf)) {
+    throw "Build failed - binary not found at $builtBinary"
+}
+
+Write-Host "Built: $builtBinary"
+
+if ($BuildOnly) {
+    Write-Host 'Done (build only).'
+    exit 0
+}
+
+New-Item -ItemType Directory -Path $cargoBinDir -Force | Out-Null
+
+$tempBinary = Join-Path $cargoBinDir ('.lean-ctx.new.' + $PID + '.exe')
+Copy-Item -Path $builtBinary -Destination $tempBinary -Force
+Stop-RunningLeanCtx
+Move-Item -Path $tempBinary -Destination $installedBinary -Force
+
+Write-Host "Installed: $installedBinary"
+
+$pathEntries = @($env:Path -split ';' | Where-Object { $_ })
+if ($pathEntries -notcontains $cargoBinDir) {
+    Write-Host ''
+    Write-Warning "$cargoBinDir is not in your PATH."
+    Write-Host 'Add it to your user PATH, then restart your shell.'
+}
+
+Write-Host ''
+Write-Host 'Done! Verify with: lean-ctx --version'


### PR DESCRIPTION
## Summary

What does this PR change and why?

I wanted to have similar experience of installing and compiling locally as it is on Linux. No impact on existing lean-ctx code, just script that executes the installation in Windows PowerShell terminal.

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [x] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases: New functionality, independant from others
- Backwards compatibility: New functionality
- Docs updated (links/files): None

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
