### PR TITLE
fix(rules): decouple rules diff/sync from rules.toml + fix phantom drift (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   match. Re-running `sync`/inject after a compression-level change now regenerates
   the block as expected; an unchanged config stays idempotent. (Second slice of the
   #548 agent-rules unification, after the Pi-template parity guard.)
+- **`rules diff`/`sync` ↔ `.lean-ctx/rules.toml` semantics, and a `rules diff`
+  false-positive (#548).** Two coupled fixes for the rules-governance commands:
+  - **`sync`/`diff` do not consume `rules.toml` — now documented and decoupled.**
+    `rules sync`/`diff` regenerate from the canonical `rules_canonical` source of
+    truth (preserving user text around the markers) and never read `rules.toml`,
+    which is the input for `rules lint` plus a user-editable inventory from `rules
+    init`. This is now stated in the `rules` help, the `init` next-steps, and the
+    `RulesConfig`/`sync` docs. `detect_drift` no longer loads `RulesConfig` at all,
+    so `rules diff` works **without** first running `rules init` (it previously
+    failed with "No rules config found") — the dead `_config` parameter is gone and
+    the command is infallible.
+  - **`rules diff` reported phantom drift after every sync.** Drift picked the
+    shared-vs-dedicated expected block from a content heuristic ("up_to_date and no
+    'existing user rules'"), which misread freshly synced *shared* files with no
+    user text (Copilot CLI, Codex CLI, Gemini/OpenCode in shared mode) as the
+    dedicated layout and flagged them as `DRIFTED` on every run. Drift now compares
+    each target against the canonical block for its **real** `RulesFormat` via the
+    new `rules_inject::expected_blocks_by_target`, keeping `sync` and `diff` in
+    agreement. Covered by new tests: `detect_drift_without_rules_toml_does_not_
+    require_init` and `sync_then_diff_reports_no_drift`. (Third slice of the #548
+    agent-rules unification.)
 - **Shadow-mode hook reads dropped ~75% of the MCP read side effects (#550).** When
   shadow/harden mode intercepts a native `view`/`grep` call it spawns `lean-ctx read`
   as a single-shot subprocess. That CLI path recorded only a fraction of what the MCP

--- a/rust/src/cli/rules_cmd.rs
+++ b/rust/src/cli/rules_cmd.rs
@@ -49,31 +49,17 @@ fn cmd_sync(ops: &ContextOps, args: &[String]) {
 }
 
 fn cmd_diff(ops: &ContextOps) {
-    match ops.detect_drift() {
-        Ok(reports) => {
-            println!("{}", contextops::format_drift(&reports));
+    // Drift is measured against the canonical rule source, so this never needs
+    // `.lean-ctx/rules.toml` (and never errors on a missing config) — see #548.
+    let reports = ops.detect_drift();
+    println!("{}", contextops::format_drift(&reports));
 
-            let drifted = reports
-                .iter()
-                .filter(|r| r.status == contextops::DriftStatus::Drifted)
-                .count();
-            if drifted > 0 {
-                println!("\n{drifted} target(s) drifted. Run `lean-ctx rules sync` to fix.");
-            }
-        }
-        Err(e) => {
-            eprintln!("Error: {e}");
-            println!("\nFalling back to status-based drift check...");
-            let statuses = ops.status();
-            let outdated: Vec<_> = statuses.iter().filter(|s| s.state == "outdated").collect();
-            if outdated.is_empty() {
-                println!("All detected targets appear up to date.");
-            } else {
-                for s in &outdated {
-                    println!("  [OUTDATED] {} ({})", s.name, s.path);
-                }
-            }
-        }
+    let drifted = reports
+        .iter()
+        .filter(|r| r.status == contextops::DriftStatus::Drifted)
+        .count();
+    if drifted > 0 {
+        println!("\n{drifted} target(s) drifted. Run `lean-ctx rules sync` to fix.");
     }
 }
 
@@ -121,10 +107,15 @@ fn cmd_init(ops: &ContextOps) {
         Ok(_config) => {
             println!("Created .lean-ctx/rules.toml from existing rules.");
             println!();
+            println!("Note: rules.toml is consumed by `lean-ctx rules lint` (cross-agent");
+            println!("consistency) and is a user-editable inventory. It is NOT the source");
+            println!("for `rules sync`/`diff` — those (re)generate from lean-ctx's built-in");
+            println!("canonical rules and preserve your own text around the markers.");
+            println!();
             println!("Next steps:");
             println!("  1. Review .lean-ctx/rules.toml");
             println!("  2. Run `lean-ctx rules lint` to check consistency");
-            println!("  3. Run `lean-ctx rules sync` to distribute");
+            println!("  3. Run `lean-ctx rules sync` to (re)write the canonical rules block");
         }
         Err(e) => {
             eprintln!("Error: {e}");
@@ -141,12 +132,18 @@ fn print_help() {
              lean-ctx rules <action> [args]\n\
          \n\
          ACTIONS:\n    \
-             sync [agent]      Sync central rules to all (or one) agent config(s)\n    \
-             diff              Show drift between central and distributed rules\n    \
-             lint              Check rules for consistency and completeness\n    \
+             sync [agent]      (Re)write the canonical lean-ctx rules block into all (or one) agent config(s)\n    \
+             diff              Show drift between the canonical rules and each agent's on-disk block\n    \
+             lint              Check .lean-ctx/rules.toml for consistency and completeness\n    \
              status            Show sync status for all targets\n    \
              init              Create .lean-ctx/rules.toml from existing rules\n    \
              dedup [--apply]   Remove duplicated lean-ctx rules (#578); dry-run by default\n    \
-             help              Show this help"
+             help              Show this help\n\
+         \n\
+         NOTES:\n    \
+             `sync` and `diff` use lean-ctx's built-in canonical rules as the source\n    \
+             of truth and preserve your own text around the `<!-- lean-ctx-rules -->`\n    \
+             markers. They do NOT read `.lean-ctx/rules.toml` — that file is the input\n    \
+             for `lint` and a user-editable inventory created by `init`."
     );
 }

--- a/rust/src/core/contextops/config.rs
+++ b/rust/src/core/contextops/config.rs
@@ -6,6 +6,15 @@ const CONFIG_FILENAME: &str = "rules.toml";
 const CONFIG_DIR: &str = ".lean-ctx";
 const LEGACY_CONFIG_DIR: &str = ".leanctx";
 
+/// User-facing rules inventory persisted at `.lean-ctx/rules.toml`.
+///
+/// **Scope (read this before wiring it into anything):** `rules.toml` is the input
+/// for `rules lint` (cross-agent consistency checks) and a user-editable export
+/// produced by `rules init`. It is deliberately **not** consumed by `rules sync`
+/// or `rules diff` — those regenerate from the canonical `rules_canonical` source
+/// of truth and preserve user text around the markers. `core.content` here is a
+/// snapshot captured at `init` time for inspection/linting, never an override that
+/// `sync` would distribute (#548).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RulesConfig {
     pub rules: RulesSection,

--- a/rust/src/core/contextops/drift.rs
+++ b/rust/src/core/contextops/drift.rs
@@ -2,8 +2,6 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use super::config::RulesConfig;
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DriftStatus {
     InSync,
@@ -35,10 +33,20 @@ pub struct DriftReport {
     pub diff: Option<String>,
 }
 
-pub fn detect_drift(home: &Path, _config: &RulesConfig) -> Vec<DriftReport> {
+/// Compare each detected agent's on-disk `<!-- lean-ctx-rules -->` block against
+/// the **canonical** rule source (`rules_canonical` via
+/// `rules_inject::rules_shared_content` / `rules_dedicated_markdown`).
+///
+/// Drift is measured purely against the canonical single-source-of-truth — it
+/// deliberately does **not** read `.lean-ctx/rules.toml`. `rules.toml` is a
+/// `rules lint` input and a user-facing export from `rules init`; it never
+/// overrides the canonical rule body (see [`super::config::RulesConfig`]). This
+/// is also why `rules diff` works without running `rules init` first (#548).
+pub fn detect_drift(home: &Path) -> Vec<DriftReport> {
     let statuses = crate::rules_inject::collect_rules_status(home);
-    let source_shared = crate::rules_inject::rules_shared_content();
-    let source_dedicated = crate::rules_inject::rules_dedicated_markdown();
+    // The canonical block lean-ctx would write for each target, keyed by name and
+    // chosen by the target's real `RulesFormat` — see the heuristic note below.
+    let expected_by_target = crate::rules_inject::expected_blocks_by_target(home);
 
     let marker = crate::core::rules_canonical::START_MARK;
     let end_marker = crate::core::rules_canonical::END_MARK;
@@ -84,14 +92,15 @@ pub fn detect_drift(home: &Path, _config: &RulesConfig) -> Vec<DriftReport> {
             }
 
             let section = extract_section(&content, marker, end_marker);
-            let is_dedicated =
-                status.state == "up_to_date" && !content.contains("existing user rules");
 
-            let expected_section = if is_dedicated {
-                extract_section(&source_dedicated, marker, end_marker)
-            } else {
-                extract_section(&source_shared, marker, end_marker)
-            };
+            // Compare against the canonical block for THIS target's format. The
+            // previous content heuristic ("up_to_date and no 'existing user
+            // rules'") misclassified freshly synced shared files (Copilot/Codex
+            // CLI) as dedicated and reported phantom drift after every sync (#548).
+            let expected_section = expected_by_target
+                .get(&status.name)
+                .map(|expected| extract_section(expected, marker, end_marker))
+                .unwrap_or_default();
 
             let section_trimmed = section.trim();
             let expected_trimmed = expected_section.trim();

--- a/rust/src/core/contextops/mod.rs
+++ b/rust/src/core/contextops/mod.rs
@@ -23,9 +23,13 @@ impl ContextOps {
         }
     }
 
-    pub fn detect_drift(&self) -> Result<Vec<DriftReport>, String> {
-        let config = RulesConfig::load(&self.project_root)?;
-        Ok(drift::detect_drift(&self.home, &config))
+    /// Drift between each agent's on-disk rules block and the canonical source.
+    ///
+    /// Infallible: drift is computed against `rules_canonical` (always present in
+    /// the binary), **not** against `.lean-ctx/rules.toml`, so `rules diff` needs
+    /// no prior `rules init` and can never fail on a missing config (#548).
+    pub fn detect_drift(&self) -> Vec<DriftReport> {
+        drift::detect_drift(&self.home)
     }
 
     pub fn sync_all(&self) -> SyncReport {
@@ -156,6 +160,33 @@ mod tests {
             Path::new("/tmp/nonexistent_contextops"),
         );
         assert!(!ops.has_config());
+    }
+
+    // #548 criterion 2: `rules diff` must not require `.lean-ctx/rules.toml`.
+    // `detect_drift` is now infallible and compares against the canonical rule
+    // source, so a project with no rules.toml produces a (possibly empty) drift
+    // report instead of the old "No rules config found" hard error. Serialized
+    // against other tests that read/write the global `CLAUDE_CONFIG_DIR`.
+    #[test]
+    #[serial_test::serial(claude_config_dir)]
+    fn detect_drift_without_rules_toml_does_not_require_init() {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let claude_dir = home.path().join(".claude").to_string_lossy().into_owned();
+        let _g = crate::setup::EnvVarGuard::set("CLAUDE_CONFIG_DIR", &claude_dir);
+
+        let ops = ContextOps::new(home.path(), project.path());
+        assert!(
+            !ops.has_config(),
+            "sandbox project must have no rules.toml for this regression test"
+        );
+
+        // The pre-#548 code path would have errored here on the missing config.
+        // Now it returns well-formed reports straight from the canonical source.
+        let reports = ops.detect_drift();
+        for r in &reports {
+            assert!(!r.target.is_empty(), "drift report missing a target name");
+        }
     }
 
     #[test]

--- a/rust/src/core/contextops/sync.rs
+++ b/rust/src/core/contextops/sync.rs
@@ -9,6 +9,14 @@ pub struct SyncReport {
     pub errors: Vec<String>,
 }
 
+/// (Re)write the canonical lean-ctx rules block into every detected agent config.
+///
+/// The source of truth is `rules_canonical` (via `rules_inject::inject_all_rules`),
+/// **not** `.lean-ctx/rules.toml`. Sync regenerates the canonical block and
+/// preserves the user's own text around the `<!-- lean-ctx-rules -->` markers;
+/// `rules.toml` is consumed only by `lint` and produced by `init` (see
+/// [`super::config::RulesConfig`]). Stating this explicitly resolves the
+/// "sync doesn't honor rules.toml" ambiguity — by design it does not (#548).
 pub fn sync_all(home: &Path) -> SyncReport {
     let inject_result = crate::rules_inject::inject_all_rules(home);
 
@@ -23,6 +31,10 @@ pub fn sync_all(home: &Path) -> SyncReport {
     }
 }
 
+/// (Re)write the canonical rules block into a single agent's config.
+///
+/// Same canonical-source contract as [`sync_all`]: regenerates from
+/// `rules_canonical` and never reads `.lean-ctx/rules.toml` (#548).
 pub fn sync_agent(home: &Path, agent: &str) -> SyncReport {
     let inject_result = crate::rules_inject::inject_rules_for_agent(home, agent);
 
@@ -107,6 +119,37 @@ mod tests {
             second.errors.is_empty(),
             "second sync reported errors: {:?}",
             second.errors
+        );
+    }
+
+    // #548 criterion 5 (setup/init/sync consistency): `sync` and `diff` share one
+    // canonical source of truth, so immediately after a `sync_all` the on-disk
+    // blocks must read back as in-sync — `detect_drift` may never report `Drifted`
+    // for a target we just wrote. This pins sync↔diff agreement and would catch a
+    // future divergence between the inject and drift comparison paths.
+    #[test]
+    #[serial_test::serial(claude_config_dir)]
+    fn sync_then_diff_reports_no_drift() {
+        use crate::core::contextops::drift::{DriftStatus, detect_drift};
+
+        let home = TempHome::new("syncdiff");
+        let _claude = scope_claude_into(&home.path);
+
+        let report = sync_all(&home.path);
+        assert!(
+            report.errors.is_empty(),
+            "sync reported errors: {:?}",
+            report.errors
+        );
+
+        let drifted: Vec<String> = detect_drift(&home.path)
+            .into_iter()
+            .filter(|r| r.status == DriftStatus::Drifted)
+            .map(|r| r.target)
+            .collect();
+        assert!(
+            drifted.is_empty(),
+            "sync left targets drifted vs the canonical source: {drifted:?}"
         );
     }
 

--- a/rust/src/rules_inject/mod.rs
+++ b/rust/src/rules_inject/mod.rs
@@ -52,6 +52,35 @@ pub fn rules_dedicated_markdown() -> String {
     )
 }
 
+/// The canonical rules block lean-ctx would write for each target, keyed by the
+/// target's display name.
+///
+/// Drift detection compares against this instead of guessing shared-vs-dedicated
+/// from a target's on-disk contents: a freshly synced `SharedMarkdown` file (e.g.
+/// Copilot CLI, Codex CLI) carries no user text, which a content heuristic
+/// mistook for the dedicated layout and then flagged as drifted on every sync.
+/// Keying by the real `RulesFormat` keeps `sync` and `diff` in agreement (#548).
+pub fn expected_blocks_by_target(
+    home: &std::path::Path,
+) -> std::collections::HashMap<String, String> {
+    let injection = crate::core::config::Config::load().rules_injection_effective();
+    let shared = canonical_rules_block();
+    let dedicated = rules_dedicated_markdown();
+    build_rules_targets(home, injection)
+        .into_iter()
+        .map(|target| {
+            let expected = match target.format {
+                RulesFormat::SharedMarkdown => shared.clone(),
+                // CursorMdc embeds the dedicated render verbatim between the
+                // markers (frontmatter lives outside them), so the extracted
+                // section matches the dedicated block.
+                RulesFormat::DedicatedMarkdown | RulesFormat::CursorMdc => dedicated.clone(),
+            };
+            (target.name.to_string(), expected)
+        })
+        .collect()
+}
+
 use detect::is_tool_detected;
 use targets::build_rules_targets;
 use write::inject_rules;

--- a/rust/src/tools/ctx_rules.rs
+++ b/rust/src/tools/ctx_rules.rs
@@ -17,27 +17,22 @@ pub fn handle(action: &str, agent: Option<&str>) -> String {
             };
             contextops::format_sync(&report)
         }
-        "diff" => match ops.detect_drift() {
-            Ok(reports) => {
-                let mut output = contextops::format_drift(&reports);
-                let drifted = reports
-                    .iter()
-                    .filter(|r| r.status == contextops::DriftStatus::Drifted)
-                    .count();
-                if drifted > 0 {
-                    output.push_str(&format!(
-                        "\n\n{drifted} target(s) drifted. Run ctx_rules(action=\"sync\") to fix."
-                    ));
-                }
-                output
+        "diff" => {
+            // Drift is measured against the canonical rule source, so this needs
+            // no `.lean-ctx/rules.toml` and cannot error on a missing config (#548).
+            let reports = ops.detect_drift();
+            let mut output = contextops::format_drift(&reports);
+            let drifted = reports
+                .iter()
+                .filter(|r| r.status == contextops::DriftStatus::Drifted)
+                .count();
+            if drifted > 0 {
+                output.push_str(&format!(
+                    "\n\n{drifted} target(s) drifted. Run ctx_rules(action=\"sync\") to fix."
+                ));
             }
-            Err(e) => {
-                let statuses = ops.status();
-                let mut output = format!("Note: {e}\n\nFallback status check:\n");
-                output.push_str(&contextops::format_status(&statuses));
-                output
-            }
-        },
+            output
+        }
         "lint" => match ops.lint() {
             Ok(warnings) => contextops::format_lint(&warnings),
             Err(e) => {
@@ -62,7 +57,7 @@ pub fn handle(action: &str, agent: Option<&str>) -> String {
                 return "Config already exists at .lean-ctx/rules.toml. Delete it first to reinitialize.".to_string();
             }
             match ops.init() {
-                Ok(_) => "Created .lean-ctx/rules.toml from existing rules.\nRun ctx_rules(action=\"lint\") to check, then ctx_rules(action=\"sync\") to distribute.".to_string(),
+                Ok(_) => "Created .lean-ctx/rules.toml from existing rules. It feeds ctx_rules(action=\"lint\") for cross-agent consistency and is a user-editable inventory; it is NOT the source for sync/diff, which (re)generate from lean-ctx's built-in canonical rules. Next: ctx_rules(action=\"lint\") to check, then ctx_rules(action=\"sync\") to (re)write the canonical block.".to_string(),
                 Err(e) => format!("Error: {e}"),
             }
         }


### PR DESCRIPTION
## Summary

Third slice of the **#548** agent-rules unification — **criterion 2** (`rules sync` honors `.lean-ctx/rules.toml` *or* docs state it doesn't) and **criterion 5** (tests cover setup/init/sync consistency). Two coupled fixes for the rules-governance commands:

### 1. `sync`/`diff` do not consume `rules.toml` — now documented and decoupled
`rules sync`/`diff` regenerate from the canonical `rules_canonical` source of truth (preserving your text around the markers) and never read `rules.toml`, which is the input for `rules lint` plus a user-editable inventory produced by `rules init`. This is now stated in:
- the `rules` help (`USAGE`/`NOTES`), the `init` "next steps", and the `RulesConfig` / `sync_all` / `sync_agent` / `detect_drift` doc comments.

`ContextOps::detect_drift` no longer loads `RulesConfig`, so it is **infallible** and `rules diff` works **without** a prior `rules init` (it previously failed with *"No rules config found"*). The dead `_config` parameter on `drift::detect_drift` is removed and both call sites (CLI `cmd_diff`, MCP `ctx_rules`) drop their now-unreachable error/fallback arms.

### 2. `rules diff` reported phantom drift after every sync
Drift picked the shared-vs-dedicated expected block from a **content heuristic** (*"up_to_date and no 'existing user rules'"*), which misread freshly synced `SharedMarkdown` files with no user text — **Copilot CLI, Codex CLI**, Gemini/OpenCode in shared mode — as the dedicated layout and flagged them `DRIFTED` on every run. Drift now compares each target against the canonical block for its **real** `RulesFormat` via the new `rules_inject::expected_blocks_by_target`, keeping `sync` and `diff` in agreement.

## Test plan

- [x] `cargo test --lib` — **6054 passed, 0 failed**.
- [x] New `core::contextops::tests::detect_drift_without_rules_toml_does_not_require_init` (criterion 2: diff works with no `rules.toml`).
- [x] New `core::contextops::sync::tests::sync_then_diff_reports_no_drift` (criterion 5 — this test caught the phantom drift before the fix; `["Copilot CLI", "Codex CLI"]` → green).
- [x] `cargo clippy --lib --tests` clean.

> Note: based on `main` after Slice A (#570). Will rebase once Slice B1 (#572) lands. Refs #548; stays open until release per the label lifecycle.

Made with [Cursor](https://cursor.com)