### PR TITLE
fix(ctx_tools): build own runtime on CLI call path (no ambient Tokio reactor)

### DIFF
--- a/rust/src/tools/ctx_tools.rs
+++ b/rust/src/tools/ctx_tools.rs
@@ -2,8 +2,10 @@
 //!
 //! Keeps the registered wrapper thin: this module owns config gating, action
 //! routing, and driving the async [`gateway`] from the synchronous tool
-//! handler. The dispatch layer already wraps handlers in `block_in_place`, so
-//! blocking on the current runtime here is safe (same pattern as `ctx_read`).
+//! handler. The MCP dispatch layer wraps handlers in `block_in_place`, so an ambient
+//! runtime handle is available there. The CLI `call` path has no ambient
+//! runtime, so `run` falls back to building its own current_thread runtime
+//! (see `Rt`) instead of panicking on `Handle::current()`.
 
 use serde_json::{Map, Value};
 
@@ -18,6 +20,23 @@ const DISABLED_HINT: &str = "gateway is disabled. Enable it in ~/.lean-ctx/confi
      transport = \"stdio\"\n\
      command = \"mcp-server-filesystem\"\n\
      args = [\"/path/to/dir\"]";
+
+/// Runtime adapter so the `rt.block_on(...)` call sites stay identical whether
+/// we run inside the MCP server's runtime (ambient `Handle`) or from the CLI
+/// `call` path, which has no ambient runtime and needs its own.
+enum Rt {
+    Handle(tokio::runtime::Handle),
+    Owned(tokio::runtime::Runtime),
+}
+
+impl Rt {
+    fn block_on<F: std::future::Future>(&self, fut: F) -> F::Output {
+        match self {
+            Rt::Handle(h) => h.block_on(fut),
+            Rt::Owned(r) => r.block_on(fut),
+        }
+    }
+}
 
 /// Execute a `ctx_tools` action, returning response text or an error message.
 pub fn run(args: &Map<String, Value>) -> Result<String, String> {
@@ -34,7 +53,16 @@ pub fn run(args: &Map<String, Value>) -> Result<String, String> {
     }
 
     let action = args.get("action").and_then(Value::as_str).unwrap_or("find");
-    let rt = tokio::runtime::Handle::current();
+    let rt = match tokio::runtime::Handle::try_current() {
+        Ok(h) => Rt::Handle(h), // MCP path: dispatch already did block_in_place
+        Err(_) => Rt::Owned(
+            // CLI path: no ambient runtime → make a one-shot current_thread one
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| format!("failed to start runtime for gateway: {e}"))?,
+        ),
+    };
 
     match action {
         "find" => {
@@ -97,5 +125,16 @@ mod tests {
         if let Err(e) = out {
             assert!(e.contains("gateway is disabled") || e.contains("no downstream"));
         }
+    }
+
+    /// CLI-Pfad-Regression (#ctx_tools): `run` wird OHNE ambienten Tokio-Runtime
+    /// aufgerufen (wie `lean-ctx call ctx_tools …`). Früher paniced
+    /// `Handle::current()` hier ("no reactor running"); jetzt baut `run` selbst
+    /// einen current_thread-Runtime. Erwartung: Ok | Err, aber NIEMALS Panik.
+    #[test]
+    fn run_without_ambient_runtime_does_not_panic() {
+        crate::test_env::remove_var("LEAN_CTX_GATEWAY");
+        let args = json!({ "action": "list" });
+        let _ = run(args.as_object().unwrap()); // Ok|Err, niemals Panic
     }
 }


### PR DESCRIPTION
## Summary

`lean-ctx call ctx_tools …` (the CLI `call` path) panicked with *"there is no
reactor running, must be called from the context of a Tokio 1.x runtime"*.

Root cause: `ctx_tools::run()` resolved the runtime via
`tokio::runtime::Handle::current()`. On the **MCP** path the dispatch layer wraps
handlers in `block_in_place`, so an ambient runtime handle exists. The **CLI**
`call` path has no ambient runtime, so `Handle::current()` panicked.

Fix (pure control flow, no output bytes change):

- Add a module-private `Rt` enum adapter (`Handle(Handle)` | `Owned(Runtime)`)
  with a single `block_on` method, so the four `rt.block_on(...)` call sites
  (`find` / `list` / `refresh` / `call`) stay byte-identical.
- Replace `Handle::current()` with `Handle::try_current()`:
  - `Ok(handle)` → MCP path, unchanged behavior.
  - `Err(_)` → CLI path, build a one-shot `current_thread` runtime instead of
    panicking.
- Fix the now-stale module doc comment.
- Add a regression test `run_without_ambient_runtime_does_not_panic` that calls
  `run()` with no ambient runtime (asserts Ok|Err, never a panic).

The MCP path (`Ok(handle)` branch) is behaviorally unchanged.

## Test plan

- [x] `cd rust && cargo nextest run run_without_ambient_runtime_does_not_panic disabled_gateway_returns_hint` → 2 passed (this repo uses `cargo nextest`, not `cargo test`)
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` → zero warnings
- [x] `cd rust && cargo fmt --check` → clean
- [x] No cookbook/packages changes (single `.rs` file)

## Notes for reviewers

- Risk areas / edge cases: a fresh `current_thread` runtime is built per CLI
  `call` invocation; `enable_all()` keeps timer/IO drivers available for the
  `gateway::*` futures. The MCP path keeps using the ambient handle and is
  unchanged.
- Backwards compatibility: fully backwards compatible — the MCP path is
  byte-identical; only the previously-panicking CLI path changes.
- Docs updated (links/files): only the in-file module doc comment.
