### PR TITLE
feat(shadow): record Context IR lineage from CLI read/grep hooks (#566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Shadow-mode CLI reads/searches now record Context IR lineage (#566).**
+  Follow-up to #550. The MCP dispatcher records a Context IR provenance entry for
+  every tool call (`server/call_tool.rs`), but the shadow-mode hook's single-shot
+  `lean-ctx read`/`grep` subprocess dropped it — so `ctx_proof` and IR exports
+  were blind to compressed shadow reads. `record_file_read`/`record_search` now
+  thread the rendered-output excerpt + measured tool duration into a disk-backed
+  `ContextIrV1` load→record→save, mirroring the MCP path (same 200-char
+  char-boundary excerpt bound; `mode`/`pattern` ride the IR `pattern` slot; the
+  read's `original_tokens` and the search's raw matched-line estimate are the IR
+  input so the stored compression ratio is accurate — no fabricated values). The
+  remaining two deferred items from #550 — the in-memory loop/correction
+  detectors and the bounce/adaptive-threshold signals — stay deferred: both need
+  cross-call state a single-shot process cannot hold, so they are gated on the
+  "connect-only daemon routing for hooks" design decision (tracked in #566).
 - **PowerShell-native cmdlets route through lean-ctx (#561).** Follow-up to #556:
   shadow/harden mode already recognised the Windows `powershell` shell tool, covering
   the Unix-style PS *aliases* (`cat`/`ls`/`rg`). The command-rewrite layer now also

--- a/rust/src/cli/common.rs
+++ b/rust/src/cli/common.rs
@@ -97,13 +97,22 @@ pub(crate) fn format_tokens_cli(tokens: u64) -> String {
     }
 }
 
-pub(crate) fn cli_track_read(path: &str, mode: &str, original_tokens: usize, output_tokens: usize) {
+pub(crate) fn cli_track_read(
+    path: &str,
+    mode: &str,
+    original_tokens: usize,
+    output_tokens: usize,
+    output: &str,
+    duration: std::time::Duration,
+) {
     crate::core::tool_lifecycle::record_file_read(
         path,
         mode,
         original_tokens,
         output_tokens,
         false,
+        duration,
+        output,
     );
 }
 
@@ -112,16 +121,38 @@ pub(crate) fn cli_track_read_cached(
     mode: &str,
     original_tokens: usize,
     output_tokens: usize,
+    output: &str,
+    duration: std::time::Duration,
 ) {
-    crate::core::tool_lifecycle::record_file_read(path, mode, original_tokens, output_tokens, true);
+    crate::core::tool_lifecycle::record_file_read(
+        path,
+        mode,
+        original_tokens,
+        output_tokens,
+        true,
+        duration,
+        output,
+    );
 }
 
 pub(crate) fn cli_track_search(
     modeled_baseline: usize,
     observed_tokens: usize,
     output_tokens: usize,
+    pattern: &str,
+    path: &str,
+    output: &str,
+    duration: std::time::Duration,
 ) {
-    crate::core::tool_lifecycle::record_search(modeled_baseline, observed_tokens, output_tokens);
+    crate::core::tool_lifecycle::record_search(
+        modeled_baseline,
+        observed_tokens,
+        output_tokens,
+        pattern,
+        path,
+        duration,
+        output,
+    );
 }
 
 pub(crate) fn cli_track_tree(original_tokens: usize, output_tokens: usize) {

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -112,6 +112,10 @@ pub fn cmd_read(args: &[String]) {
     }
     super::common::daemon_fallback_hint();
 
+    // Read latency for the Context IR lineage (#566) — the standalone path only;
+    // the daemon branch above records its own IR and returns before this.
+    let read_start = std::time::Instant::now();
+
     if !force_fresh && mode == "full" {
         use crate::core::cli_cache::{self, CacheResult};
         match cli_cache::check_and_read(path) {
@@ -119,7 +123,14 @@ pub fn cmd_read(args: &[String]) {
                 let msg = cli_cache::format_hit(&entry, &file_ref, &short);
                 println!("{msg}");
                 let sent = count_tokens(&msg);
-                super::common::cli_track_read_cached(path, "full", entry.original_tokens, sent);
+                super::common::cli_track_read_cached(
+                    path,
+                    "full",
+                    entry.original_tokens,
+                    sent,
+                    &msg,
+                    read_start.elapsed(),
+                );
                 return;
             }
             CacheResult::Miss { content } if content.is_empty() => {
@@ -133,7 +144,14 @@ pub fn cmd_read(args: &[String]) {
                 let output = cap_cli_to_raw(framed, &content, raw_tokens);
                 println!("{output}");
                 let sent = count_tokens(&output);
-                super::common::cli_track_read(path, "full", raw_tokens, sent);
+                super::common::cli_track_read(
+                    path,
+                    "full",
+                    raw_tokens,
+                    sent,
+                    &output,
+                    read_start.elapsed(),
+                );
                 return;
             }
         }
@@ -230,7 +248,14 @@ pub fn cmd_read(args: &[String]) {
             }
             let sent = count_tokens(&output_buf);
             println!("{output_buf}");
-            super::common::cli_track_read(path, "map", original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "map",
+                original_tokens,
+                sent,
+                &output_buf,
+                read_start.elapsed(),
+            );
         }
         "signatures" => {
             let sigs = signatures::extract_signatures(&content, ext);
@@ -244,7 +269,14 @@ pub fn cmd_read(args: &[String]) {
             println!("{output_buf}");
             let sent = count_tokens(&output_buf);
             print_savings(original_tokens, sent);
-            super::common::cli_track_read(path, "signatures", original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "signatures",
+                original_tokens,
+                sent,
+                &output_buf,
+                read_start.elapsed(),
+            );
         }
         "aggressive" => {
             let compressed = compressor::aggressive_compress(&content, Some(ext));
@@ -252,7 +284,14 @@ pub fn cmd_read(args: &[String]) {
             println!("{compressed}");
             let sent = count_tokens(&compressed);
             print_savings(original_tokens, sent);
-            super::common::cli_track_read(path, "aggressive", original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "aggressive",
+                original_tokens,
+                sent,
+                &compressed,
+                read_start.elapsed(),
+            );
         }
         "entropy" => {
             let result = entropy::entropy_compress(&content);
@@ -264,7 +303,14 @@ pub fn cmd_read(args: &[String]) {
             println!("{}", result.output);
             let sent = count_tokens(&result.output);
             print_savings(original_tokens, sent);
-            super::common::cli_track_read(path, "entropy", original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "entropy",
+                original_tokens,
+                sent,
+                &result.output,
+                read_start.elapsed(),
+            );
         }
         _ => {
             // `full`, `lines:` and any unrecognized mode land here. These are
@@ -290,7 +336,14 @@ pub fn cmd_read(args: &[String]) {
             let output = cap_cli_to_raw(output, &content, original_tokens);
             println!("{output}");
             let sent = count_tokens(&output);
-            super::common::cli_track_read(path, "full", original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "full",
+                original_tokens,
+                sent,
+                &output,
+                read_start.elapsed(),
+            );
         }
     }
 }
@@ -362,6 +415,9 @@ pub fn cmd_grep(args: &[String]) {
     }
     super::common::daemon_fallback_hint();
 
+    // Search latency for the Context IR lineage (#566), standalone path only.
+    let search_start = std::time::Instant::now();
+
     let outcome = crate::tools::ctx_search::handle(
         pattern,
         path,
@@ -377,6 +433,10 @@ pub fn cmd_grep(args: &[String]) {
         outcome.modeled_baseline,
         outcome.observed_tokens,
         count_tokens(&out),
+        pattern,
+        path,
+        &out,
+        search_start.elapsed(),
     );
     if outcome.modeled_baseline == 0 && out.trim_start().starts_with("0 matches") {
         std::process::exit(1);

--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -8,6 +8,7 @@
 //! NOTE: When the daemon IS running, CLI routes through `daemon_client` which
 //! calls the MCP server — these functions are NOT called in that path.
 
+use crate::core::context_ir::{ContextIrSourceKindV1, ContextIrV1, RecordIrInput};
 use crate::core::context_ledger::ContextLedger;
 use crate::core::heatmap;
 use crate::core::intent_engine::StructuredIntent;
@@ -40,13 +41,36 @@ pub(crate) fn usable_root(root: Option<&str>) -> Option<&str> {
     root.filter(|r| !r.trim().is_empty() && *r != ".")
 }
 
+/// First 200 chars of `text` on a UTF-8 boundary — the exact excerpt bound the
+/// MCP dispatcher applies before handing content to the IR store
+/// (`server/call_tool.rs`), kept identical so CLI- and MCP-recorded IR items are
+/// byte-compatible. `ContextIrV1::record` redacts and further caps it.
+fn ir_excerpt(text: &str) -> &str {
+    const MAX: usize = 200;
+    if text.len() <= MAX {
+        return text;
+    }
+    let mut end = MAX;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
 /// Record a file-read operation with full Context OS side effects.
+///
+/// `duration` and `output_excerpt` feed the Context IR lineage (#566); the MCP
+/// dispatcher records both for every tool call but the shadow-mode `lean-ctx
+/// read` subprocess used to drop them, so IR/`ctx_proof` exports were blind to
+/// compressed shadow reads.
 pub fn record_file_read(
     path: &str,
     mode: &str,
     original_tokens: usize,
     output_tokens: usize,
     is_cache_hit: bool,
+    duration: std::time::Duration,
+    output_excerpt: &str,
 ) {
     let saved = original_tokens.saturating_sub(output_tokens);
     let tool_key = format!("cli_{mode}");
@@ -124,6 +148,27 @@ pub fn record_file_read(
         is_cache_hit,
         &learning_root,
     );
+
+    // Context IR lineage (#566): the MCP dispatcher records provenance for every
+    // tool call (`server/call_tool.rs`), but the shadow-mode hook's single-shot
+    // `lean-ctx read` bypassed it. Disk-backed load→record→save persists the
+    // entry before the process exits. `mode` rides the IR `pattern` slot to match
+    // the MCP read path (which stores its `mode` arg there).
+    let mut ir = ContextIrV1::load();
+    ir.record(RecordIrInput {
+        kind: ContextIrSourceKindV1::Read,
+        tool: "ctx_read",
+        client_name: None,
+        agent_id: None,
+        path: Some(path),
+        command: None,
+        pattern: Some(mode),
+        input_tokens: original_tokens,
+        output_tokens,
+        duration,
+        content_excerpt: ir_excerpt(output_excerpt),
+    });
+    ir.save();
 }
 
 /// Replicate the MCP read path's learning side effects (`registered/ctx_read.rs`
@@ -204,8 +249,17 @@ fn record_read_learning(
 ///
 /// `modeled_baseline` (native-tool estimate, GL #479 D1) feeds the estimated
 /// stats series; `observed_tokens` (raw measured match lines, no factor) feeds
-/// the verified ledger (GL #479 D2).
-pub fn record_search(modeled_baseline: usize, observed_tokens: usize, output_tokens: usize) {
+/// the verified ledger (GL #479 D2). `pattern`/`path`/`duration`/`output_excerpt`
+/// feed the Context IR lineage (#566).
+pub fn record_search(
+    modeled_baseline: usize,
+    observed_tokens: usize,
+    output_tokens: usize,
+    pattern: &str,
+    path: &str,
+    duration: std::time::Duration,
+    output_excerpt: &str,
+) {
     stats::record("cli_grep", modeled_baseline, output_tokens);
     crate::core::savings_ledger::record_tool_event("cli_grep", observed_tokens, output_tokens);
 
@@ -222,6 +276,25 @@ pub fn record_search(modeled_baseline: usize, observed_tokens: usize, output_tok
     // left dashboard signals blind to shadow-mode (`grep` → `lean-ctx grep`) hooks.
     crate::core::anomaly::record_metric("tokens_per_call", output_tokens as f64);
     crate::core::anomaly::save_debounced();
+
+    // Context IR lineage for shadow-mode `grep` → `lean-ctx grep` (#566). The
+    // raw matched-line estimate (`observed_tokens`) is the IR input so the stored
+    // compression ratio reads matches-in / sent-out.
+    let mut ir = ContextIrV1::load();
+    ir.record(RecordIrInput {
+        kind: ContextIrSourceKindV1::Search,
+        tool: "ctx_search",
+        client_name: None,
+        agent_id: None,
+        path: Some(path),
+        command: None,
+        pattern: Some(pattern),
+        input_tokens: observed_tokens,
+        output_tokens,
+        duration,
+        content_excerpt: ir_excerpt(output_excerpt),
+    });
+    ir.save();
 }
 
 /// Record a tree/ls operation with full Context OS side effects.
@@ -306,13 +379,29 @@ mod tests {
     #[test]
     fn record_file_read_does_not_panic_without_session() {
         let _dir = crate::core::data_dir::isolated_data_dir();
-        record_file_read("/tmp/nonexistent.rs", "full", 100, 50, false);
+        record_file_read(
+            "/tmp/nonexistent.rs",
+            "full",
+            100,
+            50,
+            false,
+            std::time::Duration::from_millis(1),
+            "excerpt",
+        );
     }
 
     #[test]
     fn record_search_does_not_panic_without_session() {
         let _dir = crate::core::data_dir::isolated_data_dir();
-        record_search(500, 200, 150);
+        record_search(
+            500,
+            200,
+            150,
+            "pattern",
+            "/tmp",
+            std::time::Duration::from_millis(1),
+            "matches",
+        );
     }
 
     #[test]
@@ -347,7 +436,15 @@ mod tests {
         std::fs::write(&file, "fn main() {\n    println!(\"hi\");\n}\n").unwrap();
         let path = file.to_string_lossy();
 
-        record_file_read(&path, "full", 1000, 200, false);
+        record_file_read(
+            &path,
+            "full",
+            1000,
+            200,
+            false,
+            std::time::Duration::from_millis(2),
+            "sample.rs [3L]\nfn main() {}",
+        );
         flush_all();
 
         let data = crate::core::data_dir::lean_ctx_data_dir().expect("data dir");
@@ -364,5 +461,73 @@ mod tests {
             state.join("heatmap.json").exists(),
             "heatmap must persist after a CLI read + flush"
         );
+    }
+
+    #[test]
+    fn cli_read_records_context_ir_lineage() {
+        // #566: the MCP dispatcher records Context IR for every tool call, but the
+        // shadow-mode `lean-ctx read` subprocess used to skip it, so IR/ctx_proof
+        // exports were blind to compressed shadow reads. A single-shot CLI read
+        // must now persist exactly one IR item (disk-backed load→record→save).
+        let dir = crate::core::data_dir::isolated_data_dir();
+        let file = dir.path().join("ir_sample.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+        let path = file.to_string_lossy();
+
+        record_file_read(
+            &path,
+            "full",
+            1000,
+            200,
+            false,
+            std::time::Duration::from_millis(3),
+            "ir_sample.rs [1L]\nfn main() {}",
+        );
+
+        let ir = ContextIrV1::load();
+        assert_eq!(ir.items.len(), 1, "exactly one IR item per CLI read");
+        let item = &ir.items[0];
+        assert_eq!(item.source.tool, "ctx_read");
+        assert!(matches!(item.source.kind, ContextIrSourceKindV1::Read));
+        assert!(
+            item.source
+                .path
+                .as_deref()
+                .unwrap_or("")
+                .ends_with("ir_sample.rs"),
+            "IR records the read path, got {:?}",
+            item.source.path
+        );
+        assert_eq!(item.source.pattern.as_deref(), Some("full"));
+        assert_eq!(item.input_tokens, 1000);
+        assert_eq!(item.output_tokens, 200);
+        assert!(item.duration_us > 0, "a real duration must be recorded");
+        assert!(!item.content_excerpt.is_empty(), "excerpt must be captured");
+    }
+
+    #[test]
+    fn cli_search_records_context_ir_lineage() {
+        // #566: the shadow-mode `grep` → `lean-ctx grep` path records IR too.
+        let _dir = crate::core::data_dir::isolated_data_dir();
+
+        record_search(
+            800,
+            500,
+            120,
+            "fn handle",
+            "src/",
+            std::time::Duration::from_millis(4),
+            "src/lib.rs:12: fn handle() {}",
+        );
+
+        let ir = ContextIrV1::load();
+        assert_eq!(ir.items.len(), 1, "exactly one IR item per CLI search");
+        let item = &ir.items[0];
+        assert_eq!(item.source.tool, "ctx_search");
+        assert!(matches!(item.source.kind, ContextIrSourceKindV1::Search));
+        // Input is the raw matched-line estimate, not the modeled baseline.
+        assert_eq!(item.input_tokens, 500);
+        assert_eq!(item.output_tokens, 120);
+        assert!(item.duration_us > 0, "a real duration must be recorded");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #550. Closes the **Context IR lineage** item of #566 (1 of the 3 deferred shadow-mode parity gaps).

The MCP dispatcher records a Context IR provenance entry for **every** tool call (`server/call_tool.rs`), but the shadow-mode hook's single-shot `lean-ctx read`/`grep` subprocess dropped it — so `ctx_proof` and IR exports were blind to compressed shadow reads.

`record_file_read` / `record_search` now thread the rendered-output excerpt + the measured tool duration into a disk-backed `ContextIrV1` `load→record→save`, mirroring the MCP path:
- Same **200-char char-boundary** excerpt bound (shared `ir_excerpt` helper) → CLI- and MCP-recorded IR items are byte-compatible.
- `mode` (read) / `pattern` (search) ride the IR `pattern` slot, exactly as the MCP read path stores its `mode` arg.
- IR input is the read's `original_tokens` / the search's raw matched-line estimate, so the stored compression ratio is accurate — **no fabricated values**.
- Disk-backed, so a single-shot process persists the entry before it exits (same pattern as the #550 learning sinks).

## Still deferred (remain open under #566)

The other two #550 items need cross-call state a single-shot process cannot hold, so they stay gated on the **connect-only daemon-routing for hooks** design decision:
- in-memory loop / correction-loop detectors (`core::loop_detection`)
- bounce tracker / adaptive thresholds (require routing CLI reads through `ctx_read::handle`)

## Test plan
- [x] `cargo test --lib` — **6001 passed / 0 failed**
- [x] New: `cli_read_records_context_ir_lineage`, `cli_search_records_context_ir_lineage` (assert one disk-persisted IR item with real duration + excerpt)
- [x] `cargo fmt` + `cargo clippy --lib --tests -- -D warnings` clean
- [x] `cargo test --test reference_docs_drift` green (no schema change)

Made with [Cursor](https://cursor.com)