### PR TITLE
fix(rules): canonical ctx tool names in Pi template + registry parity test (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (gitlab #868–#871)
 
 ### Fixed
+- **Pi `AGENTS.md` advertised renamed tools that no longer exist (#548).** The Pi
+  installer writes a curated static `templates/PI_AGENTS.md`, and its tool-mapping
+  table still listed `ctx_grep`/`ctx_find`/`ctx_ls` — tools renamed long ago to
+  `ctx_search`/`ctx_glob`/`ctx_tree`. Pi agents that followed the table issued
+  unknown-tool calls. The template (and the matching `pi.rs` setup hint) now use the
+  canonical names, and a new parity test (`tests/rules_template_tool_names.rs`) ties
+  **every** shipped agent template to the live MCP registry: any `ctx_*` reference
+  that is not a registered tool fails the build, so a future rename can never drift
+  silently again. (First slice of the #548 agent-rules unification — marker/dedup
+  consolidation, content-aware freshness, and `rules.toml`↔`sync` semantics follow.)
 - **Shadow-mode hook reads dropped ~75% of the MCP read side effects (#550).** When
   shadow/harden mode intercepts a native `view`/`grep` call it spawns `lean-ctx read`
   as a single-shot subprocess. That CLI path recorded only a fraction of what the MCP

--- a/rust/src/hooks/agents/pi.rs
+++ b/rust/src/hooks/agents/pi.rs
@@ -62,7 +62,7 @@ pub(crate) fn install_pi_hook_with_mode(global: bool, mode: HookMode) {
 
     println!();
     println!(
-        "Setup complete. Prefer the ctx_* tools (ctx_read/ctx_shell/ctx_grep/ctx_find/ctx_ls) — \
+        "Setup complete. Prefer the ctx_* tools (ctx_read/ctx_shell/ctx_search/ctx_glob/ctx_tree) — \
          only those are compressed; native read/bash/grep are not."
     );
     match mode {

--- a/rust/src/templates/PI_AGENTS.md
+++ b/rust/src/templates/PI_AGENTS.md
@@ -12,9 +12,9 @@ the native `read`/`bash`/`grep`/`find`/`ls` are **not** routed through lean-ctx 
 |--------|---------------|-----|
 | `ctx_read` | `read`, `cat`/`head`/`tail` | Cached + compressed; unchanged re-reads cost ~13 tokens |
 | `ctx_shell` | `bash` | Shell output compressed via 95+ patterns |
-| `ctx_grep` | `grep` | Compact, ranked matches |
-| `ctx_find` | `find` | Compressed, .gitignore-aware |
-| `ctx_ls` | `ls` | Compact directory maps |
+| `ctx_search` | `grep` | Compact, ranked matches |
+| `ctx_glob` | `find` | Compressed, .gitignore-aware file matching |
+| `ctx_tree` | `ls` | Compact directory maps |
 
 - Use `ctx_shell` for commands with side effects (build/test/git/etc.); set `raw=true` when exact
   output matters.

--- a/rust/tests/rules_template_tool_names.rs
+++ b/rust/tests/rules_template_tool_names.rs
@@ -1,0 +1,112 @@
+//! Parity guard: every `ctx_*` tool name shipped in an agent template must map
+//! to a real registered MCP tool.
+//!
+//! Pi's `AGENTS.md` silently carried renamed tools (`ctx_grep`/`ctx_find`/
+//! `ctx_ls` → `ctx_search`/`ctx_glob`/`ctx_tree`) because it was a static
+//! template with no test tying it back to the registry. This locks every
+//! shipped template to the canonical tool surface so future renames cannot
+//! drift unnoticed (#548).
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use lean_ctx::server::registry::build_registry;
+
+fn templates_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/templates")
+}
+
+/// Extract distinct `ctx_<name>` identifiers from `text`, where `<name>` is one
+/// or more ASCII alphanumerics / underscores. Bare `ctx_` and globs like
+/// `ctx_*` carry no tool name and are skipped.
+fn ctx_tool_tokens(text: &str) -> BTreeSet<String> {
+    let bytes = text.as_bytes();
+    let mut tokens = BTreeSet::new();
+    let mut i = 0;
+    while i + 4 <= bytes.len() {
+        if &bytes[i..i + 4] == b"ctx_" {
+            let mut end = i + 4;
+            while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+                end += 1;
+            }
+            if end > i + 4 {
+                tokens.insert(text[i..end].to_string());
+            }
+            i = end.max(i + 4);
+        } else {
+            i += 1;
+        }
+    }
+    tokens
+}
+
+/// Shipped templates the agent installers write verbatim (`.md` / `.txt`).
+fn template_files() -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(templates_dir())
+        .expect("templates dir is readable")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| matches!(p.extension().and_then(|e| e.to_str()), Some("md" | "txt")))
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn templates_only_reference_registered_ctx_tools() {
+    let registry = build_registry();
+    let mut violations: Vec<String> = Vec::new();
+
+    let files = template_files();
+    assert!(!files.is_empty(), "expected at least one shipped template");
+
+    for path in files {
+        let text = std::fs::read_to_string(&path).expect("template is readable");
+        for token in ctx_tool_tokens(&text) {
+            if !registry.contains(&token) {
+                violations.push(format!(
+                    "{}: `{token}` is not a registered MCP tool",
+                    path.file_name().and_then(|n| n.to_str()).unwrap_or("?")
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "shipped agent templates reference unknown/renamed ctx_* tools:\n  {}",
+        violations.join("\n  ")
+    );
+}
+
+#[test]
+fn pi_template_tracks_canonical_search_glob_tree_tools() {
+    // Pi's AGENTS.md mapping table must track the canonical tool surface
+    // (rules_canonical::BULLETS): grep → ctx_search, find → ctx_glob,
+    // ls → ctx_tree. Guards both directions so the curated Pi template stays in
+    // parity with the single source of truth.
+    let pi = std::fs::read_to_string(templates_dir().join("PI_AGENTS.md"))
+        .expect("PI_AGENTS.md is readable");
+
+    for expected in ["ctx_search", "ctx_glob", "ctx_tree"] {
+        assert!(
+            pi.contains(expected),
+            "PI_AGENTS.md must reference `{expected}` (canonical tool surface)"
+        );
+    }
+    for renamed in ["ctx_grep", "ctx_find", "ctx_ls"] {
+        assert!(
+            !pi.contains(renamed),
+            "PI_AGENTS.md still references renamed tool `{renamed}`"
+        );
+    }
+}
+
+#[test]
+fn token_extractor_ignores_globs_and_bare_prefix() {
+    assert!(ctx_tool_tokens("use ctx_* tools and ctx_ alone").is_empty());
+    let tokens = ctx_tool_tokens("`ctx_read`/ctx_shell, ctx_search(pattern)");
+    assert!(tokens.contains("ctx_read"));
+    assert!(tokens.contains("ctx_shell"));
+    assert!(tokens.contains("ctx_search"));
+}


### PR DESCRIPTION
## Summary

First slice of **#548 (Unify Agents Rules Templates/Management)** — the concrete, user-facing bug in the set.

Pi's installer writes a curated static `templates/PI_AGENTS.md`. Its tool-mapping table still advertised `ctx_grep` / `ctx_find` / `ctx_ls` — tools renamed long ago to `ctx_search` / `ctx_glob` / `ctx_tree`. Pi agents that followed the table issued **unknown-tool calls**.

- `templates/PI_AGENTS.md` + the matching `pi.rs` setup hint now use the canonical names.
- New `tests/rules_template_tool_names.rs` ties **every** shipped agent template to the live MCP registry (`server::registry::build_registry`): any `ctx_*` reference that is not a registered tool fails the build, so a future rename can never drift silently again. Includes a positive/negative Pi parity check and a tokenizer unit test.

This satisfies acceptance criterion 3 of #548 (*"Pi AGENTS.md derives from canonical rules **or has parity tests**"*) via the parity-test route, keeping Pi's curated, Pi-specific guidance intact.

### Remaining #548 slices (separate PRs, intentionally small)
- **#1** one marker/carrier model for compression (dedup currently expects a legacy `lean-ctx-compression` block no writer emits).
- **#2** `rules sync` honor-or-document `.lean-ctx/rules.toml` (+ remove the unused `_config` in `detect_drift`).
- **#4** content/compression-aware freshness (today inject skips on `version >= RULES_VERSION` only, so a compression-level change does not propagate).

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --lib --test rules_template_tool_names -- -D warnings` clean
- [x] `cargo test --test rules_template_tool_names` (3/3)
- [x] `cargo test --lib` (6001 passed, 0 failed)
- [x] pre-push preflight passed

Part of #548

Made with [Cursor](https://cursor.com)