### PR TITLE
fix(dashboard): accept loopback Host on any port in no-auth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   the index in the background. The optional `LEAN_CTX_SEARCH_INDEX_COALESCE_MS`
   (default `0` = always verify) coalesces the stat-walk under bursty load on very
   large indexed trees. `ctx_read` was never affected (it is mtime + MD5 verified).
+- **No-auth dashboard no longer 403s behind a port-remapped Docker publish (#623).** In
+  no-auth mode every `/api/*` request is gated on a `Host` allowlist built from the
+  *bound* port. When a container binds `0.0.0.0:3333` but Docker publishes it on a
+  different host port (`-p 60000:3333`), the browser reaches `127.0.0.1:60000` and
+  sends `Host: 127.0.0.1:60000` — the *published* port, which the bind-port
+  allowlist (`127.0.0.1:3333`) rejected, so every API call returned 403 and the
+  dashboard's cards failed to load. The gate now accepts any **loopback** host
+  (`127.0.0.0/8`, `localhost`, `::1`) on **any port**: a loopback `Host` can't be a
+  DNS-rebinding target, so this is safe, and cross-origin/CSRF is still blocked by
+  the `Sec-Fetch-Site`/`Origin` checks. Port-remapped loopback publishes now work
+  out of the box without `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`.
 
 ## [3.8.17] — 2026-06-30
 

--- a/discord-faq/06-dashboard-analytics.md
+++ b/discord-faq/06-dashboard-analytics.md
@@ -41,7 +41,7 @@ No-auth mode is **not** unprotected. Instead of a token, the dashboard blocks br
 
 - **`Sec-Fetch-Site`** — requests the browser marks as `cross-site`/`same-site` are rejected; only `same-origin` and direct navigation (`none`) pass.
 - **`Origin`** — when present, must be same-origin as the dashboard.
-- **`Host` allowlist** — the request `Host` must be a loopback alias (`127.0.0.1`/`localhost`/`[::1]`), the host you bound to, or an entry in `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`. This stops DNS-rebinding attacks.
+- **`Host` allowlist** — the request `Host` must be a loopback host (`127.0.0.1`/`localhost`/`[::1]`, **on any port**), the host you bound to, or an entry in `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`. This stops DNS-rebinding attacks (loopback hosts can't be a rebinding target, so they're accepted regardless of port).
 
 Non-browser clients (curl, Prometheus scraping `/metrics`) don't send those headers and keep working, as long as they target an allowlisted host.
 
@@ -50,6 +50,9 @@ Non-browser clients (curl, Prometheus scraping `/metrics`) don't send those head
 ```bash
 lean-ctx dashboard --host=0.0.0.0 --no-auth
 docker run ... -p 127.0.0.1:3333:3333 ...
+# Remapping to a different host port works out of the box too — the Host is
+# still loopback, just on another port:
+docker run ... -p 127.0.0.1:60000:3333 ...   # reach it at http://127.0.0.1:60000
 ```
 
-If you reach the dashboard via a custom hostname, add it: `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS=box.local:3333`. Avoid binding to `0.0.0.0` with no-auth on an untrusted network — browser attacks stay blocked, but any non-browser client that can reach the port has full access.
+If you reach the dashboard via a custom (non-loopback) hostname, add it: `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS=box.local:3333`. Avoid binding to `0.0.0.0` with no-auth on an untrusted network — browser attacks stay blocked, but any non-browser client that can reach the port has full access.

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -341,6 +341,45 @@ fn host_allowed(host: &str, allowed: &[String]) -> bool {
     allowed.iter().any(|a| a.eq_ignore_ascii_case(host))
 }
 
+/// True when the `Host` header's hostname is a loopback literal
+/// (`localhost`, `127.0.0.0/8`, or `::1`), **regardless of port**.
+///
+/// A loopback `Host` is never a DNS-rebinding vector: the browser only sends one
+/// when the user navigated to a loopback URL directly (an attacker can't make
+/// their own hostname resolve to — and report a `Host` of — `127.0.0.1`). So in
+/// no-auth mode we accept loopback on any port, not just the bound one. This is
+/// what makes a port-remapped Docker publish work out of the box — e.g. the
+/// container binds `0.0.0.0:3333`, Docker publishes it as `-p 60000:3333`, and
+/// the host browser reaches `http://127.0.0.1:60000`, so the `Host` header is
+/// `127.0.0.1:60000` (the *published* port), which the bind-port allowlist
+/// (`127.0.0.1:3333`) would otherwise reject. Cross-origin/CSRF stays blocked by
+/// the `Sec-Fetch-Site`/`Origin` checks in `no_auth_request_ok`.
+fn host_is_loopback(host: &str) -> bool {
+    // Extract the hostname, dropping any `:port`. IPv6 literals are bracketed
+    // (`[::1]` / `[::1]:port`); a bare IPv6 (`::1`) can't carry a port.
+    let hostname = if let Some(rest) = host.strip_prefix('[') {
+        match rest.split_once(']') {
+            Some((inner, _)) => inner,
+            None => return false,
+        }
+    } else if host.matches(':').count() == 1 {
+        host.rsplit_once(':').map_or(host, |(h, _)| h)
+    } else {
+        // No colon (bare host[:no-port]) or multiple colons (unbracketed IPv6).
+        host
+    };
+    if hostname.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    if let Ok(v4) = hostname.parse::<std::net::Ipv4Addr>() {
+        return v4.is_loopback();
+    }
+    if let Ok(v6) = hostname.parse::<std::net::Ipv6Addr>() {
+        return v6.is_loopback();
+    }
+    false
+}
+
 /// Token-free request gate for no-auth dashboards. Applied to the same sensitive
 /// endpoints the Bearer token guards (`/api/*`, `/metrics`). Blocks browser
 /// cross-origin/CSRF and DNS-rebinding without a credential:
@@ -364,7 +403,12 @@ fn no_auth_request_ok(header_section: &str, allowed_hosts: &[String]) -> bool {
     let Some(host) = header_line_value(header_section, "Host") else {
         return false;
     };
-    if !host_allowed(host, allowed_hosts) {
+    // Accept the explicit allowlist (loopback aliases for the bound port, the
+    // bound host, and any LEAN_CTX_DASHBOARD_ALLOWED_HOSTS entries) OR any
+    // loopback host on any port. The latter covers port-remapped Docker
+    // publishes (e.g. `-p 60000:3333` reached via `127.0.0.1:60000`) without a
+    // manual allowlist entry — loopback hosts are not a rebinding vector.
+    if !host_allowed(host, allowed_hosts) && !host_is_loopback(host) {
         return false;
     }
     if let Some(origin) = header_line_value(header_section, "Origin")
@@ -1346,6 +1390,53 @@ mod tests {
     fn no_auth_rejects_missing_host() {
         let req = "GET /api/stats HTTP/1.1\r\n\r\n";
         assert!(!no_auth_request_ok(req, &allowed_loopback()));
+    }
+
+    #[test]
+    fn host_is_loopback_covers_literals_on_any_port() {
+        assert!(host_is_loopback("127.0.0.1"));
+        assert!(host_is_loopback("127.0.0.1:3333"));
+        assert!(host_is_loopback("127.0.0.1:60000")); // port-remapped Docker publish
+        assert!(host_is_loopback("localhost"));
+        assert!(host_is_loopback("localhost:60000"));
+        assert!(host_is_loopback("LocalHost:8080"));
+        assert!(host_is_loopback("127.5.6.7:9999")); // whole 127.0.0.0/8 is loopback
+        assert!(host_is_loopback("[::1]"));
+        assert!(host_is_loopback("[::1]:60000"));
+        assert!(host_is_loopback("::1"));
+        // Non-loopback hosts must NOT be treated as loopback.
+        assert!(!host_is_loopback("evil.com"));
+        assert!(!host_is_loopback("evil.com:60000"));
+        assert!(!host_is_loopback("10.0.0.5:3333"));
+        assert!(!host_is_loopback("[2001:db8::1]:3333"));
+        assert!(!host_is_loopback("box.local:3333"));
+    }
+
+    #[test]
+    fn no_auth_allows_loopback_host_on_remapped_port() {
+        // Container binds 0.0.0.0:3333; Docker publishes -p 60000:3333; the host
+        // browser reaches 127.0.0.1:60000, so Host carries the *published* port,
+        // which the bind-port allowlist does not contain. It must still pass via
+        // the loopback-any-port rule (GH no-auth Docker port-remap).
+        let allowed = build_allowed_hosts("0.0.0.0", 3333);
+        assert!(!host_allowed("127.0.0.1:60000", &allowed));
+        let req = "GET /api/stats HTTP/1.1\r\nHost: 127.0.0.1:60000\r\n\
+                   Sec-Fetch-Site: same-origin\r\n\r\n";
+        assert!(no_auth_request_ok(req, &allowed));
+
+        // localhost on a remapped port works too.
+        let req2 = "GET /api/stats HTTP/1.1\r\nHost: localhost:60000\r\n\r\n";
+        assert!(no_auth_request_ok(req2, &allowed));
+    }
+
+    #[test]
+    fn no_auth_still_rejects_rebinding_on_remapped_port() {
+        // The loopback-any-port relaxation must not weaken DNS-rebinding defense:
+        // a non-loopback Host is rejected regardless of port.
+        let allowed = build_allowed_hosts("0.0.0.0", 3333);
+        let req = "GET /api/stats HTTP/1.1\r\nHost: evil.com:60000\r\n\
+                   Sec-Fetch-Site: same-origin\r\n\r\n";
+        assert!(!no_auth_request_ok(req, &allowed));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a no-auth dashboard bug where **every `/api/*` request returns 403
behind a port-remapped Docker publish**, leaving all dashboard cards broken.

In no-auth mode each `/api/*` and `/metrics` request is gated by
`no_auth_request_ok()`, which checks the request `Host` against an allowlist
built from the **bound** port (`build_allowed_hosts`). When a container binds
`0.0.0.0:3333` but Docker publishes it on a different host port
(`-p 60000:3333`), the host browser reaches `http://127.0.0.1:60000` and sends
`Host: 127.0.0.1:60000` — the *published* port. The allowlist only contains the
bind-port forms (`127.0.0.1:3333`, bare `127.0.0.1`), so the Host check fails and
every API call returns 403. Because it's a 403 (not 401), the client's
token-prompt fallback (`lctx:unauthorized`, which only fires on 401) never shows
either — so the user just sees broken/empty cards with no explanation.

### Fix

`no_auth_request_ok` now accepts any **loopback host** (`127.0.0.0/8`,
`localhost`, `::1`) on **any port**, in addition to the existing allowlist:

```rust
if !host_allowed(host, allowed_hosts) && !host_is_loopback(host) {
    return false;
}
```

This is safe: a loopback `Host` can't be a DNS-rebinding target — the browser
only sends a loopback `Host` when the user navigated to a loopback URL directly,
and a malicious cross-origin page hitting `127.0.0.1` is still rejected by the
`Sec-Fetch-Site` / `Origin` checks (and unreadable via CORS). DNS-rebinding via a
non-loopback hostname (`evil.com`) remains blocked on any port.

Port-remapped loopback publishes (`-p 60000:3333` → `http://127.0.0.1:60000`) now
work out of the box without `LEAN_CTX_DASHBOARD_ALLOWED_HOSTS`.

## Test plan

- [ ] `cd rust && cargo test`  *(new tests: `host_is_loopback_covers_literals_on_any_port`, `no_auth_allows_loopback_host_on_remapped_port`, `no_auth_still_rejects_rebinding_on_remapped_port`)*
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd rust && cargo fmt --check`
- [ ] Manual: `lean-ctx dashboard --host=0.0.0.0 --no-auth` in a container published with `-p 127.0.0.1:60000:3333`, open `http://127.0.0.1:60000` → cards load, no 403s

## Notes for reviewers

- **Risk areas / edge cases:** the relaxation is scoped strictly to loopback
  hostnames (parsed via `Ipv4Addr::is_loopback`/`Ipv6Addr::is_loopback`, plus
  `localhost`), so it covers the whole `127.0.0.0/8` range and bracketed/bare
  IPv6 (`[::1]`, `::1`) on any port. Non-loopback hosts still go through the
  unchanged allowlist + env mechanism. Origin/Sec-Fetch-Site checks are untouched.
- **Security:** no change to the cross-origin/CSRF or DNS-rebinding posture for
  non-loopback hosts. Added a test asserting `Host: evil.com:60000` is still
  rejected.
- **Backwards compatibility:** purely additive — previously-allowed requests are
  still allowed; only previously-rejected loopback-on-other-port requests now pass.
- **Docs updated:** `discord-faq/06-dashboard-analytics.md` (loopback-any-port +
  port-remap example), `CHANGELOG.md` (`[Unreleased]`).