### PR TITLE
fix(read): omit empty [techniques] field in entropy/density output (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (gitlab #868–#871)
 
 ### Fixed
+- **`ctx_read` left an empty ` []` metadata field on incompressible files (#509).**
+  The `entropy` (and `density`) read modes append a ` [techniques…]` tag listing
+  which compression techniques fired. On a file where none did (high-entropy, no
+  duplicate blocks) the technique list is empty, so the header rendered a bare
+  ` H̄=4.2 []` — the same empty-trailing-field waste fixed for
+  `ctx_semantic_search`'s `(rrf: X, )` in #511. A `techniques_tag` helper now omits
+  the bracket segment entirely when the list is empty (and keeps the leading space
+  + `[a, b]` form otherwise), so the header is clean on both paths. (#509-A output
+  audit; output stays a deterministic function of content/mode per #498.)
 - **Pi `AGENTS.md` advertised renamed tools that no longer exist (#548).** The Pi
   installer writes a curated static `templates/PI_AGENTS.md`, and its tool-mapping
   table still listed `ctx_grep`/`ctx_find`/`ctx_ls` — tools renamed long ago to

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -45,6 +45,18 @@ impl<'a> ReadTuning<'a> {
     }
 }
 
+/// Render a trailing ` [a, b]` techniques tag, or `""` when no compression
+/// technique fired. Avoids the empty ` []` metadata field a bare `join` would
+/// leave on an incompressible file (#509 output-waste audit, same class as the
+/// `ctx_semantic_search` `(rrf: X, )` fix in #511).
+fn techniques_tag(techniques: &[String]) -> String {
+    if techniques.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", techniques.join(", "))
+    }
+}
+
 pub(crate) fn format_full_output(
     file_ref: &str,
     short: &str,
@@ -439,8 +451,11 @@ pub(crate) fn process_mode_tuned(
             };
             let avg_h = entropy::analyze_entropy(content).avg_entropy;
             let header = build_header(file_ref, short, ext, content, line_count, false);
-            let techs = result.techniques.join(", ");
-            let output = format!("{header} H̄={avg_h:.1} [{techs}]\n{}", result.output);
+            let output = format!(
+                "{header} H̄={avg_h:.1}{}\n{}",
+                techniques_tag(&result.techniques),
+                result.output
+            );
             let sent = count_tokens(&output);
             let savings = protocol::format_savings(original_tokens, sent);
             let compression_ratio = if original_tokens > 0 {
@@ -556,16 +571,15 @@ pub(crate) fn process_mode_tuned(
             } else {
                 0.0
             };
-            let techs = result.techniques.join(", ");
+            let techs = techniques_tag(&result.techniques);
+            let target_clamped = target.clamp(0.05, 1.0);
             let header = if crate::core::protocol::meta_visible() && !file_ref.is_empty() {
                 format!(
-                    "{file_ref}={short} {line_count}L density target={:.2} actual={actual:.2} [{techs}]",
-                    target.clamp(0.05, 1.0)
+                    "{file_ref}={short} {line_count}L density target={target_clamped:.2} actual={actual:.2}{techs}"
                 )
             } else {
                 format!(
-                    "{short} {line_count}L density target={:.2} actual={actual:.2} [{techs}]",
-                    target.clamp(0.05, 1.0)
+                    "{short} {line_count}L density target={target_clamped:.2} actual={actual:.2}{techs}"
                 )
             };
             let output = format!("{header}\n{}", result.output);
@@ -686,5 +700,33 @@ pub(crate) fn extract_line_range(content: &str, range_str: &str) -> String {
         "No lines matched the range.".to_string()
     } else {
         selected.join("\n")
+    }
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::techniques_tag;
+
+    #[test]
+    fn techniques_tag_omits_empty_brackets() {
+        // An incompressible file leaves no techniques — the header must not
+        // carry an empty ` []` field (#509 output-waste audit).
+        assert_eq!(techniques_tag(&[]), "");
+    }
+
+    #[test]
+    fn techniques_tag_wraps_nonempty_with_leading_space() {
+        assert_eq!(
+            techniques_tag(&["⊘ 3 low-entropy lines".to_string(), "⊘ 2 dups".to_string()]),
+            " [⊘ 3 low-entropy lines, ⊘ 2 dups]"
+        );
+    }
+
+    #[test]
+    fn techniques_tag_single() {
+        assert_eq!(
+            techniques_tag(&["density target=0.40".to_string()]),
+            " [density target=0.40]"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Small #509-A output-waste fix. The `entropy` / `density` read modes append a ` [techniques…]` tag listing which compression techniques fired. On an **incompressible** file (high-entropy, no duplicate blocks) the technique list is empty, so the header rendered a bare ` H̄=4.2 []` — the same empty-trailing-field waste already fixed for `ctx_semantic_search`'s `(rrf: X, )` in #511.

A new `techniques_tag` helper omits the bracket segment entirely when the list is empty (and keeps the leading-space `[a, b]` form otherwise), applied to both the entropy and density headers.

- Output stays a deterministic function of `(content, mode)` (#498) — only the *empty* case changes (`… []` → `…`).
- `ctx_graph_diff::flags` already uses this exact guard pattern; this brings `ctx_read` in line.

## Test plan
- [x] New unit tests: `techniques_tag` empty → `""`, non-empty → ` [a, b]`, single
- [x] `cargo test --lib` — 6067 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Part of #509 (output-waste audit of the most-used tools).

Made with [Cursor](https://cursor.com)