### PR TITLE
docs(jetbrains): replace deprecated ctx_symbol refs with ctx_search action=symbol

### DIFF
--- a/docs/reference/19-jetbrains-plugin.md
+++ b/docs/reference/19-jetbrains-plugin.md
@@ -56,7 +56,7 @@ lean-ctx becomes the sole interface for symbols, navigation, and refactoring.
 | `inline`                   | `inline`                         | `POST /inlinePreview` → `POST /inlineApply`         |
 
 > `find_symbol` (pure symbol search) is not part of `ctx_refactor` but of
-> `ctx_symbol` / `ctx_outline` (lean-ctx symbol index). See
+> `ctx_search action="symbol"` / `ctx_outline` (lean-ctx symbol index). See
 > [MCP tool map](appendix-mcp-tools.md).
 
 ---
@@ -223,7 +223,7 @@ curl -s -X POST http://127.0.0.1:$PORT/symbols_overview \
 {supertypes, subtypes}` (default `supertypes`), `scope`. `symbols_overview`: `path`.
 **Backing:** `type_hierarchy` is Backing-B-only. `symbols_overview` has a
 **lossless headless default** via the tree-sitter symbol index
-(`overview_from_index`, the same source as `ctx_symbol`/`ctx_outline`).
+(`overview_from_index`, the same source as `ctx_search action="symbol"` / `ctx_outline`).
 
 **IDE-neutral loading & degradation.** The Core `plugin.xml` depends only on
 `com.intellij.modules.platform`, so it loads in every IntelliJ IDE (RustRover, PyCharm,
@@ -801,7 +801,7 @@ ctx_refactor action=reformat path=src/Main.kt    # apply code style afterward
 
 - [Concise agent reference](appendix-jetbrains-plugin.md) — tables for quick lookup
 - [Per-IDE quickstarts](appendix-ide-quickstarts.md) — setup for JetBrains IDEs
-- [MCP tool map](appendix-mcp-tools.md) — all MCP tools incl. `ctx_refactor`, `ctx_symbol`
+- [MCP tool map](appendix-mcp-tools.md) — all MCP tools incl. `ctx_refactor`, `ctx_search`
 - [Journey 4 — Code Intelligence](04-code-intelligence.md)
 - [Journey 13 — Security & Governance](13-security-and-governance.md) — PathJail, auth
 - Source code: `rust/src/lsp/{backend,jetbrains_backend,router,edit_apply,port_discovery}.rs`,

--- a/docs/reference/appendix-jetbrains-plugin.md
+++ b/docs/reference/appendix-jetbrains-plugin.md
@@ -46,7 +46,7 @@ Backing: **B** = JetBrains IDE (plugin via HTTP); **A** = rust-analyzer
 refactoring engine (`rename`/`move`/`safe_delete`/`inline`) is two-phase
 (`*Preview`→`*Apply`, `plan_hash`-protected) and has no headless path.
 
-> `find_symbol` (Serena) → `ctx_symbol` / `ctx_outline`, not `ctx_refactor`.
+> `find_symbol` (Serena) → `ctx_search action="symbol"` / `ctx_outline`, not `ctx_refactor`.
 
 ## IDE UI surfaces (non-HTTP)
 


### PR DESCRIPTION
## Summary

The JetBrains plugin documentation still pointed readers at the deprecated
`ctx_symbol` tool. Per #509, `ctx_symbol` is a hidden, deprecated alias —
`ctx_search` with `action="symbol"` is the recommended form (see
`rust/src/server/dynamic_tools.rs`). This PR updates the four stale references
in the JetBrains docs to the recommended form. `ctx_outline` (not deprecated)
is left untouched.

Doc-only change. No source code touched — the plugin itself never calls
`ctx_symbol` (it speaks HTTP endpoints driven by `ctx_refactor` actions).

Changes:
- `docs/reference/19-jetbrains-plugin.md` — 3 references (`:59`, `:226`, `:804`)
- `docs/reference/appendix-jetbrains-plugin.md` — 1 reference (`:49`)

## Test plan

- [x] `grep -r ctx_symbol docs/reference/19-jetbrains-plugin.md docs/reference/appendix-jetbrains-plugin.md` → 0 matches
- [x] `ctx_outline` still present and unchanged in both files
- N/A `cargo test` / `clippy` / `fmt` — no Rust source changed (docs-only)

## Notes for reviewers

- Risk areas / edge cases: none — pure documentation wording.
- Backwards compatibility: no behavioral change; the `ctx_symbol` alias remains
  callable server-side, this only updates the recommended-form references.
- Docs updated (links/files): `docs/reference/19-jetbrains-plugin.md`,
  `docs/reference/appendix-jetbrains-plugin.md`. Out of scope (intentionally):
  `docs/reference/appendix-mcp-tools.md` still catalogs `ctx_symbol`.
