### PR TITLE
feat(dashboard): add no-auth mode with token-free CSRF protection

### DIFF
--- a/discord-faq/06-dashboard-analytics.md
+++ b/discord-faq/06-dashboard-analytics.md
@@ -27,3 +27,29 @@ The web dashboard (`lean-ctx gain --web`) includes a **Runtime Control Plane** p
 - **Dynamic tool categories** — which of the 6 tool categories are currently loaded, with per-category call counts
 
 This panel gives you a live view of how lean-ctx is adapting to your IDE and optimizing context in real time.
+
+**Q: Can I run the dashboard without an auth token?**
+Yes. By default the dashboard requires a Bearer token (auto-generated, or pinned via `--auth-token` / `LEAN_CTX_HTTP_TOKEN`). If juggling a token is inconvenient — e.g. a purely local setup or a Docker container you reach from the host — you can turn it off:
+
+```bash
+lean-ctx dashboard --no-auth                  # one run (alias: --auth=false)
+LEAN_CTX_DASHBOARD_AUTH=false lean-ctx dashboard
+lean-ctx config set dashboard_auth false      # persist it
+```
+
+No-auth mode is **not** unprotected. Instead of a token, the dashboard blocks browser cross-origin/CSRF and DNS-rebinding attacks with request-header validation on every `/api/*` and `/metrics` request:
+
+- **`Sec-Fetch-Site`** — requests the browser marks as `cross-site`/`same-site` are rejected; only `same-origin` and direct navigation (`none`) pass.
+- **`Origin`** — when present, must be same-origin as the dashboard.
+- **`Host` allowlist** — the request `Host` must be a loopback alias (`127.0.0.1`/`localhost`/`[::1]`), the host you bound to, or an entry in `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`. This stops DNS-rebinding attacks.
+
+Non-browser clients (curl, Prometheus scraping `/metrics`) don't send those headers and keep working, as long as they target an allowlisted host.
+
+**Best practice:** keep no-auth on loopback. For Docker, bind the container to `0.0.0.0` but publish **only** to the host loopback:
+
+```bash
+lean-ctx dashboard --host=0.0.0.0 --no-auth
+docker run ... -p 127.0.0.1:3333:3333 ...
+```
+
+If you reach the dashboard via a custom hostname, add it: `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS=box.local:3333`. Avoid binding to `0.0.0.0` with no-auth on an untrusted network — browser attacks stay blocked, but any non-browser client that can reach the port has full access.

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -28,6 +28,7 @@ Top-level configuration keys
 - `content_defined_chunking` (bool, default `false`) — Enable Rabin-Karp chunking for cache-optimal output ordering
 - `crush_verbatim_json` (bool, default `false` — env `LEAN_CTX_CRUSH_VERBATIM_JSON`) — Opt-in: losslessly crush array-heavy JSON from verbatim data commands (gh api, jq, kubectl get -o json, curl). Off by default keeps them verbatim. Reshapes only when it at least halves the payload; fully reconstructible
 - `custom_aliases` (array, default `[]`) — Custom command aliases (array of {command, alias} entries)
+- `dashboard_auth` (bool, default `true`) — Require Bearer-token auth for the dashboard (default true). Set false for no-auth mode protected by Sec-Fetch-Site/Origin/Host checks. Override per-run with --no-auth or LEAN_CTX_DASHBOARD_AUTH
 - `debug_log` (bool, default `false` — env `LEAN_CTX_DEBUG_LOG`) — Opt-in (default off): write a human-readable debug log of intercepted MCP tool calls and hook routing decisions (lean-ctx vs native, with the reason) to <state_dir>/logs/debug.log. View with `lean-ctx debug-log`
 - `default_tool_categories` (string[], default `[]`) — Tool categories active by default (core, arch, debug, memory, metrics, session). Override via LCTX_DEFAULT_CATEGORIES
 - `delta_explicit` (boolean, default `false`) — Serve explicit full/lines re-reads of changed cached files as diffs (opt-in). Override via LCTX_DELTA_EXPLICIT=1

--- a/rust/src/cli/dispatch/network.rs
+++ b/rust/src/cli/dispatch/network.rs
@@ -388,7 +388,7 @@ fn vscode_fallback_open_mode(no_open: bool) -> &'static str {
 pub(super) fn cmd_dashboard(rest: &[String]) {
     if rest.iter().any(|a| a == "--help" || a == "-h") {
         println!(
-            "Usage: lean-ctx dashboard [--port=N] [--host=H] [--base-path=PREFIX] [--auth-token=TOKEN] [--project=PATH] [--vscode] [--export]"
+            "Usage: lean-ctx dashboard [--port=N] [--host=H] [--base-path=PREFIX] [--auth-token=TOKEN] [--no-auth] [--project=PATH] [--vscode] [--export]"
         );
         println!("Examples:");
         println!("  lean-ctx dashboard");
@@ -399,6 +399,18 @@ pub(super) fn cmd_dashboard(rest: &[String]) {
         );
         println!(
             "  lean-ctx dashboard --auth-token=<token>     Pin the Bearer token (alias --token; overrides LEAN_CTX_HTTP_TOKEN)"
+        );
+        println!(
+            "  lean-ctx dashboard --no-auth                Run without a Bearer token (alias --auth=false)."
+        );
+        println!(
+            "                                              Cross-origin/CSRF + DNS-rebinding stay blocked via"
+        );
+        println!(
+            "                                              Sec-Fetch-Site/Origin/Host checks. Best on loopback;"
+        );
+        println!(
+            "                                              for Docker publish to 127.0.0.1 (-p 127.0.0.1:PORT:PORT)."
         );
         println!("  lean-ctx dashboard --export        Export HTML report (replaces visualize)");
         println!(
@@ -419,6 +431,12 @@ pub(super) fn cmd_dashboard(rest: &[String]) {
         );
         println!(
             "  LEAN_CTX_SCRAPE_TOKEN=<token> Read-only token accepted ONLY for GET /metrics — hand this to Prometheus/Datadog agents instead of the dashboard token (docs/integrations/datadog.md)."
+        );
+        println!(
+            "  LEAN_CTX_DASHBOARD_AUTH=true|false  Require the Bearer token (default true). false = no-auth mode (overridden by --no-auth/--auth=). Also settable via `lean-ctx config set dashboard_auth`."
+        );
+        println!(
+            "  LEAN_CTX_DASHBOARD_ALLOWED_HOSTS=host:port,…  Extra Host header values accepted in no-auth mode (loopback + bound host are always allowed)."
         );
         return;
     }
@@ -474,6 +492,22 @@ pub(super) fn cmd_dashboard(rest: &[String]) {
                 .or_else(|| p.strip_prefix("--token="))
         })
         .map(String::from);
+    // `--no-auth` / `--auth=<bool>`: run the dashboard without a Bearer token.
+    // No-auth is not unprotected — cross-origin/CSRF and DNS-rebinding are blocked
+    // by request-header checks (Sec-Fetch-Site/Origin/Host allowlist). Precedence:
+    // this flag > LEAN_CTX_DASHBOARD_AUTH env > `dashboard_auth` config > true.
+    // `None` = "not given on the CLI" so the env/config decides.
+    let auth_enabled = if rest.iter().any(|a| a == "--no-auth") {
+        Some(false)
+    } else {
+        rest.iter()
+            .find_map(|p| p.strip_prefix("--auth="))
+            .and_then(|v| match v.trim().to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "on" => Some(true),
+                "false" | "0" | "no" | "off" => Some(false),
+                _ => None,
+            })
+    };
     // `--open=<browser|none|vscode>`: how to reveal the URL once the server is
     // up. `--no-open` is shorthand for `--open=none` (#424). Overrides
     // LEAN_CTX_DASHBOARD_OPEN.
@@ -533,7 +567,12 @@ pub(super) fn cmd_dashboard(rest: &[String]) {
     crate::core::layout_pin::heal();
     super::spawn_proxy_if_needed();
     super::run_async(dashboard::start(
-        port, host, base_path, auth_token, open_mode,
+        port,
+        host,
+        base_path,
+        auth_token,
+        open_mode,
+        auth_enabled,
     ));
 }
 

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -136,6 +136,18 @@ pub struct Config {
     /// require the token; clients must then send `Authorization: Bearer <token>`.
     #[serde(default)]
     pub proxy_require_token: bool,
+    /// Require Bearer-token authentication for the dashboard. Default `true`:
+    /// the dashboard generates (or uses the pinned) token and rejects `/api/*`
+    /// and `/metrics` without it. Set to `false` to run the dashboard with **no
+    /// auth token** — useful for a local/Docker setup where managing a token is
+    /// inconvenient. No-auth mode is not unprotected: cross-origin and CSRF
+    /// attacks from a malicious local website are blocked by request-header
+    /// validation instead (`Sec-Fetch-Site`, `Origin`/`Host` same-origin, and a
+    /// `Host` allowlist against DNS rebinding — see `dashboard::no_auth_request_ok`).
+    /// Override per-run via the `--no-auth` / `--auth=<bool>` flag or the
+    /// `LEAN_CTX_DASHBOARD_AUTH` env var.
+    #[serde(default = "serde_defaults::default_true")]
+    pub dashboard_auth: bool,
     #[serde(default = "serde_defaults::default_buddy_enabled")]
     pub buddy_enabled: bool,
     #[serde(default = "serde_defaults::default_true")]
@@ -592,6 +604,7 @@ impl Default for Config {
             proxy_port: None,
             proxy_timeout_ms: None,
             proxy_require_token: false,
+            dashboard_auth: true,
             buddy_enabled: serde_defaults::default_buddy_enabled(),
             enable_wakeup_ctx: true,
             redirect_exclude: Vec::new(),

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -575,6 +575,14 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         ),
     );
     root.insert(
+        "dashboard_auth".into(),
+        key(
+            "bool",
+            serde_json::json!(cfg.dashboard_auth),
+            "Require Bearer-token auth for the dashboard (default true). Set false for no-auth mode protected by Sec-Fetch-Site/Origin/Host checks. Override per-run with --no-auth or LEAN_CTX_DASHBOARD_AUTH",
+        ),
+    );
+    root.insert(
         "response_verbosity".into(),
         key_enum_with_env(
             &["normal", "compact", "minimal"],

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -203,7 +203,9 @@ pub async fn start(
         }
     } else if is_local {
         // No-auth on loopback: header-based CSRF protection is the boundary.
-        println!("  Auth: \x1b[1;33mDISABLED\x1b[0m (no-auth) — CSRF protected via Sec-Fetch-Site/Origin/Host");
+        println!(
+            "  Auth: \x1b[1;33mDISABLED\x1b[0m (no-auth) — CSRF protected via Sec-Fetch-Site/Origin/Host"
+        );
         println!("  Browser URL:  http://localhost:{port}{base_path}/");
     } else {
         // No-auth + non-loopback bind (e.g. Docker --host=0.0.0.0). Browser

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -75,6 +75,7 @@ pub async fn start(
     base_path: Option<String>,
     auth_token: Option<String>,
     open_mode: Option<String>,
+    auth_enabled: Option<bool>,
 ) {
     // How to reveal the URL once the server is up: --open= flag > env > browser.
     let open = resolve_open_mode(open_mode.as_deref());
@@ -102,6 +103,18 @@ pub async fn start(
 
     let addr = format!("{host}:{port}");
     let is_local = host == "127.0.0.1" || host == "localhost" || host == "::1";
+
+    // Whether the dashboard requires a Bearer token. Precedence:
+    // `--no-auth`/`--auth=` flag > LEAN_CTX_DASHBOARD_AUTH env > `dashboard_auth`
+    // config > default `true`. When disabled, no token is generated and the
+    // sensitive endpoints (`/api/*`, `/metrics`) are guarded by request-header
+    // checks (Sec-Fetch-Site / Origin / Host allowlist) instead — see
+    // `no_auth_request_ok`.
+    let auth_required = resolve_auth_enabled(auth_enabled);
+
+    // Host values accepted in no-auth mode (anti-DNS-rebinding allowlist). Built
+    // once and shared with every connection.
+    let allowed_hosts = Arc::new(build_allowed_hosts(&host, port));
 
     // Resolve any *requested* fixed token (flag > LEAN_CTX_HTTP_TOKEN) up-front;
     // `None` means "generate a random one". Done before the already-running check
@@ -132,10 +145,21 @@ pub async fn start(
         return;
     }
 
-    // Always enable auth (even on loopback) to prevent cross-origin reads of /api/*
-    // from a malicious website (CORS is not a reliable boundary for localhost services).
-    let t = requested_token.unwrap_or_else(generate_token);
-    let token = Some(Arc::new(t));
+    // Auth defaults on (even on loopback) to prevent cross-origin reads of /api/*
+    // from a malicious website (CORS is not a reliable boundary for localhost
+    // services). When explicitly disabled, run token-less: cross-origin/CSRF and
+    // DNS-rebinding attacks are blocked by `no_auth_request_ok` instead.
+    let token = if auth_required {
+        let t = requested_token.unwrap_or_else(generate_token);
+        Some(Arc::new(t))
+    } else {
+        if requested_token.is_some() {
+            eprintln!(
+                "  \x1b[33m⚠\x1b[0m Ignoring the pinned token ({token_src}) — auth is disabled."
+            );
+        }
+        None
+    };
 
     // Bind BEFORE persisting the token: two racing `lean-ctx dashboard` starts
     // both used to write their fresh token, the bind loser exited — leaving a
@@ -177,6 +201,22 @@ pub async fn start(
                  Browser URL:  http://<your-ip>:{port}{base_path}/?token={t}"
             );
         }
+    } else if is_local {
+        // No-auth on loopback: header-based CSRF protection is the boundary.
+        println!("  Auth: \x1b[1;33mDISABLED\x1b[0m (no-auth) — CSRF protected via Sec-Fetch-Site/Origin/Host");
+        println!("  Browser URL:  http://localhost:{port}{base_path}/");
+    } else {
+        // No-auth + non-loopback bind (e.g. Docker --host=0.0.0.0). Browser
+        // cross-origin/CSRF is still blocked, but non-browser clients that can
+        // reach the address have unauthenticated access — warn loudly.
+        eprintln!(
+            "  \x1b[33m⚠\x1b[0m Auth \x1b[1;31mDISABLED\x1b[0m and binding to {host} (not loopback).\n  \
+             Browser cross-origin/CSRF stays blocked (Sec-Fetch-Site/Origin/Host),\n  \
+             but ANY non-browser client that can reach {host}:{port} has full access.\n  \
+             Docker: publish only to the host loopback → -p 127.0.0.1:{port}:{port}\n  \
+             Add reachable hostnames via LEAN_CTX_DASHBOARD_ALLOWED_HOSTS=host:port,…\n  \
+             Browser URL:  http://<your-ip>:{port}{base_path}/"
+        );
     }
 
     let stats_path = crate::core::data_dir::lean_ctx_data_dir().map_or_else(
@@ -223,7 +263,8 @@ pub async fn start(
         if let Ok((stream, _)) = listener.accept().await {
             let token_ref = token.clone();
             let base_ref = base_path.clone();
-            tokio::spawn(handle_request(stream, token_ref, base_ref));
+            let allowed_ref = allowed_hosts.clone();
+            tokio::spawn(handle_request(stream, token_ref, base_ref, allowed_ref));
         }
     }
 }
@@ -233,6 +274,106 @@ const HTTP_TOKEN_ENV: &str = "LEAN_CTX_HTTP_TOKEN";
 /// Read-only token accepted **only** for `GET /metrics` (GL #401) so
 /// monitoring agents never hold the full dashboard credential.
 const SCRAPE_TOKEN_ENV: &str = "LEAN_CTX_SCRAPE_TOKEN";
+/// Toggles dashboard Bearer-token auth. `false`/`0`/`no`/`off` disable it.
+const DASHBOARD_AUTH_ENV: &str = "LEAN_CTX_DASHBOARD_AUTH";
+/// Extra `Host` header values accepted in no-auth mode (CSV, e.g.
+/// `box.local:3333,10.0.0.5:3333`). Extends the loopback/bound-host allowlist
+/// for Docker/reverse-proxy setups reached via a custom hostname.
+const ALLOWED_HOSTS_ENV: &str = "LEAN_CTX_DASHBOARD_ALLOWED_HOSTS";
+
+/// Parse a human boolean (`true/false/1/0/yes/no/on/off`, case-insensitive).
+fn parse_human_bool(s: &str) -> Option<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Some(true),
+        "false" | "0" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Resolve whether the dashboard requires Bearer-token auth. Precedence:
+/// `--no-auth`/`--auth=` flag > `LEAN_CTX_DASHBOARD_AUTH` env > `dashboard_auth`
+/// config > default `true`.
+fn resolve_auth_enabled(flag: Option<bool>) -> bool {
+    if let Some(v) = flag {
+        return v;
+    }
+    if let Ok(raw) = std::env::var(DASHBOARD_AUTH_ENV)
+        && let Some(v) = parse_human_bool(&raw)
+    {
+        return v;
+    }
+    crate::core::config::Config::load().dashboard_auth
+}
+
+/// Build the `Host` header allowlist for no-auth mode (anti-DNS-rebinding).
+/// Always includes the loopback aliases for `port` (localhost is the intended
+/// audience), the actual bound `host:port`, and any `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`
+/// entries. Bare-host forms (no port) are added too so non-browser clients that
+/// omit the port aren't rejected. `0.0.0.0` is never added — browsers don't send
+/// `Host: 0.0.0.0`; operators expose reachable names via the env allowlist.
+fn build_allowed_hosts(host: &str, port: u16) -> Vec<String> {
+    let mut allowed: Vec<String> = Vec::new();
+    let mut push = |h: String| {
+        if !h.is_empty() && !allowed.iter().any(|e| e.eq_ignore_ascii_case(&h)) {
+            allowed.push(h);
+        }
+    };
+    for base in ["127.0.0.1", "localhost", "[::1]", "::1"] {
+        push(base.to_string());
+        push(format!("{base}:{port}"));
+    }
+    if host != "0.0.0.0" && host != "::" {
+        push(host.to_string());
+        push(format!("{host}:{port}"));
+    }
+    if let Ok(raw) = std::env::var(ALLOWED_HOSTS_ENV) {
+        for entry in raw.split(',') {
+            push(entry.trim().to_string());
+        }
+    }
+    allowed
+}
+
+/// Is the request `Host` header in the allowlist (case-insensitive)?
+fn host_allowed(host: &str, allowed: &[String]) -> bool {
+    allowed.iter().any(|a| a.eq_ignore_ascii_case(host))
+}
+
+/// Token-free request gate for no-auth dashboards. Applied to the same sensitive
+/// endpoints the Bearer token guards (`/api/*`, `/metrics`). Blocks browser
+/// cross-origin/CSRF and DNS-rebinding without a credential:
+///  * `Sec-Fetch-Site`, when sent, must be `same-origin` or `none` (the header is
+///    set by the browser and cannot be forged by page JS).
+///  * `Host` must be in `allowed_hosts` (missing `Host` is rejected).
+///  * `Origin`, when sent and not `null`, must be same-origin as `Host`.
+///
+/// Non-browser clients (curl, Prometheus) omit `Sec-Fetch-Site`/`Origin` and pass
+/// those checks — they only need to target an allowlisted `Host`.
+fn no_auth_request_ok(header_section: &str, allowed_hosts: &[String]) -> bool {
+    if let Some(sfs) = header_line_value(header_section, "Sec-Fetch-Site") {
+        let sfs = sfs.trim();
+        if !sfs.is_empty()
+            && !sfs.eq_ignore_ascii_case("same-origin")
+            && !sfs.eq_ignore_ascii_case("none")
+        {
+            return false;
+        }
+    }
+    let Some(host) = header_line_value(header_section, "Host") else {
+        return false;
+    };
+    if !host_allowed(host, allowed_hosts) {
+        return false;
+    }
+    if let Some(origin) = header_line_value(header_section, "Origin")
+        && !origin.is_empty()
+        && !origin.eq_ignore_ascii_case("null")
+        && !origin_matches_dashboard_host(origin, host)
+    {
+        return false;
+    }
+    true
+}
 
 /// Resolve the dashboard Bearer token.
 ///
@@ -558,6 +699,7 @@ async fn handle_request(
     mut stream: tokio::net::TcpStream,
     token: Option<Arc<String>>,
     base_path: Arc<String>,
+    allowed_hosts: Arc<Vec<String>>,
 ) {
     let is_loopback = stream.peer_addr().is_ok_and(|a| a.ip().is_loopback());
 
@@ -673,6 +815,21 @@ async fn handle_request(
             let _ = stream.write_all(response.as_bytes()).await;
             return;
         }
+    } else if requires_auth && !no_auth_request_ok(&header_text, &allowed_hosts) {
+        // No-auth mode: the Bearer token is gone, so cross-origin/CSRF and
+        // DNS-rebinding are blocked by request-header validation instead.
+        let body = r#"{"error":"forbidden"}"#;
+        let response = format!(
+            "HTTP/1.1 403 Forbidden\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {}\r\n\
+             Connection: close\r\n\
+             \r\n\
+             {body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        return;
     }
 
     // Route handlers are synchronous and a few (graph/index builds) do seconds
@@ -1087,5 +1244,113 @@ mod tests {
         crate::test_env::remove_var(HTTP_TOKEN_ENV);
         assert_eq!(src, HTTP_TOKEN_ENV);
         assert_eq!(token.as_deref(), Some("lctx_fromenv"));
+    }
+
+    #[test]
+    fn parse_human_bool_accepts_common_forms() {
+        for s in ["true", "TRUE", "1", "yes", "on", " On "] {
+            assert_eq!(parse_human_bool(s), Some(true), "{s}");
+        }
+        for s in ["false", "FALSE", "0", "no", "off", " Off "] {
+            assert_eq!(parse_human_bool(s), Some(false), "{s}");
+        }
+        assert_eq!(parse_human_bool("maybe"), None);
+    }
+
+    #[test]
+    fn build_allowed_hosts_covers_loopback_and_bound_host() {
+        let _g = ENV_LOCK.lock().expect("env lock");
+        crate::test_env::remove_var(ALLOWED_HOSTS_ENV);
+        let allowed = build_allowed_hosts("0.0.0.0", 3333);
+        assert!(host_allowed("127.0.0.1:3333", &allowed));
+        assert!(host_allowed("localhost:3333", &allowed));
+        assert!(host_allowed("[::1]:3333", &allowed));
+        assert!(host_allowed("127.0.0.1", &allowed)); // bare host, no port
+        // 0.0.0.0 binds all interfaces but is never a valid browser Host.
+        assert!(!host_allowed("0.0.0.0:3333", &allowed));
+        assert!(!host_allowed("evil.com", &allowed));
+    }
+
+    #[test]
+    fn build_allowed_hosts_honors_env_extra_hosts() {
+        let _g = ENV_LOCK.lock().expect("env lock");
+        crate::test_env::set_var(ALLOWED_HOSTS_ENV, "box.local:3333, 10.0.0.5:3333");
+        let allowed = build_allowed_hosts("127.0.0.1", 3333);
+        crate::test_env::remove_var(ALLOWED_HOSTS_ENV);
+        assert!(host_allowed("box.local:3333", &allowed));
+        assert!(host_allowed("10.0.0.5:3333", &allowed));
+    }
+
+    fn allowed_loopback() -> Vec<String> {
+        vec![
+            "127.0.0.1:3333".into(),
+            "localhost:3333".into(),
+            "127.0.0.1".into(),
+            "localhost".into(),
+        ]
+    }
+
+    #[test]
+    fn no_auth_allows_non_browser_client() {
+        // curl: no Sec-Fetch-Site, no Origin, just a loopback Host.
+        let req = "GET /api/stats HTTP/1.1\r\nHost: 127.0.0.1:3333\r\n\r\n";
+        assert!(no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_allows_same_origin_browser_request() {
+        let req = "GET /api/stats HTTP/1.1\r\nHost: localhost:3333\r\n\
+                   Origin: http://localhost:3333\r\nSec-Fetch-Site: same-origin\r\n\r\n";
+        assert!(no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_allows_direct_navigation() {
+        // Top-level navigation carries Sec-Fetch-Site: none and no Origin.
+        let req = "GET /api/stats HTTP/1.1\r\nHost: 127.0.0.1:3333\r\nSec-Fetch-Site: none\r\n\r\n";
+        assert!(no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_rejects_cross_site_fetch() {
+        let req = "GET /api/stats HTTP/1.1\r\nHost: 127.0.0.1:3333\r\n\
+                   Sec-Fetch-Site: cross-site\r\n\r\n";
+        assert!(!no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_rejects_same_site_fetch() {
+        let req = "GET /api/stats HTTP/1.1\r\nHost: 127.0.0.1:3333\r\n\
+                   Sec-Fetch-Site: same-site\r\n\r\n";
+        assert!(!no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_rejects_foreign_origin() {
+        let req = "POST /api/settings HTTP/1.1\r\nHost: 127.0.0.1:3333\r\n\
+                   Origin: http://evil.com\r\n\r\n";
+        assert!(!no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_rejects_dns_rebinding_host() {
+        // After DNS rebinding the browser sends the attacker's hostname as Host.
+        let req = "GET /api/stats HTTP/1.1\r\nHost: evil.com\r\n\
+                   Sec-Fetch-Site: same-origin\r\n\r\n";
+        assert!(!no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_rejects_missing_host() {
+        let req = "GET /api/stats HTTP/1.1\r\n\r\n";
+        assert!(!no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn no_auth_allows_null_origin() {
+        // Some sandboxed/file contexts send Origin: null — not attributable to a
+        // site, and the Host + Sec-Fetch-Site checks still apply.
+        let req = "GET /api/stats HTTP/1.1\r\nHost: 127.0.0.1:3333\r\nOrigin: null\r\n\r\n";
+        assert!(no_auth_request_ok(req, &allowed_loopback()));
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in **no-auth mode** for the dashboard: run it without a Bearer token while staying protected against browser cross-origin/CSRF and DNS-rebinding attacks via request-header validation instead of a credential.

Auth stays **on by default** — no behavior change for existing deployments. When disabled, the same sensitive endpoints the token guarded (`/api/*`, `/metrics`) are gated on request headers:

- **`Sec-Fetch-Site`** — only `same-origin` / `none` pass; `cross-site` / `same-site` are rejected (browser-set, not forgeable by page JS).
- **`Origin`** — when present and not `null`, must be same-origin as `Host`.
- **`Host` allowlist** — must be a loopback alias, the bound host, or an entry in `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS` (blocks DNS rebinding).

Non-browser clients (curl, Prometheus scraping `/metrics`) omit those headers and keep working as long as they target an allowlisted host.

**How to enable** (precedence: flag > env > config > default `true`):

```bash
lean-ctx dashboard --no-auth          # one run (alias --auth=false)
LEAN_CTX_DASHBOARD_AUTH=false lean-ctx dashboard
lean-ctx config set dashboard_auth false
```

No-auth also works when bound to a non-loopback host (e.g. Docker `--host=0.0.0.0` reached from the host) with a loud warning; the recommended Docker pattern publishes to the host loopback (`-p 127.0.0.1:3333:3333`).

**Files changed:**
- `rust/src/dashboard/mod.rs` — no-auth request gate (`no_auth_request_ok`), `Host` allowlist, auth resolution + 11 unit tests
- `rust/src/cli/dispatch/network.rs` — `--no-auth` / `--auth=<bool>` flag and `--help` text
- `rust/src/core/config/mod.rs` + `rust/src/core/config/schema/sections_core.rs` — `dashboard_auth` config key (default `true`)
- `discord-faq/06-dashboard-analytics.md` — no-auth docs + security model

## Test plan

- [ ] `cd rust && cargo test`
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- **Risk areas / edge cases:** the no-auth gate runs only when `token == None`; the existing token path is byte-for-byte unchanged. `Origin: null` is allowed (consistent with the existing `csrf_origin_ok`) but still subject to the `Sec-Fetch-Site` + `Host` checks. `0.0.0.0` / `::` are never added to the `Host` allowlist (browsers never send them as `Host`); bare-host forms (no port) are accepted so non-browser clients aren't rejected.
- **Backwards compatibility:** fully backward compatible — `dashboard_auth` defaults to `true`, so existing setups keep requiring the Bearer token with no changes.
- **Docs updated:** `discord-faq/06-dashboard-analytics.md` (new no-auth Q&A + security model), `lean-ctx dashboard --help` (flag + `LEAN_CTX_DASHBOARD_AUTH` / `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`).