### PR TITLE
fix(embeddings): cold-start the model download in the build path (#545)

### DIFF
--- a/rust/src/core/embedding_index.rs
+++ b/rust/src/core/embedding_index.rs
@@ -118,14 +118,24 @@ pub fn build_or_update(root: &Path, bm25: &super::bm25_index::BM25Index) -> Embe
             return EmbeddingBuildOutcome::Skipped;
         }
 
-        // Check model files exist before initializing ORT — `shared_engine()`
-        // loads the global ONNX Runtime environment which leaves behind C++
-        // static state; if model files are missing we can bail without touching
-        // ORT at all, avoiding unnecessary TLS-heavy teardown at exit.
+        // Bootstrap the model if it isn't on disk yet. `build_or_update` only
+        // runs for an explicit build request (`index build` / `build-full` /
+        // `build-semantic`), so a cold machine should download the model now
+        // rather than dead-end. `is_available()` is just a file check, so the
+        // earlier short-circuit on it meant the auto-download never started
+        // (#545). `ensure_downloaded()` is pure network/file IO and never
+        // initializes ORT, so the teardown-safety rationale for deferring the
+        // `shared_engine()` load still holds: on download failure we return
+        // without ever having touched the ONNX Runtime.
         if !crate::core::embeddings::EmbeddingEngine::is_available() {
-            let reason = "embedding model not downloaded — auto-download from HuggingFace attempted but failed (check network / logs)";
-            tracing::info!("[embedding_index] build_or_update skipped: {reason}");
-            return EmbeddingBuildOutcome::ModelNotAvailable(reason.to_string());
+            tracing::info!(
+                "[embedding_index] embedding model absent — downloading from HuggingFace"
+            );
+            if let Err(e) = crate::core::embeddings::EmbeddingEngine::ensure_downloaded() {
+                let reason = format!("embedding model auto-download from HuggingFace failed: {e}");
+                tracing::warn!("[embedding_index] build_or_update failed: {reason}");
+                return EmbeddingBuildOutcome::ModelNotAvailable(reason);
+            }
         }
 
         let Some(engine) = crate::core::embeddings::shared_engine() else {

--- a/rust/src/core/embeddings/mod.rs
+++ b/rust/src/core/embeddings/mod.rs
@@ -298,6 +298,25 @@ impl EmbeddingEngine {
             && model_dir.join(config.vocab_file.filename()).exists()
     }
 
+    /// Ensure the selected model's files exist on disk, downloading them from
+    /// HuggingFace if absent. Pure network/file IO — this never initializes the
+    /// ONNX Runtime, so a failed bootstrap costs nothing in ORT teardown (the
+    /// caller only loads ORT via [`shared_engine`] once the files are present).
+    /// After `Ok`, [`is_available`](Self::is_available) is guaranteed true; on a
+    /// warm cache it short-circuits without touching the network.
+    ///
+    /// The explicit index-build path uses this to cold-start a fresh machine.
+    /// `is_available()` alone is only a file check, so the build path must call
+    /// this to actually trigger the download instead of bailing (#545).
+    pub fn ensure_downloaded() -> anyhow::Result<()> {
+        let base_dir = Self::model_directory();
+        let selected = model_registry::resolve_model();
+        let config = selected.config();
+        let model_dir = base_dir.join(selected.storage_dir_name());
+        download::ensure_model(&model_dir, &config)?;
+        Ok(())
+    }
+
     #[cfg(feature = "embeddings")]
     fn run_inference(&self, input: &TokenizedInput) -> anyhow::Result<Vec<f32>> {
         let seq_len = input.input_ids.len();
@@ -742,12 +761,43 @@ mod tests {
 
     #[test]
     fn model_directory_env_override_and_availability() {
+        // Serialize env mutation: LEAN_CTX_MODELS_DIR is process-global and
+        // shared with `ensure_downloaded_is_offline_noop_when_model_present`.
+        let _lock = crate::core::data_dir::test_env_lock();
         let unique = "/tmp/lean_ctx_test_embed_42xyz";
         crate::test_env::set_var("LEAN_CTX_MODELS_DIR", unique);
         let dir = EmbeddingEngine::model_directory();
         assert_eq!(dir.to_string_lossy(), unique);
         assert!(!EmbeddingEngine::is_available());
         crate::test_env::remove_var("LEAN_CTX_MODELS_DIR");
+    }
+
+    /// #545: with a complete model cache, `ensure_downloaded` is a no-op that
+    /// never touches the network and agrees with `is_available` on the model
+    /// directory. The build path relies on this so a cold availability check can
+    /// route through the (real) download without redundantly re-fetching a model
+    /// that is already present. Both gates use plain existence checks, so tiny
+    /// placeholder files are enough to exercise the short-circuit offline.
+    #[test]
+    fn ensure_downloaded_is_offline_noop_when_model_present() {
+        // Serialize env mutation (LEAN_CTX_MODELS_DIR is process-global) so a
+        // sibling env test can't clobber the dir between set_var and the checks.
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = std::env::temp_dir().join(format!("lc-embed-545-{}", std::process::id()));
+        crate::test_env::set_var("LEAN_CTX_MODELS_DIR", tmp.to_str().unwrap());
+
+        let selected = model_registry::resolve_model();
+        let config = selected.config();
+        let model_dir = tmp.join(selected.storage_dir_name());
+        std::fs::create_dir_all(&model_dir).unwrap();
+        std::fs::write(model_dir.join("model.onnx"), b"onnx").unwrap();
+        std::fs::write(model_dir.join(config.vocab_file.filename()), b"vocab").unwrap();
+
+        assert!(EmbeddingEngine::is_available());
+        assert!(EmbeddingEngine::ensure_downloaded().is_ok());
+
+        crate::test_env::remove_var("LEAN_CTX_MODELS_DIR");
+        std::fs::remove_dir_all(&tmp).ok();
     }
 
     /// #519: Cargo test/bench/doctest binaries live under `…/deps/`; the shipped


### PR DESCRIPTION
## Summary
- `lean-ctx index build-semantic` dead-ended on a fresh machine: `build_or_update` checked `EmbeddingEngine::is_available()` (a pure **file-existence** check) and returned `ModelNotAvailable` **before** `shared_engine()` — which triggers the HuggingFace download via `ensure_model` — was ever reached. So the cold auto-download never started, and the surfaced error even claimed a download was "attempted but failed" when none was. (#545)
- **Root cause:** regression from #519, whose `is_available()` guard was added to skip ORT init (and its static-teardown SIGSEGV risk) when the model is missing — but it also skipped the download.
- **Fix:** add `EmbeddingEngine::ensure_downloaded()` (pure network/file IO, never initializes ORT) and call it from `build_or_update` when the model is absent. ORT is only touched once the files are present, so #519's teardown-safety rationale still holds; on download failure we now return the **real** error.
- The passive search path is unaffected — it never calls `build_or_update`.

## Test plan
- [x] `cargo test --lib core::embeddings` — 61 passed (incl. new offline no-op/consistency test for `ensure_downloaded`)
- [x] `cargo clippy --lib --tests` — clean
- [x] **E2E:** fresh `LEAN_CTX_MODELS_DIR` → `index build-semantic` downloads `model.onnx` (86 MB) + vocab → `semantic index ready`; `index status` shows Semantic Index ready
- [x] Hardened both `LEAN_CTX_MODELS_DIR` tests with `test_env_lock` (eliminates a pre-existing env race)

Fixes #545

Made with [Cursor](https://cursor.com)