### PR TITLE
fix(proxy): resolve live PowerShell $PROFILE so OneDrive redirection works (#558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (gitlab #868–#871)
 
 ### Fixed
+- **Windows PowerShell profile path hardcoded to `~\Documents` — broke under OneDrive
+  redirection (#558).** `proxy enable` and the shell-hook install resolved the
+  PowerShell profile by hardcoding `home\Documents\PowerShell\…`. Windows OneDrive
+  folder backup (on by default on most installs) redirects *Documents* to e.g.
+  `…\OneDrive\Documents\…`, so lean-ctx wrote to a file PowerShell never reads — the
+  active `$PROFILE` was never updated and the proxy received no traffic in new
+  terminals. A new `resolve_powershell_profile_path` asks PowerShell itself for
+  `$PROFILE.CurrentUserCurrentHost` (authoritative under any folder redirection,
+  preferring `pwsh` then Windows PowerShell, UTF-8 output) and falls back to the
+  documented default only when no PowerShell host can be launched. Non-Windows hosts
+  keep the static `~/.config/powershell` path and never spawn a process (#356).
 - **Copilot/VS Code Claude models ignored lean-ctx — no `.github/copilot-instructions.md` (#555).**
   `lean-ctx init --agent copilot` installed the MCP server plus a deliberately
   weak `AGENTS.md` pointer but never wrote `.github/copilot-instructions.md`, the

--- a/rust/src/cli/init_cmd.rs
+++ b/rust/src/cli/init_cmd.rs
@@ -106,7 +106,7 @@ pub fn cmd_init(args: &[String]) {
             dirs::home_dir().map_or_else(
                 || "PowerShell profile".to_string(),
                 |h| {
-                    crate::shell::platform::powershell_profile_path(&h)
+                    crate::shell::platform::resolve_powershell_profile_path(&h)
                         .to_string_lossy()
                         .into_owned()
                 },

--- a/rust/src/cli/shell_init.rs
+++ b/rust/src/cli/shell_init.rs
@@ -267,9 +267,10 @@ if ($_leanCtxShouldActivate) {{
 
 pub fn init_powershell(binary: &str) {
     // OS-aware profile path: ~/.config/powershell on macOS/Linux (never ~/Documents,
-    // which triggers a macOS TCC prompt, #356), Documents\PowerShell on Windows.
+    // which triggers a macOS TCC prompt, #356). On Windows resolve the live $PROFILE
+    // so OneDrive-redirected Documents folders are honored (#558).
     let profile_path = if let Some(home) = dirs::home_dir() {
-        let path = crate::shell::platform::powershell_profile_path(&home);
+        let path = crate::shell::platform::resolve_powershell_profile_path(&home);
         if let Some(dir) = path.parent() {
             let _ = std::fs::create_dir_all(dir);
         }

--- a/rust/src/proxy_setup.rs
+++ b/rust/src/proxy_setup.rs
@@ -233,7 +233,8 @@ pub fn uninstall_proxy_env(home: &Path, quiet: bool) {
         );
     }
 
-    let ps_profile = dirs::home_dir().map(|h| crate::shell::platform::powershell_profile_path(&h));
+    let ps_profile =
+        dirs::home_dir().map(|h| crate::shell::platform::resolve_powershell_profile_path(&h));
     if let Some(ref ps) = ps_profile
         && ps.exists()
     {
@@ -328,7 +329,8 @@ set -gx GEMINI_API_BASE_URL "{base}"
         );
     }
 
-    let ps_profile = dirs::home_dir().map(|h| crate::shell::platform::powershell_profile_path(&h));
+    let ps_profile =
+        dirs::home_dir().map(|h| crate::shell::platform::resolve_powershell_profile_path(&h));
     if let Some(ref ps) = ps_profile
         && ps.exists()
     {

--- a/rust/src/shell/platform.rs
+++ b/rust/src/shell/platform.rs
@@ -157,14 +157,20 @@ pub(crate) fn is_powershell(shell_path: &str) -> bool {
     name.contains("powershell") || name.contains("pwsh")
 }
 
-/// Path to the current-user PowerShell profile (`$PROFILE.CurrentUserCurrentHost`).
+/// Documented default location of the current-user PowerShell profile
+/// (`$PROFILE.CurrentUserCurrentHost`).
 ///
-/// Windows PowerShell stores it under `Documents\PowerShell\…`, but **PowerShell
+/// Windows PowerShell 7+ stores it under `Documents\PowerShell\…`, but **PowerShell
 /// (pwsh) on macOS/Linux reads `~/.config/powershell/…` instead** — and stat-ing
 /// anything inside `~/Documents` on macOS pops a TCC privacy prompt ("lean-ctx
 /// would like to access files in your Documents folder", #356). Resolving the
 /// profile per-OS keeps pwsh support everywhere while never touching `~/Documents`
 /// on non-Windows hosts.
+///
+/// This is the *default* path only. On Windows the real `Documents` folder is
+/// frequently redirected (OneDrive folder backup), so callers should prefer
+/// [`resolve_powershell_profile_path`], which asks PowerShell for the live location
+/// and uses this as the fallback.
 pub(crate) fn powershell_profile_path(home: &std::path::Path) -> std::path::PathBuf {
     const PROFILE_FILE: &str = "Microsoft.PowerShell_profile.ps1";
     if cfg!(windows) {
@@ -172,6 +178,59 @@ pub(crate) fn powershell_profile_path(home: &std::path::Path) -> std::path::Path
     } else {
         home.join(".config").join("powershell").join(PROFILE_FILE)
     }
+}
+
+/// Resolve the **active** current-user PowerShell profile path.
+///
+/// On Windows the profile lives under the *Documents* known folder, which OneDrive
+/// folder backup (enabled by default on most installs) routinely redirects to e.g.
+/// `…\OneDrive\Documents\PowerShell\…`. A hardcoded `~\Documents` therefore misses
+/// the real `$PROFILE`, so `proxy enable` / shell-hook install silently write to a
+/// file PowerShell never reads and the proxy receives no traffic (#558). We ask
+/// PowerShell itself for `$PROFILE.CurrentUserCurrentHost` — authoritative under any
+/// folder redirection — preferring `pwsh` (7+) then Windows PowerShell, and fall back
+/// to [`powershell_profile_path`] only when no PowerShell host can be launched (in
+/// which case the profile is moot anyway).
+///
+/// Non-Windows hosts keep the static `~/.config/powershell` path (never `~/Documents`,
+/// #356) and never spawn a process.
+pub(crate) fn resolve_powershell_profile_path(home: &std::path::Path) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        if let Some(active) = query_active_powershell_profile() {
+            return active;
+        }
+    }
+    powershell_profile_path(home)
+}
+
+/// Ask PowerShell for `$PROFILE.CurrentUserCurrentHost`, the authoritative profile
+/// path under any `Documents` redirection. Returns `None` when no PowerShell host can
+/// be launched or the output is not a usable absolute path.
+#[cfg(windows)]
+fn query_active_powershell_profile() -> Option<std::path::PathBuf> {
+    // `pwsh` (7+) and `powershell.exe` (5.1) use different profile roots; prefer the
+    // modern host (matching the `Documents\PowerShell` default above), then fall back.
+    // Force UTF-8 output so redirected paths with non-ASCII characters survive the pipe.
+    for exe in ["pwsh", "powershell"] {
+        let output = match std::process::Command::new(exe)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "[Console]::OutputEncoding=[Text.Encoding]::UTF8; $PROFILE.CurrentUserCurrentHost",
+            ])
+            .output()
+        {
+            Ok(out) if out.status.success() => out,
+            _ => continue,
+        };
+        let path = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        if path.is_absolute() && path.file_name().is_some() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 /// Windows only: argument that passes one command string to the shell binary.
@@ -560,7 +619,7 @@ mod is_powershell_tests {
 
 #[cfg(test)]
 mod powershell_profile_tests {
-    use super::powershell_profile_path;
+    use super::{powershell_profile_path, resolve_powershell_profile_path};
     use std::path::Path;
 
     #[test]
@@ -590,6 +649,29 @@ mod powershell_profile_tests {
     fn windows_uses_documents_powershell() {
         let p = powershell_profile_path(Path::new("C:\\Users\\jane"));
         assert!(p.ends_with("Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn resolver_matches_static_default_on_non_windows() {
+        // Non-Windows never spawns a process: the resolver returns the static config
+        // path verbatim (and must never touch ~/Documents, #356).
+        let home = Path::new("/Users/jane");
+        assert_eq!(
+            resolve_powershell_profile_path(home),
+            powershell_profile_path(home)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolver_returns_absolute_profile_on_windows() {
+        // On Windows the resolver asks PowerShell for the live $PROFILE (OneDrive-safe,
+        // #558); whether it queries successfully or falls back, the result is an
+        // absolute path to the profile file.
+        let p = resolve_powershell_profile_path(Path::new("C:\\Users\\jane"));
+        assert!(p.is_absolute(), "resolved profile must be absolute: {p:?}");
+        assert!(p.ends_with("Microsoft.PowerShell_profile.ps1"));
     }
 }
 


### PR DESCRIPTION
## Summary
- **Refs #558.** On Windows, `powershell_profile_path` hardcoded `home\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`. Windows OneDrive *folder backup* (enabled by default on most installs) redirects the *Documents* known folder to e.g. `C:\Users\<user>\OneDrive - <org>\Documents\`, so `lean-ctx proxy enable` and the shell-hook install wrote to a file PowerShell never reads. The active `$PROFILE` was never updated → `OPENAI_BASE_URL`/`GEMINI_API_BASE_URL` were absent in new terminals and the proxy received no traffic.
- New `resolve_powershell_profile_path(home)`: on Windows it asks PowerShell itself for `$PROFILE.CurrentUserCurrentHost` (authoritative under any folder redirection), preferring `pwsh` (7+) then Windows PowerShell 5.1, forcing UTF-8 output so redirected paths with non-ASCII characters survive the pipe. It falls back to the documented default location only when no PowerShell host can be launched (the profile is moot in that case).
- Non-Windows hosts keep the static `~/.config/powershell` path and **never spawn a process** — preserving the macOS TCC fix (#356) that keeps lean-ctx away from `~/Documents`.
- All four callers wired to the resolver: `proxy enable`, `proxy disable`/uninstall, the shell-hook install (`init_powershell`), and the `setup` dry-run path display.

## Implementation notes
- `powershell_profile_path` is retained as the *documented default* helper and the resolver's fallback (no dead code).
- The PowerShell query uses `-NoProfile -NonInteractive` and `[Console]::OutputEncoding=[Text.Encoding]::UTF8` for robust, side-effect-free resolution.

## Test plan
- [x] `cargo test --lib shell::platform` — 39 passed (incl. new `resolver_matches_static_default_on_non_windows`).
- [x] `cargo clippy --lib` — zero warnings; `cargo fmt` clean.
- [x] New Windows-gated test `resolver_returns_absolute_profile_on_windows` exercises the live `$PROFILE` query on Windows CI (absolute path ending in `Microsoft.PowerShell_profile.ps1`).
- [ ] CI: Windows test job validates the real PowerShell query end-to-end.

Refs #558

Made with [Cursor](https://cursor.com)