### PR TITLE
Adopt #581 reference wins: unified root resolution (#580) + ctx_search unification (#509) + parallel incremental BM25 (#581)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,17 @@ jobs:
             "$CARGO" test --all-features -- --test-threads=1
           fi
 
+      # #581: lock in the parallel BM25 (incremental) rebuild win against silent
+      # regression. Timing is only meaningful on a quiet, single-threaded runner,
+      # so the gate is env-opt-in (no-op in the matrix above) and runs once here.
+      - name: BM25 build-time regression gate (#581)
+        if: runner.os == 'Linux'
+        working-directory: rust
+        shell: bash
+        env:
+          LEAN_CTX_PERF_GATE: "1"
+        run: cargo test --all-features --lib -- --test-threads=1 parallel_incremental_rebuild_perf_gate --nocapture
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -577,20 +577,19 @@ Parameters: `action`*, `agent`
 
 ## `ctx_search`
 
-Regex pattern search — use when you know the exact pattern. For understanding code or
-finding answers, use ctx_compose FIRST (one call replaces search+read+symbol chains).
-pattern required; include='*.rs'; path scopes; max_results=N (default 20).
-paths=['dir1','dir2'] for multi-root. ignore_gitignore bypasses .gitignore (needs role).
+Search code; `action` picks the engine. regex (default): exact pattern, `pattern`
+required, include='*.rs', paths=[..] multi-root. semantic: by meaning (BM25+embeddings),
+`query`, mode=bm25|dense|hybrid. symbol: one symbol's body by `name` (AST-precise),
+file/kind narrow. reindex / find_related(file_path,line). For end-to-end understanding,
+use ctx_compose FIRST.
 
-Parameters: `ignore_gitignore`, `include`, `max_results`, `path`, `paths`, `pattern`*
+Parameters: `action`, `file`, `file_path`, `include`, `kind`, `line`, `max_results`, `mode`, `name`, `path`, `paths`, `pattern`, `query`, `top_k`
 
 ## `ctx_semantic_search`
 
-Search code by MEANING (BM25+embeddings) — use when you know the concept but not the exact
-symbol name. query='user auth' finds relevant code even with no keyword match.
-Different from ctx_search (regex): use ctx_search for exact patterns, this for
-fuzzy/conceptual. For understanding code end-to-end, use ctx_compose FIRST.
-find_related(file_path, line) for context neighbors. mode=bm25|dense|hybrid.
+[Deprecated → ctx_search action="semantic"] Search code by meaning (BM25+embeddings);
+reindex / find_related are ctx_search actions too. Hidden from tools/list but still
+callable for one release — prefer ctx_search.
 
 Parameters: `action`, `file_path`, `languages`, `line`, `mode`, `path`, `path_glob`, `query`*, `top_k`
 
@@ -656,11 +655,9 @@ Parameters: `action`, `query`, `top_k`
 
 ## `ctx_symbol`
 
-Get ONE symbol's body by name — exact, AST-precise (tree-sitter index).
-WORKFLOW: after ctx_compose gave overview, for one symbol's body.
-name='fnName' returns code block; file='path.rs' narrows;
-kind='fn'|'struct'|'class'|'trait'|'enum' disambiguates.
-ANTIPATTERN: NOT for finding all usages (grep) or exploring areas (ctx_compose).
+[Deprecated → ctx_search action="symbol"] Get one symbol's body by name (AST-precise);
+optional file/kind narrow. Hidden from tools/list but still callable for one release —
+prefer ctx_search.
 
 Parameters: `file`, `kind`, `name`*
 

--- a/rust/src/core/bm25_index/build.rs
+++ b/rust/src/core/bm25_index/build.rs
@@ -122,6 +122,42 @@ fn prepare_file(
     })
 }
 
+/// Per-file work for the incremental rebuild, mirroring the sequential branch:
+/// reuse the previous chunks when the file is unchanged and they carry content,
+/// otherwise re-`prepare_file`. Crucially, reused chunks are re-prepared (enrich
+/// → tokenize → lowercase) here too, so the *whole* tokenization — not just the
+/// changed files — runs on the rayon pool, off the serial merge. The reuse guard
+/// (`state` match + non-empty first chunk) and the changed-file fallthrough match
+/// `rebuild_incremental_sequential` exactly, keeping the two paths in lock-step.
+fn prepare_incremental_file(
+    root: &Path,
+    prev: &BM25Index,
+    old_by_file: &HashMap<String, Vec<CodeChunk>>,
+    content_hint: &HashMap<String, String>,
+    rel: &str,
+) -> Option<PreparedFile> {
+    let abs = root.join(rel);
+    let state = IndexedFileState::from_path(&abs)?;
+
+    let unchanged = prev.files.get(rel).is_some_and(|old| *old == state);
+    if unchanged
+        && let Some(chunks) = old_by_file.get(rel)
+        && chunks.first().is_some_and(|c| !c.content.is_empty())
+    {
+        return Some(PreparedFile {
+            rel: rel.to_string(),
+            state,
+            chunks: chunks.iter().cloned().map(prepare_chunk).collect(),
+        });
+    }
+
+    // Changed / new / previously-empty: full prepare. The size guard and content
+    // resolution live in `prepare_file`; for a changed file the resident content
+    // cache fails its (mtime, size) validation and falls through to a fresh disk
+    // read, so the bytes match the sequential path's direct read.
+    prepare_file(root, rel, content_hint)
+}
+
 impl BM25Index {
     /// Deterministic parallel full build. Fans per-file parse + tokenize across a
     /// rayon pool (order-preserving `par_iter().collect()`), then merges
@@ -138,6 +174,43 @@ impl BM25Index {
         let prepared: Vec<Option<PreparedFile>> = files
             .par_iter()
             .map(|rel| prepare_file(root, rel, content_hint))
+            .collect();
+
+        let mut index = Self::new();
+        for pf in prepared.into_iter().flatten() {
+            for pc in pf.chunks {
+                index.add_prepared(pc);
+            }
+            index.files.insert(pf.rel, pf.state);
+        }
+        index.finalize();
+        index
+    }
+
+    /// Deterministic parallel incremental rebuild (#581). Fans **all** per-file
+    /// tokenization across the rayon pool — changed files through the full
+    /// `prepare_file`, unchanged files by re-`prepare_chunk`-ing their reused
+    /// chunks — then merges sequentially in file order via `add_prepared`. The
+    /// result is identical to [`Self::rebuild_incremental_sequential`] for the same
+    /// inputs (same file order, same chunk order, same postings / `doc_freqs`),
+    /// upholding the determinism contract (#498). See `tests.rs`
+    /// (`parallel_incremental_matches_sequential`).
+    pub(crate) fn rebuild_incremental_parallel(
+        root: &Path,
+        prev: &BM25Index,
+        old_by_file: &HashMap<String, Vec<CodeChunk>>,
+        files: &[String],
+    ) -> Self {
+        // No per-build content hint for a rebuild; `prepare_file` falls back to the
+        // resident content cache (validated) then disk.
+        let empty_hint: HashMap<String, String> = HashMap::new();
+
+        // Order-preserving `par_iter().collect()` keeps the input file order, so
+        // the merge below sees files in the same order the sequential rebuild
+        // iterates — the foundation of identical output.
+        let prepared: Vec<Option<PreparedFile>> = files
+            .par_iter()
+            .map(|rel| prepare_incremental_file(root, prev, old_by_file, &empty_hint, rel))
             .collect();
 
         let mut index = Self::new();

--- a/rust/src/core/bm25_index/mod.rs
+++ b/rust/src/core/bm25_index/mod.rs
@@ -298,7 +298,11 @@ impl BM25Index {
         Self::build_sequential(root, content_hint, &files)
     }
 
-    pub fn rebuild_incremental(root: &Path, prev: &BM25Index) -> Self {
+    /// Group a previous index's chunks by file, each file's list sorted by
+    /// (start_line, end_line, symbol_name) — the deterministic reuse order shared
+    /// by both incremental rebuild paths (and the equivalence test, so it feeds
+    /// them identical inputs).
+    fn group_prev_chunks_by_file(prev: &BM25Index) -> HashMap<String, Vec<CodeChunk>> {
         let mut old_by_file: HashMap<String, Vec<CodeChunk>> = HashMap::new();
         for c in &prev.chunks {
             old_by_file
@@ -314,9 +318,40 @@ impl BM25Index {
                     .then_with(|| a.symbol_name.cmp(&b.symbol_name))
             });
         }
+        old_by_file
+    }
 
-        let mut index = Self::new();
+    pub fn rebuild_incremental(root: &Path, prev: &BM25Index) -> Self {
+        let old_by_file = Self::group_prev_chunks_by_file(prev);
         let files = list_code_files(root);
+
+        // #581: mirror `build()`'s dispatch. The edit loop is the hottest path in
+        // daily use, and its serial cost is dominated by re-tokenizing the *many
+        // unchanged* files' reused chunks — not the few changed ones. So the
+        // parallel path fans the entire tokenization (changed files via
+        // `prepare_file`, unchanged via re-`prepare_chunk`) across the rayon pool
+        // and merges sequentially in file order. The sequential path keeps the
+        // per-file memory-pressure early-break and serves small corpora / pressure.
+        // Both produce an identical index (see determinism tests).
+        if files.len() >= build::PARALLEL_MIN_FILES
+            && !crate::core::memory_guard::is_under_pressure()
+            && !crate::core::memory_guard::abort_requested()
+        {
+            return Self::rebuild_incremental_parallel(root, prev, &old_by_file, &files);
+        }
+        Self::rebuild_incremental_sequential(root, prev, &old_by_file, &files)
+    }
+
+    /// Sequential incremental rebuild with per-file memory-pressure guards. Reuses
+    /// unchanged files' chunks and re-extracts changed ones. Used for small
+    /// corpora and as the safe fallback under memory pressure.
+    pub(crate) fn rebuild_incremental_sequential(
+        root: &Path,
+        prev: &BM25Index,
+        old_by_file: &HashMap<String, Vec<CodeChunk>>,
+        files: &[String],
+    ) -> Self {
+        let mut index = Self::new();
         const MAX_FILE_SIZE_BYTES: u64 = 2 * 1024 * 1024;
 
         for (i, rel) in files.iter().enumerate() {

--- a/rust/src/core/bm25_index/tests.rs
+++ b/rust/src/core/bm25_index/tests.rs
@@ -728,7 +728,11 @@ fn parallel_incremental_matches_sequential() {
     // Build the baseline index (the corpus is large enough to take the parallel
     // full-build path), then mutate disk so the rebuild hits all branches.
     let prev = BM25Index::build_from_directory(root);
-    assert!(prev.files.contains_key("src/mod_001.rs"));
+    // `files` keys and `chunk.file_path` keep the OS-native separator (output is
+    // normalized to '/' only at render time, #324); build expected keys the same
+    // way so these lookups also hit on Windows (`src\mod_001.rs`).
+    let key = |rel: &str| rel.replace('/', std::path::MAIN_SEPARATOR_STR);
+    assert!(prev.files.contains_key(&key("src/mod_001.rs")));
 
     // Changed: different body (and size) forces a re-extract.
     std::fs::write(
@@ -760,16 +764,16 @@ fn parallel_incremental_matches_sequential() {
 
     // And the mutation actually exercised every branch (guards against a vacuous
     // pass where nothing changed).
-    assert!(par.files.contains_key("src/mod_000.rs"));
-    assert!(par.files.contains_key("src/mod_new.rs"));
+    assert!(par.files.contains_key(&key("src/mod_000.rs")));
+    assert!(par.files.contains_key(&key("src/mod_new.rs")));
     assert!(
-        !par.files.contains_key("src/mod_001.rs"),
+        !par.files.contains_key(&key("src/mod_001.rs")),
         "removed file must not survive the rebuild"
     );
     assert!(
         par.chunks
             .iter()
-            .any(|c| c.file_path == "src/mod_000.rs" && c.content.contains("recomputed")),
+            .any(|c| c.file_path == key("src/mod_000.rs") && c.content.contains("recomputed")),
         "changed file must be re-extracted with new content"
     );
 }

--- a/rust/src/core/bm25_index/tests.rs
+++ b/rust/src/core/bm25_index/tests.rs
@@ -713,6 +713,161 @@ fn build_from_directory_dispatches_parallel_and_matches_sequential() {
     assert_same_index(&seq, &public);
 }
 
+// ---- #581: parallel incremental rebuild determinism ----
+
+/// Mutate a freshly-built corpus to exercise every incremental branch — a
+/// changed file (re-extract), a new file, a removed file, and many unchanged
+/// files (reuse) — then assert the parallel and sequential incremental rebuilds
+/// produce a byte-identical index over the same `prev` + disk state.
+#[test]
+fn parallel_incremental_matches_sequential() {
+    let td = tempdir().expect("tempdir");
+    let root = td.path();
+    write_parallel_corpus(root, 40);
+
+    // Build the baseline index (the corpus is large enough to take the parallel
+    // full-build path), then mutate disk so the rebuild hits all branches.
+    let prev = BM25Index::build_from_directory(root);
+    assert!(prev.files.contains_key("src/mod_001.rs"));
+
+    // Changed: different body (and size) forces a re-extract.
+    std::fs::write(
+        root.join("src/mod_000.rs"),
+        "pub fn changed_entry() -> usize {\n    let recomputed = 42 + 7;\n    recomputed\n}\n",
+    )
+    .expect("rewrite mod_000");
+    // New file the baseline never saw.
+    std::fs::write(
+        root.join("src/mod_new.rs"),
+        "pub fn brand_new(token: Token) -> Token {\n    token\n}\n",
+    )
+    .expect("write mod_new");
+    // Removed file must drop out of the rebuilt index.
+    std::fs::remove_file(root.join("src/mod_001.rs")).expect("remove mod_001");
+
+    let old_by_file = BM25Index::group_prev_chunks_by_file(&prev);
+    let files = list_code_files(root);
+    assert!(
+        files.len() >= super::build::PARALLEL_MIN_FILES,
+        "corpus must trigger the parallel rebuild path"
+    );
+
+    let seq = BM25Index::rebuild_incremental_sequential(root, &prev, &old_by_file, &files);
+    let par = BM25Index::rebuild_incremental_parallel(root, &prev, &old_by_file, &files);
+
+    // The whole contract: identical chunk order, postings, doc_freqs, file set.
+    assert_same_index(&seq, &par);
+
+    // And the mutation actually exercised every branch (guards against a vacuous
+    // pass where nothing changed).
+    assert!(par.files.contains_key("src/mod_000.rs"));
+    assert!(par.files.contains_key("src/mod_new.rs"));
+    assert!(
+        !par.files.contains_key("src/mod_001.rs"),
+        "removed file must not survive the rebuild"
+    );
+    assert!(
+        par.chunks
+            .iter()
+            .any(|c| c.file_path == "src/mod_000.rs" && c.content.contains("recomputed")),
+        "changed file must be re-extracted with new content"
+    );
+}
+
+/// The public `rebuild_incremental` dispatcher must take the parallel path for a
+/// large corpus yet match an explicit sequential rebuild over the same inputs —
+/// guards the dispatch wiring the way the full-build test guards `build()`.
+#[test]
+fn rebuild_incremental_dispatches_parallel_and_matches_sequential() {
+    let td = tempdir().expect("tempdir");
+    let root = td.path();
+    write_parallel_corpus(root, 40);
+
+    let prev = BM25Index::build_from_directory(root);
+    std::fs::write(
+        root.join("src/mod_005.rs"),
+        "pub fn touched() -> bool {\n    true\n}\n",
+    )
+    .expect("rewrite mod_005");
+
+    let old_by_file = BM25Index::group_prev_chunks_by_file(&prev);
+    let files = list_code_files(root);
+    assert!(files.len() >= super::build::PARALLEL_MIN_FILES);
+
+    let public = BM25Index::rebuild_incremental(root, &prev);
+    let seq = BM25Index::rebuild_incremental_sequential(root, &prev, &old_by_file, &files);
+    assert_same_index(&seq, &public);
+}
+
+/// CI build-time regression gate for the parallel incremental rebuild
+/// (#581, locking in #933). Off by default — wall-clock timing is meaningless
+/// under the concurrent local / nextest runner — so it no-ops unless the CI job
+/// sets `LEAN_CTX_PERF_GATE=1` and runs it on a quiet, single-threaded runner.
+/// Asserts the parallel rebuild is not slower than the sequential one
+/// (best-of-3, generous noise slack) and stays under a catastrophic-blowup
+/// ceiling, without depending on a specific core count.
+#[test]
+fn parallel_incremental_rebuild_perf_gate() {
+    if std::env::var("LEAN_CTX_PERF_GATE").as_deref() != Ok("1") {
+        return; // CI-only gate; no-op elsewhere to avoid timing flakes
+    }
+
+    let td = tempdir().expect("tempdir");
+    let root = td.path();
+    write_parallel_corpus(root, 240);
+
+    let prev = BM25Index::build_from_directory(root);
+    // Touch a handful so the rebuild does real re-extraction on top of the reuse
+    // path; the bulk stays unchanged — the realistic edit-loop shape.
+    for i in [0usize, 60, 120, 180] {
+        std::fs::write(
+            root.join(format!("src/mod_{i:03}.rs")),
+            format!("pub fn touched_{i}() -> usize {{ {i} }}\n"),
+        )
+        .expect("touch file");
+    }
+
+    let old_by_file = BM25Index::group_prev_chunks_by_file(&prev);
+    let files = list_code_files(root);
+
+    let best = |f: &dyn Fn() -> std::time::Duration| (0..3).map(|_| f()).min().unwrap();
+    let seq = best(&|| {
+        let t = std::time::Instant::now();
+        let idx = BM25Index::rebuild_incremental_sequential(root, &prev, &old_by_file, &files);
+        std::hint::black_box(&idx);
+        t.elapsed()
+    });
+    let par = best(&|| {
+        let t = std::time::Instant::now();
+        let idx = BM25Index::rebuild_incremental_parallel(root, &prev, &old_by_file, &files);
+        std::hint::black_box(&idx);
+        t.elapsed()
+    });
+
+    eprintln!(
+        "[perf-gate] incremental rebuild: seq={seq:?} par={par:?} ratio={:.2}",
+        par.as_secs_f64() / seq.as_secs_f64().max(f64::MIN_POSITIVE)
+    );
+
+    // CI-safe gate (plan: "großzügiges CI-sicheres Budget"). The parallel path
+    // must not be *dramatically* slower than sequential: a 2x ceiling flags a path
+    // that serialized and piled on overhead (e.g. a deadlock-y merge), while
+    // tolerating scheduler noise and low-core CI runners where a small fixture's
+    // parallel speedup shrinks. Byte-for-byte equivalence is asserted separately
+    // (parallel_incremental_matches_sequential), so this guard only has to catch a
+    // catastrophic perf regression — not police a tight ratio that would flake.
+    assert!(
+        par.as_secs_f64() <= seq.as_secs_f64() * 2.0,
+        "parallel incremental rebuild regressed: par={par:?} > seq*2 ({:?})",
+        seq.mul_f64(2.0)
+    );
+    // Absolute blowup ceiling, generous for a slow debug CI runner.
+    assert!(
+        par < std::time::Duration::from_secs(30),
+        "parallel incremental rebuild absurdly slow: {par:?}"
+    );
+}
+
 #[test]
 fn parallel_build_search_parity() {
     // End-to-end: the parallel index must rank a query identically to the

--- a/rust/src/core/pathutil.rs
+++ b/rust/src/core/pathutil.rs
@@ -216,10 +216,38 @@ pub fn normalize_tool_path(path: &str) -> String {
     p
 }
 
+/// Agent/IDE CLI config or sandbox directories some clients launch their MCP
+/// server from, but which are never a user's project root. Adopting one as the
+/// project root jails every real repository path out — the root cause of #580
+/// (GitHub Copilot CLI launches from `~/.copilot`; Cursor, Windsurf, Gemini CLI
+/// and LM Studio behave similarly). This is the canonical set: every "is this an
+/// agent dir?" check across the codebase delegates here so the list never drifts.
+pub const AGENT_CONFIG_DIRS: &[&str] = &[
+    ".claude",
+    ".codex",
+    ".codebuddy",
+    ".copilot",
+    ".cursor",
+    ".windsurf",
+    ".gemini",
+    ".lmstudio",
+];
+
+/// Returns `true` if `dir` is — or lies inside — a known agent/IDE config dir
+/// ([`AGENT_CONFIG_DIRS`]). Separator-agnostic so Windows backslash paths
+/// (`C:\Users\me\.copilot`) match too; #580 is a Windows Copilot report.
+pub fn is_agent_config_dir(dir: &Path) -> bool {
+    let s = dir.to_string_lossy().replace('\\', "/");
+    AGENT_CONFIG_DIRS
+        .iter()
+        .any(|name| s.ends_with(&format!("/{name}")) || s.contains(&format!("/{name}/")))
+}
+
 /// Returns `true` if the directory is too broad to be a valid project root.
-/// Rejects home directory, filesystem root, `.` (bare CWD), and agent sandbox
-/// directories (`.claude`, `.codex`). Used to prevent writing project-scoped
-/// data (overlays, policies) into the global `~/.lean-ctx/` data directory.
+/// Rejects the home directory, filesystem root, `.` (bare CWD), and agent/IDE
+/// config directories ([`AGENT_CONFIG_DIRS`]). Used to prevent adopting a bogus
+/// project root and writing project-scoped data into the global `~/.lean-ctx/`
+/// data directory.
 pub fn is_broad_or_unsafe_root(dir: &Path) -> bool {
     if let Some(home) = dirs::home_dir()
         && dir == home
@@ -230,12 +258,7 @@ pub fn is_broad_or_unsafe_root(dir: &Path) -> bool {
     if s == "/" || s == "\\" || s == "." {
         return true;
     }
-    s.ends_with("/.claude")
-        || s.ends_with("/.codex")
-        || s.ends_with("/.codebuddy")
-        || s.contains("/.claude/")
-        || s.contains("/.codex/")
-        || s.contains("/.codebuddy/")
+    is_agent_config_dir(dir)
 }
 
 /// Well-known project markers used to identify project roots.
@@ -800,6 +823,40 @@ mod tests {
     fn broad_root_rejects_agent_dirs() {
         assert!(is_broad_or_unsafe_root(Path::new("/home/user/.claude")));
         assert!(is_broad_or_unsafe_root(Path::new("/home/user/.codex")));
+    }
+
+    #[test]
+    fn broad_root_rejects_copilot_and_friends() {
+        // #580: the previously-missing agent/IDE dirs must now be rejected so
+        // they are never adopted as the project root (the Copilot CLI case).
+        assert!(is_broad_or_unsafe_root(Path::new("/home/user/.copilot")));
+        assert!(is_broad_or_unsafe_root(Path::new("/home/user/.cursor")));
+        assert!(is_broad_or_unsafe_root(Path::new("/home/user/.windsurf")));
+        assert!(is_broad_or_unsafe_root(Path::new("/home/user/.gemini")));
+        assert!(is_broad_or_unsafe_root(Path::new("/home/user/.lmstudio")));
+    }
+
+    #[test]
+    fn agent_config_dir_matches_every_known_client() {
+        for name in AGENT_CONFIG_DIRS {
+            let leaf = format!("/home/user/{name}");
+            assert!(is_agent_config_dir(Path::new(&leaf)), "{leaf}");
+            let nested = format!("/home/user/{name}/mcp");
+            assert!(is_agent_config_dir(Path::new(&nested)), "{nested}");
+        }
+    }
+
+    #[test]
+    fn agent_config_dir_matches_windows_backslash() {
+        // #580 is a Windows Copilot report — backslash paths must match too.
+        assert!(is_agent_config_dir(Path::new(r"C:\Users\me\.copilot")));
+        assert!(is_agent_config_dir(Path::new(r"C:\Users\me\.copilot\mcp")));
+    }
+
+    #[test]
+    fn agent_config_dir_ignores_real_projects() {
+        assert!(!is_agent_config_dir(Path::new("/home/user/code/lean-ctx")));
+        assert!(!is_agent_config_dir(Path::new(r"C:\src\app")));
     }
 
     #[test]

--- a/rust/src/core/tool_profiles.rs
+++ b/rust/src/core/tool_profiles.rs
@@ -41,8 +41,8 @@ impl ToolProfile {
 
     pub fn description(&self) -> &str {
         match self {
-            Self::Minimal => "6 surgical tools — each irreplaceable (recommended)",
-            Self::Standard => "17 balanced tools (adds callgraph, execute, semantics, delta, more)",
+            Self::Minimal => "5 surgical tools — each irreplaceable (recommended)",
+            Self::Standard => "15 balanced tools (adds compose, explore, callgraph, execute, more)",
             Self::Power => "All tools exposed",
             Self::Custom(v) => {
                 if v.is_empty() {
@@ -138,30 +138,33 @@ pub fn is_unpinned_alias(name: &str) -> bool {
 
 /// Surgical core — each tool is irreplaceable. Agent learns <10 tools,
 /// reliably picks the right one for every intent.
+///
+/// #509: symbol lookup folded into `ctx_search` (action="symbol"), so the
+/// former `ctx_symbol` entry is gone — one search entry, not two.
 const MINIMAL_TOOLS: &[&str] = &[
     "ctx_read",
     "ctx_shell",
     "ctx_search",
     "ctx_glob",
     "ctx_tree",
-    "ctx_symbol",
 ];
 
 /// Balanced set. Adds power-user tools the agent picks regularly but
 /// are not essential for every session.
+///
+/// #509: `ctx_semantic_search` and `ctx_symbol` are folded into `ctx_search`
+/// (action="semantic"/"symbol") and dropped from the advertised set.
 const STANDARD_TOOLS: &[&str] = &[
     "ctx_read",
     "ctx_shell",
     "ctx_search",
     "ctx_glob",
     "ctx_tree",
-    "ctx_symbol",
     "ctx_compose",
     "ctx_explore",
     "ctx_knowledge",
     "ctx_callgraph",
     "ctx_graph",
-    "ctx_semantic_search",
     "ctx_delta",
     "ctx_execute",
     "ctx_expand",
@@ -182,13 +185,13 @@ pub fn list_profiles() -> Vec<ProfileInfo> {
     vec![
         ProfileInfo {
             name: "minimal",
-            tool_count: "6",
+            tool_count: "5",
             description: "Surgical core — each tool irreplaceable (recommended)",
         },
         ProfileInfo {
             name: "standard",
-            tool_count: "17",
-            description: "Balanced set — adds callgraph, execute, semantics, explore, delta, more",
+            tool_count: "15",
+            description: "Balanced set — adds compose, explore, callgraph, execute, delta, more",
         },
         ProfileInfo {
             name: "power",
@@ -306,7 +309,9 @@ mod tests {
         assert!(profile.is_tool_enabled("ctx_search"));
         assert!(profile.is_tool_enabled("ctx_glob"));
         assert!(profile.is_tool_enabled("ctx_tree"));
-        assert!(profile.is_tool_enabled("ctx_symbol"));
+        // #509: symbol/semantic lookups are now ctx_search actions, not their
+        // own minimal tools.
+        assert!(!profile.is_tool_enabled("ctx_symbol"));
         assert!(!profile.is_tool_enabled("ctx_semantic_search"));
         assert!(!profile.is_tool_enabled("ctx_callgraph"));
         assert!(!profile.is_tool_enabled("ctx_benchmark"));
@@ -318,17 +323,17 @@ mod tests {
         assert!(profile.is_tool_enabled("ctx_read"));
         assert!(profile.is_tool_enabled("ctx_compose"));
         assert!(profile.is_tool_enabled("ctx_explore"));
-        assert!(profile.is_tool_enabled("ctx_symbol"));
         assert!(profile.is_tool_enabled("ctx_glob"));
-        assert!(profile.is_tool_enabled("ctx_semantic_search"));
         assert!(profile.is_tool_enabled("ctx_callgraph"));
         assert!(profile.is_tool_enabled("ctx_graph"));
         assert!(profile.is_tool_enabled("ctx_delta"));
         assert!(profile.is_tool_enabled("ctx_expand"));
         assert!(profile.is_tool_enabled("ctx_execute"));
         assert!(profile.is_tool_enabled("ctx_overview"));
-        // #509: ctx_multi_read is a deprecated alias folded into ctx_read (paths=…)
-        // and was removed from the Standard set.
+        // #509: ctx_symbol + ctx_semantic_search folded into ctx_search (action=…),
+        // ctx_multi_read into ctx_read (paths=…) — all dropped from Standard.
+        assert!(!profile.is_tool_enabled("ctx_symbol"));
+        assert!(!profile.is_tool_enabled("ctx_semantic_search"));
         assert!(!profile.is_tool_enabled("ctx_multi_read"));
         assert!(profile.is_tool_enabled("ctx_url_read"));
         assert!(!profile.is_tool_enabled("ctx_benchmark"));

--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -1890,10 +1890,7 @@ pub(super) fn lsp_server_outcomes() -> Vec<Outcome> {
 /// real project (LM Studio, Claude, CodeBuddy, Codex). Matches both POSIX (`/`)
 /// and Windows (`\`) separators so the warning fires on every platform.
 fn cwd_looks_like_agent_dir(cwd_str: &str) -> bool {
-    const AGENT_DIRS: [&str; 4] = [".lmstudio", ".claude", ".codebuddy", ".codex"];
-    AGENT_DIRS
-        .iter()
-        .any(|dir| cwd_str.contains(&format!("/{dir}")) || cwd_str.contains(&format!("\\{dir}")))
+    crate::core::pathutil::is_agent_config_dir(std::path::Path::new(cwd_str))
 }
 
 /// Warn if lean-ctx is running as an MCP server from a directory that lacks
@@ -1932,7 +1929,7 @@ pub(super) fn mcp_server_cwd_outcome() -> Outcome {
         Outcome {
             ok: false,
             line: format!(
-                "{BOLD}MCP server CWD{RST}  {RED}suspicious directory without project marker{RST}  {DIM}lean-ctx was launched from {}, which is an IDE/agent config dir without a project root — \"path escapes project root\" errors will occur. Set `cwd` in your MCP client config to a real project directory, or add `allow_auto_reroot = true` + `extra_roots` in config.toml{RST}",
+                "{BOLD}MCP server CWD{RST}  {YELLOW}launched from an IDE/agent config dir{RST}  {DIM}lean-ctx was launched from {}, which is not a project root. It auto-corrects to your real project on the first absolute path (#580); for relative paths to resolve immediately, set `cwd` in your MCP client config to your project directory.{RST}",
                 cwd.display()
             ),
         }

--- a/rust/src/instructions.rs
+++ b/rust/src/instructions.rs
@@ -25,7 +25,29 @@ pub fn build_instructions(crp_mode: CrpMode) -> String {
 
 #[must_use]
 pub fn build_instructions_with_client(crp_mode: CrpMode, client_name: &str) -> String {
-    build_full_instructions(crp_mode, client_name)
+    let cfg = crate::core::config::Config::load();
+    let minimal = cfg.minimal_overhead_effective_for_client(client_name);
+    let shadow = cfg.shadow_mode;
+    // Cross-channel dedup: if the client auto-loads compression from its own rule
+    // file, skip it here to avoid duplicate billing.
+    let level = if client_loads_compression_from_file(client_name) {
+        CompressionLevel::Off
+    } else {
+        CompressionLevel::effective(&cfg)
+    };
+    build_full_instructions(crp_mode, client_name, minimal, level, shadow)
+}
+
+/// Deterministic STATIC Claude Code instructions for the char-budget test: the
+/// cold first-contact handshake surface (skeleton + shell hint + decoder +
+/// CLAUDE.md pointer + guidance). It pins `minimal=true` (the dynamic
+/// session/knowledge/gotcha payload is governed by `INSTRUCTION_CAP_TOKENS`, not
+/// the char budget) plus `level=Off`, `shadow=false` (the default template), so
+/// the result is independent of the developer's local lean-ctx config and the
+/// assertion stays deterministic (#498) for every contributor, not just clean CI.
+#[must_use]
+pub fn claude_code_static_instructions_for_test() -> String {
+    build_full_instructions(CrpMode::Off, "", true, CompressionLevel::Off, false)
 }
 
 /// Deterministic variant for tests (no session/knowledge state).
@@ -154,19 +176,13 @@ pub fn claude_config_dir_display() -> String {
 
 // ── MCP per-session instructions builder ──────────────────────
 
-fn build_full_instructions(crp_mode: CrpMode, client_name: &str) -> String {
-    let cfg = crate::core::config::Config::load();
-    let minimal = cfg.minimal_overhead_effective_for_client(client_name);
-    let shadow = cfg.shadow_mode;
-
-    // Cross-channel dedup: if the client auto-loads compression from its own
-    // rule file, skip it here to avoid duplicate billing.
-    let level = if client_loads_compression_from_file(client_name) {
-        CompressionLevel::Off
-    } else {
-        CompressionLevel::effective(&cfg)
-    };
-
+fn build_full_instructions(
+    crp_mode: CrpMode,
+    client_name: &str,
+    minimal: bool,
+    level: CompressionLevel,
+    shadow: bool,
+) -> String {
     let profile = crate::core::litm::LitmProfile::from_client_name(client_name);
     let loaded_session = if minimal {
         None

--- a/rust/src/server/dynamic_tools.rs
+++ b/rust/src/server/dynamic_tools.rs
@@ -138,6 +138,16 @@ pub fn deprecated_alias(name: &str) -> Option<DeprecatedAlias> {
             replacement: "ctx_read",
             hint: "ctx_read now batch-reads via paths=[\"a.rs\",\"b.rs\"]",
         }),
+        // #509 search consolidation: one ctx_search entry, `action` picks the
+        // engine. Aliases stay callable for one release so nothing breaks.
+        "ctx_semantic_search" => Some(DeprecatedAlias {
+            replacement: "ctx_search",
+            hint: "ctx_search with action=\"semantic\" (query=…); reindex/find_related are actions too",
+        }),
+        "ctx_symbol" => Some(DeprecatedAlias {
+            replacement: "ctx_search",
+            hint: "ctx_search with action=\"symbol\" (name=…, optional file/kind)",
+        }),
         _ => None,
     }
 }
@@ -350,6 +360,17 @@ mod tests {
         assert!(deprecated_alias("ctx_search").is_none());
         assert!(is_deprecated_alias("ctx_multi_read"));
         assert!(!is_deprecated_alias("ctx_read"));
+
+        // #509 search consolidation: the folded search tools point at ctx_search.
+        assert_eq!(
+            deprecated_alias("ctx_semantic_search").unwrap().replacement,
+            "ctx_search"
+        );
+        assert_eq!(
+            deprecated_alias("ctx_symbol").unwrap().replacement,
+            "ctx_search"
+        );
+        assert!(is_deprecated_alias("ctx_symbol"));
     }
 
     #[test]

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -45,6 +45,12 @@ pub fn build_claude_code_instructions_for_test() -> String {
     crate::instructions::claude_code_instructions()
 }
 
+/// Deterministic STATIC Claude Code instructions (cold first-contact, no dynamic
+/// session/knowledge/gotcha payload) for the char-budget benchmark.
+pub fn build_claude_code_static_instructions_for_test() -> String {
+    crate::instructions::claude_code_static_instructions_for_test()
+}
+
 fn is_home_or_agent_dir(dir: &std::path::Path) -> bool {
     if let Some(home) = dirs::home_dir()
         && dir == home

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -51,13 +51,7 @@ fn is_home_or_agent_dir(dir: &std::path::Path) -> bool {
     {
         return true;
     }
-    let dir_str = dir.to_string_lossy();
-    dir_str.ends_with("/.claude")
-        || dir_str.ends_with("/.codebuddy")
-        || dir_str.ends_with("/.codex")
-        || dir_str.contains("/.claude/")
-        || dir_str.contains("/.codebuddy/")
-        || dir_str.contains("/.codex/")
+    crate::core::pathutil::is_agent_config_dir(dir)
 }
 
 fn git_toplevel_from(dir: &std::path::Path) -> Option<String> {

--- a/rust/src/server/tool_visibility.rs
+++ b/rust/src/server/tool_visibility.rs
@@ -213,7 +213,12 @@ mod tests {
         // for one release. Removal is Phase 2.
         let _guard = crate::core::data_dir::isolated_data_dir();
         let defs = crate::server::registry::build_registry().tool_defs();
-        for name in ["ctx_smart_read", "ctx_multi_read"] {
+        for name in [
+            "ctx_smart_read",
+            "ctx_multi_read",
+            "ctx_semantic_search",
+            "ctx_symbol",
+        ] {
             assert!(
                 defs.iter().any(|t| t.name.as_ref() == name),
                 "{name} must stay registered (callable) even though hidden"
@@ -243,9 +248,25 @@ mod tests {
         // surface them.
         let p = ToolProfile::Standard;
         assert!(is_tool_visible("ctx_execute", &p, &[], false, true));
-        assert!(is_tool_visible("ctx_semantic_search", &p, &[], false, true));
+        assert!(is_tool_visible("ctx_explore", &p, &[], false, true));
         assert!(is_tool_visible("ctx_callgraph", &p, &[], false, true));
         assert!(is_tool_visible("ctx_graph", &p, &[], false, true));
+    }
+
+    #[test]
+    fn folded_search_aliases_never_visible() {
+        // #509: ctx_semantic_search + ctx_symbol are consolidated into ctx_search
+        // (action=…). Hidden from tools/list in every mode, but stay callable.
+        let p = ToolProfile::Power;
+        assert!(!is_tool_visible(
+            "ctx_semantic_search",
+            &p,
+            &[],
+            false,
+            true
+        ));
+        assert!(!is_tool_visible("ctx_symbol", &p, &[], false, true));
+        assert!(is_tool_visible("ctx_search", &p, &[], false, true));
     }
 
     #[test]
@@ -353,6 +374,12 @@ mod tests {
     /// into one (`ctx_smart_read` + `ctx_multi_read` are now deprecated aliases
     /// hidden from the surface). The net effect REDUCES the advertised surface; the
     /// only local cost is +~18 tok on `ctx_read`'s schema for the new `paths` arg.
+    ///
+    /// #509 search consolidation (cont.): `ctx_search` now subsumes semantic
+    /// search + symbol lookup via an `action` enum, so `ctx_semantic_search` left
+    /// the core set (it + `ctx_symbol` are deprecated aliases). `ctx_search` grew
+    /// (~196 → ~318 tok) but the core total DROPPED (~2298 → ~2150, one fewer
+    /// tool), so the budgets are left unchanged with comfortable headroom.
     #[test]
     fn core_tool_surface_stays_within_budget() {
         const PER_TOOL_BUDGET: usize = 360;

--- a/rust/src/tool_defs/mod.rs
+++ b/rust/src/tool_defs/mod.rs
@@ -71,8 +71,9 @@ pub const CORE_TOOL_NAMES: &[&str] = &[
     "ctx_read",
     "ctx_shell",
     "shell",
+    // #509: ctx_search now subsumes semantic search + symbol lookup via `action`;
+    // ctx_semantic_search/ctx_symbol are deprecated aliases hidden from the surface.
     "ctx_search",
-    "ctx_semantic_search",
     "ctx_glob",
     "ctx_tree",
     "ctx_session",

--- a/rust/src/tools/ctx_semantic_search.rs
+++ b/rust/src/tools/ctx_semantic_search.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fmt::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::core::bm25_index::{BM25Index, format_search_results};
 use crate::core::embedding_index::EmbeddingIndex;
@@ -23,16 +23,11 @@ pub fn handle(
     workspace: Option<bool>,
     artifacts: Option<bool>,
 ) -> String {
-    let root = Path::new(path);
-    if !root.exists() {
-        return format!("ERR: path does not exist: {path}");
-    }
-
-    let root = if root.is_file() {
-        root.parent().unwrap_or(root)
-    } else {
-        root
+    let (root_buf, subdir) = match resolve_search_root(path) {
+        Ok(v) => v,
+        Err(e) => return format!("ERR: {e}"),
     };
+    let root = root_buf.as_path();
 
     // Query-conditioned IB (#542): remember the latest search query as a
     // fallback relevance signal for subsequent compressed reads.
@@ -45,7 +40,7 @@ pub fn handle(
     }
 
     let filter = match SearchFilter::new(languages, path_glob) {
-        Ok(f) => f,
+        Ok(f) => f.with_subdir(subdir),
         Err(e) => return format!("ERR: invalid filter: {e}"),
     };
 
@@ -155,18 +150,12 @@ pub fn search_hits(
     languages: Option<&[String]>,
     path_glob: Option<&str>,
 ) -> Result<Vec<HybridResult>, String> {
-    let root = Path::new(path);
-    if !root.exists() {
-        return Err(format!("path does not exist: {path}"));
-    }
-    let root = if root.is_file() {
-        root.parent().unwrap_or(root)
-    } else {
-        root
-    };
+    let (root_buf, subdir) = resolve_search_root(path)?;
+    let root = root_buf.as_path();
 
-    let filter =
-        SearchFilter::new(languages, path_glob).map_err(|e| format!("invalid filter: {e}"))?;
+    let filter = SearchFilter::new(languages, path_glob)
+        .map_err(|e| format!("invalid filter: {e}"))?
+        .with_subdir(subdir);
 
     let index = BM25Index::load_or_build(root);
     if index.doc_count == 0 {
@@ -220,35 +209,33 @@ fn bm25_hits(
 /// Rebuilds the BM25 search index for the given directory from scratch.
 #[must_use]
 pub fn handle_reindex(path: &str) -> String {
-    let root = Path::new(path);
-    if !root.exists() {
-        return format!("ERR: path does not exist: {path}");
-    }
-    let root = if root.is_file() {
-        root.parent().unwrap_or(root)
-    } else {
-        root
+    // Promote to the project root so the rebuilt index lands in the same
+    // namespace the search path resolves to (#948) — reindexing a subdirectory
+    // would otherwise build an index the search can never find.
+    let (root_buf, _subdir) = match resolve_search_root(path) {
+        Ok(v) => v,
+        Err(e) => return format!("ERR: {e}"),
     };
+    let root = root_buf.as_path();
 
     let idx = BM25Index::build_from_directory(root);
     let files = idx.files.len();
     let chunks = idx.doc_count;
     let _ = idx.save(root);
 
-    format!("Reindexed {path}: {files} files, {chunks} chunks")
+    format!(
+        "Reindexed {}: {files} files, {chunks} chunks",
+        root.display()
+    )
 }
 
 #[must_use]
 pub fn handle_reindex_artifacts(path: &str, workspace: bool) -> String {
-    let root = Path::new(path);
-    if !root.exists() {
-        return format!("ERR: path does not exist: {path}");
-    }
-    let root = if root.is_file() {
-        root.parent().unwrap_or(root)
-    } else {
-        root
+    let (root_buf, _subdir) = match resolve_search_root(path) {
+        Ok(v) => v,
+        Err(e) => return format!("ERR: {e}"),
     };
+    let root = root_buf.as_path();
 
     let mut roots: Vec<std::path::PathBuf> = vec![root.to_path_buf()];
     let mut warnings: Vec<String> = Vec::new();
@@ -289,10 +276,11 @@ pub fn handle_find_related(
     top_k: usize,
     crp_mode: CrpMode,
 ) -> String {
-    let root = Path::new(project_root);
-    if !root.exists() {
-        return format!("ERR: path does not exist: {project_root}");
-    }
+    let (root_buf, _subdir) = match resolve_search_root(project_root) {
+        Ok(v) => v,
+        Err(e) => return format!("ERR: {e}"),
+    };
+    let root = root_buf.as_path();
 
     let index = BM25Index::load_or_build(root);
     if index.doc_count == 0 {
@@ -1455,9 +1443,55 @@ fn ensure_embeddings(
     Ok((aligned, coverage, all_files))
 }
 
+/// Resolve the index root for a search/index path.
+///
+/// The BM25 namespace is keyed on the detected *project* root (git remote /
+/// build marker), not on the literal search path: `project_identity` inspects
+/// only the exact directory it is handed and never walks up. A search launched
+/// from — or pointed at — a subdirectory therefore hashes to a different,
+/// usually empty namespace and returns zero hits, even though the real index
+/// sits one directory up (#948). Promoting the search path the same way the
+/// build does makes both agree. A genuinely requested subdirectory is kept as a
+/// result-scope filter (second tuple field) rather than becoming its own
+/// namespace.
+fn resolve_search_root(path: &str) -> Result<(PathBuf, Option<String>), String> {
+    let raw = Path::new(path);
+    if !raw.exists() {
+        return Err(format!("path does not exist: {path}"));
+    }
+    let raw_dir = if raw.is_file() {
+        raw.parent().unwrap_or(raw)
+    } else {
+        raw
+    };
+    let root = PathBuf::from(crate::core::protocol::detect_project_root_or_cwd(
+        &raw_dir.to_string_lossy(),
+    ));
+    let subdir = search_subdir_filter(&root, raw_dir);
+    Ok((root, subdir))
+}
+
+/// Project-relative prefix (forward slashes, no leading/trailing slash) for
+/// `requested` under `root`, or `None` when `requested` is the root itself or
+/// not contained in it. Lets a subdirectory search stay scoped after the path
+/// was promoted to the project root for the index namespace.
+fn search_subdir_filter(root: &Path, requested: &Path) -> Option<String> {
+    let root_c = crate::core::pathutil::safe_canonicalize_or_self(root);
+    let req_c = crate::core::pathutil::safe_canonicalize_or_self(requested);
+    let rel = req_c.strip_prefix(&root_c).ok()?;
+    let rel = rel.to_string_lossy().replace('\\', "/");
+    let rel = rel.trim_matches('/').to_string();
+    if rel.is_empty() { None } else { Some(rel) }
+}
+
 struct SearchFilter {
     allowed_exts: Option<HashSet<String>>,
     path_glob: Option<glob::Pattern>,
+    /// Relative directory prefix (forward slashes, no trailing slash) the caller
+    /// scoped the search to. Set when a subdirectory was requested but promoted
+    /// to the project root for the index namespace (#948), so results stay
+    /// restricted to that subtree without a separate (empty) index.
+    subdir: Option<String>,
 }
 
 impl SearchFilter {
@@ -1471,15 +1505,29 @@ impl SearchFilter {
         Ok(Self {
             allowed_exts,
             path_glob,
+            subdir: None,
         })
     }
 
+    /// Scope results to a project-relative subdirectory, in addition to any
+    /// language/glob filters. `None` (or empty) clears the scope.
+    fn with_subdir(mut self, subdir: Option<String>) -> Self {
+        self.subdir = subdir.filter(|s| !s.is_empty());
+        self
+    }
+
     fn is_active(&self) -> bool {
-        self.allowed_exts.is_some() || self.path_glob.is_some()
+        self.allowed_exts.is_some() || self.path_glob.is_some() || self.subdir.is_some()
     }
 
     fn matches(&self, rel_path: &str) -> bool {
         let rel_path = rel_path.replace('\\', "/");
+        if let Some(prefix) = &self.subdir
+            && rel_path != *prefix
+            && !rel_path.starts_with(&format!("{prefix}/"))
+        {
+            return false;
+        }
         if let Some(p) = &self.path_glob
             && !p.matches(&rel_path)
         {
@@ -1612,6 +1660,89 @@ mod filter_tests {
         let f = SearchFilter::new(None, Some("rust/src/**")).unwrap();
         assert!(f.matches("rust/src/core/mod.rs"));
         assert!(!f.matches("website/src/pages/index.astro"));
+    }
+}
+
+#[cfg(test)]
+mod root_resolution_tests {
+    use super::*;
+
+    #[test]
+    fn subdir_filter_scopes_results_to_subtree() {
+        let f = SearchFilter::new(None, None)
+            .unwrap()
+            .with_subdir(Some("crate_a/src".to_string()));
+        assert!(f.is_active());
+        assert!(f.matches("crate_a/src/auth.rs"));
+        assert!(f.matches("crate_a/src/nested/db.rs"));
+        assert!(!f.matches("crate_b/src/auth.rs"));
+        // Boundary: the prefix must be a whole path segment, not a substring.
+        assert!(!f.matches("crate_a/src_extra/x.rs"));
+        // Backslash input is normalized before matching.
+        assert!(f.matches(r"crate_a\src\win.rs"));
+    }
+
+    #[test]
+    fn subdir_filter_combines_with_extension_filter() {
+        let f = SearchFilter::new(Some(&["rust".to_string()]), None)
+            .unwrap()
+            .with_subdir(Some("src".to_string()));
+        assert!(f.matches("src/main.rs"));
+        assert!(!f.matches("src/readme.md"), "wrong extension");
+        assert!(!f.matches("docs/main.rs"), "outside subdir");
+    }
+
+    #[test]
+    fn empty_subdir_is_no_scope() {
+        let f = SearchFilter::new(None, None)
+            .unwrap()
+            .with_subdir(Some(String::new()));
+        assert!(!f.is_active());
+        assert!(f.matches("anything/here.rs"));
+    }
+
+    #[test]
+    fn search_subdir_filter_derives_relative_prefix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let sub = root.join("a").join("b");
+        std::fs::create_dir_all(&sub).unwrap();
+        assert_eq!(search_subdir_filter(root, &sub).as_deref(), Some("a/b"));
+        assert_eq!(search_subdir_filter(root, root), None);
+        // A path that is not under root yields no scope.
+        assert_eq!(search_subdir_filter(&sub, root), None);
+    }
+
+    #[test]
+    fn resolve_search_root_promotes_subdir_to_project_root() {
+        // #948: the index namespace is keyed on the project root; a subdir search
+        // must resolve to that same root (and keep the subdir as a scope) instead
+        // of hashing to a different, empty namespace.
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = crate::core::pathutil::safe_canonicalize_or_self(tmp.path());
+        let sub = root.join("crate_a").join("src");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // Pin the project root so resolution is deterministic regardless of host
+        // config; remove the env before asserting so a failure cannot leak it.
+        crate::test_env::set_var("LEAN_CTX_PROJECT_ROOT", root.to_string_lossy().as_ref());
+        let from_sub = resolve_search_root(&sub.to_string_lossy());
+        let from_root = resolve_search_root(&root.to_string_lossy());
+        crate::test_env::remove_var("LEAN_CTX_PROJECT_ROOT");
+
+        let (resolved, subdir) = from_sub.unwrap();
+        assert_eq!(resolved, root, "subdir must promote to the project root");
+        assert_eq!(subdir.as_deref(), Some("crate_a/src"));
+
+        let (resolved_root, subdir_root) = from_root.unwrap();
+        assert_eq!(resolved_root, root);
+        assert_eq!(subdir_root, None, "the root itself carries no subdir scope");
+    }
+
+    #[test]
+    fn resolve_search_root_errors_on_missing_path() {
+        assert!(resolve_search_root("/definitely/not/here/xyzzy-7f3a91").is_err());
     }
 }
 

--- a/rust/src/tools/mod.rs
+++ b/rust/src/tools/mod.rs
@@ -172,6 +172,92 @@ mod resolve_path_tests {
         );
     }
 
+    #[cfg(not(feature = "no-jail"))]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn resolve_path_auto_reroots_from_agent_config_dir_without_opt_in() {
+        // #580: the MCP server is launched from an agent/IDE config dir
+        // (~/.copilot-style) and wrongly adopts it as the root. With no
+        // `allow_auto_reroot` opt-in and no trusted startup root, the first
+        // absolute path into a real project must still correct the root — an
+        // agent config dir is never a real jail boundary.
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        crate::test_env::remove_var("LEAN_CTX_ALLOW_REROOT");
+        let tmp = tempfile::tempdir().unwrap();
+        let agent = tmp.path().join(".copilot");
+        let real = tmp.path().join("repo");
+        std::fs::create_dir_all(&agent).unwrap();
+        let real_root = create_git_root(&real);
+        std::fs::write(real.join("a.txt"), "ok").unwrap();
+
+        let server = LeanCtxServer::new_with_startup(
+            None,
+            None,
+            SessionMode::Personal,
+            "default",
+            "default",
+        );
+        {
+            let mut session = server.session.write().await;
+            session.project_root = Some(agent.to_string_lossy().to_string());
+            session.shell_cwd = Some(agent.to_string_lossy().to_string());
+        }
+
+        let out = server
+            .resolve_path(&real.join("a.txt").to_string_lossy())
+            .await
+            .unwrap();
+        assert!(
+            out.ends_with("/a.txt"),
+            "agent-dir jail must auto-correct: {out}"
+        );
+
+        let session = server.session.read().await;
+        assert_eq!(session.project_root.as_deref(), Some(real_root.as_str()));
+    }
+
+    #[cfg(not(feature = "no-jail"))]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn resolve_path_agent_dir_still_blocks_markerless_escape() {
+        // The agent-dir bypass only reroots to a *real* project (one carrying a
+        // marker). A markerless absolute path outside the jail stays blocked —
+        // PathJail enforcement is unchanged, only the root *choice* is corrected.
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        crate::test_env::remove_var("LEAN_CTX_ALLOW_REROOT");
+        let tmp = tempfile::tempdir().unwrap();
+        let agent = tmp.path().join(".copilot");
+        let loose = tmp.path().join("loose");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::create_dir_all(&loose).unwrap();
+        std::fs::write(loose.join("data.txt"), "no").unwrap();
+
+        let server = LeanCtxServer::new_with_startup(
+            None,
+            None,
+            SessionMode::Personal,
+            "default",
+            "default",
+        );
+        {
+            let mut session = server.session.write().await;
+            session.project_root = Some(agent.to_string_lossy().to_string());
+            session.shell_cwd = Some(agent.to_string_lossy().to_string());
+        }
+
+        let err = server
+            .resolve_path(&loose.join("data.txt").to_string_lossy())
+            .await
+            .unwrap_err();
+        assert!(err.contains("path escapes project root"), "got: {err}");
+
+        let session = server.session.read().await;
+        assert_eq!(
+            session.project_root.as_deref(),
+            Some(agent.to_string_lossy().as_ref())
+        );
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn startup_prefers_workspace_scoped_session_over_global_latest() {

--- a/rust/src/tools/registered/ctx_search.rs
+++ b/rust/src/tools/registered/ctx_search.rs
@@ -2,10 +2,53 @@ use rmcp::ErrorData;
 use rmcp::model::Tool;
 use serde_json::{Map, Value, json};
 
-use crate::server::tool_trait::{McpTool, ToolContext, ToolOutput, get_bool, get_int, get_str};
+use crate::server::tool_trait::{
+    McpTool, ToolContext, ToolOutput, get_bool, get_int, get_str, get_str_array, get_usize,
+};
 use crate::tool_defs::tool_def;
 
 pub struct CtxSearchTool;
+
+/// Which search engine a `ctx_search` call routes to (#509). One tool, many
+/// engines — replacing the former `ctx_search`/`ctx_semantic_search`/`ctx_symbol`
+/// trio with a single, less ambiguous entry point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchAction {
+    Regex,
+    Semantic,
+    Symbol,
+    Reindex,
+    FindRelated,
+}
+
+impl SearchAction {
+    /// An explicit `action` wins; otherwise the engine is inferred from which
+    /// field the caller set, so pre-#509 call sites (`pattern`/`query`/`name`)
+    /// keep working unchanged. Unknown `action` values fall through to inference.
+    fn resolve(args: &Map<String, Value>) -> Self {
+        if let Some(a) = get_str(args, "action") {
+            match a.trim().to_ascii_lowercase().as_str() {
+                "regex" | "grep" | "pattern" => return Self::Regex,
+                "semantic" | "search" => return Self::Semantic,
+                "symbol" => return Self::Symbol,
+                "reindex" => return Self::Reindex,
+                "find_related" | "related" => return Self::FindRelated,
+                _ => {}
+            }
+        }
+        if args.contains_key("pattern") {
+            Self::Regex
+        } else if args.contains_key("name") {
+            Self::Symbol
+        } else if args.contains_key("file_path") && args.contains_key("line") {
+            Self::FindRelated
+        } else if args.contains_key("query") {
+            Self::Semantic
+        } else {
+            Self::Regex
+        }
+    }
+}
 
 impl McpTool for CtxSearchTool {
     fn name(&self) -> &'static str {
@@ -15,25 +58,36 @@ impl McpTool for CtxSearchTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_search",
-            "Regex pattern search — use when you know the exact pattern. For understanding code or\n\
-             finding answers, use ctx_compose FIRST (one call replaces search+read+symbol chains).\n\
-             pattern required; include='*.rs'; path scopes; max_results=N (default 20).\n\
-             paths=['dir1','dir2'] for multi-root. ignore_gitignore bypasses .gitignore (needs role).",
+            "Search code; `action` picks the engine. regex (default): exact pattern, `pattern`\n\
+             required, include='*.rs', paths=[..] multi-root. semantic: by meaning (BM25+embeddings),\n\
+             `query`, mode=bm25|dense|hybrid. symbol: one symbol's body by `name` (AST-precise),\n\
+             file/kind narrow. reindex / find_related(file_path,line). For end-to-end understanding,\n\
+             use ctx_compose FIRST.",
             json!({
                 "type": "object",
                 "properties": {
-                    "pattern": { "type": "string", "description": "Regex pattern" },
-                    "path": { "type": "string", "description": "Search dir" },
+                    "action": {
+                        "type": "string",
+                        "enum": ["regex", "semantic", "symbol", "reindex", "find_related"]
+                    },
+                    "pattern": { "type": "string", "description": "Regex (action=regex)" },
+                    "query": { "type": "string", "description": "Meaning query (action=semantic)" },
+                    "name": { "type": "string", "description": "Symbol name (action=symbol)" },
+                    "path": { "type": "string", "description": "Scope dir / project root" },
                     "paths": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Multi-root (alternative to path)"
+                        "description": "Multi-root regex"
                     },
-                    "include": { "type": "string", "description": "Glob filter: *.ts, src/**/*.rs" },
-                    "max_results": { "type": "integer", "description": "Max results (default: 20)" },
-                    "ignore_gitignore": { "type": "boolean", "description": "Scan gitignored (needs role)" }
-                },
-                "required": ["pattern"]
+                    "include": { "type": "string", "description": "Glob: *.ts, src/**/*.rs" },
+                    "max_results": { "type": "integer" },
+                    "top_k": { "type": "integer" },
+                    "mode": { "type": "string", "enum": ["bm25", "dense", "hybrid"] },
+                    "file": { "type": "string", "description": "Narrow symbol to file" },
+                    "kind": { "type": "string", "description": "fn|struct|class|trait|enum" },
+                    "file_path": { "type": "string" },
+                    "line": { "type": "integer" }
+                }
             }),
         )
     }
@@ -43,106 +97,250 @@ impl McpTool for CtxSearchTool {
         args: &Map<String, Value>,
         ctx: &ToolContext,
     ) -> Result<ToolOutput, ErrorData> {
-        let pattern = get_str(args, "pattern")
-            .ok_or_else(|| ErrorData::invalid_params("pattern is required", None))?;
-        let resolved = crate::server::multi_path::resolve_tool_paths(args, ctx)
-            .map_err(|e| ErrorData::invalid_params(format!("ERROR: {e}"), None))?;
-        // `include` is the canonical glob filter; `ext` is the deprecated alias
-        // (bare extension → `*.{ext}`). `include` wins when both are supplied.
-        let include =
-            get_str(args, "include").or_else(|| get_str(args, "ext").map(|e| ext_to_include(&e)));
-        let max = (get_int(args, "max_results").unwrap_or(20) as usize).min(500);
-        let no_gitignore = get_bool(args, "ignore_gitignore").unwrap_or(false);
+        match SearchAction::resolve(args) {
+            SearchAction::Regex => handle_regex(args, ctx),
+            SearchAction::Semantic => handle_semantic(args, ctx),
+            SearchAction::Symbol => handle_symbol(args, ctx),
+            SearchAction::Reindex => handle_reindex(args, ctx),
+            SearchAction::FindRelated => handle_find_related(args, ctx),
+        }
+    }
+}
 
-        if no_gitignore
-            && let Err(e) = crate::core::io_boundary::ensure_ignore_gitignore_allowed("ctx_search")
-        {
-            return Ok(ToolOutput::simple(e));
+/// `action=regex` (default) — exact-pattern search over one or more roots.
+fn handle_regex(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOutput, ErrorData> {
+    let pattern = get_str(args, "pattern")
+        .ok_or_else(|| ErrorData::invalid_params("pattern is required", None))?;
+    let resolved = crate::server::multi_path::resolve_tool_paths(args, ctx)
+        .map_err(|e| ErrorData::invalid_params(format!("ERROR: {e}"), None))?;
+    // `include` is the canonical glob filter; `ext` is the deprecated alias
+    // (bare extension → `*.{ext}`). `include` wins when both are supplied.
+    let include =
+        get_str(args, "include").or_else(|| get_str(args, "ext").map(|e| ext_to_include(&e)));
+    let max = (get_int(args, "max_results").unwrap_or(20) as usize).min(500);
+    let no_gitignore = get_bool(args, "ignore_gitignore").unwrap_or(false);
+
+    if no_gitignore
+        && let Err(e) = crate::core::io_boundary::ensure_ignore_gitignore_allowed("ctx_search")
+    {
+        return Ok(ToolOutput::simple(e));
+    }
+
+    let crp = ctx.crp_mode;
+    let respect = !no_gitignore;
+    let allow_secret_paths = crate::core::roles::active_role().io.allow_secret_paths;
+
+    if !resolved.is_multi {
+        return search_single(
+            &pattern,
+            &resolved.roots[0],
+            include.as_deref(),
+            max,
+            crp,
+            respect,
+            allow_secret_paths,
+        );
+    }
+
+    let _mode_guard = crate::core::savings_footer::ModeGuard::new("search");
+    let per_root_max = (max / resolved.roots.len()).max(5);
+    let mut combined = String::new();
+    let mut total_observed: usize = 0;
+    let mut total_sent: usize = 0;
+
+    for root in &resolved.roots {
+        let search_result = tokio::task::block_in_place(|| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                crate::tools::ctx_search::handle(
+                    &pattern,
+                    root,
+                    include.as_deref(),
+                    per_root_max,
+                    crp,
+                    respect,
+                    allow_secret_paths,
+                )
+            }))
+            .ok()
+        });
+
+        let Some(outcome) = search_result else {
+            combined.push_str(&format!("── {root} ──\nERROR: search panicked\n\n"));
+            continue;
+        };
+        let result = outcome.text;
+
+        if result.trim().is_empty() {
+            continue;
         }
 
-        let crp = ctx.crp_mode;
-        let respect = !no_gitignore;
-        let allow_secret_paths = crate::core::roles::active_role().io.allow_secret_paths;
+        combined.push_str(&format!("── {root} ──\n{result}\n\n"));
 
-        if !resolved.is_multi {
-            return search_single(
-                &pattern,
-                &resolved.roots[0],
-                include.as_deref(),
-                max,
-                crp,
-                respect,
-                allow_secret_paths,
-            );
+        if result.starts_with("ERROR:") {
+            continue;
         }
 
-        let _mode_guard = crate::core::savings_footer::ModeGuard::new("search");
-        let per_root_max = (max / resolved.roots.len()).max(5);
-        let mut combined = String::new();
-        let mut total_observed: usize = 0;
-        let mut total_sent: usize = 0;
+        total_observed += outcome.observed_tokens;
+        total_sent += crate::core::tokens::count_tokens(&result);
+    }
 
-        for root in &resolved.roots {
-            let search_result = tokio::task::block_in_place(|| {
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    crate::tools::ctx_search::handle(
-                        &pattern,
-                        root,
-                        include.as_deref(),
-                        per_root_max,
-                        crp,
-                        respect,
-                        allow_secret_paths,
-                    )
-                }))
-                .ok()
-            });
+    if combined.is_empty() {
+        combined = "No matches found across any root.".to_string();
+    }
 
-            let Some(outcome) = search_result else {
-                combined.push_str(&format!("── {root} ──\nERROR: search panicked\n\n"));
-                continue;
-            };
-            let result = outcome.text;
+    // Dashboard, footer and verified ledger all use *observed* tokens —
+    // the modeled 2.5x native-grep baseline never inflates user-facing
+    // numbers (GL #573). It only feeds the explicitly-estimated stats
+    // series via `tool_lifecycle::record_search`.
+    let final_out = crate::core::protocol::append_savings(&combined, total_observed, total_sent);
+    let saved = total_observed.saturating_sub(total_sent);
+    // #685: `actual_tokens` is the *sent* output, not the saving — passing
+    // `saved` here recorded `actual=observed−sent` and `saved=sent` (both
+    // wrong). Align with cli_grep/cli_shell, which pass the output count.
+    crate::core::savings_ledger::record_tool_event("ctx_search", total_observed, total_sent);
 
-            if result.trim().is_empty() {
-                continue;
-            }
+    Ok(ToolOutput {
+        text: final_out,
+        original_tokens: total_observed,
+        saved_tokens: saved,
+        mode: None,
+        path: None,
+        changed: false,
+        shell_outcome: None,
+    })
+}
 
-            combined.push_str(&format!("── {root} ──\n{result}\n\n"));
+/// Resolve the `path` arg to a jailed path, falling back to the project root —
+/// the same precedence the former standalone semantic-search tool used.
+fn resolve_path_or_root(ctx: &ToolContext) -> Result<String, ErrorData> {
+    if let Some(p) = ctx.resolved_path("path") {
+        Ok(p.to_string())
+    } else if let Some(err) = ctx.path_error("path") {
+        Err(ErrorData::invalid_params(format!("path: {err}"), None))
+    } else {
+        Ok(ctx.project_root.clone())
+    }
+}
 
-            if result.starts_with("ERROR:") {
-                continue;
-            }
+/// Prime the per-call BM25 cache so semantic engines reuse the warmed index
+/// instead of reloading it from disk (perf parity with the former tool).
+fn prime_bm25_cache(ctx: &ToolContext) {
+    if let Some(ref cache) = ctx.bm25_cache {
+        crate::tools::ctx_semantic_search::set_thread_cache(cache.clone());
+    }
+}
 
-            total_observed += outcome.observed_tokens;
-            total_sent += crate::core::tokens::count_tokens(&result);
+/// `action=semantic` — meaning-based search, routed to the shared core fn.
+fn handle_semantic(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOutput, ErrorData> {
+    let query = get_str(args, "query")
+        .ok_or_else(|| ErrorData::invalid_params("query is required for action=semantic", None))?;
+    let path = resolve_path_or_root(ctx)?;
+    let top_k = get_usize(args, "top_k").unwrap_or(10).min(1000);
+    let mode = get_str(args, "mode");
+    let languages = get_str_array(args, "languages");
+    let path_glob = get_str(args, "path_glob");
+    let workspace = get_bool(args, "workspace").unwrap_or(false);
+    let artifacts = get_bool(args, "artifacts").unwrap_or(false);
+    prime_bm25_cache(ctx);
+
+    let result = tokio::task::block_in_place(|| {
+        crate::tools::ctx_semantic_search::handle(
+            &query,
+            &path,
+            top_k,
+            ctx.crp_mode,
+            languages.as_deref(),
+            path_glob.as_deref(),
+            mode.as_deref(),
+            Some(workspace),
+            Some(artifacts),
+        )
+    });
+    Ok(semantic_output(result))
+}
+
+/// `action=symbol` — one symbol's body by name, routed to the shared core fn.
+fn handle_symbol(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOutput, ErrorData> {
+    let name = get_str(args, "name")
+        .ok_or_else(|| ErrorData::invalid_params("name is required for action=symbol", None))?;
+    let file = get_str(args, "file");
+    let kind = get_str(args, "kind");
+
+    let (result, original) = crate::tools::ctx_symbol::handle(
+        &name,
+        file.as_deref(),
+        kind.as_deref(),
+        &ctx.project_root,
+    );
+    let sent = crate::core::tokens::count_tokens(&result);
+    Ok(ToolOutput {
+        text: result,
+        original_tokens: original,
+        saved_tokens: original.saturating_sub(sent),
+        mode: kind,
+        path: file,
+        changed: false,
+        shell_outcome: None,
+    })
+}
+
+/// `action=reindex` — rebuild the BM25 (or artifacts) index, routed to core.
+fn handle_reindex(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOutput, ErrorData> {
+    let path = resolve_path_or_root(ctx)?;
+    let workspace = get_bool(args, "workspace").unwrap_or(false);
+    let artifacts = get_bool(args, "artifacts").unwrap_or(false);
+    prime_bm25_cache(ctx);
+
+    let result = tokio::task::block_in_place(|| {
+        if artifacts {
+            crate::tools::ctx_semantic_search::handle_reindex_artifacts(&path, workspace)
+        } else {
+            crate::tools::ctx_semantic_search::handle_reindex(&path)
         }
+    });
+    Ok(semantic_output(result))
+}
 
-        if combined.is_empty() {
-            combined = "No matches found across any root.".to_string();
-        }
+/// `action=find_related` — context neighbors for a source location, via core.
+fn handle_find_related(
+    args: &Map<String, Value>,
+    ctx: &ToolContext,
+) -> Result<ToolOutput, ErrorData> {
+    let path = resolve_path_or_root(ctx)?;
+    let top_k = get_usize(args, "top_k").unwrap_or(10).min(1000);
+    let fp = get_str(args, "file_path").unwrap_or_default();
+    let line = get_int(args, "line").unwrap_or(1) as usize;
+    if fp.is_empty() {
+        return Err(ErrorData::invalid_params(
+            "find_related requires file_path and line",
+            None,
+        ));
+    }
+    prime_bm25_cache(ctx);
 
-        // Dashboard, footer and verified ledger all use *observed* tokens —
-        // the modeled 2.5x native-grep baseline never inflates user-facing
-        // numbers (GL #573). It only feeds the explicitly-estimated stats
-        // series via `tool_lifecycle::record_search`.
-        let final_out =
-            crate::core::protocol::append_savings(&combined, total_observed, total_sent);
-        let saved = total_observed.saturating_sub(total_sent);
-        // #685: `actual_tokens` is the *sent* output, not the saving — passing
-        // `saved` here recorded `actual=observed−sent` and `saved=sent` (both
-        // wrong). Align with cli_grep/cli_shell, which pass the output count.
-        crate::core::savings_ledger::record_tool_event("ctx_search", total_observed, total_sent);
+    let result = tokio::task::block_in_place(|| {
+        crate::tools::ctx_semantic_search::handle_find_related(
+            &fp,
+            line,
+            &path,
+            top_k,
+            ctx.crp_mode,
+        )
+    });
+    Ok(semantic_output(result))
+}
 
-        Ok(ToolOutput {
-            text: final_out,
-            original_tokens: total_observed,
-            saved_tokens: saved,
-            mode: None,
-            path: None,
-            changed: false,
-            shell_outcome: None,
-        })
+/// Shared `ToolOutput` shape for the semantic-engine branches (token accounting
+/// is handled inside the core fns, mirroring the former standalone tool).
+fn semantic_output(text: String) -> ToolOutput {
+    ToolOutput {
+        text,
+        original_tokens: 0,
+        saved_tokens: 0,
+        mode: Some("semantic".to_string()),
+        path: None,
+        changed: false,
+        shell_outcome: None,
     }
 }
 
@@ -228,7 +426,78 @@ fn ext_to_include(ext: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::ext_to_include;
+    use super::{SearchAction, ext_to_include};
+    use serde_json::{Map, Value, json};
+
+    fn args(pairs: &[(&str, Value)]) -> Map<String, Value> {
+        pairs
+            .iter()
+            .cloned()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    #[test]
+    fn explicit_action_selects_engine() {
+        // #509: an explicit action always wins, including synonyms.
+        assert_eq!(
+            SearchAction::resolve(&args(&[("action", json!("semantic"))])),
+            SearchAction::Semantic
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("action", json!("symbol"))])),
+            SearchAction::Symbol
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("action", json!("grep"))])),
+            SearchAction::Regex
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("action", json!("related"))])),
+            SearchAction::FindRelated
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("action", json!("reindex"))])),
+            SearchAction::Reindex
+        );
+    }
+
+    #[test]
+    fn action_inferred_from_fields_for_backward_compat() {
+        // Pre-#509 call sites set only one of these fields and no action.
+        assert_eq!(
+            SearchAction::resolve(&args(&[("pattern", json!("fn .*"))])),
+            SearchAction::Regex
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("query", json!("user auth"))])),
+            SearchAction::Semantic
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("name", json!("handle"))])),
+            SearchAction::Symbol
+        );
+        assert_eq!(
+            SearchAction::resolve(&args(&[("file_path", json!("a.rs")), ("line", json!(10))])),
+            SearchAction::FindRelated
+        );
+    }
+
+    #[test]
+    fn pattern_wins_over_query_and_unknown_action_falls_back_to_inference() {
+        // A regex caller that also carries a stray query must stay regex.
+        assert_eq!(
+            SearchAction::resolve(&args(&[("pattern", json!("x")), ("query", json!("y"))])),
+            SearchAction::Regex
+        );
+        // Unknown action value → infer from fields (here: symbol).
+        assert_eq!(
+            SearchAction::resolve(&args(&[("action", json!("bogus")), ("name", json!("f"))])),
+            SearchAction::Symbol
+        );
+        // Nothing recognizable → default regex (the empty-call default).
+        assert_eq!(SearchAction::resolve(&args(&[])), SearchAction::Regex);
+    }
 
     #[test]
     fn ext_alias_bare_extension_becomes_glob() {

--- a/rust/src/tools/registered/ctx_semantic_search.rs
+++ b/rust/src/tools/registered/ctx_semantic_search.rs
@@ -17,11 +17,9 @@ impl McpTool for CtxSemanticSearchTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_semantic_search",
-            "Search code by MEANING (BM25+embeddings) — use when you know the concept but not the exact\n\
-             symbol name. query='user auth' finds relevant code even with no keyword match.\n\
-             Different from ctx_search (regex): use ctx_search for exact patterns, this for\n\
-             fuzzy/conceptual. For understanding code end-to-end, use ctx_compose FIRST.\n\
-             find_related(file_path, line) for context neighbors. mode=bm25|dense|hybrid.",
+            "[Deprecated → ctx_search action=\"semantic\"] Search code by meaning (BM25+embeddings);\n\
+             reindex / find_related are ctx_search actions too. Hidden from tools/list but still\n\
+             callable for one release — prefer ctx_search.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_symbol.rs
+++ b/rust/src/tools/registered/ctx_symbol.rs
@@ -15,11 +15,9 @@ impl McpTool for CtxSymbolTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_symbol",
-            "Get ONE symbol's body by name — exact, AST-precise (tree-sitter index).\n\
-             WORKFLOW: after ctx_compose gave overview, for one symbol's body.\n\
-             name='fnName' returns code block; file='path.rs' narrows;\n\
-             kind='fn'|'struct'|'class'|'trait'|'enum' disambiguates.\n\
-             ANTIPATTERN: NOT for finding all usages (grep) or exploring areas (ctx_compose).",
+            "[Deprecated → ctx_search action=\"symbol\"] Get one symbol's body by name (AST-precise);\n\
+             optional file/kind narrow. Hidden from tools/list but still callable for one release —\n\
+             prefer ctx_search.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/server_paths.rs
+++ b/rust/src/tools/server_paths.rs
@@ -75,13 +75,23 @@ impl LeanCtxServer {
                             |v| v == "1" || v == "true",
                         );
                         let candidate_under_jail = resolved.starts_with(jail_root_path);
-                        let allow_reroot = if !cfg_allow || candidate_under_jail {
+                        // #580: when the server was launched from an agent/IDE
+                        // config dir (e.g. ~/.copilot), that jail is never a real
+                        // project boundary. `maybe_derive_project_root_from_absolute`
+                        // already guarantees the new root carries a real project
+                        // marker, so correcting to it is a root *fix*, not a jail
+                        // weakening — allow it without the `allow_auto_reroot`
+                        // opt-in. Non-agent weak roots keep the conservative gate.
+                        let allow_reroot = if candidate_under_jail {
+                            false
+                        } else if is_suspicious_root(jail_root_path) {
+                            true
+                        } else if !cfg_allow {
                             false
                         } else if let Some(ref trusted_root) = self.startup_project_root {
                             std::path::Path::new(trusted_root) == new_root.as_path()
                         } else {
                             !has_project_marker(jail_root_path)
-                                || is_suspicious_root(jail_root_path)
                         };
 
                         if allow_reroot {

--- a/rust/src/tools/startup.rs
+++ b/rust/src/tools/startup.rs
@@ -16,15 +16,7 @@ pub(super) fn has_project_marker(dir: &std::path::Path) -> bool {
 }
 
 pub(super) fn is_suspicious_root(dir: &std::path::Path) -> bool {
-    let s = dir.to_string_lossy();
-    s.contains("/.claude")
-        || s.contains("/.codebuddy")
-        || s.contains("/.codex")
-        || s.contains("/.lmstudio")
-        || s.contains("\\.claude")
-        || s.contains("\\.codebuddy")
-        || s.contains("\\.codex")
-        || s.contains("\\.lmstudio")
+    crate::core::pathutil::is_agent_config_dir(dir)
 }
 
 pub(super) fn canonicalize_path(path: &std::path::Path) -> String {

--- a/rust/tests/e2e_test.py
+++ b/rust/tests/e2e_test.py
@@ -234,12 +234,19 @@ pub fn check_permission(token: &AuthToken, required: &str) -> bool {
         if resp and "result" in resp:
             tools = [t["name"] for t in resp["result"].get("tools", [])]
         
-        critical_tools = ["ctx_read", "ctx_search", "ctx_semantic_search", 
+        critical_tools = ["ctx_read", "ctx_search",
                          "ctx_metrics", "ctx_tree", "ctx_shell", "ctx_overview"]
         for tool in critical_tools:
             check(f"Has tool: {tool}", tools,
                   lambda t, name=tool: name in t)
-        
+
+        # #509: ctx_semantic_search + ctx_symbol are folded into ctx_search. They
+        # stay callable as deprecated aliases (exercised in Tests 4+ via tools/call)
+        # but must be hidden from tools/list for one release.
+        for hidden in ("ctx_semantic_search", "ctx_symbol"):
+            check(f"Folded alias hidden from list: {hidden}", tools,
+                  lambda t, name=hidden: name not in t)
+
         print(f"  Total tools: {len(tools)}")
         
         # === Test 3: ctx_read ===

--- a/rust/tests/intensive_benchmarks.rs
+++ b/rust/tests/intensive_benchmarks.rs
@@ -86,13 +86,19 @@ fn bench_system_instructions_token_count() {
         "TDD instructions should be <2550 tokens, got {tok_tdd}"
     );
 
-    let claude_code_instr = lean_ctx::server::build_claude_code_instructions_for_test();
+    // The <=2048 char budget governs the STATIC cold first-contact handshake
+    // instructions. A live build also appends dynamic session/knowledge/gotcha
+    // payload, but that is capped by INSTRUCTION_CAP_TOKENS (token budget), not
+    // this char budget — and it varies with whatever session is persisted on the
+    // runner. Measuring the static surface keeps the assertion deterministic
+    // (#498) instead of order/state-dependent.
+    let claude_code_instr = lean_ctx::server::build_claude_code_static_instructions_for_test();
     let claude_chars = claude_code_instr.len();
     let claude_tokens = count_tokens(&claude_code_instr);
-    eprintln!("  Claude Code: {claude_tokens:>6} tokens ({claude_chars:>5} chars)");
+    eprintln!("  Claude Code (static): {claude_tokens:>6} tokens ({claude_chars:>5} chars)");
     assert!(
         claude_chars <= 2048,
-        "Claude Code instructions MUST be <=2048 chars, got {claude_chars}"
+        "Claude Code static instructions MUST be <=2048 chars, got {claude_chars}"
     );
     assert!(
         compact_overhead.unsigned_abs() < 300,


### PR DESCRIPTION
## Summary

Adopts the verified, real wins from @omar-mohamed-khallaf's reference PR #581 ("use as a reference", not meant to merge), each landed lean-ctx-style: one focused commit per concern, deterministic (#498), with contributor credit (`Co-authored-by` on the adoption commits).

Two of the four originally-planned concerns turned out to be **already solved — better — on `main`** while this work was in flight, so they are intentionally **not** included. This PR is the net-new, non-redundant subset, rebased cleanly on the latest `main` (incl. #957).

## Included (6 commits)

- **`fix(root)` — unify project-root resolution for search + the MCP path jail (#580).** The index was built at the git root but search ran from the CWD/subdir → different namespace hash → 0 hits; separately the MCP server adopted an agent-config dir (`.copilot`/`.cursor`/`.windsurf`/`.gemini`) as root → `path escapes project root`. One resolver (git-promotion) is now the single source of truth; an explicit subdir becomes a result filter, not its own namespace. **PathJail enforcement is unchanged** — only root *derivation* is corrected.
- **`feat(search)` — fold `ctx_semantic_search` + `ctx_symbol` into a single `ctx_search` (#509).** New `action` enum (`regex` default / `semantic` / `symbol` / `reindex` / `find_related`) routes to the existing core fns (no duplicated logic); missing `action` is inferred for backward-compat. The old tools become deprecated aliases — hidden from `tools/list`, still callable for one release — via the established #527 path. Standard profile 17→15 tools, Minimal 6→5. Per-tool token budget respected; `gen_docs` regenerated (drift test green).
- **`perf(bm25)` — parallelize the incremental rebuild + CI build-time gate (#581).** The full build was already parallel (#933); this parallelizes the *incremental* path (the edit-loop hot path). Byte-for-byte equivalent to the sequential path (asserted by `parallel_incremental_matches_sequential`). Adds a CI-safe, env-gated regression gate (`LEAN_CTX_PERF_GATE=1`, Linux step).
- **`test(e2e)` — e2e expects deprecated aliases hidden from `tools/list` but still callable (#509).**
- **`test` — deterministic Claude Code instruction char-budget (#498).** Measures the static cold-handshake surface instead of the runner-dependent live session/knowledge payload (which is governed by `INSTRUCTION_CAP_TOKENS`), so the `<=2048` assertion no longer flakes. `build_full_instructions` becomes a pure fn; the live path computes its args exactly as before, so production output is byte-identical.
- **`fix(test)` — OS-native path-separator in the new BM25 incremental test (#324).** The store keeps OS-native separators internally (output is normalized to `/` only at render time, #324); the assertions now build expected keys via `MAIN_SEPARATOR_STR`, so `windows-latest` is green too while Unix behavior is unchanged.

## Deliberately dropped (superseded on `main`)

- **Cross-conversation cache reset (#528).** `main` independently shipped a strictly better per-conversation stub-gating system (#952/#955/#956: `core/conversation.rs` + `read_stub_index`, persisted across restarts, subagent-scoped via `task:{id}`). Our coarse global `reset_delivery_flags()` is redundant against it.
- **Degrade-threshold test rework (#941).** `main`'s #957 replaced the brittle source-grep with a behavioral test over a pure `CompressionLevel::degrade_action`. Ours is superseded; only the independent instruction-budget determinism fix is kept.

## Credit

Reference source: #581 by @omar-mohamed-khallaf. The adoption commits carry `Co-authored-by` credit.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --lib` — 6223 passed / 0 failed
- [x] contract/docs/drift cluster (reference_docs_drift, docs_tool_counts, mcp_manifest, rules_*) — green
- [x] Phase 1 root/jail: index_scoping_scenarios (11), security_resolve_path_guard (2), legacy_path_firewall (1), read_fidelity (2) — green
- [x] hn_hardening_scenarios (main's #957 behavioral test) — 37 green
- [x] intensive_benchmarks (token budget) — 43 green
- [x] BM25 perf gate `LEAN_CTX_PERF_GATE=1` — par/seq ratio ~0.6 (CI-safe 2x slack)
- [x] full CI matrix incl. Windows runners — 24/24 CI-workflow checks green (`cla` is a non-blocking owner-email artifact)

## Note on issue lifecycle

References (not "Closes") #580, #509 so merge doesn't auto-close them — per repo convention they move to `status: integrated` + milestone until the release ships. #581 (reference PR) to be closed with thanks once this lands.
