### PR TITLE
feat(sessions): Added functionality to remove session by id

### DIFF
--- a/docs/reference/03-memory-and-knowledge.md
+++ b/docs/reference/03-memory-and-knowledge.md
@@ -76,6 +76,7 @@ knows where we were" work. If it *doesn't* work, see Journey 6 →
 ```bash
 lean-ctx sessions list             # all saved snapshots
 lean-ctx sessions show [id]        # inspect one
+lean-ctx sessions delete <id>      # delete one snapshot
 lean-ctx sessions cleanup [days]   # prune old snapshots
 lean-ctx sessions doctor [--fix]   # diagnose/repair session restore
 ```

--- a/docs/reference/appendix-cli-map.md
+++ b/docs/reference/appendix-cli-map.md
@@ -47,7 +47,7 @@ Every CLI command lean-ctx exposes, grouped by purpose. Source of truth:
 | Command | Purpose |
 |---------|---------|
 | `session` | Tasks/findings/decisions + adoption stats: `task`, `finding`, `decision`, `save`, `load`, `status`, `reset` |
-| `sessions` (`session-store`) | Manage saved CCP snapshots: `list`, `show`, `cleanup`, `doctor` |
+| `sessions` (`session-store`) | Manage saved CCP snapshots: `list`, `show`, `delete`, `cleanup`, `doctor` |
 | `knowledge` | Project knowledge: `remember`, `recall`, `search`, `export`, `import`, `remove`, `consolidate [--all]`, `status`, `health`, `lifecycle` |
 | `overview [task]` | Project overview (task-contextualized) |
 | `compress` | Context-compression checkpoint; `--signatures` |

--- a/rust/README.md
+++ b/rust/README.md
@@ -216,6 +216,7 @@ lean-ctx wrapped               # Shareable savings report (CCP)
 lean-ctx wrapped --week        # Weekly savings report
 lean-ctx sessions list         # List CCP sessions
 lean-ctx sessions show <id>    # Show session details
+lean-ctx sessions delete <id>  # Delete one session
 lean-ctx sessions cleanup      # Remove old sessions
 lean-ctx benchmark run         # Real project benchmark (terminal)
 lean-ctx benchmark run --json  # Machine-readable JSON output
@@ -451,6 +452,7 @@ New in v2.0.0: CCP provides cross-session memory that persists across chats, con
 ```bash
 lean-ctx sessions list              # List all sessions
 lean-ctx sessions show <id>         # Show session details
+lean-ctx sessions delete <id>       # Delete one session
 lean-ctx sessions cleanup           # Remove old sessions
 lean-ctx wrapped                    # Shareable savings report
 lean-ctx wrapped --week             # Weekly report

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -161,7 +161,7 @@ COMMANDS:
     daemon start|stop|restart|status  IPC daemon management
     daemon enable|disable          Auto-start daemon on login (systemd/LaunchAgent; prints service file)
     cache [list|clear|stats]       Show/manage file read cache
-    sessions [list|show|cleanup]   Manage saved session snapshots — PLURAL; see 'session' for live memory (alias: session-store)
+    sessions [list|show|delete|cleanup]  Manage saved session snapshots — PLURAL; see 'session' for live memory (alias: session-store)
     benchmark run [path] [--json]  Run real benchmark on project files
     benchmark report [path]        Generate shareable Markdown report
     benchmark compare [--output F] Head-to-head comparison vs competitors
@@ -313,6 +313,7 @@ EXAMPLES:
     lean-ctx savings verify-batch <file>  Verify a signed batch offline (no ledger needed)
     lean-ctx sessions list         List all CCP sessions
     lean-ctx sessions show         Show latest session state
+    lean-ctx sessions delete <id>  Delete one saved session
     lean-ctx discover              Find missed savings in shell history
     lean-ctx discover --card       Shareable 'before' SVG -> lean-ctx-before.svg
     lean-ctx onboard               One-command setup (shell + editors + verify)

--- a/rust/src/cli/session_cmd.rs
+++ b/rust/src/cli/session_cmd.rs
@@ -343,6 +343,23 @@ pub fn cmd_sessions(args: &[String]) {
                 );
             }
         }
+        "delete" | "rm" => {
+            let Some(id) = args.get(1) else {
+                eprintln!("Usage: lean-ctx sessions delete <id>");
+                std::process::exit(1);
+            };
+            match SessionState::delete_session(id) {
+                Ok(true) => println!("Deleted session {id}."),
+                Ok(false) => {
+                    eprintln!("Session not found: {id}");
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Failed to delete session {id}: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
         "doctor" => {
             let apply = args.iter().any(|a| a == "--apply" || a == "--fix");
             let (found, quarantined) = SessionState::doctor_quarantine_unsafe_roots(apply);
@@ -364,7 +381,9 @@ pub fn cmd_sessions(args: &[String]) {
             }
         }
         _ => {
-            eprintln!("Usage: lean-ctx sessions [list|show [id]|cleanup [days]|doctor [--apply]]");
+            eprintln!(
+                "Usage: lean-ctx sessions [list|show [id]|delete <id>|cleanup [days]|doctor [--apply]]"
+            );
             std::process::exit(1);
         }
     }

--- a/rust/src/core/session/mod.rs
+++ b/rust/src/core/session/mod.rs
@@ -14,8 +14,9 @@ pub use types::{
 
 #[cfg(test)]
 mod tests {
-    use super::paths::extract_cd_target;
+    use super::paths::{extract_cd_target, sessions_dir};
     use super::types::*;
+    use chrono::{Duration, Utc};
 
     #[test]
     fn load_latest_for_broad_root_returns_none_without_scanning() {
@@ -51,6 +52,66 @@ mod tests {
         // Root is not an agent/temp dir → kept as-is, no probe needed.
         assert_eq!(normalized.project_root.as_deref(), Some(docs_root.as_str()));
         crate::test_env::remove_var("LEAN_CTX_TCC_STANDALONE");
+    }
+
+    #[test]
+    fn delete_session_removes_file_snapshot_and_latest_pointer() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let mut session = SessionState::new();
+        session.id = "delete-me".to_string();
+        session.save().unwrap();
+
+        let dir = sessions_dir().unwrap();
+        let path = dir.join("delete-me.json");
+        let snapshot = dir.join("delete-me_snapshot.txt");
+        let latest = dir.join("latest.json");
+        std::fs::write(&snapshot, "snapshot").unwrap();
+        assert!(path.exists());
+        assert!(snapshot.exists());
+        assert!(latest.exists());
+
+        assert!(SessionState::delete_session("delete-me").unwrap());
+
+        assert!(!path.exists());
+        assert!(!snapshot.exists());
+        assert!(!latest.exists());
+        assert!(SessionState::list_sessions().is_empty());
+    }
+
+    #[test]
+    fn delete_latest_session_repoints_latest_to_newest_remaining() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let mut older = SessionState::new();
+        older.id = "older".to_string();
+        older.updated_at = Utc::now() - Duration::days(1);
+        older.save().unwrap();
+
+        let mut newer = SessionState::new();
+        newer.id = "newer".to_string();
+        newer.updated_at = Utc::now();
+        newer.save().unwrap();
+        assert_eq!(
+            SessionState::load_global_latest_pointer().unwrap().id,
+            "newer"
+        );
+
+        assert!(SessionState::delete_session("newer").unwrap());
+
+        let latest = SessionState::load_global_latest_pointer().unwrap();
+        assert_eq!(latest.id, "older");
+        assert_eq!(SessionState::list_sessions().len(), 1);
+    }
+
+    #[test]
+    fn delete_session_rejects_path_traversal_id() {
+        let data = crate::core::data_dir::isolated_data_dir();
+        let outside = data.path().join("outside.json");
+        std::fs::write(&outside, "{}").unwrap();
+
+        let err = SessionState::delete_session("../outside").unwrap_err();
+
+        assert_eq!(err, "invalid session id");
+        assert!(outside.exists());
     }
 
     #[test]

--- a/rust/src/core/session/persistence.rs
+++ b/rust/src/core/session/persistence.rs
@@ -16,6 +16,19 @@ fn restrict_file_permissions(path: &std::path::Path) {
 #[cfg(not(unix))]
 fn restrict_file_permissions(_path: &std::path::Path) {}
 
+fn validate_session_id(id: &str) -> Result<(), String> {
+    if id.is_empty()
+        || id == "latest"
+        || id.starts_with('.')
+        || id.contains('/')
+        || id.contains('\\')
+        || id.contains(std::path::MAIN_SEPARATOR)
+    {
+        return Err("invalid session id".to_string());
+    }
+    Ok(())
+}
+
 impl PreparedSave {
     /// Writes the pre-serialized session data, latest pointer, and compaction
     /// snapshot to disk atomically.
@@ -164,11 +177,60 @@ impl SessionState {
 
     /// Loads a specific session from disk by its unique ID.
     pub fn load_by_id(id: &str) -> Option<Self> {
+        validate_session_id(id).ok()?;
         let dir = sessions_dir()?;
         let path = dir.join(format!("{id}.json"));
         let json = std::fs::read_to_string(&path).ok()?;
         let session: Self = serde_json::from_str(&json).ok()?;
         Some(normalize_loaded_session(session))
+    }
+
+    /// Deletes a saved session and its compaction snapshot.
+    ///
+    /// If the deleted session is the global latest pointer, the pointer is
+    /// moved to the newest remaining session or removed when none remain.
+    pub fn delete_session(id: &str) -> Result<bool, String> {
+        validate_session_id(id)?;
+        let Some(dir) = sessions_dir() else {
+            return Ok(false);
+        };
+        let path = dir.join(format!("{id}.json"));
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        std::fs::remove_file(&path).map_err(|e| e.to_string())?;
+
+        let snapshot = dir.join(format!("{id}_snapshot.txt"));
+        match std::fs::remove_file(&snapshot) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.to_string()),
+        }
+
+        let latest_path = dir.join("latest.json");
+        let points_to_deleted = std::fs::read_to_string(&latest_path)
+            .ok()
+            .and_then(|json| serde_json::from_str::<LatestPointer>(&json).ok())
+            .is_some_and(|pointer| pointer.id == id);
+        if points_to_deleted {
+            if let Some(next) = Self::list_sessions().into_iter().next() {
+                let latest_tmp = dir.join(".latest.json.tmp");
+                let pointer_json = serde_json::to_string(&LatestPointer { id: next.id })
+                    .map_err(|e| e.to_string())?;
+                std::fs::write(&latest_tmp, pointer_json).map_err(|e| e.to_string())?;
+                restrict_file_permissions(&latest_tmp);
+                std::fs::rename(&latest_tmp, &latest_path).map_err(|e| e.to_string())?;
+            } else {
+                match std::fs::remove_file(&latest_path) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.to_string()),
+                }
+            }
+        }
+
+        Ok(true)
     }
 
     /// Lists all saved sessions as summaries, sorted by most recently updated.

--- a/rust/tests/cli_characterization.rs
+++ b/rust/tests/cli_characterization.rs
@@ -2,7 +2,10 @@
 //! assert stable exit codes + output invariants. These freeze the existing
 //! behavior so that future refactors of `cli/dispatch` can't silently regress.
 
-use std::process::{Command, Output};
+use std::{
+    fs,
+    process::{Command, Output},
+};
 
 fn lean_ctx() -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_lean-ctx"));
@@ -67,6 +70,34 @@ fn help_short_flag() {
     let out = run(&["-h"]);
     assert_eq!(exit_code(&out), 0);
     assert!(!stdout(&out).is_empty());
+}
+
+#[test]
+fn sessions_delete_removes_saved_session_and_snapshot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let sessions = tmp.path().join("sessions");
+    fs::create_dir_all(&sessions).expect("sessions dir");
+    let mut session = lean_ctx::core::session::SessionState::new();
+    session.id = "cli-delete-me".to_string();
+    fs::write(
+        sessions.join("cli-delete-me.json"),
+        serde_json::to_string_pretty(&session).unwrap(),
+    )
+    .unwrap();
+    fs::write(sessions.join("cli-delete-me_snapshot.txt"), "snapshot").unwrap();
+    fs::write(sessions.join("latest.json"), r#"{"id":"cli-delete-me"}"#).unwrap();
+
+    let out = lean_ctx()
+        .env("LEAN_CTX_DATA_DIR", tmp.path())
+        .args(["sessions", "delete", "cli-delete-me"])
+        .output()
+        .expect("failed to spawn lean-ctx binary");
+
+    assert_eq!(exit_code(&out), 0, "stderr: {}", stderr(&out));
+    assert!(stdout(&out).contains("Deleted session cli-delete-me."));
+    assert!(!sessions.join("cli-delete-me.json").exists());
+    assert!(!sessions.join("cli-delete-me_snapshot.txt").exists());
+    assert!(!sessions.join("latest.json").exists());
 }
 
 #[test]

--- a/skills/lean-ctx/SKILL.md
+++ b/skills/lean-ctx/SKILL.md
@@ -134,6 +134,7 @@ If MCP is enabled for your IDE, the same capabilities are also available as MCP 
 ```bash
 lean-ctx sessions list          # List all CCP sessions
 lean-ctx sessions show          # Show latest session state
+lean-ctx sessions delete <id>   # Delete one saved session
 lean-ctx wrapped                # Weekly savings report card
 lean-ctx wrapped --month        # Monthly savings report card
 lean-ctx benchmark run          # Real project benchmark (terminal output)


### PR DESCRIPTION
## Summary

  Adds lean-ctx sessions delete <id> for removing one saved session snapshot.

  Changes:

  - Adds delete / rm under lean-ctx sessions.
  - Deletes <id>.json and matching <id>_snapshot.txt.
  - Repoints or removes latest.json when deleting latest session.
  - Rejects invalid/path-like session IDs.
  - Updates CLI help, README, reference docs, and skill docs.
  - Adds unit and CLI regression coverage.

## Test plan

  - [x] cd rust && cargo test - unrelated tests failed
  - [x] cd rust && cargo clippy -- -W clippy::all
  - [x] cd rust && cargo fmt
  - [x] cd rust && cargo test delete_session --lib
  - [x] cd rust && cargo test delete_latest_session_repoints_latest_to_newest_remaining --lib
  - [x] cd rust && cargo test sessions_delete_removes_saved_session_and_snapshot --test cli_characterization
  - [ ] If cookbook/packages changed: relevant npm test / build steps

  ## Notes for reviewers

  - Risk areas / edge cases: latest pointer rewrite/removal; deleting snapshot sidecar; invalid session IDs/path traversal.
  - Backwards compatibility: additive CLI command; existing list, show, cleanup, and doctor behavior unchanged.