### PR TITLE
fix(hooks): intercept glob + Windows powershell tool calls in shadow mode (#556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (gitlab #868–#871)
 
 ### Fixed
+- **Shadow mode ignored `glob` and Windows `powershell` tool calls (#556).**
+  Shadow/harden mode silently passed two documented Copilot CLI tools straight
+  through: the `glob` tool ("find files matching patterns") had no arm in the
+  redirect hook, and the `powershell` shell tool (paired with `bash` on Windows)
+  was not recognised as a shell, so command rewrites never fired there.
+  `handle_redirect` now intercepts `Glob`/`glob` — warming the shared `ctx_glob`
+  core via a new `lean-ctx glob` subcommand and recording the intercept in
+  `shadow.log`, then letting the native path-list result through — `is_shell_tool`
+  (now shared by both hook entry points) covers `PowerShell`/`powershell`/`pwsh`,
+  and the Claude/Cursor/CodeBuddy redirect matchers include `Glob` so the hook
+  fires for it. Copilot CLI already dispatches every tool, so its `glob`/
+  `powershell` calls are covered automatically.
 - **Codex proxy never compressed — ChatGPT login bypasses it; the API-key config
   was a no-op (#554).** `lean-ctx proxy enable` reported success for Codex yet
   `Requests/Compressed/Tokens saved` stayed at `0`, for two reasons. (1) A Codex

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -386,6 +386,11 @@ pub fn run() {
                 core::stats::flush();
                 return;
             }
+            "glob" => {
+                super::cmd_glob(&rest);
+                core::stats::flush();
+                return;
+            }
             "find" => {
                 super::cmd_find(&rest);
                 core::stats::flush();

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -383,6 +383,49 @@ pub fn cmd_grep(args: &[String]) {
     }
 }
 
+/// `lean-ctx glob <pattern> [path]` — find files by glob pattern, shares the
+/// exact `ctx_glob` core so the CLI, the MCP tool, and the shadow-mode redirect
+/// (#556) all return identical results. Prefers the daemon (warms its cache),
+/// falling back to an in-process call.
+pub fn cmd_glob(args: &[String]) {
+    if args.is_empty() {
+        eprintln!("Usage: lean-ctx glob <pattern> [path]");
+        std::process::exit(1);
+    }
+
+    let pattern = &args[0];
+    let raw_path = args.get(1).map_or(".", std::string::String::as_str);
+    let abs_path = resolve_cli_path(raw_path);
+    let path = abs_path.as_str();
+
+    #[cfg(unix)]
+    if let Some(out) = crate::daemon_client::try_daemon_tool_call_blocking_text(
+        "ctx_glob",
+        Some(serde_json::json!({
+            "pattern": pattern,
+            "path": path,
+        })),
+    ) {
+        let out = super::common::filter_daemon_output(&out);
+        println!("{out}");
+        return;
+    }
+    super::common::daemon_fallback_hint();
+
+    let (out, _original) = crate::tools::ctx_glob::handle(
+        pattern,
+        path,
+        true,
+        roles::active_role().io.allow_secret_paths,
+        200,
+    );
+    println!("{out}");
+    crate::core::stats::record("cli_glob", 0, 0);
+    if out.starts_with("ERROR:") {
+        std::process::exit(1);
+    }
+}
+
 pub fn cmd_find(args: &[String]) {
     if args.is_empty() {
         eprintln!("Usage: lean-ctx find <pattern> [path]");

--- a/rust/src/doctor/integrations.rs
+++ b/rust/src/doctor/integrations.rs
@@ -1344,7 +1344,7 @@ fn check_cursor_hooks(path: &std::path::Path, binary: &str) -> NamedCheck {
     let has_redirect = pre.iter().any(|e| {
         matches!(
             e.get("matcher").and_then(|m| m.as_str()),
-            Some("Read|Grep" | "Read" | "Grep")
+            Some("Read|Grep|Glob" | "Read|Grep" | "Read" | "Grep")
         ) && e
             .get("command")
             .and_then(|c| c.as_str())

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -128,6 +128,27 @@ fn build_dual_rewrite_output(tool_input: Option<&serde_json::Value>, rewritten: 
     .to_string()
 }
 
+/// True when a host tool name denotes a shell/terminal command tool.
+///
+/// Copilot CLI exposes `powershell` as a first-class shell tool on Windows
+/// (paired with `bash` per the CLI tool reference); without it Windows shell
+/// calls bypass rewrite (#556). Shared by `handle_rewrite` and `handle_copilot`.
+fn is_shell_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "Bash"
+            | "bash"
+            | "Shell"
+            | "shell"
+            | "runInTerminal"
+            | "run_in_terminal"
+            | "terminal"
+            | "PowerShell"
+            | "powershell"
+            | "pwsh"
+    )
+}
+
 pub fn handle_rewrite() {
     let allow = build_dual_allow_output();
     if is_disabled() {
@@ -154,11 +175,7 @@ pub fn handle_rewrite() {
         return;
     };
 
-    let is_shell_tool = matches!(
-        tool_name.as_str(),
-        "Bash" | "bash" | "Shell" | "shell" | "runInTerminal" | "run_in_terminal" | "terminal"
-    );
-    if !is_shell_tool {
+    if !is_shell_tool(&tool_name) {
         print!("{allow}");
         return;
     }
@@ -493,6 +510,7 @@ pub fn handle_redirect() {
     match tool_name.as_str() {
         "Read" | "read" | "read_file" => redirect_read(tool_args.as_ref()),
         "Grep" | "grep" | "search" | "ripgrep" => redirect_grep(tool_args.as_ref()),
+        "Glob" | "glob" => redirect_glob(tool_args.as_ref()),
         _ => print!("{allow}"),
     }
 }
@@ -647,6 +665,68 @@ fn redirect_grep(tool_input: Option<&serde_json::Value>) {
         "lean-ctx grep produced no output",
     );
     print!("{}", build_dual_allow_output());
+}
+
+/// Redirect Glob through lean-ctx in shadow/harden mode (#556).
+///
+/// Glob differs from Read/Grep: its result is a list of paths matched against
+/// the filesystem, not file content, so `build_redirect_output` (which swaps a
+/// field to a temp file the host then *reads*) cannot carry it. We therefore
+/// only act when shadow or harden mode is active — warm lean-ctx's own glob
+/// path (parity with `ctx_glob`) and record the intercept in shadow.log — then
+/// allow the native call through unchanged. Outside those modes there is nothing
+/// to gain, so we pass through immediately without spawning a subprocess.
+fn redirect_glob(tool_input: Option<&serde_json::Value>) {
+    let allow = build_dual_allow_output();
+    let shadow = is_shadow_mode_active();
+    if !shadow && !is_harden_active() {
+        print!("{allow}");
+        return;
+    }
+
+    let pattern = tool_input
+        .and_then(|ti| ti.get("pattern"))
+        .and_then(|p| p.as_str())
+        .unwrap_or("");
+    if pattern.is_empty() {
+        debug_log::log_hook_decision(
+            "redirect",
+            "Glob",
+            Route::Native,
+            "<none>",
+            "no pattern in tool input",
+        );
+        print!("{allow}");
+        return;
+    }
+    let search_path = tool_input
+        .and_then(|ti| ti.get("path"))
+        .and_then(|p| p.as_str())
+        .unwrap_or(".");
+
+    tracing::info!(
+        "[hook redirect] {} active, warming ctx_glob for {pattern}",
+        if shadow { "shadow mode" } else { "harden mode" }
+    );
+
+    // Warm lean-ctx's glob path (populates caches, parity with the ctx_glob the
+    // shadow header nudges toward); the native result is kept untouched.
+    let binary = resolve_binary();
+    let _ = run_with_timeout(
+        &binary,
+        &["glob", pattern, search_path],
+        REDIRECT_SUBPROCESS_TIMEOUT,
+    );
+
+    debug_log::log_hook_decision(
+        "redirect",
+        "Glob",
+        Route::Native,
+        &format!("{pattern} in {search_path}"),
+        "shadow/harden warm — native passthrough",
+    );
+    log_shadow_intercept("Glob", &format!("{pattern} in {search_path}"));
+    print!("{allow}");
 }
 
 const REDIRECT_SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(10);
@@ -876,11 +956,7 @@ pub fn handle_copilot() {
         return;
     };
 
-    let is_shell_tool = matches!(
-        tool_name.as_str(),
-        "Bash" | "bash" | "Shell" | "shell" | "runInTerminal" | "run_in_terminal" | "terminal"
-    );
-    if !is_shell_tool {
+    if !is_shell_tool(&tool_name) {
         return;
     }
 

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -588,3 +588,34 @@ fn session_start_uses_codex_additional_context_channel() {
         "prefer lean-ctx -c"
     );
 }
+
+#[test]
+fn is_shell_tool_matches_powershell_variants() {
+    // #556: Copilot CLI's `powershell` shell tool was bypassing rewrite on
+    // Windows because it was not recognised as a shell tool.
+    assert!(is_shell_tool("powershell"));
+    assert!(is_shell_tool("PowerShell"));
+    assert!(is_shell_tool("pwsh"));
+}
+
+#[test]
+fn is_shell_tool_matches_existing_shell_names() {
+    for name in [
+        "Bash",
+        "bash",
+        "Shell",
+        "shell",
+        "runInTerminal",
+        "run_in_terminal",
+        "terminal",
+    ] {
+        assert!(is_shell_tool(name), "{name} should be a shell tool");
+    }
+}
+
+#[test]
+fn is_shell_tool_rejects_non_shell_tools() {
+    for name in ["Read", "read", "Grep", "Glob", "glob", "view", "edit", ""] {
+        assert!(!is_shell_tool(name), "{name} must not be a shell tool");
+    }
+}

--- a/rust/src/hooks/agents/claude.rs
+++ b/rust/src/hooks/agents/claude.rs
@@ -286,7 +286,7 @@ pub(crate) fn install_claude_hook_scripts(home: &std::path::Path) {
 }
 
 /// The `Read|…` tool matcher shared by every Claude redirect hook (global + project).
-const REDIRECT_MATCHER: &str = "Read|read|ReadFile|read_file|View|view|Grep|grep|Search|search|ListFiles|list_files|ListDirectory|list_directory";
+const REDIRECT_MATCHER: &str = "Read|read|ReadFile|read_file|View|view|Grep|grep|Search|search|ListFiles|list_files|ListDirectory|list_directory|Glob|glob";
 
 /// The trailing action token of a lean-ctx hook command, e.g. `"hook rewrite"`.
 ///
@@ -732,6 +732,14 @@ mod tests {
             commands_for(&pre, "hook redirect"),
             ["lean-ctx hook redirect"]
         );
+    }
+
+    #[test]
+    fn redirect_matcher_covers_glob() {
+        // #556: shadow mode must intercept the Glob tool, so it has to be part
+        // of the redirect matcher Claude installs.
+        assert!(REDIRECT_MATCHER.contains("Glob"));
+        assert!(REDIRECT_MATCHER.contains("glob"));
     }
 
     #[test]

--- a/rust/src/hooks/agents/codebuddy.rs
+++ b/rust/src/hooks/agents/codebuddy.rs
@@ -268,7 +268,7 @@ pub(crate) fn install_codebuddy_hook_scripts(home: &std::path::Path) {
     let _ = wrapper;
 }
 
-const REDIRECT_MATCHER: &str = "Read|read|ReadFile|read_file|View|view|Grep|grep|Search|search|ListFiles|list_files|ListDirectory|list_directory";
+const REDIRECT_MATCHER: &str = "Read|read|ReadFile|read_file|View|view|Grep|grep|Search|search|ListFiles|list_files|ListDirectory|list_directory|Glob|glob";
 
 fn lean_ctx_action_token(command: &str) -> &str {
     match command.rfind(" hook ") {

--- a/rust/src/hooks/agents/cursor.rs
+++ b/rust/src/hooks/agents/cursor.rs
@@ -91,8 +91,8 @@ fn merge_cursor_hooks(existing: &mut serde_json::Value, rewrite_cmd: &str, redir
     ensure_pretooluse_hook(pre_arr, &["Shell"], "Shell", rewrite_cmd);
     ensure_pretooluse_hook(
         pre_arr,
-        &["Read|Grep", "Read", "Grep"],
-        "Read|Grep",
+        &["Read|Grep|Glob", "Read|Grep", "Read", "Grep"],
+        "Read|Grep|Glob",
         redirect_cmd,
     );
 
@@ -313,7 +313,7 @@ mod tests {
                 && e.get("command").and_then(|c| c.as_str()) == Some("/new/bin hook rewrite")
         }));
         assert!(pre.iter().any(|e| {
-            e.get("matcher").and_then(|m| m.as_str()) == Some("Read|Grep")
+            e.get("matcher").and_then(|m| m.as_str()) == Some("Read|Grep|Glob")
                 && e.get("command").and_then(|c| c.as_str()) == Some("/new/bin hook redirect")
         }));
     }

--- a/rust/tests/glob_cli_556.rs
+++ b/rust/tests/glob_cli_556.rs
@@ -1,0 +1,81 @@
+//! Integration test for `lean-ctx glob` (#556).
+//!
+//! The shadow-mode Glob redirect warms the cache by spawning `lean-ctx glob`,
+//! so the CLI subcommand must exist and resolve files through the shared
+//! `ctx_glob` core. Before #556 there was no `glob` subcommand at all.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Build an isolated project dir with a marker so the walk-root guard accepts
+/// it, and an isolated `HOME` (the parent) so no real user state is touched.
+fn project_in(home: &Path) -> PathBuf {
+    let proj = home.join("proj");
+    fs::create_dir_all(&proj).unwrap();
+    // `Cargo.toml` is a project marker -> `is_safe_scan_root` accepts the root.
+    fs::write(proj.join("Cargo.toml"), "[package]\nname = \"t\"\n").unwrap();
+    proj
+}
+
+fn run_glob(args: &[&str], home: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_lean-ctx"))
+        .args(args)
+        .env("HOME", home)
+        // Hook-child flag keeps the daemon from auto-starting; the command falls
+        // back to the in-process ctx_glob path, which is what we want to assert.
+        .env("LEAN_CTX_HOOK_CHILD", "1")
+        .output()
+        .expect("failed to spawn lean-ctx binary")
+}
+
+#[test]
+fn glob_lists_matching_files_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = project_in(tmp.path());
+    fs::write(proj.join("alpha.rs"), "fn a() {}\n").unwrap();
+    fs::write(proj.join("beta.rs"), "fn b() {}\n").unwrap();
+    fs::write(proj.join("notes.txt"), "hello\n").unwrap();
+
+    let out = run_glob(&["glob", "*.rs", proj.to_str().unwrap()], tmp.path());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "glob should exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("alpha.rs"), "missing alpha.rs in: {stdout}");
+    assert!(stdout.contains("beta.rs"), "missing beta.rs in: {stdout}");
+    assert!(
+        !stdout.contains("notes.txt"),
+        "*.rs must not match notes.txt: {stdout}"
+    );
+}
+
+#[test]
+fn glob_without_pattern_exits_nonzero() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_glob(&["glob"], tmp.path());
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "missing pattern must exit 1; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn glob_no_match_reports_zero() {
+    let tmp = tempfile::tempdir().unwrap();
+    let proj = project_in(tmp.path());
+    fs::write(proj.join("only.txt"), "x\n").unwrap();
+
+    let out = run_glob(&["glob", "*.rs", proj.to_str().unwrap()], tmp.path());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("0 files matched"),
+        "expected zero-match report, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
Shadow/harden mode silently passed two **documented Copilot CLI tools** straight through:

- **`glob`** ("find files matching patterns") had no arm in `handle_redirect`, so it was never intercepted on any agent.
- **`powershell`** (the Windows shell tool, paired with `bash` in the Copilot CLI tool reference) was not recognised by `is_shell_tool`, so command rewrites never fired for it.

## Changes
- Extract a shared `is_shell_tool` (removes the duplicated matcher across `handle_rewrite` / `handle_copilot`) and add `PowerShell` / `powershell` / `pwsh`.
- Add a `Glob | glob` arm → new `redirect_glob`: in shadow/harden mode it warms the shared `ctx_glob` core via a new `lean-ctx glob` subcommand and records the intercept in `shadow.log`, then passes the native path-list result through (a glob result is a path list, so `build_redirect_output` does not apply). Outside those modes it passes through immediately — no overhead.
- New **`lean-ctx glob`** CLI reusing `ctx_glob::handle` (byte-parity with the MCP `ctx_glob` tool the shadow header nudges toward).
- Add `Glob` to the **Claude / Cursor / CodeBuddy** redirect matchers and accept the new Cursor matcher in `doctor`. Copilot CLI dispatches every tool, so its `glob` / `powershell` calls are covered automatically.

## Test plan
- [x] `cargo test --lib` — unit tests: `is_shell_tool` (powershell variants + rejects non-shell), `redirect_matcher_covers_glob`, updated Cursor matcher test (5985 pass; the one unrelated `proxy::cold_prefix` failure is pre-existing parallel-run flakiness, passes in isolation).
- [x] `cargo test --test glob_cli_556` — integration: `lean-ctx glob` lists matching files only, errors without a pattern, reports zero matches.
- [x] `cargo clippy --lib --tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.

Closes #556.

Made with [Cursor](https://cursor.com)