### PR TITLE
fix(rules): stop CLAUDE.md/CODEBUDDY.md block duplication (#549)

### DIFF
--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -1903,8 +1903,8 @@ mod tests {
             ".claude/CLAUDE.md",
             &format!(
                 "{}\ncontent\n{}",
-                crate::core::rules_canonical::START_MARK,
-                crate::core::rules_canonical::END_MARK,
+                crate::core::rules_canonical::AGENTS_BLOCK_START,
+                crate::core::rules_canonical::AGENTS_BLOCK_END,
             ),
         );
         write(tmp.path(), ".claude/skills/lean-ctx/SKILL.md", "skill");
@@ -1920,7 +1920,7 @@ mod tests {
         write(
             tmp.path(),
             ".claude/CLAUDE.md",
-            &format!("{}\nx", crate::core::rules_canonical::START_MARK),
+            &format!("{}\nx", crate::core::rules_canonical::AGENTS_BLOCK_START),
         );
         let out = check(tmp.path(), RulesScope::Global, RulesInjection::Shared);
         assert!(out.ok, "{}", out.line);

--- a/rust/src/doctor/common.rs
+++ b/rust/src/doctor/common.rs
@@ -747,4 +747,63 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn claude_instructions_state_detects_pointer_block() {
+        // GH #549: the check must recognise the pointer block the installer
+        // actually writes (delimited by `<!-- lean-ctx -->`), not the retired
+        // full-rules marker — otherwise it falsely reports the block missing.
+        let _lock = crate::core::data_dir::test_env_lock();
+        use crate::core::config::{RulesInjection, RulesScope};
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let dir = crate::core::editor_registry::claude_state_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("CLAUDE.md"),
+            format!(
+                "# notes\n\n{}\n## lean-ctx\n{}\n",
+                crate::hooks::agents::CLAUDE_MD_BLOCK_START,
+                crate::core::rules_canonical::AGENTS_BLOCK_END
+            ),
+        )
+        .unwrap();
+
+        let state =
+            super::claude_instructions_state(home, RulesScope::Global, RulesInjection::Shared);
+        assert_ne!(
+            state,
+            super::ClaudeInstructionsState::Missing,
+            "doctor must detect the CLAUDE.md pointer block (#549)"
+        );
+        assert!(state.ok(), "a detected block must be a healthy state");
+    }
+
+    #[test]
+    fn codebuddy_instructions_state_detects_pointer_block() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        use crate::core::config::{RulesInjection, RulesScope};
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let dir = crate::core::editor_registry::codebuddy_state_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("CODEBUDDY.md"),
+            format!(
+                "# notes\n\n{}\n## lean-ctx\n{}\n",
+                crate::hooks::agents::CODEBUDDY_MD_BLOCK_START,
+                crate::core::rules_canonical::AGENTS_BLOCK_END
+            ),
+        )
+        .unwrap();
+
+        let state =
+            super::codebuddy_instructions_state(home, RulesScope::Global, RulesInjection::Shared);
+        assert_ne!(
+            state,
+            super::ClaudeInstructionsState::Missing,
+            "doctor must detect the CODEBUDDY.md pointer block (#549)"
+        );
+        assert!(state.ok());
+    }
 }

--- a/rust/src/hooks/agents/claude.rs
+++ b/rust/src/hooks/agents/claude.rs
@@ -2,6 +2,7 @@ use super::super::{
     HookMode, REDIRECT_SCRIPT_CLAUDE, generate_rewrite_script, make_executable,
     mcp_server_quiet_mode, resolve_binary_path, resolve_binary_path_for_bash, write_file,
 };
+use super::shared::remove_all_blocks;
 
 pub(crate) fn install_claude_hook_with_mode(global: bool, mode: HookMode) {
     let Some(home) = crate::core::home::resolve_home_dir() else {
@@ -83,8 +84,15 @@ fn install_claude_mcp_server(home: &std::path::Path) {
 
 /// Shared with `doctor` so the instructions check recognises the same block
 /// this installer writes (GH #396: doctor must not demand the retired rules file).
-pub(crate) const CLAUDE_MD_BLOCK_START: &str = crate::core::rules_canonical::START_MARK;
-const CLAUDE_MD_BLOCK_END: &str = crate::core::rules_canonical::END_MARK;
+///
+/// The CLAUDE.md block is a lightweight *pointer* block, so it is delimited by
+/// `AGENTS_BLOCK_START`/`END` (`<!-- lean-ctx -->`), NOT the full-rules markers
+/// `START_MARK`/`END_MARK` (`<!-- lean-ctx-rules -->`). Pointing these at the
+/// rules markers made `contains()` never match the block lean-ctx actually
+/// writes, so `doctor` reported it missing and every `setup`/`doctor --fix`
+/// appended a duplicate (GH #549).
+pub(crate) const CLAUDE_MD_BLOCK_START: &str = crate::core::rules_canonical::AGENTS_BLOCK_START;
+const CLAUDE_MD_BLOCK_END: &str = crate::core::rules_canonical::AGENTS_BLOCK_END;
 const CLAUDE_MD_BLOCK_VERSION: &str = "lean-ctx-claude-v3";
 
 // v3 (GL #555): self-contained, no `@rules/lean-ctx.md` import. Claude Code
@@ -134,22 +142,21 @@ fn install_claude_global_claude_md_for_mode(home: &std::path::Path, mode: HookMo
         HookMode::Mcp | HookMode::Hybrid => CLAUDE_MD_BLOCK_VERSION,
     };
 
-    if existing.contains(CLAUDE_MD_BLOCK_START) {
-        if existing.contains(block_version) {
-            return;
-        }
-        let cleaned = remove_block(&existing, CLAUDE_MD_BLOCK_START, CLAUDE_MD_BLOCK_END);
-        let updated = format!("{}\n\n{}\n", cleaned.trim(), block);
-        write_file(&claude_md_path, &updated);
+    // A single up-to-date block needs no rewrite. Otherwise — a stale version
+    // *or* duplicate blocks accumulated from the pre-#549 marker mismatch —
+    // collapse every lean-ctx block and write exactly one canonical copy back.
+    let block_count = existing.matches(CLAUDE_MD_BLOCK_START).count();
+    if block_count == 1 && existing.contains(block_version) {
         return;
     }
-
-    if existing.trim().is_empty() {
-        write_file(&claude_md_path, block);
+    let cleaned = remove_all_blocks(&existing, CLAUDE_MD_BLOCK_START, CLAUDE_MD_BLOCK_END);
+    let cleaned = cleaned.trim();
+    let updated = if cleaned.is_empty() {
+        format!("{block}\n")
     } else {
-        let updated = format!("{}\n\n{}\n", existing.trim(), block);
-        write_file(&claude_md_path, &updated);
-    }
+        format!("{cleaned}\n\n{block}\n")
+    };
+    write_file(&claude_md_path, &updated);
 }
 
 /// Remove the lean-ctx block from `CLAUDE.md` (dedicated mode). Deletes the file
@@ -161,31 +168,11 @@ fn strip_claude_md_block(claude_md_path: &std::path::Path) {
     if !existing.contains(CLAUDE_MD_BLOCK_START) {
         return;
     }
-    let cleaned = remove_block(&existing, CLAUDE_MD_BLOCK_START, CLAUDE_MD_BLOCK_END);
+    let cleaned = remove_all_blocks(&existing, CLAUDE_MD_BLOCK_START, CLAUDE_MD_BLOCK_END);
     if cleaned.trim().is_empty() {
         let _ = std::fs::remove_file(claude_md_path);
     } else {
         write_file(claude_md_path, &format!("{}\n", cleaned.trim_end()));
-    }
-}
-
-fn remove_block(content: &str, start: &str, end: &str) -> String {
-    let s = content.find(start);
-    let e = content.find(end);
-    match (s, e) {
-        (Some(si), Some(ei)) if ei >= si => {
-            let after_end = ei + end.len();
-            let before = content[..si].trim_end_matches('\n');
-            let after = &content[after_end..];
-            let mut out = before.to_string();
-            out.push('\n');
-            if !after.trim().is_empty() {
-                out.push('\n');
-                out.push_str(after.trim_start_matches('\n'));
-            }
-            out
-        }
-        _ => content.to_string(),
     }
 }
 
@@ -785,5 +772,69 @@ mod tests {
         assert!(home.join(".claude/skills/lean-ctx/SKILL.md").exists());
         remove_claude_skill(home);
         assert!(!home.join(".claude/skills/lean-ctx").exists());
+    }
+
+    #[test]
+    fn claude_block_content_carries_detection_markers() {
+        // GH #549 regression guard: the written block MUST contain the markers the
+        // doctor + installer detect with — otherwise detection silently fails and
+        // every `setup`/`doctor --fix` appends a fresh duplicate.
+        assert!(
+            CLAUDE_MD_BLOCK_CONTENT_MCP.contains(CLAUDE_MD_BLOCK_START),
+            "block content must contain its own start marker"
+        );
+        assert!(
+            CLAUDE_MD_BLOCK_CONTENT_MCP.contains(CLAUDE_MD_BLOCK_END),
+            "block content must contain its own end marker"
+        );
+    }
+
+    #[test]
+    fn installer_writes_single_claude_block_and_is_idempotent() {
+        // GH #549: repeated installs must converge on exactly one block.
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let md = crate::core::editor_registry::claude_state_dir(home).join("CLAUDE.md");
+
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
+        install_claude_global_claude_md_for_mode(home, HookMode::Mcp);
+        install_claude_global_claude_md_for_mode(home, HookMode::Mcp);
+        crate::test_env::remove_var("LEAN_CTX_RULES_INJECTION");
+
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert_eq!(
+            after.matches(CLAUDE_MD_BLOCK_START).count(),
+            1,
+            "exactly one block after repeated installs, got:\n{after}"
+        );
+        assert!(after.contains(CLAUDE_MD_BLOCK_VERSION));
+    }
+
+    #[test]
+    fn installer_heals_duplicate_claude_blocks() {
+        // GH #549: pre-fix installs accumulated duplicate blocks; a re-run must
+        // collapse them to exactly one while preserving the user's own content.
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let dir = crate::core::editor_registry::claude_state_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let md = dir.join("CLAUDE.md");
+        let b = CLAUDE_MD_BLOCK_CONTENT_MCP;
+        let dupes = format!("# my notes\n\n{b}\n\n{b}\n\n{b}\n");
+        std::fs::write(&md, dupes).unwrap();
+
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
+        install_claude_global_claude_md_for_mode(home, HookMode::Mcp);
+        crate::test_env::remove_var("LEAN_CTX_RULES_INJECTION");
+
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert_eq!(
+            after.matches(CLAUDE_MD_BLOCK_START).count(),
+            1,
+            "duplicates must collapse to one, got:\n{after}"
+        );
+        assert!(after.contains("# my notes"), "user content must survive");
     }
 }

--- a/rust/src/hooks/agents/codebuddy.rs
+++ b/rust/src/hooks/agents/codebuddy.rs
@@ -2,6 +2,7 @@ use super::super::{
     HookMode, REDIRECT_SCRIPT_CLAUDE, generate_rewrite_script, make_executable,
     mcp_server_quiet_mode, resolve_binary_path, resolve_binary_path_for_bash, write_file,
 };
+use super::shared::remove_all_blocks;
 
 pub(crate) fn install_codebuddy_hook_with_mode(global: bool, mode: HookMode) {
     let Some(home) = crate::core::home::resolve_home_dir() else {
@@ -79,9 +80,12 @@ fn install_codebuddy_mcp_server(home: &std::path::Path) {
 }
 
 /// Shared with `doctor` so the instructions check recognises the same block
-/// this installer writes.
-pub(crate) const CODEBUDDY_MD_BLOCK_START: &str = crate::core::rules_canonical::START_MARK;
-const CODEBUDDY_MD_BLOCK_END: &str = crate::core::rules_canonical::END_MARK;
+/// this installer writes. The CODEBUDDY.md block is a lightweight *pointer*
+/// block, so it uses `AGENTS_BLOCK_START`/`END` (`<!-- lean-ctx -->`), not the
+/// full-rules markers (`<!-- lean-ctx-rules -->`) — pointing them at the rules
+/// markers broke detection and caused duplicate blocks (GH #549).
+pub(crate) const CODEBUDDY_MD_BLOCK_START: &str = crate::core::rules_canonical::AGENTS_BLOCK_START;
+const CODEBUDDY_MD_BLOCK_END: &str = crate::core::rules_canonical::AGENTS_BLOCK_END;
 const CODEBUDDY_MD_BLOCK_VERSION: &str = "lean-ctx-codebuddy-v1";
 
 const CODEBUDDY_MD_BLOCK_CONTENT_MCP: &str = "\
@@ -126,22 +130,21 @@ fn install_codebuddy_global_codebuddy_md_for_mode(home: &std::path::Path, mode: 
         HookMode::Mcp | HookMode::Hybrid => CODEBUDDY_MD_BLOCK_VERSION,
     };
 
-    if existing.contains(CODEBUDDY_MD_BLOCK_START) {
-        if existing.contains(block_version) {
-            return;
-        }
-        let cleaned = remove_block(&existing, CODEBUDDY_MD_BLOCK_START, CODEBUDDY_MD_BLOCK_END);
-        let updated = format!("{}\n\n{}\n", cleaned.trim(), block);
-        write_file(&codebuddy_md_path, &updated);
+    // A single up-to-date block needs no rewrite. Otherwise — a stale version
+    // *or* duplicate blocks accumulated from the pre-#549 marker mismatch —
+    // collapse every lean-ctx block and write exactly one canonical copy back.
+    let block_count = existing.matches(CODEBUDDY_MD_BLOCK_START).count();
+    if block_count == 1 && existing.contains(block_version) {
         return;
     }
-
-    if existing.trim().is_empty() {
-        write_file(&codebuddy_md_path, block);
+    let cleaned = remove_all_blocks(&existing, CODEBUDDY_MD_BLOCK_START, CODEBUDDY_MD_BLOCK_END);
+    let cleaned = cleaned.trim();
+    let updated = if cleaned.is_empty() {
+        format!("{block}\n")
     } else {
-        let updated = format!("{}\n\n{}\n", existing.trim(), block);
-        write_file(&codebuddy_md_path, &updated);
-    }
+        format!("{cleaned}\n\n{block}\n")
+    };
+    write_file(&codebuddy_md_path, &updated);
 }
 
 fn strip_codebuddy_md_block(codebuddy_md_path: &std::path::Path) {
@@ -151,31 +154,11 @@ fn strip_codebuddy_md_block(codebuddy_md_path: &std::path::Path) {
     if !existing.contains(CODEBUDDY_MD_BLOCK_START) {
         return;
     }
-    let cleaned = remove_block(&existing, CODEBUDDY_MD_BLOCK_START, CODEBUDDY_MD_BLOCK_END);
+    let cleaned = remove_all_blocks(&existing, CODEBUDDY_MD_BLOCK_START, CODEBUDDY_MD_BLOCK_END);
     if cleaned.trim().is_empty() {
         let _ = std::fs::remove_file(codebuddy_md_path);
     } else {
         write_file(codebuddy_md_path, &format!("{}\n", cleaned.trim_end()));
-    }
-}
-
-fn remove_block(content: &str, start: &str, end: &str) -> String {
-    let s = content.find(start);
-    let e = content.find(end);
-    match (s, e) {
-        (Some(si), Some(ei)) if ei >= si => {
-            let after_end = ei + end.len();
-            let before = content[..si].trim_end_matches('\n');
-            let after = &content[after_end..];
-            let mut out = before.to_string();
-            out.push('\n');
-            if !after.trim().is_empty() {
-                out.push('\n');
-                out.push_str(after.trim_start_matches('\n'));
-            }
-            out
-        }
-        _ => content.to_string(),
     }
 }
 
@@ -629,5 +612,64 @@ mod tests {
         assert!(home.join(".codebuddy/skills/lean-ctx/SKILL.md").exists());
         remove_codebuddy_skill(home);
         assert!(!home.join(".codebuddy/skills/lean-ctx").exists());
+    }
+
+    #[test]
+    fn codebuddy_block_content_carries_detection_markers() {
+        // GH #549 regression guard (see claude.rs for the full rationale).
+        assert!(
+            CODEBUDDY_MD_BLOCK_CONTENT_MCP.contains(CODEBUDDY_MD_BLOCK_START),
+            "block content must contain its own start marker"
+        );
+        assert!(
+            CODEBUDDY_MD_BLOCK_CONTENT_MCP.contains(CODEBUDDY_MD_BLOCK_END),
+            "block content must contain its own end marker"
+        );
+    }
+
+    #[test]
+    fn installer_writes_single_codebuddy_block_and_is_idempotent() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let md = crate::core::editor_registry::codebuddy_state_dir(home).join("CODEBUDDY.md");
+
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
+        install_codebuddy_global_codebuddy_md_for_mode(home, HookMode::Mcp);
+        install_codebuddy_global_codebuddy_md_for_mode(home, HookMode::Mcp);
+        crate::test_env::remove_var("LEAN_CTX_RULES_INJECTION");
+
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert_eq!(
+            after.matches(CODEBUDDY_MD_BLOCK_START).count(),
+            1,
+            "exactly one block after repeated installs, got:\n{after}"
+        );
+        assert!(after.contains(CODEBUDDY_MD_BLOCK_VERSION));
+    }
+
+    #[test]
+    fn installer_heals_duplicate_codebuddy_blocks() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let dir = crate::core::editor_registry::codebuddy_state_dir(home);
+        std::fs::create_dir_all(&dir).unwrap();
+        let md = dir.join("CODEBUDDY.md");
+        let b = CODEBUDDY_MD_BLOCK_CONTENT_MCP;
+        let dupes = format!("# my notes\n\n{b}\n\n{b}\n\n{b}\n");
+        std::fs::write(&md, dupes).unwrap();
+
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
+        install_codebuddy_global_codebuddy_md_for_mode(home, HookMode::Mcp);
+        crate::test_env::remove_var("LEAN_CTX_RULES_INJECTION");
+
+        let after = std::fs::read_to_string(&md).unwrap();
+        assert_eq!(
+            after.matches(CODEBUDDY_MD_BLOCK_START).count(),
+            1,
+            "duplicates must collapse to one, got:\n{after}"
+        );
+        assert!(after.contains("# my notes"), "user content must survive");
     }
 }

--- a/rust/src/hooks/agents/shared.rs
+++ b/rust/src/hooks/agents/shared.rs
@@ -50,3 +50,42 @@ pub(super) fn prepare_project_rules_path(global: bool, file_name: &str) -> Optio
 
     Some(rules_path)
 }
+
+/// Remove the first lean-ctx block delimited by `start`..`end` from `content`.
+/// Shared by the Claude/CodeBuddy CLAUDE.md/CODEBUDDY.md installers and `doctor`.
+pub(super) fn remove_block(content: &str, start: &str, end: &str) -> String {
+    let s = content.find(start);
+    let e = content.find(end);
+    match (s, e) {
+        (Some(si), Some(ei)) if ei >= si => {
+            let after_end = ei + end.len();
+            let before = content[..si].trim_end_matches('\n');
+            let after = &content[after_end..];
+            let mut out = before.to_string();
+            out.push('\n');
+            if !after.trim().is_empty() {
+                out.push('\n');
+                out.push_str(after.trim_start_matches('\n'));
+            }
+            out
+        }
+        _ => content.to_string(),
+    }
+}
+
+/// Remove *every* lean-ctx block delimited by `start`..`end`. Heals files that
+/// accumulated duplicate blocks from the pre-#549 marker mismatch (the detector
+/// constant pointed at `<!-- lean-ctx-rules -->` while the written block used
+/// `<!-- lean-ctx -->`, so every `setup`/`doctor --fix` appended a fresh copy).
+/// Callers then write exactly one canonical block back.
+pub(super) fn remove_all_blocks(content: &str, start: &str, end: &str) -> String {
+    let mut out = content.to_string();
+    while out.contains(start) {
+        let next = remove_block(&out, start, end);
+        if next == out {
+            break; // malformed (start without end) — avoid an infinite loop
+        }
+        out = next;
+    }
+    out
+}


### PR DESCRIPTION
## Summary
- The CLAUDE.md / CODEBUDDY.md block-detection constants pointed at the full-rules markers (`<!-- lean-ctx-rules -->`) while the installer writes a lightweight *pointer* block (`<!-- lean-ctx -->`). `contains()` therefore never matched: `doctor` reported the instructions missing, and every `setup` / `doctor --fix` appended a fresh duplicate block.
- Repoint the markers to `rules_canonical::AGENTS_BLOCK_START/END` (what the installer actually writes).
- Add a shared `remove_all_blocks` helper and collapse any accumulated duplicates to exactly one canonical block on install and strip, so affected users self-heal on the next setup/upgrade.
- Centralise the previously per-file `remove_block` into `agents::shared` (no more duplication).

## Test plan
- [x] `doctor` detection returns a non-`Missing` state for the real pointer block (Claude + CodeBuddy)
- [x] Installer idempotency: running twice yields exactly one block
- [x] Healing: a file pre-seeded with N duplicate blocks collapses to one; user content preserved
- [x] `cargo test --lib`, `cargo clippy --lib --tests` (zero warnings), `cargo fmt --check`, preflight gate green

Refs #549

Made with [Cursor](https://cursor.com)