### PR TITLE
fix(rules): Cline/Roo rules are MCP-first — drop the stale `lean-ctx -c` prefix guidance (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   Default off — the request is byte-identical until you opt in.
 
 ### Fixed
+- **Cline/Roo rules are MCP-first — dropped the stale `lean-ctx -c` prefix guidance
+  (GH #603).** `install_cline_rules` hardcoded a `.clinerules` body telling the agent
+  to prefix every shell command with `lean-ctx -c`, even though Cline/Roo get the
+  lean-ctx MCP server installed and the shell hook already wraps real terminal
+  commands — so the manual prefix re-wrapped an already-wrapped command, tripped the
+  re-entry passthrough and returned uncompressed output. The body now derives from
+  `core::rules_canonical` (the single source of truth) like every other dedicated
+  rule file: MCP-first (`ctx_*`), no `lean-ctx -c`, wrapped in the canonical markers
+  so `uninstall` can strip it (the old freeform header was not removable). Reported
+  by @ousatov-ua.
 - **lean-ctx no longer touches Codex under a ChatGPT subscription login (GH #597).**
   GH #568 pinned `model_provider = "leanctx-chatgpt"` (plus a
   `[model_providers.leanctx-chatgpt]` block) and `openai_base_url`/`chatgpt_base_url`

--- a/rust/src/hooks/agents/cline.rs
+++ b/rust/src/hooks/agents/cline.rs
@@ -19,24 +19,35 @@ pub(crate) fn install_cline_rules(global: bool) {
         return;
     };
 
-    let binary = resolve_binary_path();
-    let rules = format!(
-        r"# lean-ctx Shell Optimization
-# Prefix all shell commands with `{binary} -c` for 60-90% token savings.
-
-When running shell commands, always prefix them with `{binary} -c` to compress output. For example:
-- `{binary} -c git status` instead of `git status`
-- `{binary} -c cargo test` instead of `cargo test`
-- `{binary} -c ls src/` instead of `ls src/`
-
-Supported commands: git, cargo, npm, pnpm, docker, kubectl, pip, ruff, go, curl, grep, find, ls, aws, helm, and 95+ more.
-"
-    );
-
-    write_file(&rules_path, &rules);
+    let shadow = crate::core::config::Config::load().shadow_mode;
+    write_file(&rules_path, &cline_rules_body(shadow));
     if !mcp_server_quiet_mode() {
         eprintln!("Installed .clinerules in current project.");
     }
+}
+
+/// Builds the `.clinerules` body from `rules_canonical` (the single source of
+/// truth) via the canonical `Dedicated` render.
+///
+/// Cline and Roo get the lean-ctx **MCP server** installed above, and the shell
+/// hook already wraps real terminal commands, so the rules must steer the agent
+/// to the `ctx_*` MCP tools — NOT tell it to hand-prefix every command with
+/// `lean-ctx -c`. The old guidance did exactly that, which double-wraps an
+/// already-wrapped command and trips the re-entry passthrough, so output came
+/// back uncompressed (GH #603).
+///
+/// Rendered at [`CompressionLevel::Off`](crate::core::config::CompressionLevel::Off)
+/// on purpose: the per-turn output-style payload is delivered by the MCP
+/// instructions channel and the deduped global `.cline/rules/lean-ctx.md`
+/// carrier. `.clinerules` is a project file the dedup pass does not scan, so
+/// emitting the compression block here too would only duplicate it (#684). The
+/// `START_MARK`/`END_MARK` wrapper is what `uninstall` strips.
+fn cline_rules_body(shadow: bool) -> String {
+    crate::core::rules_canonical::render(
+        shadow,
+        crate::core::rules_canonical::Wrapper::Dedicated,
+        crate::core::config::CompressionLevel::Off,
+    )
 }
 
 fn install_vscode_mcp_for_cline(mcp_path: &std::path::Path) {
@@ -55,4 +66,50 @@ fn install_vscode_mcp_for_cline(mcp_path: &std::path::Path) {
         "servers",
         entry,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::rules_canonical::{COMPRESSION_BLOCK_START, END_MARK, START_MARK};
+
+    /// #603: the old `.clinerules` told the agent to hand-prefix every shell
+    /// command with `lean-ctx -c`, which re-wraps an already-wrapped command and
+    /// passes through uncompressed. The rules must be MCP-first and carry NO
+    /// `lean-ctx -c` prefix guidance, derived from `rules_canonical`.
+    #[test]
+    fn cline_rules_are_mcp_first_without_lean_ctx_dash_c() {
+        let body = cline_rules_body(false);
+        assert!(
+            body.contains(START_MARK),
+            "must carry the canonical markers"
+        );
+        assert!(body.contains(END_MARK));
+        assert!(
+            body.contains("ctx_shell"),
+            "must steer to the ctx_* MCP tools:\n{body}"
+        );
+        assert!(
+            !body.contains("lean-ctx -c"),
+            "must NOT tell the agent to hand-prefix lean-ctx -c (#603):\n{body}"
+        );
+    }
+
+    /// #684: `.clinerules` is not scanned by the dedup pass, so it must never
+    /// carry the per-turn compression payload (delivered via MCP + the deduped
+    /// global carrier) — in either shadow or non-shadow mode.
+    #[test]
+    fn cline_rules_omit_per_turn_compression_block() {
+        for shadow in [false, true] {
+            let body = cline_rules_body(shadow);
+            assert!(
+                !body.contains(COMPRESSION_BLOCK_START),
+                "shadow={shadow}: .clinerules must not duplicate the compression block:\n{body}"
+            );
+            assert!(
+                !body.contains("lean-ctx -c"),
+                "shadow={shadow}: no lean-ctx -c prefix guidance:\n{body}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`install_cline_rules` hardcoded a `.clinerules` body that told the agent to **prefix every shell command with `lean-ctx -c`**. That guidance is both redundant and harmful:

- Cline/Roo get the lean-ctx **MCP server** installed in the very same function, so shell commands should go through `ctx_shell` (like every other agent's rules).
- The lean-ctx **shell hook** already wraps real terminal commands. Telling the agent to *also* hand-prefix `lean-ctx -c` re-wraps an already-wrapped command, which trips the re-entry passthrough → output comes back **uncompressed** (the #603 symptom).

This rewrites the body to derive from `core::rules_canonical` — the documented single source of truth (*"Every injected rule file MUST derive its content from this module"*) — via the canonical `Dedicated` render, exactly like the other dedicated rule files (Cursor, OpenCode, Gemini, …). The result is MCP-first (`ctx_*`) with **no** `lean-ctx -c` prefix guidance.

## Details

- **`CompressionLevel::Off`** on purpose: `.clinerules` is a project file the dedup pass (`cli::rules_dedup`) does not scan. The per-turn output-style payload is already delivered by the MCP instructions channel and the deduped global `.cline/rules/lean-ctx.md` carrier, so emitting the compression block here too would only duplicate it (#684).
- The canonical `START_MARK`/`END_MARK` wrapper additionally makes the block **removable by `uninstall`** (`remove_lean_ctx_section_from_rules` keys on `START_MARK`); the old freeform `# lean-ctx Shell Optimization` header was matched by neither the marker nor the heading path.
- Extracted a small testable `cline_rules_body(shadow)` helper.

## Test plan

- [x] `cargo test --lib cline` — new hermetic tests: MCP-first + carries markers + **no `lean-ctx -c`**; compression block omitted in shadow & non-shadow
- [x] `scripts/preflight.sh fast` (fmt + clippy `--all-features -D warnings` + rustdoc + `gen_docs --check` + Windows cross-compile) — green
- [x] pre-commit hook (fmt + clippy `--all-targets -D warnings`) — green

Reported by @ousatov-ua (follow-up to the #616 discussion).

Made with [Cursor](https://cursor.com)