### PR TITLE
# feat(knowledge): consolidate memory with capacity guard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -810,7 +810,7 @@ flowchart LR
 | `cli/pack_cmd.rs` | `lean-ctx pack` — PR context bundle |
 | `cli/index_cmd.rs` | `lean-ctx index` — graph/BM25 index management |
 | `cli/profile_cmd.rs` | `lean-ctx profile` — profile management |
-| `cli/knowledge_cmd.rs` | `lean-ctx knowledge remember/recall/search/export/import/remove/consolidate/status/health/lifecycle` |
+| `cli/knowledge_cmd.rs` | `lean-ctx knowledge remember/recall/search/export/import/remove/consolidate [--all]/status/health/lifecycle` |
 | `cli/overview_cmd.rs` | `lean-ctx overview [task]` |
 | `cli/compress_cmd.rs` | `lean-ctx compress` |
 | `cli/session_cmd.rs` | Extended: `lean-ctx session task/finding/save/load/decision/reset/status` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -810,7 +810,7 @@ flowchart LR
 | `cli/pack_cmd.rs` | `lean-ctx pack` — PR context bundle |
 | `cli/index_cmd.rs` | `lean-ctx index` — graph/BM25 index management |
 | `cli/profile_cmd.rs` | `lean-ctx profile` — profile management |
-| `cli/knowledge_cmd.rs` | `lean-ctx knowledge remember/recall/search/export/import/remove/status/health` |
+| `cli/knowledge_cmd.rs` | `lean-ctx knowledge remember/recall/search/export/import/remove/consolidate/status/health/lifecycle` |
 | `cli/overview_cmd.rs` | `lean-ctx overview [task]` |
 | `cli/compress_cmd.rs` | `lean-ctx compress` |
 | `cli/session_cmd.rs` | Extended: `lean-ctx session task/finding/save/load/decision/reset/status` |

--- a/LEANCTX_FEATURE_CATALOG.md
+++ b/LEANCTX_FEATURE_CATALOG.md
@@ -105,7 +105,7 @@ Full CLI parity with MCP `ctx_knowledge`:
 - `export [--format json|jsonl|simple] [--output <path>]` — export knowledge (stdout or file)
 - `import <path> [--merge replace|append|skip-existing] [--dry-run]` — import from JSON/JSONL
 - `remove --category <c> --key <k>` — remove a fact
-- `consolidate` — import latest session if present, then run the knowledge lifecycle
+- `consolidate [--all]` — import latest session if present, run lifecycle, then leave 25% facts/history/procedures capacity free; `--all` repeats this for every stored project root
 - `status` — knowledge base summary
 - `health` — health report with quality metrics
 - `lifecycle` — read-only lifecycle/capacity report

--- a/LEANCTX_FEATURE_CATALOG.md
+++ b/LEANCTX_FEATURE_CATALOG.md
@@ -105,8 +105,10 @@ Full CLI parity with MCP `ctx_knowledge`:
 - `export [--format json|jsonl|simple] [--output <path>]` — export knowledge (stdout or file)
 - `import <path> [--merge replace|append|skip-existing] [--dry-run]` — import from JSON/JSONL
 - `remove --category <c> --key <k>` — remove a fact
+- `consolidate` — import latest session if present, then run the knowledge lifecycle
 - `status` — knowledge base summary
 - `health` — health report with quality metrics
+- `lifecycle` — read-only lifecycle/capacity report
 
 Import supports three formats: native `ProjectKnowledge` JSON, simple `[{category, key, value}]` array, and JSONL (one fact per line). The `simple` format serves as the community interop schema for migration from other tools.
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Your agent reads less and searches smarter — automatically.
 lean-ctx overview                    # task-aware project recap
 lean-ctx knowledge recall "auth"     # facts that survive resets
 lean-ctx knowledge consolidate       # import session + compact lifecycle
+lean-ctx knowledge consolidate --all # compact every project store
 ```
 Session memory + a project knowledge graph persist across chats.
 → **[Journey 3 — Memory & Knowledge](docs/reference/03-memory-and-knowledge.md)**

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Your agent reads less and searches smarter — automatically.
 ```bash
 lean-ctx overview                    # task-aware project recap
 lean-ctx knowledge recall "auth"     # facts that survive resets
+lean-ctx knowledge consolidate       # import session + compact lifecycle
 ```
 Session memory + a project knowledge graph persist across chats.
 → **[Journey 3 — Memory & Knowledge](docs/reference/03-memory-and-knowledge.md)**

--- a/docs/reference/03-memory-and-knowledge.md
+++ b/docs/reference/03-memory-and-knowledge.md
@@ -99,6 +99,7 @@ lean-ctx knowledge search "stripe"
 lean-ctx knowledge status          # counts, capacity
 lean-ctx knowledge health          # integrity check
 lean-ctx knowledge consolidate     # import session + run lifecycle
+lean-ctx knowledge consolidate --all
 lean-ctx knowledge export --output kb.json
 lean-ctx knowledge import kb.json --merge
 ```
@@ -118,9 +119,13 @@ bundle). `ctx_knowledge action=consolidate` and
 session exists, findings/decisions/history are imported first; if not, session
 import is skipped. Both paths then run the memory lifecycle over all project
 knowledge and report `run_memory_lifecycle` stats: decayed, consolidated,
-archived, compacted, and remaining facts. Capacity is bounded by
-`[memory.knowledge] max_facts` (default 200) — at capacity, `doctor` warns and
-`consolidate` reclaims space.
+archived, compacted, and remaining facts. Explicit consolidate then enforces the
+75% target for facts/history/procedures in the same run, so at least 25%
+capacity remains free after session import. Capacity is bounded by
+`[memory.knowledge] max_facts` and `[memory.procedural] max_procedures` — near
+capacity, `doctor` warns and `consolidate` reclaims space.
+The CLI `--all` flag scans stored project knowledge roots and invokes that same
+per-project consolidation function for each one.
 
 ### Gotchas — auto-learned mistakes
 

--- a/docs/reference/03-memory-and-knowledge.md
+++ b/docs/reference/03-memory-and-knowledge.md
@@ -98,6 +98,7 @@ lean-ctx knowledge recall "how do payments work"
 lean-ctx knowledge search "stripe"
 lean-ctx knowledge status          # counts, capacity
 lean-ctx knowledge health          # integrity check
+lean-ctx knowledge consolidate     # import session + run lifecycle
 lean-ctx knowledge export --output kb.json
 lean-ctx knowledge import kb.json --merge
 ```
@@ -111,8 +112,13 @@ recall uses the knowledge embeddings (`knowledge/<hash>/embeddings.json`).
 
 **Under the hood:** stored under `knowledge/<project-hash>/knowledge.json`.
 The MCP tool adds richer actions: `relate`/`relations` (link facts),
-`consolidate` (merge duplicates), `timeline`, `rooms`, and `wakeup` (the
-session-start recall bundle). Capacity is bounded by
+`consolidate`, `timeline`, `rooms`, and `wakeup` (the session-start recall
+bundle). `ctx_knowledge action=consolidate` and
+`lean-ctx knowledge consolidate` call the same implementation: if a latest
+session exists, findings/decisions/history are imported first; if not, session
+import is skipped. Both paths then run the memory lifecycle over all project
+knowledge and report `run_memory_lifecycle` stats: decayed, consolidated,
+archived, compacted, and remaining facts. Capacity is bounded by
 `[memory.knowledge] max_facts` (default 200) — at capacity, `doctor` warns and
 `consolidate` reclaims space.
 

--- a/docs/reference/appendix-cli-map.md
+++ b/docs/reference/appendix-cli-map.md
@@ -48,7 +48,7 @@ Every CLI command lean-ctx exposes, grouped by purpose. Source of truth:
 |---------|---------|
 | `session` | Tasks/findings/decisions + adoption stats: `task`, `finding`, `decision`, `save`, `load`, `status`, `reset` |
 | `sessions` (`session-store`) | Manage saved CCP snapshots: `list`, `show`, `cleanup`, `doctor` |
-| `knowledge` | Project knowledge: `remember`, `recall`, `search`, `export`, `import`, `remove`, `consolidate`, `status`, `health`, `lifecycle` |
+| `knowledge` | Project knowledge: `remember`, `recall`, `search`, `export`, `import`, `remove`, `consolidate [--all]`, `status`, `health`, `lifecycle` |
 | `overview [task]` | Project overview (task-contextualized) |
 | `compress` | Context-compression checkpoint; `--signatures` |
 | `control` | Context field manipulation: exclude/pin/priority |

--- a/docs/reference/appendix-cli-map.md
+++ b/docs/reference/appendix-cli-map.md
@@ -48,7 +48,7 @@ Every CLI command lean-ctx exposes, grouped by purpose. Source of truth:
 |---------|---------|
 | `session` | Tasks/findings/decisions + adoption stats: `task`, `finding`, `decision`, `save`, `load`, `status`, `reset` |
 | `sessions` (`session-store`) | Manage saved CCP snapshots: `list`, `show`, `cleanup`, `doctor` |
-| `knowledge` | Project knowledge: `remember`, `recall`, `search`, `export`, `import`, `remove`, `status`, `health` |
+| `knowledge` | Project knowledge: `remember`, `recall`, `search`, `export`, `import`, `remove`, `consolidate`, `status`, `health`, `lifecycle` |
 | `overview [task]` | Project overview (task-contextualized) |
 | `compress` | Context-compression checkpoint; `--signatures` |
 | `control` | Context field manipulation: exclude/pin/priority |

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -748,3 +748,4 @@ Use when your MCP client prefers shell/bash over ctx_shell — transparently
 delegates to ctx_shell internals.
 
 Parameters: `command`*, `cwd`
+

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -345,7 +345,7 @@ Persistent memory across sessions — remember decisions, patterns, and facts fo
 WORKFLOW: save after completing significant tasks; recall at session start.
 action=remember key='X' value='Y' saves a fact (both required).
 action=recall query='X' retrieves it. action=status shows all categories.
-action=consolidate imports latest session if present, then runs knowledge lifecycle.
+action=consolidate imports latest session if present, runs lifecycle, then frees 25% facts/history/procedures capacity.
 action=gotcha trigger='X' resolution='Y' for known pitfalls.
 mode=semantic|exact for recall. category groups related facts.
 
@@ -748,4 +748,3 @@ Use when your MCP client prefers shell/bash over ctx_shell — transparently
 delegates to ctx_shell internals.
 
 Parameters: `command`*, `cwd`
-

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -345,6 +345,7 @@ Persistent memory across sessions — remember decisions, patterns, and facts fo
 WORKFLOW: save after completing significant tasks; recall at session start.
 action=remember key='X' value='Y' saves a fact (both required).
 action=recall query='X' retrieves it. action=status shows all categories.
+action=consolidate imports latest session if present, then runs knowledge lifecycle.
 action=gotcha trigger='X' resolution='Y' for known pitfalls.
 mode=semantic|exact for recall. category groups related facts.
 

--- a/rust/src/cli/cheatsheet_cmd.rs
+++ b/rust/src/cli/cheatsheet_cmd.rs
@@ -27,7 +27,7 @@ pub fn cmd_cheatsheet() {
   ctx_session finding \"...\"       \x1b[2m# record what you discovered\x1b[0m
   ctx_session decision \"...\"      \x1b[2m# record architectural choices\x1b[0m
   ctx_knowledge action=remember   \x1b[2m# store permanent project facts\x1b[0m
-  ctx_knowledge action=consolidate \x1b[2m# auto-extract session insights\x1b[0m
+  ctx_knowledge action=consolidate \x1b[2m# import session + run lifecycle\x1b[0m
   ctx_metrics                     \x1b[2m# see session statistics\x1b[0m
 
 \x1b[1;34m━━━ MULTI-AGENT ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m

--- a/rust/src/cli/knowledge_cmd.rs
+++ b/rust/src/cli/knowledge_cmd.rs
@@ -14,7 +14,7 @@ pub(crate) fn cmd_knowledge(args: &[String]) {
         Some("export") => cmd_export(args, &project_root),
         Some("remove") => cmd_remove(args, &project_root),
         Some("import") => cmd_import(args, &project_root),
-        Some("consolidate") => cmd_consolidate(&project_root),
+        Some("consolidate") => cmd_consolidate(args, &project_root),
         Some("status") => {
             #[cfg(unix)]
             {
@@ -542,9 +542,17 @@ fn recall_json(project_root: &str, category: Option<&str>, query: Option<&str>) 
     println!("{json}");
 }
 
-fn cmd_consolidate(project_root: &str) {
-    match ctx_knowledge::consolidate_project_knowledge(project_root) {
-        Ok(report) => println!("{}", ctx_knowledge::format_consolidation_report(&report)),
+fn cmd_consolidate(args: &[String], project_root: &str) {
+    let result = if args.iter().any(|a| a == "--all") {
+        ctx_knowledge::consolidate_all_project_knowledge()
+            .map(|reports| ctx_knowledge::format_all_consolidation_reports(&reports))
+    } else {
+        ctx_knowledge::consolidate_project_knowledge(project_root)
+            .map(|report| ctx_knowledge::format_consolidation_report(&report))
+    };
+
+    match result {
+        Ok(out) => println!("{out}"),
         Err(e) => {
             eprintln!("{e}");
             std::process::exit(1);
@@ -671,7 +679,7 @@ Usage:
   lean-ctx knowledge export [--format json|jsonl|simple] [--output <path>]
   lean-ctx knowledge import <path> [--merge replace|append|skip-existing] [--dry-run]
   lean-ctx knowledge remove --category <cat> --key <key>
-  lean-ctx knowledge consolidate
+  lean-ctx knowledge consolidate [--all]
   lean-ctx knowledge status
   lean-ctx knowledge health
   lean-ctx knowledge lifecycle
@@ -683,6 +691,7 @@ Examples:
   lean-ctx knowledge import backup.json --merge skip-existing --dry-run
   lean-ctx knowledge remove --category auth --key token-type
   lean-ctx knowledge consolidate
+  lean-ctx knowledge consolidate --all
   lean-ctx knowledge status"
     );
 }

--- a/rust/src/cli/knowledge_cmd.rs
+++ b/rust/src/cli/knowledge_cmd.rs
@@ -14,6 +14,7 @@ pub(crate) fn cmd_knowledge(args: &[String]) {
         Some("export") => cmd_export(args, &project_root),
         Some("remove") => cmd_remove(args, &project_root),
         Some("import") => cmd_import(args, &project_root),
+        Some("consolidate") => cmd_consolidate(&project_root),
         Some("status") => {
             #[cfg(unix)]
             {
@@ -541,6 +542,16 @@ fn recall_json(project_root: &str, category: Option<&str>, query: Option<&str>) 
     println!("{json}");
 }
 
+fn cmd_consolidate(project_root: &str) {
+    match ctx_knowledge::consolidate_project_knowledge(project_root) {
+        Ok(report) => println!("{}", ctx_knowledge::format_consolidation_report(&report)),
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 /// Filters to current facts (optional category + substring query), newest
 /// first, capped, and serializes with the `{category, content, timestamp}`
 /// contract the editor extensions consume (plus key + confidence).
@@ -660,6 +671,7 @@ Usage:
   lean-ctx knowledge export [--format json|jsonl|simple] [--output <path>]
   lean-ctx knowledge import <path> [--merge replace|append|skip-existing] [--dry-run]
   lean-ctx knowledge remove --category <cat> --key <key>
+  lean-ctx knowledge consolidate
   lean-ctx knowledge status
   lean-ctx knowledge health
   lean-ctx knowledge lifecycle
@@ -670,6 +682,7 @@ Examples:
   lean-ctx knowledge export --format jsonl --output backup.jsonl
   lean-ctx knowledge import backup.json --merge skip-existing --dry-run
   lean-ctx knowledge remove --category auth --key token-type
+  lean-ctx knowledge consolidate
   lean-ctx knowledge status"
     );
 }

--- a/rust/src/core/knowledge/mod.rs
+++ b/rust/src/core/knowledge/mod.rs
@@ -10,6 +10,7 @@ mod ranking;
 mod types;
 
 pub use import_export::{ImportMerge, ImportResult, SimpleFactEntry, parse_import_data};
+pub(crate) use ranking::sort_fact_for_output;
 pub use ranking::{SimilarFact, find_cross_key_similar};
 pub use types::*;
 

--- a/rust/src/core/knowledge/persist.rs
+++ b/rust/src/core/knowledge/persist.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -84,6 +84,35 @@ fn write_json_atomic(dir: &Path, path: &Path, json: &str) -> Result<(), String> 
 }
 
 impl ProjectKnowledge {
+    pub fn list_project_roots() -> Result<Vec<String>, String> {
+        let base = crate::core::data_dir::lean_ctx_data_dir()?.join("knowledge");
+        if !base.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut roots = Vec::new();
+        let mut seen = HashSet::new();
+        let entries = std::fs::read_dir(&base).map_err(|e| e.to_string())?;
+        for entry in entries.flatten() {
+            let path = entry.path().join("knowledge.json");
+            if !path.is_file() {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(knowledge) = serde_json::from_str::<Self>(&content) else {
+                continue;
+            };
+            if seen.insert(knowledge.project_root.clone()) {
+                roots.push(knowledge.project_root);
+            }
+        }
+
+        roots.sort();
+        Ok(roots)
+    }
+
     pub fn save(&self) -> Result<(), String> {
         let dir = knowledge_dir(&self.project_hash)?;
         std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;

--- a/rust/src/core/knowledge/ranking.rs
+++ b/rust/src/core/knowledge/ranking.rs
@@ -36,7 +36,7 @@ pub(super) fn string_similarity(a: &str, b: &str) -> f32 {
     intersection as f32 / union as f32
 }
 
-pub(super) fn sort_fact_for_output(a: &KnowledgeFact, b: &KnowledgeFact) -> std::cmp::Ordering {
+pub(crate) fn sort_fact_for_output(a: &KnowledgeFact, b: &KnowledgeFact) -> std::cmp::Ordering {
     // Pure salience ordering for display/grouping. The observation tier (#802) lives
     // in the *selection* layer (`recall_for_output`, `semantic_recall`,
     // `recall_by_category_for_output`) which has query context to keep a summary above

--- a/rust/src/core/memory_lifecycle.rs
+++ b/rust/src/core/memory_lifecycle.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use super::knowledge::KnowledgeFact;
+use super::knowledge::{KnowledgeFact, sort_fact_for_output};
 
 const DEFAULT_DECAY_RATE: f32 = 0.01;
 const DEFAULT_MAX_FACTS: usize = 1000;
@@ -325,23 +325,27 @@ pub fn compact(
 
     to_archive.sort_unstable();
     to_archive.dedup();
-    let count = to_archive.len();
 
     for idx in to_archive.into_iter().rev() {
         archived.push(facts.remove(idx));
     }
 
-    if facts.len() > config.max_facts {
+    if facts.len() >= config.max_facts && config.max_facts > 0 {
+        let target = reclaim_target_capacity(config.max_facts);
         facts.sort_by(|a, b| {
-            b.confidence
-                .partial_cmp(&a.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            b.is_current()
+                .cmp(&a.is_current())
+                .then_with(|| sort_fact_for_output(a, b))
         });
-        let excess: Vec<KnowledgeFact> = facts.drain(config.max_facts..).collect();
+        let excess: Vec<KnowledgeFact> = facts.drain(target..).collect();
         archived.extend(excess);
     }
 
-    (count, archived)
+    (archived.len(), archived)
+}
+
+fn reclaim_target_capacity(max_facts: usize) -> usize {
+    max_facts.saturating_sub(max_facts.div_ceil(4))
 }
 
 /// Guardrails for cluster compaction (#971). See
@@ -874,6 +878,45 @@ mod tests {
         assert_eq!(facts.len(), 1);
         assert_eq!(archived.len(), 1);
         assert_eq!(archived[0].key, "cache");
+    }
+
+    #[test]
+    fn compact_at_capacity_reclaims_twenty_five_percent() {
+        let config = LifecycleConfig {
+            max_facts: 8,
+            ..Default::default()
+        };
+        let mut facts: Vec<KnowledgeFact> = (0..8)
+            .map(|i| make_fact("finding", &format!("k{i}"), &format!("value {i}"), 0.8))
+            .collect();
+
+        let (count, archived) = compact(&mut facts, &config);
+
+        assert_eq!(count, 2);
+        assert_eq!(archived.len(), 2);
+        assert_eq!(facts.len(), 6);
+    }
+
+    #[test]
+    fn compact_prefers_current_high_salience_facts() {
+        let config = LifecycleConfig {
+            max_facts: 4,
+            ..Default::default()
+        };
+        let decision = make_fact("decision", "keep-decision", "important decision", 0.7);
+        let finding = make_fact("finding", "keep-finding", "fresh finding", 0.9);
+        let mut old = make_fact("decision", "drop-archived", "old decision", 0.95);
+        old.valid_until = Some(Utc::now());
+        let low = make_fact("misc", "drop-low", "low salience", 0.6);
+        let mut facts = vec![old, low, finding, decision];
+
+        let (_count, archived) = compact(&mut facts, &config);
+        let keys: Vec<&str> = facts.iter().map(|f| f.key.as_str()).collect();
+        let archived_keys: Vec<&str> = archived.iter().map(|f| f.key.as_str()).collect();
+
+        assert!(keys.contains(&"keep-decision"));
+        assert!(keys.contains(&"keep-finding"));
+        assert!(archived_keys.contains(&"drop-archived"));
     }
 
     #[test]

--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -1870,9 +1870,9 @@ pub(super) fn capacity_warnings() -> Vec<Outcome> {
 /// is behind and the operator should compact or raise the limit.
 fn capacity_hint(critical: bool) -> &'static str {
     if critical {
-        "over cap — eviction is behind. Run `ctx_knowledge action=\"cognition_loop\"` to compact + archive now, or raise the limit (memory.knowledge.max_facts / LEAN_CTX_MAX_FACTS)"
+        "over cap — eviction is behind. Run `lean-ctx knowledge consolidate --all` to compact project memory now, or raise the relevant memory.* cap"
     } else {
-        "at/near cap is healthy by design — lean-ctx self-curates (write-time dedup #970, hourly cluster-compaction #971, 90-day prune #972). Raise a cap only if recall quality drops (memory.knowledge.max_facts)"
+        "at/near cap is healthy by design — lean-ctx self-curates (write-time dedup #970, hourly cluster-compaction #971, 90-day prune #972). Raise a cap only if recall quality drops"
     }
 }
 

--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -1872,7 +1872,7 @@ fn capacity_hint(critical: bool) -> &'static str {
     if critical {
         "over cap — eviction is behind. Run `lean-ctx knowledge consolidate --all` to compact project memory now, or raise the relevant memory.* cap"
     } else {
-        "at/near cap is healthy by design — lean-ctx self-curates (write-time dedup #970, hourly cluster-compaction #971, 90-day prune #972). Raise a cap only if recall quality drops"
+        "at/near cap is healthy by design — lean-ctx self-curates (write-time dedup #970, hourly cluster-compaction #971, 90-day prune #972). Raise a cap only if recall quality drops (memory.*)"
     }
 }
 
@@ -1984,12 +1984,12 @@ mod tests {
         // WARN (at/near cap): reassure it is by-design, point at the cap lever.
         let warn = capacity_hint(false);
         assert!(warn.contains("healthy by design"));
-        assert!(warn.contains("max_facts"));
+        assert!(warn.contains("memory.*"));
 
         // CRIT (over cap): give an immediate compaction action.
         let crit = capacity_hint(true);
-        assert!(crit.contains("cognition_loop"));
-        assert!(crit.contains("max_facts"));
+        assert!(crit.contains("lean-ctx knowledge consolidate --all"));
+        assert!(crit.contains("memory.*"));
 
         assert_ne!(warn, crit);
     }

--- a/rust/src/tools/ctx_knowledge/mod.rs
+++ b/rust/src/tools/ctx_knowledge/mod.rs
@@ -32,7 +32,7 @@ pub(crate) fn consolidate_project_knowledge(
     project_root: &str,
 ) -> Result<KnowledgeConsolidationReport, String> {
     let policy = load_policy_or_error()?;
-    let session = SessionState::load_latest();
+    let session = SessionState::load_latest_for_project_root(project_root);
 
     let (_knowledge, report) = ProjectKnowledge::mutate_locked(project_root, |knowledge| {
         let mut session_items = 0usize;
@@ -965,6 +965,48 @@ fn handle_wakeup(project_root: &str) -> String {
 mod tests {
     use super::*;
 
+    struct CurrentDirGuard {
+        previous: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CurrentDirGuard {
+        fn enter(dir: &std::path::Path) -> Self {
+            static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+            let lock = LOCK.get_or_init(|| std::sync::Mutex::new(()));
+            let guard = lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let previous = std::env::current_dir().unwrap();
+            std::env::set_current_dir(dir).unwrap();
+            Self {
+                previous,
+                _lock: guard,
+            }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.previous).unwrap();
+        }
+    }
+
+    struct DataDirGuard;
+
+    impl DataDirGuard {
+        fn set(path: &std::path::Path) -> Self {
+            crate::test_env::set_var("LEAN_CTX_DATA_DIR", path);
+            Self
+        }
+    }
+
+    impl Drop for DataDirGuard {
+        fn drop(&mut self) {
+            crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
+        }
+    }
+
     fn report(session_id: Option<String>, session_items: usize) -> KnowledgeConsolidationReport {
         KnowledgeConsolidationReport {
             session_id,
@@ -997,5 +1039,49 @@ mod tests {
         assert!(out.contains("Session import: s1 (6 item(s))"));
         assert!(out.contains("Facts: 7, Patterns: 2, History: 3"));
         assert!(out.contains("archived 3, compacted 4, remaining 5"));
+    }
+
+    #[test]
+    fn consolidation_loads_session_for_requested_project_root() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
+        let data_dir = tempfile::tempdir().unwrap();
+        let _data_dir = DataDirGuard::set(data_dir.path());
+        let cwd_project = tempfile::tempdir().unwrap();
+        let target_project = tempfile::tempdir().unwrap();
+        let cwd_root = cwd_project.path().to_string_lossy().to_string();
+        let target_root = target_project.path().to_string_lossy().to_string();
+
+        let mut cwd_session = SessionState::new();
+        cwd_session.project_root = Some(cwd_root);
+        cwd_session.add_finding(None, None, "wrong cwd finding");
+        cwd_session.save().unwrap();
+
+        let mut target_session = SessionState::new();
+        target_session.project_root = Some(target_root.clone());
+        target_session.add_finding(None, None, "target project finding");
+        target_session.save().unwrap();
+
+        let _cwd = CurrentDirGuard::enter(cwd_project.path());
+        let report = consolidate_project_knowledge(&target_root).unwrap();
+
+        assert_eq!(
+            report.session_id.as_deref(),
+            Some(target_session.id.as_str())
+        );
+        assert_eq!(report.session_items, 1);
+
+        let knowledge = ProjectKnowledge::load(&target_root).unwrap();
+        assert!(
+            knowledge
+                .facts
+                .iter()
+                .any(|f| f.value == "target project finding")
+        );
+        assert!(
+            !knowledge
+                .facts
+                .iter()
+                .any(|f| f.value == "wrong cwd finding")
+        );
     }
 }

--- a/rust/src/tools/ctx_knowledge/mod.rs
+++ b/rust/src/tools/ctx_knowledge/mod.rs
@@ -3,9 +3,10 @@ use chrono::Utc;
 #[cfg(feature = "embeddings")]
 use crate::core::embeddings::EmbeddingEngine;
 
-use crate::core::knowledge::ProjectKnowledge;
+use crate::core::knowledge::{ProjectKnowledge, sort_fact_for_output};
 use crate::core::memory_lifecycle::LifecycleReport;
 use crate::core::memory_policy::MemoryPolicy;
+use crate::core::procedural_memory::{ProceduralStore, Procedure};
 use crate::core::session::SessionState;
 pub(crate) mod embeddings;
 pub(crate) use embeddings::*;
@@ -23,8 +24,17 @@ pub(crate) struct KnowledgeConsolidationReport {
     pub session_id: Option<String>,
     pub session_items: usize,
     pub facts: usize,
+    pub active_facts: usize,
+    pub archived_facts: usize,
+    pub fact_capacity_target: usize,
+    pub fact_capacity_archived: usize,
     pub patterns: usize,
     pub history: usize,
+    pub history_capacity_target: usize,
+    pub history_compacted: usize,
+    pub procedures: usize,
+    pub procedure_capacity_target: usize,
+    pub procedures_compacted: usize,
     pub lifecycle: LifecycleReport,
 }
 
@@ -99,19 +109,53 @@ pub(crate) fn consolidate_project_knowledge(
         }
 
         let lifecycle = knowledge.run_memory_lifecycle(&policy);
+        let fact_capacity_target = reclaim_target_capacity(policy.knowledge.max_facts);
+        let fact_capacity_archived =
+            compact_facts_for_capacity(knowledge, policy.knowledge.max_facts)?;
+        let history_capacity_target = reclaim_target_capacity(policy.knowledge.max_history);
+        let history_compacted =
+            compact_history_for_capacity(knowledge, policy.knowledge.max_history);
+        let (procedures, procedure_capacity_target, procedures_compacted) =
+            compact_procedures_for_capacity(
+                &knowledge.project_hash,
+                policy.procedural.max_procedures,
+            )?;
+        let active_facts = knowledge.facts.iter().filter(|f| f.is_current()).count();
+        let archived_facts = knowledge.facts.len().saturating_sub(active_facts);
 
-        KnowledgeConsolidationReport {
+        Ok(KnowledgeConsolidationReport {
             session_id,
             session_items,
             facts: knowledge.facts.len(),
+            active_facts,
+            archived_facts,
+            fact_capacity_target,
+            fact_capacity_archived,
             patterns: knowledge.patterns.len(),
             history: knowledge.history.len(),
+            history_capacity_target,
+            history_compacted,
+            procedures,
+            procedure_capacity_target,
+            procedures_compacted,
             lifecycle,
-        }
+        })
     })
     .map_err(|e| format!("Consolidation done but save failed: {e}"))?;
 
-    Ok(report)
+    report
+}
+
+pub(crate) fn consolidate_all_project_knowledge()
+-> Result<Vec<(String, KnowledgeConsolidationReport)>, String> {
+    let roots = ProjectKnowledge::list_project_roots()?;
+    let mut reports = Vec::with_capacity(roots.len());
+    for root in roots {
+        let report = consolidate_project_knowledge(&root)
+            .map_err(|e| format!("Consolidation failed for {}: {e}", project_label(&root)))?;
+        reports.push((root, report));
+    }
+    Ok(reports)
 }
 
 pub(crate) fn format_consolidation_report(report: &KnowledgeConsolidationReport) -> String {
@@ -127,17 +171,135 @@ pub(crate) fn format_consolidation_report(report: &KnowledgeConsolidationReport)
 
     format!(
         "{session_line}\n\
-         Facts: {}, Patterns: {}, History: {}\n\
+         Facts: {} active, {} archived, {} total (target <= {}, archived-to-target {})\n\
+         Patterns: {}, History: {} (target <= {}, compacted {})\n\
+         Procedures: {} (target <= {}, compacted {})\n\
          Lifecycle: decayed {}, consolidated {}, archived {}, compacted {}, remaining {}",
+        report.active_facts,
+        report.archived_facts,
         report.facts,
+        report.fact_capacity_target,
+        report.fact_capacity_archived,
         report.patterns,
         report.history,
+        report.history_capacity_target,
+        report.history_compacted,
+        report.procedures,
+        report.procedure_capacity_target,
+        report.procedures_compacted,
         report.lifecycle.decayed_count,
         report.lifecycle.consolidated_count,
         report.lifecycle.archived_count,
         report.lifecycle.compacted_count,
         report.lifecycle.remaining_facts
     )
+}
+
+pub(crate) fn format_all_consolidation_reports(
+    reports: &[(String, KnowledgeConsolidationReport)],
+) -> String {
+    if reports.is_empty() {
+        return "No project knowledge stores found.".to_string();
+    }
+
+    let mut out = format!("Projects consolidated: {}", reports.len());
+    for (project_root, report) in reports {
+        out.push_str("\n\nProject: ");
+        out.push_str(project_label(project_root));
+        out.push('\n');
+        out.push_str(&format_consolidation_report(report));
+    }
+    out
+}
+
+fn project_label(project_root: &str) -> &str {
+    if project_root.trim().is_empty() {
+        "(empty project root)"
+    } else {
+        project_root
+    }
+}
+
+fn compact_facts_for_capacity(
+    knowledge: &mut ProjectKnowledge,
+    max_facts: usize,
+) -> Result<usize, String> {
+    if max_facts == 0 {
+        return Ok(0);
+    }
+    let target = reclaim_target_capacity(max_facts);
+    if knowledge.facts.len() <= target {
+        return Ok(0);
+    }
+
+    knowledge.facts.sort_by(|a, b| {
+        b.is_current()
+            .cmp(&a.is_current())
+            .then_with(|| sort_fact_for_output(a, b))
+    });
+
+    let archived = knowledge.facts.split_off(target);
+    let archived_count = archived.len();
+    if let Err(e) = crate::core::memory_lifecycle::archive_facts(&archived) {
+        knowledge.facts.extend(archived);
+        return Err(format!("Capacity archive failed: {e}"));
+    }
+
+    Ok(archived_count)
+}
+
+fn compact_history_for_capacity(knowledge: &mut ProjectKnowledge, max_history: usize) -> usize {
+    if max_history == 0 {
+        return 0;
+    }
+    let target = reclaim_target_capacity(max_history);
+    if knowledge.history.len() <= target {
+        return 0;
+    }
+    let compacted = knowledge.history.len().saturating_sub(target);
+    if compacted > 0 {
+        knowledge.history.drain(0..compacted);
+    }
+    compacted
+}
+
+fn compact_procedures_for_capacity(
+    project_hash: &str,
+    max_procedures: usize,
+) -> Result<(usize, usize, usize), String> {
+    let target = reclaim_target_capacity(max_procedures);
+    let Some(mut store) = ProceduralStore::load(project_hash) else {
+        return Ok((0, target, 0));
+    };
+    if max_procedures == 0 || store.procedures.len() <= target {
+        return Ok((store.procedures.len(), target, 0));
+    }
+
+    store.procedures.sort_by(sort_procedure_for_retention);
+    let compacted = store.procedures.len().saturating_sub(target);
+    store.procedures.truncate(target);
+    store
+        .save()
+        .map_err(|e| format!("Procedure capacity compact failed: {e}"))?;
+    Ok((store.procedures.len(), target, compacted))
+}
+
+fn sort_procedure_for_retention(a: &Procedure, b: &Procedure) -> std::cmp::Ordering {
+    procedure_score(b)
+        .total_cmp(&procedure_score(a))
+        .then_with(|| b.last_used.cmp(&a.last_used))
+        .then_with(|| b.created_at.cmp(&a.created_at))
+        .then_with(|| a.name.cmp(&b.name))
+        .then_with(|| a.id.cmp(&b.id))
+}
+
+fn procedure_score(procedure: &Procedure) -> f32 {
+    let use_score = (procedure.times_used.min(20) as f32) / 20.0;
+    procedure.confidence * 0.5 + procedure.success_rate() * 0.3 + use_score * 0.2
+}
+
+fn reclaim_target_capacity(max_items: usize) -> usize {
+    max_items.saturating_sub(max_items.div_ceil(4))
 }
 
 /// Dispatches knowledge base actions (remember, recall, pattern, timeline, etc.).
@@ -1012,8 +1174,17 @@ mod tests {
             session_id,
             session_items,
             facts: 7,
+            active_facts: 5,
+            archived_facts: 2,
+            fact_capacity_target: 6,
+            fact_capacity_archived: 1,
             patterns: 2,
             history: 3,
+            history_capacity_target: 6,
+            history_compacted: 1,
+            procedures: 4,
+            procedure_capacity_target: 6,
+            procedures_compacted: 2,
             lifecycle: LifecycleReport {
                 decayed_count: 1,
                 consolidated_count: 2,
@@ -1037,8 +1208,149 @@ mod tests {
         let out = format_consolidation_report(&report(Some("s1".to_string()), 6));
 
         assert!(out.contains("Session import: s1 (6 item(s))"));
-        assert!(out.contains("Facts: 7, Patterns: 2, History: 3"));
+        assert!(
+            out.contains(
+                "Facts: 5 active, 2 archived, 7 total (target <= 6, archived-to-target 1)"
+            )
+        );
+        assert!(out.contains("Patterns: 2, History: 3 (target <= 6, compacted 1)"));
+        assert!(out.contains("Procedures: 4 (target <= 6, compacted 2)"));
         assert!(out.contains("archived 3, compacted 4, remaining 5"));
+    }
+
+    #[test]
+    fn compact_history_reclaims_capacity_above_target() {
+        let mut knowledge = ProjectKnowledge::new("/tmp/lean-ctx-history-compact-test");
+        for i in 0..7 {
+            knowledge
+                .history
+                .push(crate::core::knowledge::ConsolidatedInsight {
+                    summary: format!("summary {i}"),
+                    from_sessions: vec![format!("s{i}")],
+                    timestamp: Utc::now(),
+                });
+        }
+
+        let compacted = compact_history_for_capacity(&mut knowledge, 8);
+
+        assert_eq!(compacted, 1);
+        assert_eq!(knowledge.history.len(), 6);
+        assert_eq!(knowledge.history[0].summary, "summary 1");
+    }
+
+    #[test]
+    fn compact_facts_reclaims_capacity_above_target() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
+        let data_dir = tempfile::tempdir().unwrap();
+        let _data_dir = DataDirGuard::set(data_dir.path());
+        let policy = MemoryPolicy::default();
+        let mut knowledge = ProjectKnowledge::new("/tmp/lean-ctx-fact-compact-test");
+        for i in 0..7 {
+            knowledge.remember(
+                "finding",
+                &format!("k{i}"),
+                &format!("value {i}"),
+                "s1",
+                0.8,
+                &policy,
+            );
+        }
+
+        let archived = compact_facts_for_capacity(&mut knowledge, 8).unwrap();
+
+        assert_eq!(archived, 1);
+        assert_eq!(knowledge.facts.len(), 6);
+    }
+
+    fn test_procedure(id: usize, confidence: f32) -> Procedure {
+        Procedure {
+            id: format!("p-{id}"),
+            name: format!("workflow-{id}"),
+            description: "test workflow".to_string(),
+            steps: Vec::new(),
+            activation_keywords: Vec::new(),
+            confidence,
+            times_used: id as u32,
+            times_succeeded: id as u32,
+            last_used: Utc::now(),
+            project_specific: true,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn consolidation_compacts_procedures_above_target() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
+        let data_dir = tempfile::tempdir().unwrap();
+        let _data_dir = DataDirGuard::set(data_dir.path());
+        let project = tempfile::tempdir().unwrap();
+        let root = project.path().to_string_lossy().to_string();
+        let project_hash = ProjectKnowledge::new(&root).project_hash;
+        let mut store = ProceduralStore::new(&project_hash);
+        for i in 0..80 {
+            store.procedures.push(test_procedure(i, i as f32 / 100.0));
+        }
+        store.save().unwrap();
+
+        let report = consolidate_project_knowledge(&root).unwrap();
+        let reloaded = ProceduralStore::load(&project_hash).unwrap();
+
+        assert_eq!(report.procedures, 75);
+        assert_eq!(report.procedure_capacity_target, 75);
+        assert_eq!(report.procedures_compacted, 5);
+        assert_eq!(reloaded.procedures.len(), 75);
+        assert!(!reloaded.procedures.iter().any(|p| p.id == "p-0"));
+    }
+
+    #[test]
+    fn consolidation_does_not_capacity_compact_at_twenty_five_percent_free() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
+        let data_dir = tempfile::tempdir().unwrap();
+        let _data_dir = DataDirGuard::set(data_dir.path());
+        let project = tempfile::tempdir().unwrap();
+        let root = project.path().to_string_lossy().to_string();
+        let policy = MemoryPolicy::default();
+        let mut knowledge = ProjectKnowledge::new(&root);
+
+        for i in 0..150 {
+            knowledge.remember(
+                &format!("category-{i}"),
+                &format!("k{i}"),
+                &format!("unique stable fact value {i}"),
+                "s1",
+                0.8,
+                &policy,
+            );
+        }
+        for i in 0..75 {
+            knowledge
+                .history
+                .push(crate::core::knowledge::ConsolidatedInsight {
+                    summary: format!("summary {i}"),
+                    from_sessions: vec![format!("s{i}")],
+                    timestamp: Utc::now(),
+                });
+        }
+        knowledge.save().unwrap();
+
+        let mut procedures = ProceduralStore::new(&knowledge.project_hash);
+        for i in 0..75 {
+            procedures
+                .procedures
+                .push(test_procedure(i, i as f32 / 100.0));
+        }
+        procedures.save().unwrap();
+
+        let report = consolidate_project_knowledge(&root).unwrap();
+        let reloaded = ProjectKnowledge::load(&root).unwrap();
+        let reloaded_procedures = ProceduralStore::load(&knowledge.project_hash).unwrap();
+
+        assert_eq!(report.fact_capacity_archived, 0);
+        assert_eq!(report.history_compacted, 0);
+        assert_eq!(report.procedures_compacted, 0);
+        assert_eq!(reloaded.facts.len(), 150);
+        assert_eq!(reloaded.history.len(), 75);
+        assert_eq!(reloaded_procedures.procedures.len(), 75);
     }
 
     #[test]
@@ -1083,5 +1395,47 @@ mod tests {
                 .iter()
                 .any(|f| f.value == "wrong cwd finding")
         );
+    }
+
+    #[test]
+    fn consolidate_all_project_knowledge_runs_every_known_project() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
+        let data_dir = tempfile::tempdir().unwrap();
+        let _data_dir = DataDirGuard::set(data_dir.path());
+        let project_a = tempfile::tempdir().unwrap();
+        let project_b = tempfile::tempdir().unwrap();
+        let root_a = project_a.path().to_string_lossy().to_string();
+        let root_b = project_b.path().to_string_lossy().to_string();
+        let policy = MemoryPolicy::default();
+
+        let mut knowledge_a = ProjectKnowledge::new(&root_a);
+        knowledge_a.remember("finding", "a", "project a fact", "s1", 0.8, &policy);
+        knowledge_a.save().unwrap();
+
+        let mut knowledge_b = ProjectKnowledge::new(&root_b);
+        knowledge_b.remember("finding", "b", "project b fact", "s1", 0.8, &policy);
+        knowledge_b.save().unwrap();
+
+        let reports = consolidate_all_project_knowledge().unwrap();
+        let roots: Vec<_> = reports.iter().map(|(root, _)| root.clone()).collect();
+        let mut expected = vec![root_a, root_b];
+        expected.sort();
+
+        assert_eq!(roots, expected);
+        assert_eq!(reports.len(), 2);
+        assert!(
+            reports
+                .iter()
+                .all(|(_, report)| report.session_id.is_none())
+        );
+    }
+
+    #[test]
+    fn all_consolidation_report_marks_empty_store_set() {
+        let reports = Vec::new();
+
+        let out = format_all_consolidation_reports(&reports);
+
+        assert_eq!(out, "No project knowledge stores found.");
     }
 }

--- a/rust/src/tools/ctx_knowledge/mod.rs
+++ b/rust/src/tools/ctx_knowledge/mod.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use crate::core::embeddings::EmbeddingEngine;
 
 use crate::core::knowledge::ProjectKnowledge;
+use crate::core::memory_lifecycle::LifecycleReport;
 use crate::core::memory_policy::MemoryPolicy;
 use crate::core::session::SessionState;
 pub(crate) mod embeddings;
@@ -15,6 +16,128 @@ pub(crate) use search::*;
 
 fn load_policy_or_error() -> Result<MemoryPolicy, String> {
     super::knowledge_shared::load_policy_or_error()
+}
+
+#[derive(Debug)]
+pub(crate) struct KnowledgeConsolidationReport {
+    pub session_id: Option<String>,
+    pub session_items: usize,
+    pub facts: usize,
+    pub patterns: usize,
+    pub history: usize,
+    pub lifecycle: LifecycleReport,
+}
+
+pub(crate) fn consolidate_project_knowledge(
+    project_root: &str,
+) -> Result<KnowledgeConsolidationReport, String> {
+    let policy = load_policy_or_error()?;
+    let session = SessionState::load_latest();
+
+    let (_knowledge, report) = ProjectKnowledge::mutate_locked(project_root, |knowledge| {
+        let mut session_items = 0usize;
+        let mut session_id = None;
+
+        if let Some(session) = session.as_ref() {
+            session_id = Some(session.id.clone());
+
+            for finding in &session.findings {
+                let key_text = if let Some(ref file) = finding.file {
+                    if let Some(line) = finding.line {
+                        format!("{file}:{line}")
+                    } else {
+                        file.clone()
+                    }
+                } else {
+                    format!("finding-{session_items}")
+                };
+
+                knowledge.remember(
+                    "finding",
+                    &key_text,
+                    &finding.summary,
+                    &session.id,
+                    0.7,
+                    &policy,
+                );
+                session_items += 1;
+            }
+
+            for decision in &session.decisions {
+                let key_text = decision
+                    .summary
+                    .chars()
+                    .take(50)
+                    .collect::<String>()
+                    .replace(' ', "-")
+                    .to_lowercase();
+
+                knowledge.remember(
+                    "decision",
+                    &key_text,
+                    &decision.summary,
+                    &session.id,
+                    0.85,
+                    &policy,
+                );
+                session_items += 1;
+            }
+
+            let task_desc = session
+                .task
+                .as_ref()
+                .map_or_else(|| "(no task)".into(), |t| t.description.clone());
+
+            let summary = format!(
+                "Session {}: {} — {} findings, {} decisions consolidated",
+                session.id,
+                task_desc,
+                session.findings.len(),
+                session.decisions.len()
+            );
+            knowledge.consolidate(&summary, vec![session.id.clone()], &policy);
+        }
+
+        let lifecycle = knowledge.run_memory_lifecycle(&policy);
+
+        KnowledgeConsolidationReport {
+            session_id,
+            session_items,
+            facts: knowledge.facts.len(),
+            patterns: knowledge.patterns.len(),
+            history: knowledge.history.len(),
+            lifecycle,
+        }
+    })
+    .map_err(|e| format!("Consolidation done but save failed: {e}"))?;
+
+    Ok(report)
+}
+
+pub(crate) fn format_consolidation_report(report: &KnowledgeConsolidationReport) -> String {
+    let session_line = match report.session_id.as_deref() {
+        Some(session_id) => {
+            format!(
+                "Session import: {session_id} ({} item(s))",
+                report.session_items
+            )
+        }
+        None => "Session import: none (no active session)".to_string(),
+    };
+
+    format!(
+        "{session_line}\n\
+         Facts: {}, Patterns: {}, History: {}\n\
+         Lifecycle: decayed {}, consolidated {}, archived {}, compacted {}, remaining {}",
+        report.facts,
+        report.patterns,
+        report.history,
+        report.lifecycle.decayed_count,
+        report.lifecycle.consolidated_count,
+        report.lifecycle.archived_count,
+        report.lifecycle.compacted_count,
+        report.lifecycle.remaining_facts
+    )
 }
 
 /// Dispatches knowledge base actions (remember, recall, pattern, timeline, etc.).
@@ -640,94 +763,9 @@ fn handle_export(project_root: &str) -> String {
 }
 
 fn handle_consolidate(project_root: &str) -> String {
-    let Some(session) = SessionState::load_latest() else {
-        return "No active session to consolidate.".to_string();
-    };
-    let policy = match crate::core::config::Config::load().memory_policy_effective() {
-        Ok(p) => p,
-        Err(e) => {
-            let path = crate::core::config::Config::path().map_or_else(
-                || "~/.lean-ctx/config.toml".to_string(),
-                |p| p.display().to_string(),
-            );
-            return format!("Error: invalid memory policy: {e}\nFix: edit {path}");
-        }
-    };
-
-    // Read-modify-write under the cross-process lock (#326/#594) so a parallel
-    // remember/consolidate cannot drop facts via a lost update.
-    let result = ProjectKnowledge::mutate_locked(project_root, |knowledge| {
-        let mut consolidated = 0u32;
-
-        for finding in &session.findings {
-            let key_text = if let Some(ref file) = finding.file {
-                if let Some(line) = finding.line {
-                    format!("{file}:{line}")
-                } else {
-                    file.clone()
-                }
-            } else {
-                format!("finding-{consolidated}")
-            };
-
-            knowledge.remember(
-                "finding",
-                &key_text,
-                &finding.summary,
-                &session.id,
-                0.7,
-                &policy,
-            );
-            consolidated += 1;
-        }
-
-        for decision in &session.decisions {
-            let key_text = decision
-                .summary
-                .chars()
-                .take(50)
-                .collect::<String>()
-                .replace(' ', "-")
-                .to_lowercase();
-
-            knowledge.remember(
-                "decision",
-                &key_text,
-                &decision.summary,
-                &session.id,
-                0.85,
-                &policy,
-            );
-            consolidated += 1;
-        }
-
-        let task_desc = session
-            .task
-            .as_ref()
-            .map_or_else(|| "(no task)".into(), |t| t.description.clone());
-
-        let summary = format!(
-            "Session {}: {} — {} findings, {} decisions consolidated",
-            session.id,
-            task_desc,
-            session.findings.len(),
-            session.decisions.len()
-        );
-        knowledge.consolidate(&summary, vec![session.id.clone()], &policy);
-        let _ = knowledge.run_memory_lifecycle(&policy);
-        consolidated
-    });
-
-    match result {
-        Ok((knowledge, consolidated)) => format!(
-            "Consolidated {consolidated} items from session {} into project knowledge.\n\
-             Facts: {}, Patterns: {}, History: {}",
-            session.id,
-            knowledge.facts.len(),
-            knowledge.patterns.len(),
-            knowledge.history.len()
-        ),
-        Err(e) => format!("Consolidation done but save failed: {e}"),
+    match consolidate_project_knowledge(project_root) {
+        Ok(report) => format_consolidation_report(&report),
+        Err(e) => e,
     }
 }
 
@@ -921,4 +959,43 @@ fn handle_wakeup(project_root: &str) -> String {
         return "No knowledge yet. Start using ctx_knowledge(action=\"remember\") to build project memory.".to_string();
     }
     format!("WAKE-UP BRIEFING:\n{aaak}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(session_id: Option<String>, session_items: usize) -> KnowledgeConsolidationReport {
+        KnowledgeConsolidationReport {
+            session_id,
+            session_items,
+            facts: 7,
+            patterns: 2,
+            history: 3,
+            lifecycle: LifecycleReport {
+                decayed_count: 1,
+                consolidated_count: 2,
+                archived_count: 3,
+                compacted_count: 4,
+                remaining_facts: 5,
+            },
+        }
+    }
+
+    #[test]
+    fn consolidation_report_marks_no_session_import() {
+        let out = format_consolidation_report(&report(None, 0));
+
+        assert!(out.contains("Session import: none (no active session)"));
+        assert!(out.contains("Lifecycle: decayed 1, consolidated 2"));
+    }
+
+    #[test]
+    fn consolidation_report_includes_session_and_lifecycle_stats() {
+        let out = format_consolidation_report(&report(Some("s1".to_string()), 6));
+
+        assert!(out.contains("Session import: s1 (6 item(s))"));
+        assert!(out.contains("Facts: 7, Patterns: 2, History: 3"));
+        assert!(out.contains("archived 3, compacted 4, remaining 5"));
+    }
 }

--- a/rust/src/tools/ctx_knowledge/search.rs
+++ b/rust/src/tools/ctx_knowledge/search.rs
@@ -314,62 +314,6 @@ pub(crate) fn short_hash(hash: &str) -> &str {
     if hash.len() > 8 { &hash[..8] } else { hash }
 }
 
-pub(crate) fn sort_fact_for_output(
-    a: &crate::core::knowledge::KnowledgeFact,
-    b: &crate::core::knowledge::KnowledgeFact,
-) -> std::cmp::Ordering {
-    // Pure salience ordering. The observation tier (#802) is applied at the selection
-    // layer (recall_*), not here; this comparator is the as-of recall tiebreak and the
-    // display only preserves the order the recall functions already produced.
-    salience_score(b)
-        .cmp(&salience_score(a))
-        .then_with(|| {
-            b.quality_score()
-                .partial_cmp(&a.quality_score())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .then_with(|| {
-            b.confidence
-                .partial_cmp(&a.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .then_with(|| b.confirmation_count.cmp(&a.confirmation_count))
-        .then_with(|| b.retrieval_count.cmp(&a.retrieval_count))
-        .then_with(|| b.last_retrieved.cmp(&a.last_retrieved))
-        .then_with(|| b.last_confirmed.cmp(&a.last_confirmed))
-        .then_with(|| a.category.cmp(&b.category))
-        .then_with(|| a.key.cmp(&b.key))
-        .then_with(|| a.value.cmp(&b.value))
-}
-
-pub(crate) fn salience_score(f: &crate::core::knowledge::KnowledgeFact) -> u32 {
-    let cat = f.category.to_lowercase();
-    let base: u32 = match cat.as_str() {
-        "decision" => 70,
-        "gotcha" => 75,
-        "architecture" | "arch" => 60,
-        "security" => 65,
-        "testing" | "tests" | "deployment" | "deploy" => 55,
-        "conventions" | "convention" => 45,
-        "finding" => 40,
-        _ => 30,
-    };
-
-    let quality_bonus = (f.quality_score() * 60.0) as u32;
-    let recency_bonus = f.last_retrieved.map_or(0u32, |t| {
-        let days = chrono::Utc::now().signed_duration_since(t).num_days();
-        if days <= 7 {
-            10u32
-        } else if days <= 30 {
-            5u32
-        } else {
-            0u32
-        }
-    });
-
-    base + quality_bonus + recency_bonus
-}
-
 #[cfg(test)]
 mod tests {
     use crate::core::knowledge::{COGNITION_SYNTHESIS_SOURCE, ProjectKnowledge};

--- a/rust/src/tools/registered/ctx_knowledge.rs
+++ b/rust/src/tools/registered/ctx_knowledge.rs
@@ -21,7 +21,7 @@ impl McpTool for CtxKnowledgeTool {
              WORKFLOW: save after completing significant tasks; recall at session start.\n\
              action=remember key='X' value='Y' saves a fact (both required).\n\
              action=recall query='X' retrieves it. action=status shows all categories.\n\
-             action=consolidate imports latest session if present, then runs knowledge lifecycle.\n\
+action=consolidate imports latest session if present, runs lifecycle, then frees 25% facts/history/procedures capacity.\n\
              action=gotcha trigger='X' resolution='Y' for known pitfalls.\n\
              mode=semantic|exact for recall. category groups related facts.",
             json!({

--- a/rust/src/tools/registered/ctx_knowledge.rs
+++ b/rust/src/tools/registered/ctx_knowledge.rs
@@ -21,6 +21,7 @@ impl McpTool for CtxKnowledgeTool {
              WORKFLOW: save after completing significant tasks; recall at session start.\n\
              action=remember key='X' value='Y' saves a fact (both required).\n\
              action=recall query='X' retrieves it. action=status shows all categories.\n\
+             action=consolidate imports latest session if present, then runs knowledge lifecycle.\n\
              action=gotcha trigger='X' resolution='Y' for known pitfalls.\n\
              mode=semantic|exact for recall. category groups related facts.",
             json!({

--- a/skills/lean-ctx/SKILL.md
+++ b/skills/lean-ctx/SKILL.md
@@ -101,7 +101,7 @@ lean-ctx knowledge search "query"
 lean-ctx knowledge export [--format json|jsonl|simple] [--output <path>]
 lean-ctx knowledge import <path> [--merge replace|append|skip-existing] [--dry-run]
 lean-ctx knowledge remove --category <c> --key <k>
-lean-ctx knowledge consolidate
+lean-ctx knowledge consolidate [--all]
 
 lean-ctx session task "what you're doing"
 lean-ctx session finding "what you found"

--- a/skills/lean-ctx/SKILL.md
+++ b/skills/lean-ctx/SKILL.md
@@ -101,6 +101,7 @@ lean-ctx knowledge search "query"
 lean-ctx knowledge export [--format json|jsonl|simple] [--output <path>]
 lean-ctx knowledge import <path> [--merge replace|append|skip-existing] [--dry-run]
 lean-ctx knowledge remove --category <c> --key <k>
+lean-ctx knowledge consolidate
 
 lean-ctx session task "what you're doing"
 lean-ctx session finding "what you found"


### PR DESCRIPTION
## Summary

  Adds project memory consolidation as both `ctx_knowledge action=consolidate`
  and `lean-ctx knowledge consolidate [--all]`.

  Consolidation imports the latest session for the current project root, persists
  findings and decisions into project knowledge, writes a session summary, then
  runs the existing memory lifecycle.

  After lifecycle, consolidation reclaims facts, history, and procedural memory
  to keep 25% free capacity. `--all` applies the same pass to every persisted
  project knowledge store.

  ## Test plan

  - [x] `cd rust && cargo test`
  - [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cd rust && cargo fmt --check`

  ## Notes for reviewers

  - Risk areas / edge cases: retention order during capacity reclaim, project-root
    session matching, procedure-store saves, `--all` partial failures.
  - Backwards compatibility: additive CLI/MCP behavior; consolidation is opt-in.
  - Docs updated (links/files): `README.md`, `ARCHITECTURE/appendix-cli-map.md`,
    `docs/reference/generated/mcp-tools.md`, `skills/lean-ctx/SKILL.md`.