### PR TITLE
fix(rules): unify compression marker model so cross-channel dedup fires (#548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
     agreement. Covered by new tests: `detect_drift_without_rules_toml_does_not_
     require_init` and `sync_then_diff_reports_no_drift`. (Third slice of the #548
     agent-rules unification.)
+- **Compression block had two disagreeing marker models, so cross-channel dedup
+  never fired (#548).** `rules_canonical::render` embedded the output-style
+  compression prompt *inline* inside the `<!-- lean-ctx-rules -->` block with no
+  delimiters, but the coverage/dedup readers (`rules_channel`, `rules dedup`)
+  detect the payload by a separate `<!-- lean-ctx-compression -->` … `<!--
+  /lean-ctx-compression -->` block. Since the writer never emitted those markers,
+  `cursor_compression_covered`/`client_autoloads_compression` were always false on
+  freshly written rule files — so the MCP per-session instructions kept repeating
+  the compression block even for Cursor/Codex that already load it from their rule
+  file (double billing), and `rules dedup` could not thin a render-produced shared
+  `AGENTS.md`. The two models are now one: the `COMPRESSION_BLOCK_*` markers live in
+  `rules_canonical` (single marker source, re-exported from `rules_channel`), and
+  `render` wraps the compression prompt in them for the persistent carriers
+  (`Dedicated`/`Shared` — every injected rule file). The ephemeral `Bare` MCP
+  channel stays unmarked by design (its inclusion is *governed* by carrier coverage,
+  so a per-session marker would be noise). Content-aware freshness (second slice)
+  re-propagates the new block on the next `sync` without a version bump. Covered by
+  new tests asserting carriers wrap / `Bare` does not / `Off` emits nothing, and an
+  end-to-end check that a `render`-produced Cursor block is now recognised as
+  compression coverage. (Fourth slice of the #548 agent-rules unification — closes
+  the "one canonical carrier/marker model" acceptance criterion.)
 - **Shadow-mode hook reads dropped ~75% of the MCP read side effects (#550).** When
   shadow/harden mode intercepts a native `view`/`grep` call it spawns `lean-ctx read`
   as a single-shot subprocess. That CLI path recorded only a fraction of what the MCP

--- a/rust/src/core/rules_canonical.rs
+++ b/rust/src/core/rules_canonical.rs
@@ -35,6 +35,23 @@ pub const AGENTS_BLOCK_END: &str = "<!-- /lean-ctx -->";
 /// Closing marker that ends a lean-ctx rule section.
 pub const END_MARK: &str = "<!-- /lean-ctx-rules -->";
 
+/// Markers of the heavy compression / output-style block — the per-turn payload
+/// that drives cross-channel duplication (#684/#548).
+///
+/// `render()` wraps the compression prompt in these markers for **persistent
+/// carriers** (the `Dedicated` and `Shared` wrappers, i.e. every injected rule
+/// file). This is the single carrier/marker model: coverage and dedup
+/// (`core::rules_channel`, `cli::rules_dedup`) detect and thin the payload by
+/// these markers, so the writer and the readers can never disagree again. The
+/// ephemeral `Bare` MCP-instructions channel deliberately omits the markers —
+/// its inclusion is *governed* by carrier coverage (`client_autoloads_compression`),
+/// so a per-session marker would be pure noise.
+pub const COMPRESSION_BLOCK_START: &str = "<!-- lean-ctx-compression -->";
+
+/// Closing marker of the compression / output-style block (see
+/// [`COMPRESSION_BLOCK_START`]).
+pub const COMPRESSION_BLOCK_END: &str = "<!-- /lean-ctx-compression -->";
+
 /// Current rules version (monotonically increasing integer).  Embedded as
 /// `<!-- version: {RULES_VERSION} -->` right after `START_MARK` so the
 /// injection layer can parse it and decide whether a file is up-to-date.
@@ -200,11 +217,22 @@ pub fn render(shadow: bool, wrapper: Wrapper, level: CompressionLevel) -> String
 
     let mut body = profile.join("\n\n");
 
-    // Append compression prompt for active levels
+    // Append the compression / output-style prompt for active levels. Persistent
+    // carriers (Dedicated, Shared) wrap it in the canonical COMPRESSION_BLOCK
+    // markers so coverage/dedup (rules_channel, rules_dedup) can detect and thin
+    // it; the ephemeral Bare MCP channel keeps it unmarked (#684/#548).
     let compression = compression_text(level);
     if !compression.is_empty() {
         body.push('\n');
-        body.push_str(compression);
+        if matches!(wrapper, Wrapper::Bare) {
+            body.push_str(compression);
+        } else {
+            body.push_str(COMPRESSION_BLOCK_START);
+            body.push('\n');
+            body.push_str(compression);
+            body.push('\n');
+            body.push_str(COMPRESSION_BLOCK_END);
+        }
     }
 
     if matches!(wrapper, Wrapper::Bare) {
@@ -565,6 +593,56 @@ mod tests {
         assert!(compression_text(CompressionLevel::Lite).contains("Bullet"));
         assert!(compression_text(CompressionLevel::Standard).contains("fn, cfg"));
         assert!(compression_text(CompressionLevel::Max).contains("Telegraph"));
+    }
+
+    // --- Compression marker model (#548 B2) ---
+
+    #[test]
+    fn carrier_wrappers_wrap_compression_in_markers() {
+        // Persistent carriers must delimit the compression payload so coverage
+        // and dedup can detect/thin it (#684/#548).
+        for wrapper in [Wrapper::Dedicated, Wrapper::Shared] {
+            let out = render(false, wrapper, CompressionLevel::Standard);
+            assert!(
+                out.contains(COMPRESSION_BLOCK_START) && out.contains(COMPRESSION_BLOCK_END),
+                "{wrapper:?} must wrap compression in COMPRESSION_BLOCK markers"
+            );
+            // The marked region must actually contain the prompt body.
+            let start = out.find(COMPRESSION_BLOCK_START).unwrap();
+            let end = out.find(COMPRESSION_BLOCK_END).unwrap();
+            assert!(start < end, "{wrapper:?}: start marker precedes end marker");
+            assert!(out[start..end].contains("OUTPUT STYLE: dense"));
+        }
+    }
+
+    #[test]
+    fn bare_wrapper_emits_compression_without_markers() {
+        // The ephemeral MCP channel keeps the payload unmarked — its inclusion is
+        // governed by carrier coverage, so per-session markers would be noise.
+        let out = render(false, Wrapper::Bare, CompressionLevel::Standard);
+        assert!(out.contains("OUTPUT STYLE: dense"));
+        assert!(!out.contains(COMPRESSION_BLOCK_START));
+        assert!(!out.contains(COMPRESSION_BLOCK_END));
+    }
+
+    #[test]
+    fn compression_off_emits_no_markers_in_any_wrapper() {
+        for wrapper in [Wrapper::Dedicated, Wrapper::Shared, Wrapper::Bare] {
+            let out = render(false, wrapper, CompressionLevel::Off);
+            assert!(
+                !out.contains(COMPRESSION_BLOCK_START) && !out.contains(COMPRESSION_BLOCK_END),
+                "{wrapper:?}: Off must emit no compression markers"
+            );
+        }
+    }
+
+    #[test]
+    fn rendered_carrier_block_is_seen_as_carrying_compression() {
+        // The detection helper that coverage/dedup rely on must agree with the
+        // writer's output (the bug this slice fixes: it previously never did).
+        let dedicated = render(false, Wrapper::Dedicated, CompressionLevel::Lite);
+        assert!(crate::core::rules_channel::carries_full_rules(&dedicated));
+        assert!(dedicated.contains(COMPRESSION_BLOCK_START));
     }
 
     // --- Wrapper round-trip ---

--- a/rust/src/core/rules_channel.rs
+++ b/rust/src/core/rules_channel.rs
@@ -16,9 +16,10 @@
 use std::path::Path;
 
 /// Markers of the heavy compression / output-style block — the per-turn payload
-/// that actually drives cross-channel duplication.
-pub const COMPRESSION_BLOCK_START: &str = "<!-- lean-ctx-compression -->";
-pub const COMPRESSION_BLOCK_END: &str = "<!-- /lean-ctx-compression -->";
+/// that actually drives cross-channel duplication. Defined in `rules_canonical`
+/// (the single marker source of truth) and re-exported here so the coverage/dedup
+/// readers and the `render()` writer can never disagree (#548).
+pub use crate::core::rules_canonical::{COMPRESSION_BLOCK_END, COMPRESSION_BLOCK_START};
 
 /// The agents that auto-load the shared project `AGENTS.md`. Kept in sync with
 /// `core::rules_overhead::collect_rules_files`, which attributes `AGENTS.md` to
@@ -211,5 +212,35 @@ mod tests {
         // Empty / unknown clients never auto-load a file copy.
         assert!(!client_autoloads_compression("", home));
         assert!(!client_autoloads_compression("some-other-agent", home));
+    }
+
+    #[test]
+    fn render_output_is_detected_as_compression_coverage() {
+        // The slice's core guarantee (#548 B2): the bytes the writer (`render`)
+        // emits into a carrier file are recognised by the coverage detection the
+        // MCP cross-channel dedup depends on. Before the unified marker model,
+        // render embedded the prompt inline (no markers) so this was always
+        // false → Cursor was billed for the compression block twice (rule file +
+        // every MCP session).
+        use crate::core::config::CompressionLevel;
+        use crate::core::rules_canonical::{Wrapper, render};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        assert!(!cursor_compression_covered(home));
+
+        // Exactly what `rules_content`/inject writes to the Cursor mdc (frontmatter
+        // is irrelevant to substring detection).
+        let block = render(false, Wrapper::Dedicated, CompressionLevel::Standard);
+        std::fs::create_dir_all(home.join(".cursor/rules")).unwrap();
+        std::fs::write(home.join(".cursor/rules/lean-ctx.mdc"), &block).unwrap();
+
+        assert!(cursor_compression_covered(home));
+        assert!(client_autoloads_compression("cursor", home));
+
+        // An Off render carries no payload, so it must NOT count as coverage.
+        let off = render(false, Wrapper::Dedicated, CompressionLevel::Off);
+        std::fs::write(home.join(".cursor/rules/lean-ctx.mdc"), &off).unwrap();
+        assert!(!cursor_compression_covered(home));
     }
 }


### PR DESCRIPTION
## Summary

Fourth and final code slice of the #548 agent-rules unification. Closes the **"one canonical carrier/marker model for compression rules"** acceptance criterion.

**The bug.** `rules_canonical::render` embedded the output-style compression prompt *inline* inside the `<!-- lean-ctx-rules -->` block with no delimiters, but the coverage/dedup readers (`rules_channel`, `rules dedup`) detect the payload via a *separate* `<!-- lean-ctx-compression -->` … `<!-- /lean-ctx-compression -->` block. The writer never emitted those markers, so on every freshly written rule file:

- `cursor_compression_covered` / `client_autoloads_compression` were **always false** → the MCP per-session instructions kept repeating the compression block even for Cursor/Codex that already load it from their own rule file (**double billing** every session).
- `rules dedup` could **not** thin a render-produced shared `AGENTS.md` (the `StripCompression` action never matched).

**The fix — one model.**
- The `COMPRESSION_BLOCK_*` markers now live in `rules_canonical` (the single marker source of truth) and are re-exported from `rules_channel` (zero call-site churn).
- `render()` wraps the compression prompt in those markers for the **persistent carriers** (`Dedicated` / `Shared` — every injected rule file).
- The ephemeral `Bare` MCP-instructions channel stays **unmarked by design**: its inclusion is *governed* by carrier coverage (`client_autoloads_compression`), so a per-session marker would be pure noise (and would tax the static instruction budget).
- Content-aware freshness (B1) re-propagates the new block on the next `sync` **without a version bump**, so existing installs self-heal.

## Test plan
- [x] `cargo test --lib` — 6064 passed, 0 failed
- [x] New unit tests: carriers wrap compression / `Bare` does not / `Off` emits no markers / `render`-produced carrier block is detected as coverage (`rules_channel`)
- [x] `cargo test --test terse_agent_tests --test rules_template_tool_names` — green (MCP `Bare` compression presence/absence unchanged)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Part of #548.

Made with [Cursor](https://cursor.com)