### PR TITLE
fix(hooks): redirect Copilot CLI `view` (read) and `rg` (search) tool calls (#562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   preferring `pwsh` then Windows PowerShell, UTF-8 output) and falls back to the
   documented default only when no PowerShell host can be launched. Non-Windows hosts
   keep the static `~/.config/powershell` path and never spawn a process (#356).
+- **Copilot CLI `view` (read) and `rg` (search) tool calls passed through uncompressed (#562).**
+  `handle_redirect` dispatched on the tool name but only matched `Read`/`read`/
+  `read_file` and `Grep`/`grep`/`search`/`ripgrep`, so two documented GitHub Copilot
+  CLI tool names — `view` (its read tool) and `rg` (its search alias) — slipped
+  through without compression in shadow/harden mode. The dispatch is now a tested
+  `classify_redirect` helper that includes `view` (→ read) and `rg` (→ grep); the
+  Claude/Cursor/CodeBuddy matchers are unchanged because those hosts never emit
+  those names and Copilot CLI fires the hook for every tool call.
 - **Copilot/VS Code Claude models ignored lean-ctx — no `.github/copilot-instructions.md` (#555).**
   `lean-ctx init --agent copilot` installed the MCP server plus a deliberately
   weak `AGENTS.md` pointer but never wrote `.github/copilot-instructions.md`, the

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -484,6 +484,30 @@ fn build_rewrite_compound(cmd: &str, binary: &str) -> Option<String> {
     })
 }
 
+/// The lean-ctx redirect a host tool name maps to, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RedirectKind {
+    Read,
+    Grep,
+    Glob,
+    None,
+}
+
+/// Classify a host tool name into the lean-ctx redirect it should take.
+///
+/// Covers the documented read/search/glob tool names across hosts. Copilot CLI
+/// fires the redirect hook for *every* tool call and dispatches purely on the tool
+/// name, so its aliases must be listed here: `view` (its read tool) and `rg` (its
+/// search alias) were previously unmatched and passed through uncompressed (#562).
+fn classify_redirect(tool_name: &str) -> RedirectKind {
+    match tool_name {
+        "Read" | "read" | "read_file" | "view" => RedirectKind::Read,
+        "Grep" | "grep" | "search" | "ripgrep" | "rg" => RedirectKind::Grep,
+        "Glob" | "glob" => RedirectKind::Glob,
+        _ => RedirectKind::None,
+    }
+}
+
 pub fn handle_redirect() {
     let allow = build_dual_allow_output();
     if is_disabled() {
@@ -507,11 +531,11 @@ pub fn handle_redirect() {
     let tool_name = payload::resolve_tool_name(&v).unwrap_or_default();
     let tool_args = payload::resolve_tool_args(&v);
 
-    match tool_name.as_str() {
-        "Read" | "read" | "read_file" => redirect_read(tool_args.as_ref()),
-        "Grep" | "grep" | "search" | "ripgrep" => redirect_grep(tool_args.as_ref()),
-        "Glob" | "glob" => redirect_glob(tool_args.as_ref()),
-        _ => print!("{allow}"),
+    match classify_redirect(&tool_name) {
+        RedirectKind::Read => redirect_read(tool_args.as_ref()),
+        RedirectKind::Grep => redirect_grep(tool_args.as_ref()),
+        RedirectKind::Glob => redirect_glob(tool_args.as_ref()),
+        RedirectKind::None => print!("{allow}"),
     }
 }
 

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -619,3 +619,42 @@ fn is_shell_tool_rejects_non_shell_tools() {
         assert!(!is_shell_tool(name), "{name} must not be a shell tool");
     }
 }
+
+#[test]
+fn classify_redirect_covers_copilot_view_and_rg() {
+    // #562: Copilot CLI's documented `view` (read) and `rg` (search) tool names must
+    // be redirected, not passed through uncompressed in shadow/harden mode.
+    assert_eq!(classify_redirect("view"), RedirectKind::Read);
+    assert_eq!(classify_redirect("rg"), RedirectKind::Grep);
+}
+
+#[test]
+fn classify_redirect_covers_existing_tool_names() {
+    for n in ["Read", "read", "read_file"] {
+        assert_eq!(classify_redirect(n), RedirectKind::Read, "{n}");
+    }
+    for n in ["Grep", "grep", "search", "ripgrep"] {
+        assert_eq!(classify_redirect(n), RedirectKind::Grep, "{n}");
+    }
+    for n in ["Glob", "glob"] {
+        assert_eq!(classify_redirect(n), RedirectKind::Glob, "{n}");
+    }
+}
+
+#[test]
+fn classify_redirect_passes_through_shell_and_unknown() {
+    // Shell tools are rewritten by handle_rewrite, not redirected; edits/writes and
+    // unknown names must not be intercepted here.
+    for n in [
+        "Bash",
+        "bash",
+        "powershell",
+        "pwsh",
+        "edit",
+        "Write",
+        "Unknown",
+        "",
+    ] {
+        assert_eq!(classify_redirect(n), RedirectKind::None, "{n}");
+    }
+}


### PR DESCRIPTION
## Summary
- **Refs #562.** `handle_redirect` dispatches on the tool name but only matched `Read`/`read`/`read_file` (read) and `Grep`/`grep`/`search`/`ripgrep` (grep). Two documented GitHub Copilot CLI tool names — **`view`** (its read tool) and **`rg`** (its search alias) — slipped through *uncompressed* in shadow/harden mode (adjacent gap found while fixing #556).
- Extracted the inline dispatch into a small, tested `classify_redirect(tool_name) -> RedirectKind` helper and added `view → read` and `rg → grep`.
- The Claude/Cursor/CodeBuddy `REDIRECT_MATCHER`s are intentionally **unchanged**: those hosts never emit `view`/`rg`, and Copilot CLI fires the redirect hook for *every* preToolUse and dispatches purely on the tool name — so the arms are sufficient and no dead matcher entries are added.

## Test plan
- [x] `cargo test --lib hook_handlers` — 79 passed, incl. 3 new `classify_redirect_*` tests covering `view`/`rg`, the existing names, and shell/unknown passthrough.
- [x] `cargo clippy --lib` — zero warnings; `cargo fmt` clean.

Refs #562

Made with [Cursor](https://cursor.com)