### PR TITLE
fix(test): restore CI green — Windows testbench determinism + static char budget

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,9 @@
 # is byte-stable — Windows checkouts would otherwise convert them to CRLF and
 # fail the comparison.
 docs/reference/generated/*.md text eol=lf
+
+# Testbench fixtures, suites, recordings and lock feed `RecordedRunner` replay
+# keys verbatim (file bytes are embedded into the assembled context that is
+# hashed). Pin them to LF so Windows checkouts don't convert them to CRLF and
+# break the byte-identical key match (off-vs-on testbench, #611/#498).
+rust/eval/testbench/** text eol=lf

--- a/rust/src/core/eval_ab/conditions.rs
+++ b/rust/src/core/eval_ab/conditions.rs
@@ -197,11 +197,17 @@ fn resolve(root: &Path, file_path: &str) -> PathBuf {
 }
 
 /// Label for a file inside the workspace (relative when possible, else the file name).
+///
+/// Separators are normalized to `/` so the assembled context — and therefore
+/// every `RecordedRunner` replay key derived from it — is byte-identical on
+/// Windows and Unix (#498). Without this, a nested fixture such as
+/// `config/seed-data.json` would label as `config\seed-data.json` on Windows and
+/// never match the committed Unix-generated recording.
 fn rel_label(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
-        .into_owned()
+        .replace('\\', "/")
 }
 
 /// Walks `root` (respecting .gitignore + hidden filters) and returns every readable UTF-8 file

--- a/rust/tests/intensive_benchmarks.rs
+++ b/rust/tests/intensive_benchmarks.rs
@@ -86,19 +86,25 @@ fn bench_system_instructions_token_count() {
         "TDD instructions should be <2550 tokens, got {tok_tdd}"
     );
 
-    // The <=2048 char budget governs the STATIC cold first-contact handshake
+    // The char budget governs the STATIC cold first-contact handshake
     // instructions. A live build also appends dynamic session/knowledge/gotcha
     // payload, but that is capped by INSTRUCTION_CAP_TOKENS (token budget), not
     // this char budget — and it varies with whatever session is persisted on the
     // runner. Measuring the static surface keeps the assertion deterministic
     // (#498) instead of order/state-dependent.
+    //
+    // Budget history: 2048 → 2400 (#609). The agent-loop taxonomy added the
+    // `LOOP_NAV_COMPACT` one-liner to the COMPACT/Bare channel the cold handshake
+    // renders, growing it to 2201 bytes on Unix; Windows adds the platform shell
+    // hint (~48 bytes) on top, so 2400 clears every runner with headroom while
+    // still catching a runaway regression.
     let claude_code_instr = lean_ctx::server::build_claude_code_static_instructions_for_test();
     let claude_chars = claude_code_instr.len();
     let claude_tokens = count_tokens(&claude_code_instr);
     eprintln!("  Claude Code (static): {claude_tokens:>6} tokens ({claude_chars:>5} chars)");
     assert!(
-        claude_chars <= 2048,
-        "Claude Code static instructions MUST be <=2048 chars, got {claude_chars}"
+        claude_chars <= 2400,
+        "Claude Code static instructions MUST be <=2400 chars, got {claude_chars}"
     );
     assert!(
         compact_overhead.unsigned_abs() < 300,


### PR DESCRIPTION
## Problem

`main` CI has been **red on every platform** since the #607–#611 merge. Two independent regressions, both surfacing in the `Test` job (everything else — Clippy, Format, Build, Docs, cargo-deny, Coverage — stayed green):

| Platform | Failing test | Cause |
|---|---|---|
| Ubuntu + macOS | `bench_system_instructions_token_count` (`tests/intensive_benchmarks.rs`) | static handshake grew past the 2048-byte budget |
| Windows | `core::eval_ab::testbench::{committed_subset_replays_and_gates, determinism_digest_is_stable_across_runs}` | replay keys diverge from the committed recording |

Windows only ever showed the testbench failures because the lib suite aborts before reaching the integration tests — once that's fixed it would have hit the char budget too.

## Root cause & fix

**1. Static char budget (all platforms)** — #609 added the `LOOP_NAV_COMPACT` one-liner to the COMPACT/Bare channel that the cold-start handshake renders, growing it from `<=2048` to **2201 bytes** (Windows adds the platform shell hint on top). The token guards (`tok_off < 2300`, …) still pass; only the separate byte guard tripped. → raise the budget to **2400** (still a meaningful guard, with cross-platform headroom) and document the history.

**2. Windows testbench determinism** — `RecordedRunner` replay keys are SHA-256 over the assembled context, whose bytes include file labels + raw file content. On Windows two things diverged from the committed (Unix-generated) `recording.json`, so no key matched (`must cover every replay key`):
- `rel_label` emitted `\` separators (e.g. `config\seed-data.json`) → normalize to `/` so labels are platform-independent (#498).
- git converted LF fixtures to CRLF on checkout → pin `rust/eval/testbench/**` to LF via `.gitattributes`, mirroring the existing generated-docs rule.

Both testbench fixes are **backward-compatible with the committed recording** (Unix already uses `/` + LF), so no regeneration is needed — the pre-commit drift gate confirmed `recording.json` is up to date.

## Verification

- Local: `eval_ab` suite **68/68 green**, static handshake measured at **2201 bytes ≤ 2400**.
- Preflight CI-parity gate (fmt / clippy / docs / gen_docs drift / **Windows cross-compile**): **all green**.
- Windows runtime behaviour validated by this PR's CI matrix.

## Test plan

- [ ] CI green on ubuntu / macOS / windows
- [ ] `CI Green` aggregate check passes

Made with [Cursor](https://cursor.com)