### PR TITLE
ctx_shell: surface a hint when cwd is rejected by the project-root jail

### DIFF
--- a/rust/src/core/session/mod.rs
+++ b/rust/src/core/session/mod.rs
@@ -130,6 +130,32 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    /// The checked variant must report *why* a jailed cwd was rejected, so
+    /// ctx_shell can surface it instead of silently swapping in the root (#629).
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn effective_cwd_checked_reports_jail_rejection_reason() {
+        let tmp = std::env::temp_dir().join("lean-ctx-test-cwd-checked");
+        let _ = std::fs::create_dir_all(&tmp);
+        let root_canon = crate::core::pathutil::safe_canonicalize_or_self(&tmp)
+            .to_string_lossy()
+            .to_string();
+
+        let mut session = SessionState::new();
+        session.project_root = Some(root_canon.clone());
+
+        // Rejected: falls back to root AND surfaces a reason.
+        let (path, reason) = session.effective_cwd_checked(Some("/nonexistent-outside-path"));
+        assert_eq!(path, root_canon);
+        assert!(reason.is_some(), "jailed cwd must report a rejection reason");
+
+        // Accepted (no explicit cwd): no reason.
+        let (_p, none_reason) = session.effective_cwd_checked(None);
+        assert!(none_reason.is_none(), "non-jailed path must not report a reason");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     #[test]
     fn effective_cwd_shell_cwd_second_priority() {
         let mut session = SessionState::new();

--- a/rust/src/core/session/state.rs
+++ b/rust/src/core/session/state.rs
@@ -411,6 +411,15 @@ impl SessionState {
     /// Explicit CWD and stored shell_cwd are jail-checked against the project root
     /// to prevent MCP clients from escaping the workspace.
     pub fn effective_cwd(&self, explicit_cwd: Option<&str>) -> String {
+        self.effective_cwd_checked(explicit_cwd).0
+    }
+
+    /// Like [`Self::effective_cwd`], but also reports when an explicit `cwd`
+    /// request was rejected by the project-root jail and silently replaced
+    /// with the project root (#629) -- callers that surface output to a
+    /// human/agent should report this instead of letting the substitution
+    /// pass unnoticed.
+    pub fn effective_cwd_checked(&self, explicit_cwd: Option<&str>) -> (String, Option<String>) {
         let root = self.project_root.as_deref().unwrap_or(".");
         if let Some(cwd) = explicit_cwd
             && !cwd.is_empty()
@@ -419,22 +428,27 @@ impl SessionState {
             return Self::jail_cwd(cwd, root);
         }
         if let Some(ref cwd) = self.shell_cwd {
-            return cwd.clone();
+            return (cwd.clone(), None);
         }
         if let Some(ref r) = self.project_root {
-            return r.clone();
+            return (r.clone(), None);
         }
-        std::env::current_dir()
-            .map_or_else(|_| ".".to_string(), |p| p.to_string_lossy().to_string())
+        (
+            std::env::current_dir()
+                .map_or_else(|_| ".".to_string(), |p| p.to_string_lossy().to_string()),
+            None,
+        )
     }
 
     /// Verifies that `candidate` is within the project jail.
-    /// Falls back to `fallback_root` if the candidate escapes.
-    fn jail_cwd(candidate: &str, fallback_root: &str) -> String {
+    /// Falls back to `fallback_root` if the candidate escapes, returning the
+    /// jail-rejection reason so callers can surface it instead of silently
+    /// substituting the root (#629).
+    fn jail_cwd(candidate: &str, fallback_root: &str) -> (String, Option<String>) {
         let p = std::path::Path::new(candidate);
         match crate::core::pathjail::jail_path(p, std::path::Path::new(fallback_root)) {
-            Ok(jailed) => jailed.to_string_lossy().to_string(),
-            Err(_) => fallback_root.to_string(),
+            Ok(jailed) => (jailed.to_string_lossy().to_string(), None),
+            Err(reason) => (fallback_root.to_string(), Some(reason)),
         }
     }
 

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -73,13 +73,23 @@ impl McpTool for CtxShellTool {
                 .ok_or_else(|| ErrorData::internal_error("session not available", None))?;
 
             let explicit_cwd = get_str(args, "cwd");
-            let effective_cwd = {
+            let (effective_cwd, cwd_jail_reason) = {
                 let guard = crate::server::bounded_lock::read(session_lock, "ctx_shell_cwd");
                 match guard {
-                    Some(session) => session.effective_cwd(explicit_cwd.as_deref()),
-                    None => explicit_cwd.unwrap_or_else(|| ".".to_string()),
+                    Some(session) => session.effective_cwd_checked(explicit_cwd.as_deref()),
+                    None => (explicit_cwd.clone().unwrap_or_else(|| ".".to_string()), None),
                 }
             };
+            // Surfaced at the end of the output so a jailed `cwd` request
+            // (rejected and silently replaced with the project root) is
+            // visible to the caller instead of passing unnoticed (#629).
+            let cwd_jail_hint = cwd_jail_reason
+                .map(|reason| {
+                    format!(
+                        "\n[cwd: requested path rejected by project-root jail ({reason}) \u{2014} ran in {effective_cwd} instead]"
+                    )
+                })
+                .unwrap_or_default();
 
             {
                 let Some(mut session) =
@@ -224,7 +234,7 @@ impl McpTool for CtxShellTool {
             } else {
                 String::new()
             };
-            let final_out = format!("{result_out}{tee_hint}{shell_mismatch}{exit_suffix}");
+            let final_out = format!("{result_out}{tee_hint}{shell_mismatch}{cwd_jail_hint}{exit_suffix}");
 
             Ok(ToolOutput {
                 text: final_out,


### PR DESCRIPTION
## What

`ctx_shell`'s `cwd` jail (`effective_cwd`/`jail_cwd` in `rust/src/core/session/state.rs`) is intentional sandboxing: a `cwd` outside the session's `project_root` is rejected and silently replaced with the project root. That's correct security behavior, but the silence is confusing — I initially reported it as a bug (#629) before realizing it's by design.

This PR keeps the jail exactly as-is and only adds visibility: when an explicit `cwd` gets rejected, `ctx_shell`'s output now includes a hint instead of staying silent.

## How

- `SessionState::effective_cwd` is now a thin wrapper around a new `effective_cwd_checked`, which returns `(String, Option<String>)` — the resolved cwd plus the jail-rejection reason, if any. Existing callers/behavior of `effective_cwd` are unchanged.
- `jail_cwd` likewise now returns the rejection reason instead of swallowing it.
- `ctx_shell`'s tool handler captures that reason and appends a `\n[cwd: requested path rejected by project-root jail (...) — ran in <root> instead]` line to the tool output, alongside the existing `tee_hint`/`shell_mismatch` hints.

## Scope check

`effective_cwd(...)` had exactly 3 non-test call sites; only the `ctx_shell` one needed the new info, so I left it as the only caller of `effective_cwd_checked`.

## Testing — verified locally ✅

Built and tested clean against this branch:

- `cargo check -p lean-ctx` → **Finished, 0 errors**.
- `cargo test -p lean-ctx --lib effective_cwd` → **6 passed; 0 failed**, including the existing jail tests and a new `effective_cwd_checked_reports_jail_rejection_reason` test that asserts the reason is `Some(..)` on a jailed cwd and `None` otherwise.

Toolchain note: my pinned stable was `rustc 1.91.1`, on which `rusqlite 0.40.1` / `libsqlite3-sys 0.38.1` fail to build because they use the still-unstable `cfg_select` std macro. I verified on `nightly 1.98.0` (`2026-06-29`), where `cfg_select` compiles, by pointing `RUSTC` at the nightly toolchain. This toolchain constraint is independent of this change (it reproduces on `main`); flagging in case it affects CI on older toolchains.

Clarifies #629.
