### PR TITLE
feat(hooks): map PowerShell-native cmdlets (Get-Content/Select-String/Get-ChildItem) to lean-ctx (#561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **PowerShell-native cmdlets route through lean-ctx (#561).** Follow-up to #556:
+  shadow/harden mode already recognised the Windows `powershell` shell tool, covering
+  the Unix-style PS *aliases* (`cat`/`ls`/`rg`). The command-rewrite layer now also
+  maps the PowerShell-**native** cmdlets and their short aliases — `Get-Content`/`gc`
+  → `lean-ctx read` (honoring `-Path`, `-TotalCount`/`-Head`/`-First` and
+  `-Tail`/`-Last`), `Select-String`/`sls` → `lean-ctx grep` (`-Pattern`, `-Path`),
+  and `Get-ChildItem`/`gci` → `lean-ctx ls` (`-Path`). Parameter names are matched
+  case-insensitively; anything with an unrecognised flag, a pipeline, multiple
+  operands, or an out-of-project path passes through untouched (same conservative
+  contract as the Unix rewrites), so determinism and redaction guarantees are
+  inherited. The PowerShell cmdlets are detected only in the rewrite path and are
+  deliberately kept out of the POSIX shell-alias surface.
 - **Addon security hardening — trust, policy, signing, sandbox, audit (#863).**
   Because an addon is executable trust (a stdio addon runs code on your machine;
   an http addon receives your context; its output enters the model), the

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -274,7 +274,10 @@ fn rewrite_candidate(cmd: &str, binary: &str) -> Option<String> {
 /// Rewrites cat/head/tail to lean-ctx read with appropriate arguments.
 /// Only rewrites simple single-file reads within the project scope.
 fn rewrite_file_read_command(cmd: &str, binary: &str) -> Option<String> {
-    if !rewrite_registry::is_file_read_command(cmd) {
+    // Unix file-read commands come from the central registry; PowerShell-native
+    // cmdlets (Get-Content/gc) are detected here so they are not added to the POSIX
+    // shell-alias/registry surface (#561).
+    if !rewrite_registry::is_file_read_command(cmd) && !is_powershell_file_read(cmd) {
         return None;
     }
 
@@ -325,7 +328,52 @@ fn rewrite_file_read_command(cmd: &str, binary: &str) -> Option<String> {
             let lines = n.unwrap_or(10);
             Some(format!("{binary} read {qp} -m lines:-{lines}"))
         }
+        "Get-Content" | "gc" => rewrite_get_content(&parts, binary),
         _ => None,
+    }
+}
+
+/// True if the command is a PowerShell-native file-read cmdlet (`Get-Content`/`gc`).
+fn is_powershell_file_read(cmd: &str) -> bool {
+    matches!(cmd.split_whitespace().next(), Some("Get-Content" | "gc"))
+}
+
+/// Maps `Get-Content`/`gc` to `lean-ctx read`, honoring `-Path`/`-LiteralPath`, the
+/// positional path, `-TotalCount`/`-Head`/`-First` (first N lines) and `-Tail`/`-Last`
+/// (last N lines). PowerShell parameter names are case-insensitive. Any other flag, a
+/// missing path, multiple files, or both head+tail makes it pass through (conservative,
+/// mirroring the Unix cat/head/tail handling).
+fn rewrite_get_content(parts: &[String], binary: &str) -> Option<String> {
+    let mut path: Option<String> = None;
+    let mut head_n: Option<u64> = None;
+    let mut tail_n: Option<u64> = None;
+    let mut i = 1;
+    while i < parts.len() {
+        if let Some(flag) = parts[i].strip_prefix('-') {
+            let value = parts.get(i + 1);
+            match flag.to_ascii_lowercase().as_str() {
+                "path" | "literalpath" => path = Some(value?.clone()),
+                "totalcount" | "head" | "first" => head_n = Some(value?.parse().ok()?),
+                "tail" | "last" => tail_n = Some(value?.parse().ok()?),
+                _ => return None,
+            }
+            i += 2;
+        } else if path.is_none() {
+            path = Some(parts[i].clone());
+            i += 1;
+        } else {
+            return None;
+        }
+    }
+    let path = path?;
+    if is_outside_project_path(&path) || (head_n.is_some() && tail_n.is_some()) {
+        return None;
+    }
+    let qp = shell_quote(&path);
+    match (head_n, tail_n) {
+        (Some(n), None) => Some(format!("{binary} read {qp} -m lines:1-{n}")),
+        (None, Some(n)) => Some(format!("{binary} read {qp} -m lines:-{n}")),
+        _ => Some(format!("{binary} read {qp}")),
     }
 }
 
@@ -372,36 +420,103 @@ fn is_outside_project_path(path: &str) -> bool {
     false
 }
 
-/// Rewrites `rg <pattern> [path]` to `lean-ctx grep <pattern> [path]` for simple forms.
+/// Rewrites `rg <pattern> [path]` (and PowerShell `Select-String`/`sls`, #561) to
+/// `lean-ctx grep <pattern> [path]` for simple forms.
 fn rewrite_search_command(cmd: &str, binary: &str) -> Option<String> {
     let parts = shell_tokenize(cmd);
-    if parts.first().map(String::as_str) != Some("rg") {
-        return None;
+    match parts.first().map(String::as_str) {
+        Some("rg") => {
+            if parts.len() < 2 || parts.len() > 3 || parts[1].starts_with('-') {
+                return None;
+            }
+            let pattern = &parts[1];
+            match parts.get(2) {
+                Some(p) if p.starts_with('-') => None,
+                Some(p) => Some(format!("{binary} grep {pattern} {}", shell_quote(p))),
+                None => Some(format!("{binary} grep {pattern}")),
+            }
+        }
+        Some("Select-String" | "sls") => rewrite_select_string(&parts, binary),
+        _ => None,
     }
-    if parts.len() < 2 || parts.len() > 3 {
-        return None;
+}
+
+/// Maps `Select-String`/`sls` to `lean-ctx grep`, honoring `-Pattern` and
+/// `-Path`/`-LiteralPath` plus the positional `<pattern> [path]` form. Patterns are
+/// quoted (PowerShell patterns often contain spaces). Any other flag, a missing
+/// pattern, or extra operands makes it pass through.
+fn rewrite_select_string(parts: &[String], binary: &str) -> Option<String> {
+    let mut pattern: Option<String> = None;
+    let mut path: Option<String> = None;
+    let mut i = 1;
+    while i < parts.len() {
+        if let Some(flag) = parts[i].strip_prefix('-') {
+            let value = parts.get(i + 1);
+            match flag.to_ascii_lowercase().as_str() {
+                "pattern" => pattern = Some(value?.clone()),
+                "path" | "literalpath" => path = Some(value?.clone()),
+                _ => return None,
+            }
+            i += 2;
+        } else if pattern.is_none() {
+            pattern = Some(parts[i].clone());
+            i += 1;
+        } else if path.is_none() {
+            path = Some(parts[i].clone());
+            i += 1;
+        } else {
+            return None;
+        }
     }
-    if parts[1].starts_with('-') {
-        return None;
-    }
-    let pattern = &parts[1];
-    match parts.get(2) {
-        Some(p) if p.starts_with('-') => None,
-        Some(p) => Some(format!("{binary} grep {pattern} {}", shell_quote(p))),
+    let pattern = shell_quote(&pattern?);
+    match path {
+        Some(p) if is_outside_project_path(&p) => None,
+        Some(p) => Some(format!("{binary} grep {pattern} {}", shell_quote(&p))),
         None => Some(format!("{binary} grep {pattern}")),
     }
 }
 
-/// Rewrites simple `ls [path]` to `lean-ctx ls [path]`.
+/// Rewrites simple `ls [path]` (and PowerShell `Get-ChildItem`/`gci`, #561) to
+/// `lean-ctx ls [path]`.
 fn rewrite_dir_list_command(cmd: &str, binary: &str) -> Option<String> {
     let parts = shell_tokenize(cmd);
-    if parts.first().map(String::as_str) != Some("ls") {
-        return None;
-    }
-    match parts.len() {
-        1 => Some(format!("{binary} ls")),
-        2 if !parts[1].starts_with('-') => Some(format!("{binary} ls {}", shell_quote(&parts[1]))),
+    match parts.first().map(String::as_str) {
+        Some("ls") => match parts.len() {
+            1 => Some(format!("{binary} ls")),
+            2 if !parts[1].starts_with('-') => {
+                Some(format!("{binary} ls {}", shell_quote(&parts[1])))
+            }
+            _ => None,
+        },
+        Some("Get-ChildItem" | "gci") => rewrite_get_childitem(&parts, binary),
         _ => None,
+    }
+}
+
+/// Maps `Get-ChildItem`/`gci` to `lean-ctx ls`, honoring `-Path`/`-LiteralPath` and the
+/// positional path. Other flags (e.g. `-Recurse`, `-Filter`) or extra operands pass
+/// through.
+fn rewrite_get_childitem(parts: &[String], binary: &str) -> Option<String> {
+    let mut path: Option<String> = None;
+    let mut i = 1;
+    while i < parts.len() {
+        if let Some(flag) = parts[i].strip_prefix('-') {
+            let value = parts.get(i + 1);
+            match flag.to_ascii_lowercase().as_str() {
+                "path" | "literalpath" => path = Some(value?.clone()),
+                _ => return None,
+            }
+            i += 2;
+        } else if path.is_none() {
+            path = Some(parts[i].clone());
+            i += 1;
+        } else {
+            return None;
+        }
+    }
+    match path {
+        Some(p) => Some(format!("{binary} ls {}", shell_quote(&p))),
+        None => Some(format!("{binary} ls")),
     }
 }
 

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -181,6 +181,121 @@ fn file_read_still_rewrites_project_relative_paths() {
     );
 }
 
+// --- #561: PowerShell-native cmdlet rewrites ---
+
+#[test]
+fn ps_get_content_basic_and_alias() {
+    assert_eq!(
+        rewrite_file_read_command("Get-Content src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("gc src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("Get-Content -Path src/lib.rs", "lean-ctx"),
+        Some("lean-ctx read src/lib.rs".to_string())
+    );
+}
+
+#[test]
+fn ps_get_content_head_and_tail() {
+    // -TotalCount / -Head / -First == head; -Tail / -Last == tail. Case-insensitive.
+    assert_eq!(
+        rewrite_file_read_command("Get-Content -TotalCount 20 src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:1-20".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("Get-Content src/main.rs -head 5", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:1-5".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("gc -Tail 10 src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:-10".to_string())
+    );
+}
+
+#[test]
+fn ps_get_content_passthrough() {
+    // Unknown flag, both head+tail, outside-project path, and pipelines pass through.
+    assert_eq!(
+        rewrite_file_read_command("Get-Content -Raw src/main.rs", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_file_read_command("Get-Content -TotalCount 5 -Tail 5 src/main.rs", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_file_read_command("Get-Content ~/secret.txt", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_file_read_command("Get-Content a.txt | Select-String x", "lean-ctx"),
+        None
+    );
+}
+
+#[test]
+fn ps_select_string_forms() {
+    assert_eq!(
+        rewrite_search_command("Select-String TODO src/main.rs", "lean-ctx"),
+        Some("lean-ctx grep TODO src/main.rs".to_string())
+    );
+    assert_eq!(
+        rewrite_search_command("sls TODO", "lean-ctx"),
+        Some("lean-ctx grep TODO".to_string())
+    );
+    assert_eq!(
+        rewrite_search_command("Select-String -Pattern TODO -Path src/lib.rs", "lean-ctx"),
+        Some("lean-ctx grep TODO src/lib.rs".to_string())
+    );
+    // Unknown flag passes through.
+    assert_eq!(
+        rewrite_search_command("Select-String -CaseSensitive TODO", "lean-ctx"),
+        None
+    );
+}
+
+#[test]
+fn ps_get_childitem_forms() {
+    assert_eq!(
+        rewrite_dir_list_command("Get-ChildItem", "lean-ctx"),
+        Some("lean-ctx ls".to_string())
+    );
+    assert_eq!(
+        rewrite_dir_list_command("gci src", "lean-ctx"),
+        Some("lean-ctx ls src".to_string())
+    );
+    assert_eq!(
+        rewrite_dir_list_command("Get-ChildItem -Path src", "lean-ctx"),
+        Some("lean-ctx ls src".to_string())
+    );
+    // -Recurse and other flags pass through.
+    assert_eq!(
+        rewrite_dir_list_command("Get-ChildItem -Recurse", "lean-ctx"),
+        None
+    );
+}
+
+#[test]
+fn ps_cmdlets_route_through_rewrite_candidate() {
+    // End-to-end: the dispatcher picks the right rewrite for PowerShell cmdlets.
+    assert_eq!(
+        rewrite_candidate("Get-Content src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs".to_string())
+    );
+    assert_eq!(
+        rewrite_candidate("Select-String TODO src/main.rs", "lean-ctx"),
+        Some("lean-ctx grep TODO src/main.rs".to_string())
+    );
+    assert_eq!(
+        rewrite_candidate("gci src", "lean-ctx"),
+        Some("lean-ctx ls src".to_string())
+    );
+}
+
 #[test]
 fn is_outside_project_path_tests() {
     assert!(is_outside_project_path("~/foo"));


### PR DESCRIPTION
## Summary
- **Refs #561** (follow-up to #556). #556 made shadow/harden mode recognise the Windows `powershell` shell tool, which covered the Unix-style PS *aliases* (`cat`/`ls`/`rg`). This adds the PowerShell-**native** cmdlets and their short aliases to the command-rewrite layer:

| PowerShell | lean-ctx | Parameters honored |
|---|---|---|
| `Get-Content` / `gc` | `lean-ctx read` | `-Path`/`-LiteralPath`, positional, `-TotalCount`/`-Head`/`-First` (head), `-Tail`/`-Last` (tail) |
| `Select-String` / `sls` | `lean-ctx grep` | `-Pattern`, `-Path`/`-LiteralPath`, positional `<pattern> [path]` |
| `Get-ChildItem` / `gci` | `lean-ctx ls` | `-Path`/`-LiteralPath`, positional |

## Design
- Parameter names match **case-insensitively** (PowerShell semantics).
- **Conservative contract** (mirrors the existing Unix `cat`/`head`/`tail`/`rg`/`ls` rewrites): an unrecognised flag, a pipeline (`|`), a redirect, multiple operands, or an out-of-project path makes the command **pass through untouched**. Determinism + redaction guarantees are therefore inherited from `lean-ctx read`/`grep`/`ls`.
- Detection lives **only** in the rewrite functions (`rewrite_file_read_command`, `rewrite_search_command`, `rewrite_dir_list_command`). The cmdlets are deliberately kept **out of the central rewrite registry**, so the POSIX shell-alias / bash-case surface is unchanged (no `gc`/`gci` aliases leak onto Unix shells).
- Primary beneficiary is Copilot CLI on Windows, which fires the redirect/rewrite hook for every tool call.

## Test plan
- [x] `cargo test --lib hook_handlers` — 82 passed, incl. 6 new `ps_*` tests (Get-Content basic/alias/head/tail/passthrough, Select-String forms, Get-ChildItem forms, and end-to-end via `rewrite_candidate`).
- [x] `cargo clippy --lib` — zero warnings; `cargo fmt --check` clean.

Refs #561

Made with [Cursor](https://cursor.com)