### PR TITLE
fix(deps): bump anyhow 1.0.102 → 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
## Summary
- Bumps `anyhow` `1.0.102` → `1.0.103` (Cargo.lock only) to clear **RUSTSEC-2026-0190** (unsoundness in `anyhow::Error::downcast_mut`).
- This advisory was published after the `anyhow 1.0.102` lock landed and broke `cargo-deny` (`advisories FAILED`) on **`main` and every open PR** (e.g. #614), even for docs-only changes.
- `1.0.103` is a semver-compatible patch; no source changes required.

## Verification
- `cargo deny check advisories` → `advisories ok`
- pre-commit (`cargo fmt --check` + `cargo clippy --all-targets -D warnings`) and pre-push preflight (fmt/clippy/doc/gen_docs/cross-compile) both green locally.

## Test plan
- [x] cargo-deny advisories clean
- [x] clippy `-D warnings` clean

Made with [Cursor](https://cursor.com)