### PR TITLE
fix(rules): content-aware freshness for rule injection (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   that is not a registered tool fails the build, so a future rename can never drift
   silently again. (First slice of the #548 agent-rules unification — marker/dedup
   consolidation, content-aware freshness, and `rules.toml`↔`sync` semantics follow.)
+- **Rule injection skipped content/compression changes when the version was unchanged (#548).**
+  The injector's freshness check was version-only: it compared the on-disk
+  `<!-- version: N -->` against `RULES_VERSION` and skipped the rewrite when they
+  matched. So a change that alters the rendered body *without* bumping the version —
+  toggling `shadow_mode`, switching `compression_level`, or editing a canonical
+  section between releases — left every agent's rules block stale until the next
+  version bump. `RulesFile::block_matches_render` now compares the on-disk block
+  byte-for-byte (whitespace-insensitive) against a fresh render for the active
+  parameters, and the skip path requires *both* `is_current()` **and** that content
+  match. Re-running `sync`/inject after a compression-level change now regenerates
+  the block as expected; an unchanged config stays idempotent. (Second slice of the
+  #548 agent-rules unification, after the Pi-template parity guard.)
 - **Shadow-mode hook reads dropped ~75% of the MCP read side effects (#550).** When
   shadow/harden mode intercepts a native `view`/`grep` call it spawns `lean-ctx read`
   as a single-shot subprocess. That CLI path recorded only a fraction of what the MCP

--- a/rust/src/core/rules_canonical.rs
+++ b/rust/src/core/rules_canonical.rs
@@ -295,6 +295,36 @@ impl<'a> RulesFile<'a> {
             .map_or("", |e| self.content[e + END_MARK.len()..].trim())
     }
 
+    /// The lean-ctx block on disk, from `START_MARK` through `END_MARK`
+    /// (inclusive), if both markers are present.
+    fn block(&self) -> Option<&'a str> {
+        match (self.start, self.end) {
+            (Some(s), Some(e)) if e >= s => Some(&self.content[s..e + END_MARK.len()]),
+            _ => None,
+        }
+    }
+
+    /// Whether the on-disk block is already byte-identical (ignoring surrounding
+    /// whitespace) to a fresh [`render`] for these parameters.
+    ///
+    /// [`is_current`](Self::is_current) only compares the embedded
+    /// `<!-- version: N -->` against [`RULES_VERSION`], so a change that keeps
+    /// the version but alters the rendered body — toggling `shadow_mode`,
+    /// switching `compression_level`, or editing a canonical section without a
+    /// version bump — would otherwise be skipped by the injector. Callers pair
+    /// this with `is_current()` to detect that content/compression drift (#548).
+    pub fn block_matches_render(
+        &self,
+        shadow: bool,
+        wrapper: Wrapper,
+        level: CompressionLevel,
+    ) -> bool {
+        match self.block() {
+            Some(block) => block.trim() == render(shadow, wrapper, level).trim(),
+            None => false,
+        }
+    }
+
     /// Merge freshly-rendered rules into this file.
     ///
     /// * If a lean-ctx section exists → replaces content between `START_MARK`
@@ -578,6 +608,47 @@ mod tests {
         let f = RulesFile::parse("just user stuff");
         assert!(!f.has_content());
         assert_eq!(f.version(), 0);
+    }
+
+    #[test]
+    fn block_matches_render_true_for_fresh_render() {
+        let fresh = render(false, Wrapper::Dedicated, CompressionLevel::Off);
+        let content = format!("user before\n{fresh}\nuser after");
+        let f = RulesFile::parse(&content);
+        assert!(f.is_current(), "fresh render carries the current version");
+        assert!(
+            f.block_matches_render(false, Wrapper::Dedicated, CompressionLevel::Off),
+            "an unchanged block must compare equal to a fresh render"
+        );
+    }
+
+    #[test]
+    fn block_matches_render_false_on_compression_change() {
+        // Body rendered at Off, then asked whether it matches a Max render:
+        // the version is identical but the compression payload differs (#548).
+        let content = render(false, Wrapper::Dedicated, CompressionLevel::Off);
+        let f = RulesFile::parse(&content);
+        assert!(f.is_current());
+        assert!(
+            !f.block_matches_render(false, Wrapper::Dedicated, CompressionLevel::Max),
+            "a compression-level change must be detected as drift"
+        );
+    }
+
+    #[test]
+    fn block_matches_render_false_on_shadow_change() {
+        let content = render(false, Wrapper::Dedicated, CompressionLevel::Lite);
+        let f = RulesFile::parse(&content);
+        assert!(
+            !f.block_matches_render(true, Wrapper::Dedicated, CompressionLevel::Lite),
+            "a shadow-mode toggle must be detected as drift"
+        );
+    }
+
+    #[test]
+    fn block_matches_render_false_without_block() {
+        let f = RulesFile::parse("plain user content, no markers");
+        assert!(!f.block_matches_render(false, Wrapper::Dedicated, CompressionLevel::Off));
     }
 
     #[test]

--- a/rust/src/rules_inject/tests.rs
+++ b/rust/src/rules_inject/tests.rs
@@ -268,6 +268,50 @@ fn inject_rules_for_unknown_agent_is_empty() {
 }
 
 #[test]
+fn inject_rewrites_on_compression_change_without_version_bump() {
+    // #548: a version-only freshness check skips the rewrite when the
+    // compression level changes but RULES_VERSION stays the same. Drive the real
+    // inject path through LEAN_CTX_COMPRESSION to prove the block is regenerated.
+    let _guard = crate::core::data_dir::test_env_lock();
+
+    let dir = std::env::temp_dir().join("lc_test_inject_compression_drift");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let target = RulesTarget {
+        name: "test",
+        path: dir.join("lean-ctx.md"),
+        format: RulesFormat::DedicatedMarkdown,
+    };
+
+    crate::test_env::set_var("LEAN_CTX_COMPRESSION", "off");
+    assert!(matches!(
+        super::write::inject_rules(&target).unwrap(),
+        RulesResult::Updated
+    ));
+    let off = std::fs::read_to_string(&target.path).unwrap();
+
+    // Same level → idempotent (block already matches a fresh render).
+    assert!(matches!(
+        super::write::inject_rules(&target).unwrap(),
+        RulesResult::AlreadyPresent
+    ));
+
+    // Switch to max → must rewrite even though RULES_VERSION is unchanged.
+    crate::test_env::set_var("LEAN_CTX_COMPRESSION", "max");
+    assert!(matches!(
+        super::write::inject_rules(&target).unwrap(),
+        RulesResult::Updated
+    ));
+    let max = std::fs::read_to_string(&target.path).unwrap();
+
+    crate::test_env::remove_var("LEAN_CTX_COMPRESSION");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert_ne!(off, max, "compression-level change must alter the body");
+    assert!(max.contains(&format!("<!-- version: {RULES_VERSION} -->")));
+}
+
+#[test]
 fn any_rules_marker_present_detects_opencode() {
     let home = std::env::temp_dir().join("lc_test_marker_opencode");
     let _ = std::fs::remove_dir_all(&home);

--- a/rust/src/rules_inject/write.rs
+++ b/rust/src/rules_inject/write.rs
@@ -24,7 +24,15 @@ pub(super) fn inject_rules(target: &RulesTarget) -> Result<RulesResult, String> 
         let content = std::fs::read_to_string(&target.path).map_err(|e| e.to_string())?;
         let file = RulesFile::parse(&content);
 
-        if file.has_content() && file.is_current() {
+        // Skip the rewrite only when the on-disk block is BOTH version-current
+        // AND already byte-identical to a fresh render. A version-only check
+        // would leave a `compression_level` / `shadow_mode` / canonical-text
+        // change unpropagated whenever RULES_VERSION happens to be unchanged
+        // (#548).
+        if file.has_content()
+            && file.is_current()
+            && file.block_matches_render(shadow, wrapper, level)
+        {
             return Ok(RulesResult::AlreadyPresent);
         }
 


### PR DESCRIPTION
## Summary

Second slice of the **#548** agent-rules unification (after the Pi-template parity guard in #570).

The rule injector's freshness check was **version-only**: it compared the on-disk `<!-- version: N -->` against `RULES_VERSION` and skipped the rewrite when they matched. A change that alters the *rendered body* **without** a version bump — toggling `shadow_mode`, switching `compression_level`, or editing a canonical section between releases — left every agent's rules block **stale** until the next version bump.

- `RulesFile::block_matches_render(shadow, wrapper, level)` compares the on-disk block (`START_MARK`…`END_MARK`, inclusive) byte-for-byte (whitespace-insensitive) against a fresh `render()` for the active parameters.
- `rules_inject::write::inject_rules` now skips the rewrite only when **both** `is_current()` **and** `block_matches_render(...)` hold. A compression/shadow/canonical-text change regenerates the block; an unchanged config stays idempotent.
- Correctness across formats: `render()` is the verbatim block body for **every** wrapper — `merged()`/`initial()` embed it directly, and CursorMdc wraps it with frontmatter *before* `START_MARK` (preserved as `prefix()`), so `block() == render()` for a freshly written file in all of Shared / Dedicated / CursorMdc. No idempotency regression.

## Test plan

- [x] `cargo test --lib rules_canonical` — 4 new unit tests for `block_matches_render` (fresh render → true; compression change → false; shadow toggle → false; no block → false).
- [x] `cargo test --lib rules_inject` — new E2E `inject_rewrites_on_compression_change_without_version_bump` drives `LEAN_CTX_COMPRESSION` off→max and asserts: same level ⇒ `AlreadyPresent` (idempotent), level change ⇒ `Updated` (regenerated) with `RULES_VERSION` unchanged.
- [x] `cargo clippy -- -D warnings` clean.
- [x] Rebased on top of #571 (green `main`).

Refs #548. Stays open until release per the project label lifecycle.

Made with [Cursor](https://cursor.com)