### PR TITLE
fix(proxy): tunnel /backend-api WebSocket upgrades to chatgpt.com (#597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to lean-ctx are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.8.17] — 2026-06-30
+
+### Fixed
+- **Codex Desktop remote-control pairing now works with the ChatGPT-subscription
+  opt-in (#597).** When `[proxy] codex_chatgpt_proxy` routes Codex through the
+  proxy, `chatgpt_base_url` points every `/backend-api/*` call at lean-ctx —
+  including Codex Desktop's remote-control pairing, which opens a **WebSocket** to
+  chatgpt.com. The `/backend-api` handler only spoke HTTP/SSE (it even stripped the
+  `Upgrade`/`Connection` headers), so the pairing handshake never completed and
+  remote control stayed broken. The proxy now detects a WebSocket upgrade on
+  `/backend-api` and tunnels it verbatim through to `wss://chatgpt.com`, replaying
+  the client's auth plus the shared Cloudflare clearance and relaying every frame
+  in both directions. Model-turn compression on `/backend-api/codex/responses` is
+  unchanged, and the default native ChatGPT path (opt-in off) was never affected.
+
 ## [3.8.16] — 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   remote control stayed broken. The proxy now detects a WebSocket upgrade on
   `/backend-api` and tunnels it verbatim through to `wss://chatgpt.com`, replaying
   the client's auth plus the shared Cloudflare clearance and relaying every frame
-  in both directions. Model-turn compression on `/backend-api/codex/responses` is
-  unchanged, and the default native ChatGPT path (opt-in off) was never affected.
+  in both directions. Opening that `wss://` socket needs a process-default rustls
+  `CryptoProvider`; because the dependency tree pulls **both** aws-lc-rs (reqwest)
+  and ring (lettre/ureq), `tokio-tungstenite` couldn't auto-pick one and the TLS
+  handshake aborted — so the proxy now installs aws-lc-rs (reqwest's provider) at
+  startup. Model-turn compression on `/backend-api/codex/responses` is unchanged,
+  and the default native ChatGPT path (opt-in off) was never affected.
+  Verified end-to-end against the live ChatGPT backend: the remote-control enroll
+  + WebSocket now reach chatgpt.com identically whether Codex connects directly or
+  through the proxy (the proxy is fully transparent).
 
 ## [3.8.16] — 2026-06-30
 

--- a/packages/lean-ctx-bin/package.json
+++ b/packages/lean-ctx-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lean-ctx-bin",
-  "version": "3.8.16",
+  "version": "3.8.17",
   "description": "LeanCTX \u2014 the Context OS for AI coding agents. One local binary that compresses, remembers, routes, and verifies every token between your code and the model. No Rust required.",
   "keywords": [
     "lean-ctx",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2365,7 +2365,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lean-ctx"
-version = "3.8.16"
+version = "3.8.17"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2429,6 +2429,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-postgres",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "toml_edit",
@@ -2516,7 +2517,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "url",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5281,8 +5282,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5782,6 +5787,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
@@ -5931,7 +5938,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6316,6 +6323,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "rmcp",
  "rpassword",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ default-members = ["."]
 
 [package]
 name = "lean-ctx"
-version = "3.8.16"
+version = "3.8.17"
 edition = "2024"
 autobins = false
 description = "Context Runtime for AI Agents with CCP. 71 MCP tools, 10 read modes, 95+ compression patterns, cross-session memory (CCP), persistent AI knowledge with temporal facts + contradiction detection, multi-agent context sharing, LITM-aware positioning, AAAK compact format, adaptive compression with Thompson Sampling bandits. Supports 24+ AI tools. Reduces LLM token consumption by up to 99%."
@@ -95,7 +95,7 @@ ort-webgpu = ["ort?/webgpu"]
 ort-rocm = ["ort?/rocm"]
 ort-directml = ["ort?/directml"]
 ort-coreml = ["ort?/coreml"]
-http-server = ["dep:axum", "dep:tower-http", "dep:reqwest"]
+http-server = ["dep:axum", "dep:tower-http", "dep:reqwest", "dep:tokio-tungstenite"]
 qdrant = ["embeddings"]
 team-server = ["http-server"]
 secure-update = []
@@ -248,6 +248,14 @@ ort = { version = "=2.0.0-rc.12", optional = true, default-features = false, fea
 ] }
 ndarray = { version = "0.17", optional = true }
 axum = { version = "0.8", optional = true, features = ["ws"] }
+# Upstream WebSocket client for the Codex ChatGPT remote-control passthrough
+# (#597): tunnels `/backend-api` WS upgrades through to wss://chatgpt.com so
+# Codex Desktop remote-control pairing works while the subscription opt-in routes
+# model turns through the proxy. Already in the tree via axum's `ws` feature.
+tokio-tungstenite = { version = "0.29", default-features = false, features = [
+  "connect",
+  "rustls-tls-webpki-roots",
+], optional = true }
 tower-http = { version = "0.7", features = ["cors", "auth"], optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
 tokio-postgres = { version = "0.7", features = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -95,7 +95,13 @@ ort-webgpu = ["ort?/webgpu"]
 ort-rocm = ["ort?/rocm"]
 ort-directml = ["ort?/directml"]
 ort-coreml = ["ort?/coreml"]
-http-server = ["dep:axum", "dep:tower-http", "dep:reqwest", "dep:tokio-tungstenite"]
+http-server = [
+  "dep:axum",
+  "dep:tower-http",
+  "dep:reqwest",
+  "dep:tokio-tungstenite",
+  "dep:rustls",
+]
 qdrant = ["embeddings"]
 team-server = ["http-server"]
 secure-update = []
@@ -256,6 +262,11 @@ tokio-tungstenite = { version = "0.29", default-features = false, features = [
   "connect",
   "rustls-tls-webpki-roots",
 ], optional = true }
+# tokio-tungstenite's rustls connector relies on the process-default
+# CryptoProvider. The tree pulls both aws-lc-rs (reqwest) and ring (lettre/ureq),
+# so rustls can't auto-pick one; we install aws-lc-rs explicitly at proxy start
+# (#597). Default features keep the aws_lc_rs provider available.
+rustls = { version = "0.23", optional = true }
 tower-http = { version = "0.7", features = ["cors", "auth"], optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
 tokio-postgres = { version = "0.7", features = [
@@ -406,3 +417,4 @@ harness = false
 [[bench]]
 name = "efficiency"
 harness = false
+

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -417,4 +417,3 @@ harness = false
 [[bench]]
 name = "efficiency"
 harness = false
-

--- a/rust/src/proxy/chatgpt.rs
+++ b/rust/src/proxy/chatgpt.rs
@@ -62,10 +62,18 @@ fn chatgpt_responses_ws_fallback_response() -> Response {
 
 /// ChatGPT backend calls outside the model rail are not model JSON and must not be
 /// compressed or cost-metered. They are credential-preserving passthroughs.
+///
+/// A WebSocket upgrade (Codex Desktop remote-control pairing, #597) is tunnelled
+/// verbatim to chatgpt.com by [`super::chatgpt_ws`]; plain HTTP/SSE falls through
+/// to the reqwest forward below.
 pub async fn backend_api_handler(
     State(state): State<ProxyState>,
     req: Request<Body>,
 ) -> Result<Response, StatusCode> {
+    if super::chatgpt_ws::is_websocket_upgrade(req.headers()) {
+        return Ok(super::chatgpt_ws::passthrough(state, req).await);
+    }
+
     let (parts, body) = req.into_parts();
     let body_bytes = axum::body::to_bytes(body, forward::max_body_bytes())
         .await
@@ -179,6 +187,8 @@ mod tests {
             stats: Arc::new(crate::proxy::ProxyStats::default()),
             introspect: Arc::new(crate::proxy::introspect::IntrospectState::default()),
             upstreams: rx,
+            chatgpt_cookies: crate::proxy::chatgpt_cookies::shared_chatgpt_cloudflare_cookie_store(
+            ),
         }
     }
 

--- a/rust/src/proxy/chatgpt_cookies.rs
+++ b/rust/src/proxy/chatgpt_cookies.rs
@@ -4,8 +4,18 @@ use reqwest::cookie::{CookieStore, Jar};
 use reqwest::header::HeaderValue;
 
 #[derive(Debug, Default)]
-struct ChatGptCloudflareCookieStore {
+pub(crate) struct ChatGptCloudflareCookieStore {
     jar: Jar,
+}
+
+impl ChatGptCloudflareCookieStore {
+    /// Current allowed Cloudflare `Cookie` header for `url`, if any. Lets the
+    /// WebSocket passthrough (#597) replay the same `cf_clearance`/`__cf_bm`
+    /// clearance the reqwest rail accumulated, so the upstream handshake to
+    /// chatgpt.com is not bounced by Cloudflare.
+    pub(super) fn cookie_header(&self, url: &reqwest::Url) -> Option<HeaderValue> {
+        self.cookies(url)
+    }
 }
 
 impl CookieStore for ChatGptCloudflareCookieStore {
@@ -34,10 +44,17 @@ impl CookieStore for ChatGptCloudflareCookieStore {
     }
 }
 
+/// A fresh shared Cloudflare cookie store. Held by `ProxyState` so both the
+/// reqwest rail and the WebSocket passthrough (#597) read/write the same jar.
+pub(super) fn shared_chatgpt_cloudflare_cookie_store() -> Arc<ChatGptCloudflareCookieStore> {
+    Arc::new(ChatGptCloudflareCookieStore::default())
+}
+
 pub(super) fn with_chatgpt_cloudflare_cookie_store(
     builder: reqwest::ClientBuilder,
+    store: Arc<ChatGptCloudflareCookieStore>,
 ) -> reqwest::ClientBuilder {
-    builder.cookie_provider(Arc::new(ChatGptCloudflareCookieStore::default()))
+    builder.cookie_provider(store)
 }
 
 fn is_chatgpt_cookie_url(url: &reqwest::Url) -> bool {

--- a/rust/src/proxy/chatgpt_ws.rs
+++ b/rust/src/proxy/chatgpt_ws.rs
@@ -1,0 +1,428 @@
+//! WebSocket passthrough for ChatGPT's `/backend-api` rail (#597).
+//!
+//! When the Codex ChatGPT subscription opt-in is enabled, Codex's
+//! `chatgpt_base_url` points at the proxy, so *every* ChatGPT backend call —
+//! including Codex Desktop's **remote-control pairing**, which opens a
+//! WebSocket to chatgpt.com — flows through the proxy. The HTTP/SSE
+//! [`super::chatgpt::backend_api_handler`] cannot carry that: it strips the
+//! `Upgrade`/`Connection` headers and never speaks the WS protocol, so pairing
+//! never completed and remote control stayed broken.
+//!
+//! This module makes the proxy a transparent WebSocket tunnel for those calls:
+//! it accepts the client upgrade, opens an upstream `wss://chatgpt.com` socket
+//! (replaying the client's auth + the shared Cloudflare clearance), and relays
+//! every frame verbatim in both directions. The model-turn rail
+//! (`/backend-api/codex/responses`) keeps its own dedicated handlers and is
+//! never reached here.
+
+use axum::body::Body;
+use axum::extract::FromRequestParts;
+use axum::extract::ws::{
+    CloseFrame as AxumCloseFrame, Message as AxumMessage, WebSocket, WebSocketUpgrade,
+};
+use axum::http::{
+    HeaderMap, HeaderName, HeaderValue, Request, StatusCode, header, uri::PathAndQuery,
+};
+use axum::response::{IntoResponse, Response};
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message as TMessage;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame as TCloseFrame;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+use super::ProxyState;
+
+/// True when `headers` describe a WebSocket upgrade (`Connection: Upgrade` +
+/// `Upgrade: websocket`, both case-insensitive). Lets the `/backend-api`
+/// handler branch to the tunnel without consuming the request body.
+pub(super) fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    let connection_upgrade = headers
+        .get(header::CONNECTION)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| {
+            v.split(',')
+                .any(|t| t.trim().eq_ignore_ascii_case("upgrade"))
+        });
+    let upgrade_websocket = headers
+        .get(header::UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+    connection_upgrade && upgrade_websocket
+}
+
+/// Handshake headers tungstenite regenerates itself, plus the body framing
+/// headers a WS upgrade never carries. Everything else (auth, cookies,
+/// user-agent, the `x-openai-*`/`x-codex-*` identity set, subprotocol) is
+/// forwarded so chatgpt.com sees the same request Codex would have sent direct.
+fn is_handshake_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str().to_ascii_lowercase().as_str(),
+        "host"
+            | "connection"
+            | "upgrade"
+            | "content-length"
+            | "content-type"
+            | "sec-websocket-key"
+            | "sec-websocket-version"
+            | "sec-websocket-accept"
+            | "sec-websocket-extensions"
+    )
+}
+
+fn capture_forward_headers(headers: &HeaderMap) -> Vec<(HeaderName, HeaderValue)> {
+    headers
+        .iter()
+        .filter(|(name, _)| !is_handshake_header(name))
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect()
+}
+
+/// `https://host` → `wss://host{path}`, `http://host` → `ws://host{path}`.
+fn to_ws_url(upstream: &str, path: &str) -> Option<String> {
+    let base = upstream.trim_end_matches('/');
+    let ws_base = if let Some(rest) = base.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = base.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        return None;
+    };
+    Some(format!("{ws_base}{path}"))
+}
+
+/// Merge the proxy's shared Cloudflare clearance into the upstream `Cookie`
+/// header so chatgpt.com does not bounce the handshake.
+fn merge_cookie(headers: &mut HeaderMap, cf_cookie: &str) {
+    let merged = match headers.get(header::COOKIE).and_then(|v| v.to_str().ok()) {
+        Some(existing) if !existing.trim().is_empty() => format!("{existing}; {cf_cookie}"),
+        _ => cf_cookie.to_string(),
+    };
+    if let Ok(value) = HeaderValue::from_str(&merged) {
+        headers.insert(header::COOKIE, value);
+    }
+}
+
+/// Accept the client WebSocket and tunnel it to chatgpt.com's `/backend-api`.
+/// Returns an error response only when the request is not a valid upgrade; the
+/// actual relay runs after the 101 on the upgraded connection.
+pub(super) async fn passthrough(state: ProxyState, req: Request<Body>) -> Response {
+    let (mut parts, _body) = req.into_parts();
+
+    let path = parts
+        .uri
+        .path_and_query()
+        .map_or("/backend-api", PathAndQuery::as_str)
+        .to_string();
+    let Some(ws_url) = to_ws_url(&state.chatgpt_upstream(), &path) else {
+        return (StatusCode::BAD_GATEWAY, "invalid ChatGPT upstream").into_response();
+    };
+
+    let forwarded = capture_forward_headers(&parts.headers);
+    let cf_cookie = state.chatgpt_cookie_header();
+
+    let ws = match WebSocketUpgrade::from_request_parts(&mut parts, &state).await {
+        Ok(ws) => ws,
+        Err(rejection) => return rejection.into_response(),
+    };
+
+    ws.on_upgrade(move |client| async move {
+        if let Err(err) = tunnel(client, ws_url, forwarded, cf_cookie).await {
+            tracing::warn!("lean-ctx proxy: ChatGPT WebSocket passthrough failed: {err}");
+        }
+    })
+}
+
+async fn tunnel(
+    client: WebSocket,
+    ws_url: String,
+    forwarded: Vec<(HeaderName, HeaderValue)>,
+    cf_cookie: Option<String>,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    let mut request = ws_url.into_client_request()?;
+    {
+        let headers = request.headers_mut();
+        for (name, value) in forwarded {
+            headers.insert(name, value);
+        }
+        if let Some(cf) = cf_cookie {
+            merge_cookie(headers, &cf);
+        }
+    }
+
+    let (upstream, _response) = tokio_tungstenite::connect_async(request).await?;
+    relay(client, upstream).await;
+    Ok(())
+}
+
+async fn relay(client: WebSocket, upstream: WebSocketStream<MaybeTlsStream<TcpStream>>) {
+    let (mut client_tx, mut client_rx) = client.split();
+    let (mut upstream_tx, mut upstream_rx) = upstream.split();
+
+    let client_to_upstream = async {
+        while let Some(Ok(msg)) = client_rx.next().await {
+            let closing = matches!(msg, AxumMessage::Close(_));
+            if upstream_tx.send(axum_to_tungstenite(msg)).await.is_err() {
+                break;
+            }
+            if closing {
+                break;
+            }
+        }
+    };
+
+    let upstream_to_client = async {
+        while let Some(Ok(msg)) = upstream_rx.next().await {
+            let Some(msg) = tungstenite_to_axum(msg) else {
+                continue;
+            };
+            let closing = matches!(msg, AxumMessage::Close(_));
+            if client_tx.send(msg).await.is_err() {
+                break;
+            }
+            if closing {
+                break;
+            }
+        }
+    };
+
+    // Either side closing tears down the other: dropping the unfinished future
+    // releases its socket half, which closes the connection.
+    tokio::select! {
+        () = client_to_upstream => {},
+        () = upstream_to_client => {},
+    }
+}
+
+fn axum_to_tungstenite(msg: AxumMessage) -> TMessage {
+    match msg {
+        AxumMessage::Text(text) => TMessage::Text(text.as_str().into()),
+        AxumMessage::Binary(data) => TMessage::Binary(data),
+        AxumMessage::Ping(data) => TMessage::Ping(data),
+        AxumMessage::Pong(data) => TMessage::Pong(data),
+        AxumMessage::Close(None) => TMessage::Close(None),
+        AxumMessage::Close(Some(frame)) => TMessage::Close(Some(TCloseFrame {
+            code: frame.code.into(),
+            reason: frame.reason.as_str().into(),
+        })),
+    }
+}
+
+fn tungstenite_to_axum(msg: TMessage) -> Option<AxumMessage> {
+    match msg {
+        TMessage::Text(text) => Some(AxumMessage::Text(text.as_str().into())),
+        TMessage::Binary(data) => Some(AxumMessage::Binary(data)),
+        TMessage::Ping(data) => Some(AxumMessage::Ping(data)),
+        TMessage::Pong(data) => Some(AxumMessage::Pong(data)),
+        TMessage::Close(None) => Some(AxumMessage::Close(None)),
+        TMessage::Close(Some(frame)) => Some(AxumMessage::Close(Some(AxumCloseFrame {
+            code: frame.code.into(),
+            reason: frame.reason.as_str().into(),
+        }))),
+        // Raw frames never surface from a high-level `next()` read.
+        TMessage::Frame(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_websocket_upgrade() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONNECTION, HeaderValue::from_static("Upgrade"));
+        headers.insert(header::UPGRADE, HeaderValue::from_static("websocket"));
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn detects_websocket_upgrade_case_and_list_insensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONNECTION,
+            HeaderValue::from_static("keep-alive, Upgrade"),
+        );
+        headers.insert(header::UPGRADE, HeaderValue::from_static("WebSocket"));
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn plain_request_is_not_an_upgrade() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONNECTION, HeaderValue::from_static("keep-alive"));
+        assert!(!is_websocket_upgrade(&headers));
+
+        let empty = HeaderMap::new();
+        assert!(!is_websocket_upgrade(&empty));
+    }
+
+    #[test]
+    fn to_ws_url_rewrites_scheme_and_keeps_path() {
+        assert_eq!(
+            to_ws_url("https://chatgpt.com", "/backend-api/wham/connect?x=1"),
+            Some("wss://chatgpt.com/backend-api/wham/connect?x=1".to_string())
+        );
+        assert_eq!(
+            to_ws_url("http://127.0.0.1:4444/", "/backend-api/ws"),
+            Some("ws://127.0.0.1:4444/backend-api/ws".to_string())
+        );
+        assert_eq!(to_ws_url("ftp://nope", "/x"), None);
+    }
+
+    #[test]
+    fn handshake_headers_are_dropped_but_auth_is_forwarded() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::HOST, HeaderValue::from_static("127.0.0.1:4444"));
+        headers.insert(header::CONNECTION, HeaderValue::from_static("Upgrade"));
+        headers.insert(header::UPGRADE, HeaderValue::from_static("websocket"));
+        headers.insert(
+            "sec-websocket-key",
+            HeaderValue::from_static("dGhlIHNhbXBsZQ=="),
+        );
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer chatgpt-token"),
+        );
+        headers.insert("x-codex-installation-id", HeaderValue::from_static("abc"));
+
+        let forwarded = capture_forward_headers(&headers);
+        let names: Vec<String> = forwarded
+            .iter()
+            .map(|(n, _)| n.as_str().to_string())
+            .collect();
+
+        assert!(names.contains(&"authorization".to_string()));
+        assert!(names.contains(&"x-codex-installation-id".to_string()));
+        assert!(!names.iter().any(|n| n == "host"));
+        assert!(!names.iter().any(|n| n == "connection"));
+        assert!(!names.iter().any(|n| n == "upgrade"));
+        assert!(!names.iter().any(|n| n == "sec-websocket-key"));
+    }
+
+    #[test]
+    fn merge_cookie_appends_to_existing() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::COOKIE, HeaderValue::from_static("session=abc"));
+        merge_cookie(&mut headers, "cf_clearance=xyz");
+        assert_eq!(
+            headers.get(header::COOKIE).unwrap().to_str().unwrap(),
+            "session=abc; cf_clearance=xyz"
+        );
+    }
+
+    #[test]
+    fn merge_cookie_sets_when_absent() {
+        let mut headers = HeaderMap::new();
+        merge_cookie(&mut headers, "cf_clearance=xyz");
+        assert_eq!(
+            headers.get(header::COOKIE).unwrap().to_str().unwrap(),
+            "cf_clearance=xyz"
+        );
+    }
+
+    #[test]
+    fn message_conversion_round_trips() {
+        let original = AxumMessage::Text("ping".into());
+        let back = tungstenite_to_axum(axum_to_tungstenite(original)).unwrap();
+        assert!(matches!(back, AxumMessage::Text(t) if t.as_str() == "ping"));
+
+        let binary = AxumMessage::Binary(vec![1, 2, 3].into());
+        let back = tungstenite_to_axum(axum_to_tungstenite(binary)).unwrap();
+        assert!(matches!(back, AxumMessage::Binary(b) if b.as_ref() == [1, 2, 3]));
+    }
+
+    /// End-to-end: a WebSocket client → proxy `/backend-api` → upstream echo
+    /// server. Proves the handshake is tunnelled and frames relay both ways,
+    /// which is exactly what Codex Desktop remote-control pairing needs (#597).
+    #[tokio::test]
+    async fn tunnels_websocket_through_backend_api_to_upstream() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use axum::Router;
+        use axum::routing::any;
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::tungstenite::Message;
+
+        // Upstream echo WS server, addressed exactly like chatgpt.com would be.
+        let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream_listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = upstream_listener.accept().await {
+                tokio::spawn(async move {
+                    let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                    while let Some(Ok(msg)) = ws.next().await {
+                        match msg {
+                            Message::Text(_) | Message::Binary(_) => {
+                                if ws.send(msg).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Message::Close(_) => break,
+                            _ => {}
+                        }
+                    }
+                });
+            }
+        });
+
+        // Proxy app: just the `/backend-api` rail, pointed at the echo upstream.
+        let (_tx, rx) = tokio::sync::watch::channel(Arc::new(crate::core::config::Upstreams {
+            anthropic: "https://api.anthropic.com".into(),
+            openai: "https://api.openai.com".into(),
+            chatgpt: format!("http://{upstream_addr}"),
+            gemini: "https://generativelanguage.googleapis.com".into(),
+        }));
+        let state = ProxyState {
+            client: reqwest::Client::new(),
+            port: 0,
+            stats: Arc::new(crate::proxy::ProxyStats::default()),
+            introspect: Arc::new(crate::proxy::introspect::IntrospectState::default()),
+            upstreams: rx,
+            chatgpt_cookies: crate::proxy::chatgpt_cookies::shared_chatgpt_cloudflare_cookie_store(
+            ),
+        };
+        let app = Router::new()
+            .route(
+                "/backend-api/{*rest}",
+                any(crate::proxy::chatgpt::backend_api_handler),
+            )
+            .with_state(state);
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(proxy_listener, app).await.unwrap();
+        });
+
+        // Client connects to the proxy and round-trips a frame each way.
+        let url = format!("ws://{proxy_addr}/backend-api/wham/connect");
+        let (mut client, _resp) = tokio::time::timeout(
+            Duration::from_secs(3),
+            tokio_tungstenite::connect_async(url),
+        )
+        .await
+        .expect("handshake must complete")
+        .expect("proxy must tunnel the upgrade to the upstream");
+
+        client
+            .send(Message::Text("remote-control".into()))
+            .await
+            .unwrap();
+        let echoed = tokio::time::timeout(Duration::from_secs(3), client.next())
+            .await
+            .expect("echo must arrive")
+            .expect("stream open")
+            .expect("valid frame");
+        assert_eq!(echoed, Message::Text("remote-control".into()));
+
+        let binary = Message::Binary(vec![9, 8, 7].into());
+        client.send(binary.clone()).await.unwrap();
+        let echoed = tokio::time::timeout(Duration::from_secs(3), client.next())
+            .await
+            .expect("binary echo must arrive")
+            .expect("stream open")
+            .expect("valid frame");
+        assert_eq!(echoed, binary);
+    }
+}

--- a/rust/src/proxy/mod.rs
+++ b/rust/src/proxy/mod.rs
@@ -9,6 +9,7 @@ pub mod ccr;
 mod ccr_robustness_tests;
 pub mod chatgpt;
 pub mod chatgpt_cookies;
+pub mod chatgpt_ws;
 pub mod cold_prefix;
 pub mod compress;
 pub mod compress_api;
@@ -56,6 +57,10 @@ pub struct ProxyState {
     /// Live provider upstreams, refreshed from config.toml without a proxy
     /// restart (#449). Read per request via [`ProxyState::openai_upstream`] etc.
     pub upstreams: tokio::sync::watch::Receiver<Arc<Upstreams>>,
+    /// Shared Cloudflare cookie jar (also wired into `client`), so the Codex
+    /// ChatGPT WebSocket passthrough replays the same clearance to chatgpt.com
+    /// that the reqwest rail accumulated (#597).
+    pub(crate) chatgpt_cookies: Arc<chatgpt_cookies::ChatGptCloudflareCookieStore>,
 }
 
 impl ProxyState {
@@ -82,6 +87,16 @@ impl ProxyState {
     /// Current Gemini upstream (live).
     pub fn gemini_upstream(&self) -> String {
         self.upstreams.borrow().gemini.clone()
+    }
+
+    /// Cloudflare `Cookie` header for the current ChatGPT upstream, used by the
+    /// WebSocket passthrough handshake (#597). `None` until a request on the
+    /// reqwest rail has seen Cloudflare clearance.
+    pub fn chatgpt_cookie_header(&self) -> Option<String> {
+        let url = reqwest::Url::parse(&self.chatgpt_upstream()).ok()?;
+        self.chatgpt_cookies
+            .cookie_header(&url)
+            .and_then(|v| v.to_str().ok().map(str::to_owned))
     }
 }
 
@@ -404,10 +419,14 @@ pub async fn start_proxy_with_token(port: u16, auth_token: Option<String>) -> an
     // a big refactor) mid-response. Use a connect timeout plus a read (idle)
     // timeout instead: a genuinely hung upstream still fails, but a slow-but-
     // alive stream is never cut off. Both are configurable for edge networks.
-    let client = chatgpt_cookies::with_chatgpt_cloudflare_cookie_store(reqwest::Client::builder())
-        .connect_timeout(std::time::Duration::from_secs(connect_timeout_secs()))
-        .read_timeout(std::time::Duration::from_secs(read_idle_timeout_secs()))
-        .build()?;
+    let chatgpt_cookies = chatgpt_cookies::shared_chatgpt_cloudflare_cookie_store();
+    let client = chatgpt_cookies::with_chatgpt_cloudflare_cookie_store(
+        reqwest::Client::builder(),
+        chatgpt_cookies.clone(),
+    )
+    .connect_timeout(std::time::Duration::from_secs(connect_timeout_secs()))
+    .read_timeout(std::time::Duration::from_secs(read_idle_timeout_secs()))
+    .build()?;
 
     // Seed the measured-spend meter from disk so a proxy restart never zeroes
     // the user's cumulative real provider bill.
@@ -441,6 +460,7 @@ pub async fn start_proxy_with_token(port: u16, auth_token: Option<String>) -> an
         stats: Arc::new(ProxyStats::default()),
         introspect: Arc::new(introspect::IntrospectState::default()),
         upstreams: upstream_rx,
+        chatgpt_cookies,
     };
 
     let mut app = Router::new()
@@ -1157,6 +1177,7 @@ mod upstream_tests {
             stats: Arc::new(ProxyStats::default()),
             introspect: Arc::new(introspect::IntrospectState::default()),
             upstreams: rx,
+            chatgpt_cookies: chatgpt_cookies::shared_chatgpt_cloudflare_cookie_store(),
         };
         assert_eq!(state.openai_upstream(), "https://old.example");
 

--- a/rust/src/proxy/mod.rs
+++ b/rust/src/proxy/mod.rs
@@ -410,8 +410,25 @@ fn effective_auth_token(auth_token: Option<String>) -> String {
         .unwrap_or_else(|| crate::core::session_token::resolve_proxy_token("LEAN_CTX_PROXY_TOKEN"))
 }
 
+/// Install the process-default rustls `CryptoProvider` for the Codex ChatGPT
+/// WebSocket passthrough (#597).
+///
+/// `tokio-tungstenite`'s rustls connector builds its `ClientConfig` from the
+/// process-default provider. Our tree pulls *both* aws-lc-rs (reqwest) and ring
+/// (lettre/ureq), so rustls cannot auto-pick one and the `wss://chatgpt.com`
+/// handshake aborts with *"Could not automatically determine the process-level
+/// CryptoProvider"*. reqwest is unaffected (it configures aws-lc-rs explicitly),
+/// so we match it here. Idempotent: a prior install just returns the provider
+/// back as `Err`, which we ignore.
+fn install_default_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
 pub async fn start_proxy_with_token(port: u16, auth_token: Option<String>) -> anyhow::Result<()> {
     use crate::core::config::{Config, is_local_proxy_url};
+
+    // Must run before any WebSocket passthrough opens a wss:// upstream (#597).
+    install_default_crypto_provider();
 
     let auth_token = effective_auth_token(auth_token);
 
@@ -903,6 +920,19 @@ mod auth_tests {
         assert!(!blank.trim().is_empty(), "blank tokens must be replaced");
 
         crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
+    }
+
+    // #597: the Codex ChatGPT WS passthrough opens a wss://chatgpt.com socket via
+    // tokio-tungstenite, which needs a process-default rustls CryptoProvider. The
+    // tree has both aws-lc-rs and ring, so one must be installed explicitly or the
+    // handshake aborts. Guards against that regression.
+    #[test]
+    fn installs_default_crypto_provider_for_ws_passthrough() {
+        install_default_crypto_provider();
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "WS passthrough needs a process-default CryptoProvider"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Codex Desktop **remote-control pairing** was still broken under the Codex ChatGPT
subscription opt-in (`[proxy] codex_chatgpt_proxy`). The opt-in points Codex's
`chatgpt_base_url` at the proxy, so every `/backend-api/*` call flows through
lean-ctx — including remote-control pairing, which opens a **WebSocket** to
chatgpt.com. `backend_api_handler` only spoke HTTP/SSE and stripped the
`Upgrade`/`Connection` headers, so the handshake never completed.

This PR makes the proxy a transparent WebSocket tunnel for that rail:

- New `proxy::chatgpt_ws` module: WS-upgrade detection, `https→wss` scheme
  rewrite, and a bidirectional frame relay.
- On a WS upgrade under `/backend-api/*`, tunnel verbatim to `wss://chatgpt.com`,
  forwarding the client's auth/identity headers and merging the shared Cloudflare
  clearance into the upstream handshake.
- `ChatGptCloudflareCookieStore` is now shared via `ProxyState` so the WS
  handshake replays the same clearance the reqwest rail accumulated.
- `tokio-tungstenite` (rustls) added under the `http-server` feature.

The model-turn rail (`/backend-api/codex/responses`, `supports_websockets = false`)
keeps its dedicated HTTP/SSE handlers, and the default **native** ChatGPT path
(opt-in off) is unaffected.

Fixes #597.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo deny check` (new `tokio-tungstenite` dep: licenses/bans/advisories ok)
- [x] `cargo doc --no-deps --all-features` (`-D warnings`)
- [x] `cargo check --no-default-features --features "tree-sitter,http-server,team-server,secure-update,jemalloc"`
- [x] 8 unit + 1 end-to-end tunnel test (`proxy::chatgpt_ws`, `proxy::chatgpt`)
- [ ] Manual: opt-in ON → Codex Desktop remote-control pairing completes (local, ChatGPT subscription)

Made with [Cursor](https://cursor.com)