### PR TITLE
fix(config): empty tool_profile unpins + ctx_call docs + correct minimal/standard counts (#613)

### DIFF
--- a/docs/reference/02-daily-use.md
+++ b/docs/reference/02-daily-use.md
@@ -207,8 +207,8 @@ compression opportunities in your shell history).
 AI sees. Fewer tools = less per-call overhead.
 
 ```bash
-lean-ctx tools minimal       # 10 essential tools
-lean-ctx tools standard      # 19 tools (balanced)
+lean-ctx tools minimal       # 5 essential tools
+lean-ctx tools standard      # 15 tools (balanced)
 lean-ctx tools power         # all 69 (default for existing installs)
 lean-ctx tools show          # current profile
 lean-ctx tools list          # what each profile contains

--- a/docs/reference/appendix-glossary.md
+++ b/docs/reference/appendix-glossary.md
@@ -57,8 +57,8 @@ tokens instead of the whole file.
 
 ## Profiles (two different things!)
 
-**Tool profile** — *how many MCP tools* your AI sees: `minimal` (10), `standard`
-(19), `power` (72). Set with `lean-ctx tools`.
+**Tool profile** — *how many MCP tools* your AI sees: `minimal` (5), `standard`
+(15), `power` (all). Set with `lean-ctx tools`.
 
 **Context profile** — *compression/read-mode behavior* tuning. Set with
 `lean-ctx profile`. Different from tool profile despite the similar name.

--- a/docs/reference/appendix-mcp-tools.md
+++ b/docs/reference/appendix-mcp-tools.md
@@ -12,12 +12,12 @@ shows the smallest tool profile that exposes the tool (`M` minimal, `S` standard
 
 | Profile | Count | Who it's for |
 |---------|-------|--------------|
-| **minimal** | 10 | Lowest context overhead; the absolute essentials |
-| **standard** | 19 | Balanced default for most coding workflows |
+| **minimal** | 5 | Lowest context overhead; the absolute essentials |
+| **standard** | 15 | Balanced default for most coding workflows |
 | **power** | 76 | Everything (default for existing installs) |
 
-- **minimal (10):** `ctx_read`, `ctx_shell`, `shell`, `ctx_search`, `ctx_glob`, `ctx_tree`, `ctx_session`, `ctx_compose`, `ctx_knowledge`, `ctx_symbol`
-- **standard (+10):** + `ctx_callgraph`, `ctx_graph`, `ctx_semantic_search`, `ctx_explore`, `ctx_delta`, `ctx_execute`, `ctx_expand`, `ctx_overview`, `ctx_multi_read`, `ctx_url_read`
+- **minimal (5):** `ctx_read`, `ctx_shell`, `ctx_search`, `ctx_glob`, `ctx_tree`
+- **standard (+10):** + `ctx_compose`, `ctx_explore`, `ctx_knowledge`, `ctx_callgraph`, `ctx_graph`, `ctx_delta`, `ctx_execute`, `ctx_expand`, `ctx_overview`, `ctx_url_read`
 - **power (+48):** all remaining tools.
 
 ---

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -88,7 +88,7 @@ Top-level configuration keys
 - `terse_agent` (enum: off | lite | full | ultra, default `off` — env `LEAN_CTX_TERSE_AGENT`) — Controls agent output verbosity via instructions injection
 - `theme` (string, default `default`) — Dashboard color theme
 - `tool_profile` (enum: minimal | standard | power, default `""`) — Tool visibility profile: minimal (5 tools), standard (15), power (all). Override via LEAN_CTX_TOOL_PROFILE
-- `tools_enabled` (string[], default `[]`) — Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list.
+- `tools_enabled` (string[], default `[]`) — Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list. The universal invoker ctx_call stays advertised so unlisted tools remain reachable — add it to disabled_tools (disabled_tools = ["ctx_call"]) to make this allowlist authoritative.
 - `ultra_compact` (bool, default `false`) — Legacy flag for maximum compression (use compression_level instead)
 - `update_check_disabled` (bool, default `false` — env `LEAN_CTX_NO_UPDATE_CHECK`) — Disable the daily version check
 

--- a/rust/src/cli/profile_cmd.rs
+++ b/rust/src/cli/profile_cmd.rs
@@ -536,8 +536,8 @@ fn print_profile_help() {
 TOOL PROFILES — how many MCP tools your agent sees:
   lean-ctx tools                Show current tool profile
   lean-ctx tools lean           Lazy core advertised, all via ctx_call (default)
-  lean-ctx tools minimal        6 essential tools
-  lean-ctx tools standard       17 balanced tools
+  lean-ctx tools minimal        5 essential tools
+  lean-ctx tools standard       15 balanced tools
   lean-ctx tools power          All tools (highest context overhead)
   lean-ctx tools list           List tool profiles with counts
 

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -193,12 +193,14 @@ pub struct Config {
     /// Set via `lean-ctx config set profile passthrough` or editing config.toml.
     #[serde(default)]
     pub profile: Option<String>,
-    /// Tool visibility profile: "minimal" (10), "standard" (19), or "power" (all).
+    /// Tool visibility profile: "minimal" (5), "standard" (15), or "power" (all).
     /// Override via LEAN_CTX_TOOL_PROFILE env var.
     /// Existing installs default to "power" (backward compat).
     #[serde(default)]
     pub tool_profile: Option<String>,
     /// Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list.
+    /// The universal invoker `ctx_call` stays advertised so unlisted tools remain
+    /// reachable — add `ctx_call` to `disabled_tools` to make this allowlist authoritative.
     /// Example: `tools_enabled = ["ctx_read", "ctx_shell", "ctx_search"]`
     #[serde(default)]
     pub tools_enabled: Vec<String>,

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -169,7 +169,7 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         key(
             "string[]",
             serde_json::json!(cfg.tools_enabled),
-            "Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list.",
+            "Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list. The universal invoker ctx_call stays advertised so unlisted tools remain reachable — add it to disabled_tools (disabled_tools = [\"ctx_call\"]) to make this allowlist authoritative.",
         ),
     );
     root.insert(

--- a/rust/src/core/context_overhead.rs
+++ b/rust/src/core/context_overhead.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn minimal_arm_per_turn_prefix_stays_within_budget() {
-        // The "faithful arm" (#361): tool_profile=minimal (6 tools) +
+        // The "faithful arm" (#361): tool_profile=minimal (5 tools) +
         // LEAN_CTX_MINIMAL (no session/knowledge prefix) + rules_injection=off
         // (no rules block) must keep the fixed per-turn prefix tiny. This is the
         // regression guard for the "~3K tokens/turn injected" critique — if any

--- a/rust/src/core/tool_profiles.rs
+++ b/rust/src/core/tool_profiles.rs
@@ -125,14 +125,17 @@ impl fmt::Display for ToolProfile {
     }
 }
 
-/// `lean`/`lazy`/`reset` are not pinned tiers — they are the *unpin* sentinel
-/// that clears any pin so the default returns (lazy core advertised, everything
-/// callable via `ctx_call`). Centralised so the config loader, the CLI
-/// (`lean-ctx profile lean`) and the dashboard all agree on the same set (#431).
+/// `""`/`lean`/`lazy`/`reset` are not pinned tiers — they are the *unpin*
+/// sentinel that clears any pin so the default returns (lazy core advertised,
+/// everything callable via `ctx_call`). Empty/whitespace is the documented
+/// default of `tool_profile` (#613); treating it as unpinned avoids a spurious
+/// `Unknown tool_profile ''` warning on the documented default. Centralised so
+/// the config loader, the CLI (`lean-ctx profile lean`) and the dashboard all
+/// agree on the same set (#431).
 pub fn is_unpinned_alias(name: &str) -> bool {
     matches!(
         name.trim().to_ascii_lowercase().as_str(),
-        "lean" | "lazy" | "reset"
+        "" | "lean" | "lazy" | "reset"
     )
 }
 
@@ -447,6 +450,30 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(ToolProfile::from_config(&cfg), ToolProfile::Standard);
+    }
+
+    #[test]
+    fn empty_tool_profile_is_unpinned_so_tools_enabled_applies() {
+        // #613: `tool_profile = ""` is the documented default ("unpin"), not a
+        // bogus profile. It must resolve silently via the unpinned path (so an
+        // explicit `tools_enabled` takes effect) instead of warning
+        // "Unknown tool_profile ''".
+        assert!(is_unpinned_alias(""));
+        assert!(is_unpinned_alias("   "));
+
+        if std::env::var("LEAN_CTX_TOOL_PROFILE").is_ok() {
+            return;
+        }
+        let cfg = crate::core::config::Config {
+            tool_profile: Some(String::new()),
+            tools_enabled: vec!["ctx_read".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            ToolProfile::from_config(&cfg),
+            ToolProfile::Custom(vec!["ctx_read".to_string()]),
+            "empty tool_profile must unpin so tools_enabled takes effect"
+        );
     }
 
     #[test]

--- a/rust/src/dashboard/static/components/cockpit-settings.js
+++ b/rust/src/dashboard/static/components/cockpit-settings.js
@@ -30,7 +30,7 @@ var SETTINGS_META = {
   tool_profile: {
     label: 'Tool profile',
     env: 'LEAN_CTX_TOOL_PROFILE',
-    desc: 'How many MCP tools are exposed: minimal (10), standard (19), power (all), or lean (unpinned default).',
+    desc: 'How many MCP tools are exposed: minimal (5), standard (15), power (all), or lean (unpinned default).',
   },
   structure_first: {
     label: 'Structure first',

--- a/rust/src/setup/helpers.rs
+++ b/rust/src/setup/helpers.rs
@@ -170,9 +170,9 @@ pub(crate) fn configure_tool_profile() {
         "  {cyan}lean{rst}      — {lazy_count} tools  {dim}(lazy core, recommended — lowest token overhead){rst}"
     );
     println!(
-        "  {cyan}minimal{rst}   — 6 tools  {dim}(ctx_read, ctx_shell, ctx_search, ctx_glob, ctx_tree, ctx_symbol){rst}"
+        "  {cyan}minimal{rst}   — 5 tools  {dim}(ctx_read, ctx_shell, ctx_search, ctx_glob, ctx_tree){rst}"
     );
-    println!("  {cyan}standard{rst}  — 17 tools  {dim}(balanced set for most workflows){rst}");
+    println!("  {cyan}standard{rst}  — 15 tools  {dim}(balanced set for most workflows){rst}");
     println!(
         "  {cyan}power{rst}     — {registry_count} tools  {dim}(everything advertised, costs the most context){rst}"
     );


### PR DESCRIPTION
Follow-ups for #613 (the inverted-precedence doc fix itself landed in #614).

## Changes
- **`tool_profile = ""` no longer warns.** The documented default `""` (and whitespace) is now treated as the unpin sentinel in `is_unpinned_alias()`, so it resolves silently and an explicit `tools_enabled` list takes effect — instead of logging `Unknown tool_profile ''`. Regression test added (`empty_tool_profile_is_unpinned_so_tools_enabled_applies`).
- **`ctx_call` behaviour documented.** The universal invoker stays advertised even with an explicit `tools_enabled` allowlist (by design — hidden tools stay reachable). Documented that `disabled_tools = ["ctx_call"]` makes the allowlist authoritative (config schema + `Config::tools_enabled` rustdoc + generated `config-keys.md`).
- **Stale profile counts corrected to minimal (5) / standard (15)** across CLI (`profile_cmd`), setup (`helpers`), dashboard (`cockpit-settings.js`) and docs (`02-daily-use`, `appendix-glossary`, `appendix-mcp-tools`). #614 fixed only the schema string; the `tool_profile` field rustdoc still said 10/19. Also corrected the stale minimal/standard tool **lists** in `appendix-mcp-tools.md`.

No behaviour change beyond silencing the spurious warning. Power/total counts (a separate pre-existing inconsistency) are intentionally untouched.

## Verification
- `cargo fmt --check`, `cargo clippy --all-features -D warnings`, `cargo doc --all-features` (`-D warnings`), `gen_docs --check`, Windows cross-compile — all green via pre-push preflight.

Closes #613

Made with [Cursor](https://cursor.com)