### PR TITLE
feat(doctor): warn when MCP server CWD lacks project root

### DIFF
--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -1871,6 +1871,59 @@ pub(super) fn lsp_server_outcomes() -> Vec<Outcome> {
         .collect()
 }
 
+/// Warn if lean-ctx is running as an MCP server from a directory that lacks
+/// a project marker and looks like an IDE/agent tool directory (e.g. .lmstudio,
+/// .claude). This usually means the MCP client launched the process from the
+/// wrong CWD, causing "path escapes project root" errors for every tool call.
+pub(super) fn mcp_server_cwd_outcome() -> Outcome {
+    let is_mcp = std::env::var("LEAN_CTX_MCP_SERVER").is_ok_and(|v| v == "1");
+    if !is_mcp {
+        return Outcome {
+            ok: true,
+            line: format!("{BOLD}MCP server CWD{RST}  {DIM}(not running as MCP server){RST}"),
+        };
+    }
+
+    let Ok(cwd) = std::env::current_dir() else {
+        return Outcome {
+            ok: true,
+            line: format!("{BOLD}MCP server CWD{RST}  {YELLOW}could not resolve{RST}"),
+        };
+    };
+
+    let has_marker = crate::core::pathutil::has_project_marker(&cwd);
+    let cwd_str = cwd.to_string_lossy();
+    let suspicious = cwd_str.contains("/.lmstudio")
+        || cwd_str.contains("/.claude")
+        || cwd_str.contains("/.codebuddy")
+        || cwd_str.contains("/.codex");
+
+    if has_marker {
+        Outcome {
+            ok: true,
+            line: format!(
+                "{BOLD}MCP server CWD{RST}  {GREEN}under project root{RST}  {DIM}{}{RST}",
+                cwd.display()
+            ),
+        }
+    } else if suspicious {
+        Outcome {
+            ok: false,
+            line: format!(
+                "{BOLD}MCP server CWD{RST}  {RED}suspicious directory without project marker{RST}  {DIM}lean-ctx was launched from {cwd}, which is an IDE/agent config dir without a project root — \"path escapes project root\" errors will occur. Set `cwd` in your MCP client config to a real project directory, or add `allow_auto_reroot = true` + `extra_roots` in config.toml{RST}"
+            ),
+        }
+    } else {
+        Outcome {
+            ok: false,
+            line: format!(
+                "{BOLD}MCP server CWD{RST}  {YELLOW}no project marker found in CWD{RST}  {DIM}cwd={} — \"path escapes project root\" errors may occur for files outside this directory. Add `cwd` to your MCP client config or add `extra_roots` / `allow_paths` in config.toml{RST}",
+                cwd.display()
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -1871,6 +1871,16 @@ pub(super) fn lsp_server_outcomes() -> Vec<Outcome> {
         .collect()
 }
 
+/// True when `cwd_str` points inside an IDE/agent config directory rather than a
+/// real project (LM Studio, Claude, CodeBuddy, Codex). Matches both POSIX (`/`)
+/// and Windows (`\`) separators so the warning fires on every platform.
+fn cwd_looks_like_agent_dir(cwd_str: &str) -> bool {
+    const AGENT_DIRS: [&str; 4] = [".lmstudio", ".claude", ".codebuddy", ".codex"];
+    AGENT_DIRS
+        .iter()
+        .any(|dir| cwd_str.contains(&format!("/{dir}")) || cwd_str.contains(&format!("\\{dir}")))
+}
+
 /// Warn if lean-ctx is running as an MCP server from a directory that lacks
 /// a project marker and looks like an IDE/agent tool directory (e.g. .lmstudio,
 /// .claude). This usually means the MCP client launched the process from the
@@ -1893,10 +1903,7 @@ pub(super) fn mcp_server_cwd_outcome() -> Outcome {
 
     let has_marker = crate::core::pathutil::has_project_marker(&cwd);
     let cwd_str = cwd.to_string_lossy();
-    let suspicious = cwd_str.contains("/.lmstudio")
-        || cwd_str.contains("/.claude")
-        || cwd_str.contains("/.codebuddy")
-        || cwd_str.contains("/.codex");
+    let suspicious = cwd_looks_like_agent_dir(&cwd_str);
 
     if has_marker {
         Outcome {
@@ -1910,7 +1917,8 @@ pub(super) fn mcp_server_cwd_outcome() -> Outcome {
         Outcome {
             ok: false,
             line: format!(
-                "{BOLD}MCP server CWD{RST}  {RED}suspicious directory without project marker{RST}  {DIM}lean-ctx was launched from {cwd}, which is an IDE/agent config dir without a project root — \"path escapes project root\" errors will occur. Set `cwd` in your MCP client config to a real project directory, or add `allow_auto_reroot = true` + `extra_roots` in config.toml{RST}"
+                "{BOLD}MCP server CWD{RST}  {RED}suspicious directory without project marker{RST}  {DIM}lean-ctx was launched from {}, which is an IDE/agent config dir without a project root — \"path escapes project root\" errors will occur. Set `cwd` in your MCP client config to a real project directory, or add `allow_auto_reroot = true` + `extra_roots` in config.toml{RST}",
+                cwd.display()
             ),
         }
     } else {
@@ -1938,6 +1946,33 @@ mod tests {
 
     fn check(home: &Path, scope: RulesScope, injection: RulesInjection) -> Outcome {
         claude_instructions_check(home, scope, injection)
+    }
+
+    #[test]
+    fn cwd_looks_like_agent_dir_matches_both_separators() {
+        for sep in ['/', '\\'] {
+            for dir in [".lmstudio", ".claude", ".codebuddy", ".codex"] {
+                let cwd = format!("C:{sep}Users{sep}me{sep}{dir}{sep}mcp");
+                assert!(
+                    cwd_looks_like_agent_dir(&cwd),
+                    "expected {cwd} to be flagged as an agent dir"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cwd_looks_like_agent_dir_ignores_real_projects() {
+        for cwd in [
+            "/home/me/work/myproj",
+            "/Users/me/code/lean-ctx",
+            "C:\\src\\app",
+        ] {
+            assert!(
+                !cwd_looks_like_agent_dir(cwd),
+                "{cwd} is a real project and must not be flagged"
+            );
+        }
     }
 
     // GH #396: the exact post-`setup` state — CLAUDE.md block + skill, rules

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -546,6 +546,10 @@ pub fn run() {
     let deprecation_check = deprecations::deprecations_outcome();
     board.check(&deprecation_check);
 
+    // MCP server CWD warning (informational, only fires when running as MCP)
+    let mcp_cwd = mcp_server_cwd_outcome();
+    board.check(&mcp_cwd);
+
     // LSP servers (optional, informational)
     println!("\n  {BOLD}{WHITE}LSP (optional — for ctx_refactor):{RST}");
     let lsp_outcomes = lsp_server_outcomes();

--- a/rust/src/doctor/report.rs
+++ b/rust/src/doctor/report.rs
@@ -11,7 +11,8 @@
 use serde::Serialize;
 
 use super::checks::{
-    capacity_warnings, mcp_config_outcome, shell_aliases_outcome, skill_files_outcome,
+    capacity_warnings, mcp_config_outcome, mcp_server_cwd_outcome, shell_aliases_outcome,
+    skill_files_outcome,
 };
 use super::common::{path_in_path_env, resolve_lean_ctx_binary};
 use super::deprecations::deprecations_outcome;
@@ -161,6 +162,10 @@ pub fn health_report() -> HealthReport {
     let dep = deprecations_outcome();
     if !dep.ok {
         warnings.push(strip_ansi(&dep.line));
+    }
+    let mcp_cwd = mcp_server_cwd_outcome();
+    if !mcp_cwd.ok {
+        warnings.push(strip_ansi(&mcp_cwd.line));
     }
 
     let level = HealthReport::classify(passed, total, !warnings.is_empty());

--- a/rust/src/server/server_handler.rs
+++ b/rust/src/server/server_handler.rs
@@ -118,8 +118,10 @@ impl ServerHandler for LeanCtxServer {
                 let root_suspicious = crate::core::pathutil::is_broad_or_unsafe_root(root_path)
                     || root_str.contains("/var/folders/")
                     || root_str.contains("/tmp/")
+                    || root_str.contains("/.lmstudio")
                     || root_str.contains("\\AppData\\Local\\Temp")
-                    || root_str.contains("\\Temp\\");
+                    || root_str.contains("\\Temp\\")
+                    || root_str.contains("\\.lmstudio");
                 if root_suspicious && !root_has_marker {
                     tracing::info!("Dropping suspicious persisted project root: {root}");
                     session.project_root = None;

--- a/rust/src/tools/startup.rs
+++ b/rust/src/tools/startup.rs
@@ -20,9 +20,11 @@ pub(super) fn is_suspicious_root(dir: &std::path::Path) -> bool {
     s.contains("/.claude")
         || s.contains("/.codebuddy")
         || s.contains("/.codex")
+        || s.contains("/.lmstudio")
         || s.contains("\\.claude")
         || s.contains("\\.codebuddy")
         || s.contains("\\.codex")
+        || s.contains("\\.lmstudio")
 }
 
 pub(super) fn canonicalize_path(path: &std::path::Path) -> String {


### PR DESCRIPTION
## Summary

Adds `mcp_server_cwd_outcome` to `lean-ctx doctor` that detects when the MCP server process is running from a directory without a project marker (e.g. inside `.lmstudio`, `.claude`, `.codebuddy`, `.codex`).

This is a common source of `"path escapes project root"` errors — the MCP client (IDE/agent) spawned lean-ctx from the wrong working directory, so all file reads outside that directory fail.

## Changes

### `rust/src/tools/startup.rs`
- Add `.lmstudio` to `is_suspicious_root` check alongside existing `.claude`/`.codebuddy`/`.codex`

### `rust/src/server/server_handler.rs`
- Add `.lmstudio` to the suspicious persisted-project-root drop list

### `rust/src/doctor/checks.rs`
- New `mcp_server_cwd_outcome()` function: checks `LEAN_CTX_MCP_SERVER`, validates CWD has a project marker, warns if running from a suspicious or marker-less directory

### `rust/src/doctor/mod.rs`
- Wire the new check into the doctor board

### `rust/src/doctor/report.rs`
- Add to structured health report warnings (dashboard signal)

## Description

When lean-ctx is launched as an MCP server by a client that does not set the working directory explicitly, the process inherits the client's CWD. If that CWD is an IDE/agent config directory (like `~/.lmstudio/...`) or any directory without a `.git`/project marker, the path jail defaults to that directory, and every `ctx_read` for files outside it fails with `"path escapes project root"`.

The doctor warning tells the user:
```
MCP server CWD  ✗ suspicious directory without project marker
  lean-ctx was launched from ~/.lmstudio/... without a project root.
  Set `cwd` in your MCP client config or add
  `allow_auto_reroot = true` + `extra_roots` in config.toml
```

## Testing

- `lean-ctx doctor` shows a clean pass when not in MCP mode
- `LEAN_CTX_MCP_SERVER=1 lean-ctx doctor` validates the CWD and warns if needed
- The server handler drops persisted sessions with contaminated roots early