### PR TITLE
docs: fix inverted tools_enabled precedence + stale profile counts

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -87,8 +87,8 @@ Top-level configuration keys
 - `tee_mode` (enum: never | failures | always, default `failures`) — Controls when shell output is tee'd to disk for later retrieval
 - `terse_agent` (enum: off | lite | full | ultra, default `off` — env `LEAN_CTX_TERSE_AGENT`) — Controls agent output verbosity via instructions injection
 - `theme` (string, default `default`) — Dashboard color theme
-- `tool_profile` (enum: minimal | standard | power, default `""`) — Tool visibility profile: minimal (6 tools), standard (17), power (all). Override via LEAN_CTX_TOOL_PROFILE
-- `tools_enabled` (string[], default `[]`) — Explicit list of enabled tool names (overrides tool_profile when non-empty)
+- `tool_profile` (enum: minimal | standard | power, default `""`) — Tool visibility profile: minimal (5 tools), standard (15), power (all). Override via LEAN_CTX_TOOL_PROFILE
+- `tools_enabled` (string[], default `[]`) — Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list.
 - `ultra_compact` (bool, default `false`) — Legacy flag for maximum compression (use compression_level instead)
 - `update_check_disabled` (bool, default `false` — env `LEAN_CTX_NO_UPDATE_CHECK`) — Disable the daily version check
 

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -198,7 +198,7 @@ pub struct Config {
     /// Existing installs default to "power" (backward compat).
     #[serde(default)]
     pub tool_profile: Option<String>,
-    /// Explicit list of enabled tool names (overrides tool_profile when non-empty).
+    /// Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list.
     /// Example: `tools_enabled = ["ctx_read", "ctx_shell", "ctx_search"]`
     #[serde(default)]
     pub tools_enabled: Vec<String>,

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -161,7 +161,7 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             key_enum(
                 &["minimal", "standard", "power"],
                 cfg.tool_profile.as_deref().unwrap_or(""),
-                "Tool visibility profile: minimal (6 tools), standard (17), power (all). Override via LEAN_CTX_TOOL_PROFILE",
+                "Tool visibility profile: minimal (5 tools), standard (15), power (all). Override via LEAN_CTX_TOOL_PROFILE",
             ),
         );
     root.insert(
@@ -169,7 +169,7 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         key(
             "string[]",
             serde_json::json!(cfg.tools_enabled),
-            "Explicit list of enabled tool names (overrides tool_profile when non-empty)",
+            "Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list.",
         ),
     );
     root.insert(


### PR DESCRIPTION
Refs #613.

Doc-only fix for two inaccuracies in the `tool_profile` / `tools_enabled` schema docs. **No behavior change.**

### 1. `tools_enabled` precedence was documented inverted

The schema said `tools_enabled` *"overrides tool_profile when non-empty"*. The real (intended, test-pinned) precedence is `env > tool_profile > tools_enabled > default` — a pinned `tool_profile` wins, and `tools_enabled` only applies when no profile is pinned:

- `ToolProfile::from_config` — https://github.com/yvgude/lean-ctx/blob/main/rust/src/core/tool_profiles.rs#L88-L119
- pinned by `tool_profile_takes_precedence_over_tools_enabled` (same file)

So the code is correct; the description was wrong. Setting both `tool_profile = "minimal"` and a `tools_enabled` list silently ignores the list — which is what the old wording tells users to do.

### 2. Stale tool counts

`tool_profile` description said `minimal (6 tools), standard (17)`. Actual: **minimal = 5** (`MINIMAL_TOOLS`; lost `ctx_symbol` when #509 folded symbol lookup into `ctx_search`), **standard = 15** (`STANDARD_TOOLS`).

### Changed

- `rust/src/core/config/mod.rs` — rustdoc on `Config::tools_enabled`
- `rust/src/core/config/schema/sections_core.rs` — schema description strings (precedence + counts)
- `docs/reference/generated/config-keys.md` — mirrored the two generated lines (please re-run the docs generator to confirm byte-identical output)

### Not included (tracked in #613)

- QoL: `tool_profile = ""` warns `Unknown tool_profile ''` even though `""` is its documented default — proposed 1-line fix in `is_unpinned_alias`. Happy to fold in here or as a follow-up.
- Question: `ctx_call` is advertised even for an explicit `Custom`/`tools_enabled` allowlist (reaches every tool) — intended, or should an explicit list be authoritative?
