### PR TITLE
fix(lean-ctx): adjust command execution to prefer shell compression over nested wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,10 @@ lean-ctx optimizes LLM context by compressing file reads, shell output, and sear
 ## Integration Mode: Hybrid
 
 - **Reads/Search** → MCP tools (`ctx_read`, `ctx_search`) for caching + compression
-- **Shell commands** → `lean-ctx -c "…"` via CLI (preferred) or `ctx_shell` via MCP (both work)
+- **Shell commands** → run the command normally in agent shells; the shell/tool
+  wrapper may already compress output. Use `lean-ctx -c "…"` only when the user
+  explicitly requests it or task setup/docs explicitly say the shell is not
+  wrapped. Do not probe env vars just to decide; users may forbid env access.
 - **File editing** → native Edit/StrReplace (lean-ctx only handles READ operations)
 
 The canonical tool-mapping table is auto-injected per session via
@@ -15,8 +18,9 @@ deliberately not duplicated here.
 ## CLI commands (optimized shell, lower overhead)
 
 ```bash
-lean-ctx -c "git status"     # compressed shell output
-lean-ctx -c "cargo test"     # compressed test output
+git status                   # compressed by configured agent shell/wrapper
+cargo test                   # compressed by configured agent shell/wrapper
+lean-ctx -c "git status"     # only if explicitly requested / documented unwrapped
 lean-ctx ls src/              # directory map
 ```
 

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -100,6 +100,68 @@ fn wait_with_limits(mut child: Child, max_bytes: usize, timeout: std::time::Dura
     }
 }
 
+#[cfg(test)]
+mod nested_lean_ctx_exec_tests {
+    #[test]
+    fn collapses_single_nested_c() {
+        assert_eq!(
+            super::collapse_nested_lean_ctx_exec("lean-ctx -c 'git status'").as_deref(),
+            Some("git status")
+        );
+    }
+
+    #[test]
+    fn collapses_repeated_nested_c() {
+        assert_eq!(
+            super::collapse_nested_lean_ctx_exec("lean-ctx -c 'lean-ctx -c \"git status\"'")
+                .as_deref(),
+            Some("git status")
+        );
+    }
+
+    #[test]
+    fn preserves_inner_shell_quoting() {
+        assert_eq!(
+            super::collapse_nested_lean_ctx_exec("lean-ctx -c \"git commit -m 'hello world'\"")
+                .as_deref(),
+            Some("git commit -m 'hello world'")
+        );
+        assert_eq!(
+            super::collapse_nested_lean_ctx_exec("lean-ctx -c git commit -m 'hello world'")
+                .as_deref(),
+            Some("git commit -m 'hello world'")
+        );
+    }
+
+    #[test]
+    fn collapses_exec_alias_and_path() {
+        assert_eq!(
+            super::collapse_nested_lean_ctx_exec("/usr/local/bin/lean-ctx exec 'git status'")
+                .as_deref(),
+            Some("git status")
+        );
+    }
+
+    #[test]
+    fn leaves_non_wrappers_alone() {
+        assert!(super::collapse_nested_lean_ctx_exec("git status").is_none());
+    }
+
+    #[test]
+    fn wrapped_nested_wrapper_still_owns_one_compression_pass() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::set_var(super::super::reentry::WRAP_MARKER, "1");
+
+        assert!(super::should_delegate_wrapped_to_shell_default(false));
+        assert!(
+            !super::should_delegate_wrapped_to_shell_default(true),
+            "collapsed nested wrappers must not fall through to raw shell-default path"
+        );
+
+        crate::test_env::remove_var(super::super::reentry::WRAP_MARKER);
+    }
+}
+
 const DEFAULT_MAX_BYTES: usize = 8 * 1024 * 1024; // 8 MB
 const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(2);
 const HEAVY_MAX_BYTES: usize = 32 * 1024 * 1024; // 32 MB
@@ -378,7 +440,16 @@ pub fn exec(command: &str) -> i32 {
     // allowlist would otherwise hard-block on every single call. The cwd snapshot
     // is preserved so the host keeps tracking the working directory.
     let unwrapped = super::agent_wrapper::unwrap_agent_wrapper(command).map(|u| u.rebuild());
+    let mut collapsed_nested = false;
+    let collapsed;
     let command = unwrapped.as_deref().unwrap_or(command);
+    let command = if let Some(c) = collapse_nested_lean_ctx_exec(command) {
+        collapsed_nested = true;
+        collapsed = c;
+        collapsed.as_str()
+    } else {
+        command
+    };
 
     if let Some(code) = allowlist_gate(command) {
         return code;
@@ -388,8 +459,11 @@ pub fn exec(command: &str) -> i32 {
     let command = crate::tools::ctx_shell::normalize_command_for_shell(command);
     let command = command.as_str();
 
-    if super::reentry::should_pass_through() {
+    if super::reentry::is_disabled() {
         return exec_inherit(command, &shell, &shell_flag);
+    }
+    if should_delegate_wrapped_to_shell_default(collapsed_nested) {
+        return exec_shell_default(command, &shell, &shell_flag);
     }
 
     let cfg = config::Config::load();
@@ -438,6 +512,124 @@ pub fn exec(command: &str) -> i32 {
     exec_buffered(command, &shell, &shell_flag, &cfg)
 }
 
+fn collapse_nested_lean_ctx_exec(command: &str) -> Option<String> {
+    let mut current = command.trim().to_string();
+    let mut changed = false;
+
+    loop {
+        let Some(next) = strip_one_lean_ctx_exec(&current) else {
+            break;
+        };
+        if next == current {
+            break;
+        }
+        current = next;
+        changed = true;
+    }
+
+    changed.then_some(current)
+}
+
+fn should_delegate_wrapped_to_shell_default(collapsed_nested: bool) -> bool {
+    // After collapsing `lean-ctx -c "lean-ctx -c ..."` the current process is the
+    // one compression pass that would otherwise be owned by the shell default.
+    // Delegating again would drop back to raw execution or re-enter the hook.
+    super::reentry::is_wrapped() && !collapsed_nested
+}
+
+fn strip_one_lean_ctx_exec(command: &str) -> Option<String> {
+    let words = split_simple_shell_words(command)?;
+    if words.len() < 3 || !is_lean_ctx_bin(&words[0].value) {
+        return None;
+    }
+    if words[1].value != "-c" && words[1].value != "exec" {
+        return None;
+    }
+    if words[2..].iter().any(|w| {
+        matches!(
+            w.value.as_str(),
+            "|" | "||" | "&" | "&&" | ";" | "<" | ">" | ">>"
+        )
+    }) {
+        return None;
+    }
+    if words.len() == 3 {
+        Some(words[2].value.trim().to_string())
+    } else {
+        Some(command[words[2].start..].trim().to_string())
+    }
+}
+
+fn is_lean_ctx_bin(word: &str) -> bool {
+    std::path::Path::new(word)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "lean-ctx" || name == "lean-ctx.exe")
+}
+
+struct SimpleShellWord {
+    value: String,
+    start: usize,
+}
+
+fn split_simple_shell_words(command: &str) -> Option<Vec<SimpleShellWord>> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut current_start: Option<usize> = None;
+    let mut chars = command.char_indices().peekable();
+    let mut quote: Option<char> = None;
+
+    while let Some((idx, ch)) = chars.next() {
+        match quote {
+            Some('\'') if ch == '\'' => quote = None,
+            Some('"') if ch == '"' => quote = None,
+            Some('"') if ch == '\\' => {
+                current_start.get_or_insert(idx);
+                if let Some((_, next)) = chars.next() {
+                    current.push(next);
+                }
+            }
+            Some(_) => {
+                current_start.get_or_insert(idx);
+                current.push(ch);
+            }
+            None if ch == '\'' || ch == '"' => {
+                current_start.get_or_insert(idx);
+                quote = Some(ch);
+            }
+            None if ch == '\\' => {
+                current_start.get_or_insert(idx);
+                if let Some((_, next)) = chars.next() {
+                    current.push(next);
+                }
+            }
+            None if ch.is_whitespace() => {
+                if let Some(start) = current_start.take() {
+                    words.push(SimpleShellWord {
+                        value: std::mem::take(&mut current),
+                        start,
+                    });
+                }
+            }
+            None => {
+                current_start.get_or_insert(idx);
+                current.push(ch);
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return None;
+    }
+    if let Some(start) = current_start {
+        words.push(SimpleShellWord {
+            value: current,
+            start,
+        });
+    }
+    (!words.is_empty()).then_some(words)
+}
+
 fn exec_inherit(command: &str, shell: &str, shell_flag: &str) -> i32 {
     let mut cmd = Command::new(shell);
     cmd.arg(shell_flag)
@@ -454,6 +646,27 @@ fn exec_inherit(command: &str, shell: &str, shell_flag: &str) -> i32 {
         Ok(s) => s.code().unwrap_or(1),
         Err(e) => {
             tracing::error!("lean-ctx: failed to execute: {e}");
+            127
+        }
+    }
+}
+
+fn exec_shell_default(command: &str, shell: &str, shell_flag: &str) -> i32 {
+    let mut cmd = Command::new(shell);
+    cmd.arg(shell_flag)
+        .arg(command)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    super::reentry::clear_shell_default_markers(&mut cmd);
+    super::platform::apply_utf8_locale(&mut cmd);
+    super::platform::apply_profile_free_env(&mut cmd);
+    let status = cmd.status();
+
+    match status {
+        Ok(s) => s.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("lean-ctx: failed to execute '{}': {}", command, e);
             127
         }
     }

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -516,10 +516,7 @@ fn collapse_nested_lean_ctx_exec(command: &str) -> Option<String> {
     let mut current = command.trim().to_string();
     let mut changed = false;
 
-    loop {
-        let Some(next) = strip_one_lean_ctx_exec(&current) else {
-            break;
-        };
+    while let Some(next) = strip_one_lean_ctx_exec(&current) {
         if next == current {
             break;
         }
@@ -583,21 +580,11 @@ fn split_simple_shell_words(command: &str) -> Option<Vec<SimpleShellWord>> {
         match quote {
             Some('\'') if ch == '\'' => quote = None,
             Some('"') if ch == '"' => quote = None,
-            Some('"') if ch == '\\' => {
-                current_start.get_or_insert(idx);
-                if let Some((_, next)) = chars.next() {
-                    current.push(next);
-                }
-            }
-            Some(_) => {
-                current_start.get_or_insert(idx);
-                current.push(ch);
-            }
             None if ch == '\'' || ch == '"' => {
                 current_start.get_or_insert(idx);
                 quote = Some(ch);
             }
-            None if ch == '\\' => {
+            Some('"') | None if ch == '\\' => {
                 current_start.get_or_insert(idx);
                 if let Some((_, next)) = chars.next() {
                     current.push(next);
@@ -611,7 +598,7 @@ fn split_simple_shell_words(command: &str) -> Option<Vec<SimpleShellWord>> {
                     });
                 }
             }
-            None => {
+            Some(_) | None => {
                 current_start.get_or_insert(idx);
                 current.push(ch);
             }
@@ -666,7 +653,7 @@ fn exec_shell_default(command: &str, shell: &str, shell_flag: &str) -> i32 {
     match status {
         Ok(s) => s.code().unwrap_or(1),
         Err(e) => {
-            eprintln!("lean-ctx: failed to execute '{}': {}", command, e);
+            eprintln!("lean-ctx: failed to execute '{command}': {e}");
             127
         }
     }

--- a/rust/src/shell/reentry.rs
+++ b/rust/src/shell/reentry.rs
@@ -25,17 +25,31 @@ pub(crate) const WRAP_MARKER: &str = "LEAN_CTX_WRAPPED";
 /// command, but it no longer gates compression on its own.
 pub(crate) const ACTIVE_MARKER: &str = "LEAN_CTX_ACTIVE";
 
-/// True when `lean-ctx -c` / `-t` must run the command **raw** instead of
-/// compressing it again: either a parent lean-ctx already owns this command
-/// tree ([`WRAP_MARKER`]) or compression is globally disabled
-/// (`LEAN_CTX_DISABLED`).
+/// True when `LEAN_CTX_DISABLED` forces `lean-ctx -c` / `-t` to run the
+/// command raw instead of compressing it.
+#[must_use]
+pub(crate) fn is_disabled() -> bool {
+    std::env::var("LEAN_CTX_DISABLED").is_ok()
+}
+
+/// True when a parent lean-ctx already owns this command tree. Nested explicit
+/// `lean-ctx -c` should defer to the ambient shell defaults, not force raw
+/// command bytes, so shell-hook compression can still apply when configured.
+#[must_use]
+pub(crate) fn is_wrapped() -> bool {
+    std::env::var(WRAP_MARKER).is_ok()
+}
+
+/// True when `lean-ctx -c` / `-t` must avoid owning compression itself: either
+/// a parent lean-ctx already owns this command tree ([`WRAP_MARKER`]) or
+/// compression is globally disabled (`LEAN_CTX_DISABLED`).
 ///
 /// Deliberately does **not** consult `LEAN_CTX_ACTIVE`: that flag is only a
 /// shell-hook re-entry guard, and an agent's top-level process can inherit it,
 /// which previously suppressed compression for every command it ran (#533).
 #[must_use]
 pub(crate) fn should_pass_through() -> bool {
-    std::env::var(WRAP_MARKER).is_ok() || std::env::var("LEAN_CTX_DISABLED").is_ok()
+    is_wrapped() || is_disabled()
 }
 
 /// Stamp a child command so nested lean-ctx invocations pass through and the
@@ -45,9 +59,21 @@ pub(crate) fn mark_child(cmd: &mut Command) {
     cmd.env(ACTIVE_MARKER, "1").env(WRAP_MARKER, "1");
 }
 
+/// Clear lean-ctx ownership/force markers before delegating to the user's shell
+/// defaults. This lets a nested explicit wrapper behave like typing the command
+/// in that shell: configured hooks may compress; unconfigured shells run raw.
+pub(crate) fn clear_shell_default_markers(cmd: &mut Command) {
+    cmd.env_remove(ACTIVE_MARKER)
+        .env_remove(WRAP_MARKER)
+        .env_remove("LEAN_CTX_COMPRESS");
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ACTIVE_MARKER, WRAP_MARKER, mark_child, should_pass_through};
+    use super::{
+        ACTIVE_MARKER, WRAP_MARKER, clear_shell_default_markers, is_disabled, is_wrapped,
+        mark_child, should_pass_through,
+    };
 
     #[test]
     fn wrap_marker_triggers_passthrough() {
@@ -55,6 +81,7 @@ mod tests {
         crate::test_env::remove_var("LEAN_CTX_DISABLED");
         crate::test_env::remove_var(ACTIVE_MARKER);
         crate::test_env::set_var(WRAP_MARKER, "1");
+        assert!(is_wrapped());
         assert!(should_pass_through());
         crate::test_env::remove_var(WRAP_MARKER);
     }
@@ -65,6 +92,7 @@ mod tests {
         crate::test_env::remove_var(WRAP_MARKER);
         crate::test_env::remove_var(ACTIVE_MARKER);
         crate::test_env::set_var("LEAN_CTX_DISABLED", "1");
+        assert!(is_disabled());
         assert!(should_pass_through());
         crate::test_env::remove_var("LEAN_CTX_DISABLED");
     }
@@ -93,5 +121,28 @@ mod tests {
             .collect();
         assert_eq!(envs.get(WRAP_MARKER).map(String::as_str), Some("1"));
         assert_eq!(envs.get(ACTIVE_MARKER).map(String::as_str), Some("1"));
+    }
+
+    #[test]
+    fn clear_shell_default_markers_removes_wrapping_state() {
+        let mut cmd = std::process::Command::new("true");
+        mark_child(&mut cmd);
+        cmd.env("LEAN_CTX_COMPRESS", "1");
+
+        clear_shell_default_markers(&mut cmd);
+
+        let envs: std::collections::HashMap<String, Option<String>> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_str()?.to_string(),
+                    v.and_then(|v| v.to_str().map(str::to_string)),
+                ))
+            })
+            .collect();
+
+        assert_eq!(envs.get(WRAP_MARKER), Some(&None));
+        assert_eq!(envs.get(ACTIVE_MARKER), Some(&None));
+        assert_eq!(envs.get("LEAN_CTX_COMPRESS"), Some(&None));
     }
 }

--- a/skills/lean-ctx/SKILL.md
+++ b/skills/lean-ctx/SKILL.md
@@ -33,27 +33,35 @@ lean-ctx supports two integration styles (auto-detected per agent):
 
 ## When to use lean-ctx
 
-Always prefer `lean-ctx -c <command>` over running commands directly when:
+Prefer the current shell's configured compression over nested wrappers. In agent
+shells, run commands normally unless the user explicitly asks for
+`lean-ctx -c <command>` or task setup/docs explicitly say the shell is not
+wrapped. Do not inspect env vars just to decide; users may forbid env access.
+
+Use `lean-ctx -c <command>` over running commands directly only when:
 - The command produces verbose output (build logs, git diffs, dependency trees, test results)
 - You are reading files and only need the structure or API surface
 - You want to check token savings for the current session
 
-## Shell commands (use instead of raw exec)
+## Shell commands
 
 ```bash
-lean-ctx -c git status          # Compressed git output
-lean-ctx -c git diff            # Only meaningful diff lines
-lean-ctx -c git log --oneline -10
-lean-ctx -c npm install         # Strips progress bars, noise
-lean-ctx -c cargo build
-lean-ctx -c cargo test
-lean-ctx -c docker ps
-lean-ctx -c kubectl get pods
-lean-ctx -c aws ec2 describe-instances
-lean-ctx -c helm list
-lean-ctx -c prisma migrate dev
-lean-ctx -c curl -s <url>       # JSON schema extraction
-lean-ctx -c ls -la <dir>        # Grouped directory listing
+git status                      # Compressed by configured agent shell/wrapper
+git diff                        # Meaningful diff lines when configured
+git log --oneline -10
+npm install                     # Strips progress bars/noise when configured
+cargo build
+cargo test
+docker ps
+kubectl get pods
+aws ec2 describe-instances
+helm list
+prisma migrate dev
+curl -s <url>                   # JSON schema extraction
+ls -la <dir>                    # Grouped directory listing
+
+# Explicit user request / documented unwrapped shell:
+lean-ctx -c "git status"
 ```
 
 Supported: git, npm, pnpm, yarn, bun, deno, cargo, docker, kubectl, helm, gh, pip, ruff, go, eslint, prettier, tsc, aws, psql, mysql, prisma, swift, zig, cmake, ansible, composer, mix, bazel, systemd, terraform, make, maven, dotnet, flutter, poetry, rubocop, playwright, curl, wget, and more.


### PR DESCRIPTION
## Summary

Fixes lean-ctx CLI shell re-entry so nested lean-ctx -c / exec wrappers collapse safely while preserving one configured compression pass. Also separates disabled vs wrapped markers and updates docs to prefer already-wrapped agent shells without env probing.

## Test plan

  - [x] cd rust && cargo test
  - [x] cd rust && cargo clippy --all-targets --all-features -- -D warnings
  - [x] cd rust && cargo fmt --check

## Notes for reviewers
  - Risk areas / edge cases: nested wrappers, quoted shell args, shell-hook re-entry, marker cleanup.
  - Backwards compatibility: explicit lean-ctx -c still works; docs only change default agent guidance.
  - Docs updated (links/files): AGENTS.md, skills/lean-ctx/SKILL.md