### PR TITLE
fix(updater): validate TLS against the OS trust store (ureq PlatformVerifier)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -475,6 +475,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cff-parser"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,6 +2191,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2192,7 +2214,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -2211,6 +2233,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3945,7 +3976,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -4177,13 +4208,34 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -5813,6 +5865,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
  "socks",
  "ureq-proto",
  "utf8-zero",
@@ -6437,6 +6490,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6469,6 +6531,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6515,6 +6592,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6527,6 +6610,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6536,6 +6625,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6563,6 +6658,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6572,6 +6673,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6587,6 +6694,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6596,6 +6709,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -187,7 +187,9 @@ tree-sitter-c-sharp = { version = "0.23", optional = true }
 tree-sitter-kotlin-ng = { version = "1.1", optional = true }
 tree-sitter-swift = { version = "0.7", optional = true }
 tree-sitter-php = { version = "0.24", optional = true }
-ureq = "3.3"
+# platform-verifier: validate TLS against the OS trust store (corp proxy CAs),
+# not just compiled-in webpki-roots. Opt-in per-agent via RootCerts::PlatformVerifier.
+ureq = { version = "3.3", features = ["platform-verifier"] }
 # PDF → text extraction for ctx_url_read (research context layer).
 # 0.12 pulls lopdf >=0.42 (RUSTSEC-2026-0187: stack overflow on deeply nested PDFs).
 pdf-extract = "0.12"

--- a/rust/src/core/updater.rs
+++ b/rust/src/core/updater.rs
@@ -655,10 +655,25 @@ fn release_api_url(version: Option<&str>) -> String {
     }
 }
 
+/// ureq agent that trusts the OS store (incl. corporate proxy CAs) via the
+/// platform verifier. ureq's default `RootCerts::WebPki` ignores the system
+/// store, so updates fail with `UnknownIssuer` behind TLS-intercepting proxies.
+fn https_agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+                .build(),
+        )
+        .build()
+        .into()
+}
+
 /// Fetches release metadata from GitHub. `version = None` returns the latest
 /// release; `Some(v)` returns the specific tagged release for version pinning.
 fn fetch_release(version: Option<&str>) -> Result<serde_json::Value, String> {
-    let response = ureq::get(&release_api_url(version))
+    let response = https_agent()
+        .get(&release_api_url(version))
         .header("User-Agent", &format!("lean-ctx/{CURRENT_VERSION}"))
         .header("Accept", "application/vnd.github.v3+json")
         .call()
@@ -701,7 +716,8 @@ fn find_asset_url(release: &serde_json::Value, asset_name: &str) -> Option<Strin
 }
 
 fn download_bytes(url: &str) -> Result<Vec<u8>, String> {
-    let response = ureq::get(url)
+    let response = https_agent()
+        .get(url)
         .header("User-Agent", &format!("lean-ctx/{CURRENT_VERSION}"))
         .call()
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
## What

Make `lean-ctx update` validate TLS certificates against the OS trust store so it works behind corporate TLS-intercepting proxies (SASE / TLS inspection), where the proxy's CA lives in the system store.

Fixes #578 

## Why

ureq's `TlsConfig::default()` uses `RootCerts::WebPki` (the compiled-in webpki-roots bundle) and ignores the OS trust store. The updater calls the free `ureq::get`/`ureq::post` functions, which inherit that default, so any host whose chain terminates in a corporate CA fails with `UnknownIssuer`, even though curl/git/pip/npm/browsers on the same machine succeed.

## Changes

- `rust/Cargo.toml`: enable the `platform-verifier` feature on `ureq`.
- `rust/src/core/updater.rs`: add an `https_agent()` helper that builds a ureq agent with `RootCerts::PlatformVerifier`, and route `fetch_release()` /  `download_bytes()` through it. The local health check against   `http://127.0.0.1` is left on the default agent (plain HTTP, no TLS).

## Scope

Intentionally narrow: only the updater's HTTPS calls are changed. We could follow up with the same agent pattern for the other ureq callers (`doctor`, `cloud_client`, `report`) so they behave consistently behind the same proxies.


## Test plan

- [ ] `cd rust && cargo test` — not run on my side: this corporate network (TLS-intercepting proxy) throttles the `rmcp` crate download from crates.io, so a clean full build can't complete here. Should pass in CI.
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — same as above; not run locally for the same reason.
- [x] `cd rust && cargo fmt --check` — passes.
- [ ] If cookbook/packages changed: relevant `npm test` / build steps — N/A, no cookbook/package changes.

## Notes for reviewers

- Risk areas / edge cases:
  - Scope is limited to the updater's outbound HTTPS calls (`fetch_release`,  `download_bytes`), now routed through an agent built with `RootCerts::PlatformVerifier`. The localhost health check over plain `http://127.0.0.1` is intentionally left on the default agent (no TLS).
  - `PlatformVerifier` delegates to the OS trust store. On a normal machine that store already contains the public roots, so non-proxied environments are unaffected; behind a TLS-intercepting proxy it now picks up the corporate CA.
- Backwards compatibility:
  - No API or behavior change for end users. The update flow works exactly as before on machines without TLS interception, and additionally succeeds on machines where the trust anchor lives in the OS store.
  - Adds the `platform-verifier` feature to the existing `ureq` dependency; no new top-level dependency and no MSRV change.
- Docs updated (links/files): none required — internal behavior change only.

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
