### PR TITLE
fix(stats): report daemon status on Windows in gain footer (#576)

### DIFF
--- a/rust/src/core/gain/mod.rs
+++ b/rust/src/core/gain/mod.rs
@@ -115,7 +115,8 @@ impl GainEngine {
             None
         };
         let score = GainScore::compute(&self.stats, &self.costs, &self.pricing, model);
-        #[cfg(unix)]
+        // is_daemon_running() is cross-platform; the old #[cfg(not(unix))] = None
+        // branch suppressed daemon state on Windows. See #576.
         let daemon_hint = if crate::daemon::is_daemon_running() {
             None
         } else {
@@ -124,8 +125,6 @@ impl GainEngine {
                     .to_string(),
             )
         };
-        #[cfg(not(unix))]
-        let daemon_hint: Option<String> = None;
         let injected_overhead_tokens_per_turn =
             crate::core::context_overhead::ContextOverhead::cached().total_tokens() as u64;
         // Reconcile to the real bill: the proxy is the only component that sees

--- a/rust/src/core/stats/format/dashboard.rs
+++ b/rust/src/core/stats/format/dashboard.rs
@@ -690,10 +690,11 @@ fn append_gain_footer(out: &mut Vec<String>, t: &Theme, store: &StatsStore) {
             }
         }
 
-        #[cfg(unix)]
+        // is_daemon_running() is cross-platform (reads daemon.pid + ipc::process::is_alive,
+        // which has a Windows OpenProcess impl). The old #[cfg(not(unix))] = false branch
+        // hardcoded "offline" on Windows even when `serve --status` reported the daemon
+        // running — gating away a working check. See #576.
         let daemon_running = crate::daemon::is_daemon_running();
-        #[cfg(not(unix))]
-        let daemon_running = false;
 
         if daemon_running {
             ctx_items.push(format!("   Daemon: {c}running{rst}", c = t.success.fg()));


### PR DESCRIPTION
## What

On Windows, `gain --deep`'s Context OS footer always printed `Daemon: offline` even while `serve --status` reported the daemon running.

Root cause — `core/stats/format/dashboard.rs`:

```rust
#[cfg(unix)]
let daemon_running = crate::daemon::is_daemon_running();
#[cfg(not(unix))]
let daemon_running = false;   // Windows hardcoded offline
```

The `#[cfg(not(unix))]` branch hardcoded `false`, so the footer never reflected real daemon state on Windows. `daemon::is_daemon_running()` is already cross-platform (reads `daemon.pid` + `ipc::process::is_alive`, which has a Windows `OpenProcess`/`GetExitCodeProcess` impl and is the exact path `serve --status` uses), so the gate threw away a working check for no reason.

The sibling daemon-hint in `core/gain/mod.rs` had the same gate (forced `None` on Windows) and is fixed the same way.

Fixes #576.

## Test plan

Built the binary and ran `gain --deep` on Windows 11 against a live daemon:

| Daemon state | `gain --deep` footer |
|---|---|
| running (PID 10448) | `Daemon: running` |
| stopped | `Daemon: offline` |
| restarted | `Daemon: running` |

`serve --status` agreed in every case. Before this change the same scenarios all printed `Daemon: offline`.

Commands run (from `rust/`):

```
cargo fmt --check          # clean
cargo check                # green
cargo build --bin lean-ctx # green
target/debug/lean-ctx gain --deep   # observed the table above
```
