### PR TITLE
feat(recovery): visibly reversible compressed output + drop redundant Codex `lean-ctx -c` nag (#625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Compressed output is now visibly reversible — a first-class recovery layer on
+  every surface (#625).** Agents (Codex especially) were re-reading compressed
+  views line-by-line because nothing taught them how to get the raw bytes back —
+  the real cause behind "too compressed" reports. The escape hatch already
+  existed; it is now *discoverable* and *consistent*, with the non-MCP path
+  treated as first-class (many orgs forbid MCP):
+  - **Proactive (MCP rules v4).** A new `RECOVER` rule states the invariant —
+    compressed output is reversible, never re-read it line-by-line — and names the
+    recovery grammar: read the shown file path with any tool (no MCP), or
+    `ctx_read(mode=full|raw=true)`; `[Archived]`/tee/firewall handles →
+    `ctx_expand(id=…)`.
+  - **Reactive (ctx_read footer).** Every lossy `ctx_read` view ends with a
+    recovery footer that leads with the native file path, then the MCP fallbacks;
+    `full`/`raw` views carry no footer (deduped by mode). `ctx_read` gained an
+    explicit `raw` parameter (verbatim bytes, unframed escape hatch).
+  - **CLI / shell-hook surface.** `lean-ctx raw "<command>"` is now surfaced in
+    `help`, `help all` and the cheatsheet, so the raw path is reachable without
+    MCP.
+  - **Guaranteed raw on disk.** The default `tee_mode` is now `high-compression`:
+    whenever a view compresses heavily a verbatim copy is one `ctx_expand`/file
+    read away. The new `recovery_hints` config (`off|minimal|full`) tunes footer
+    verbosity. All recovery grammar (archive, firewall, spill, tee, ctx_shell)
+    flows through one `recovery` module, so every channel speaks the same
+    non-MCP-first sentence.
+
 ### Fixed
+- **The Codex `lean-ctx -c` SessionStart hook is no longer a redundant nag (#625).**
+  Codex's `PreToolUse` hook already rewrites every rewritable Bash command to
+  `lean-ctx -c "<command>"` transparently (`permissionDecision: allow` +
+  `updatedInput`), so the old SessionStart line ("prefer `lean-ctx -c`") taught
+  nothing actionable — and crucially said nothing about getting *raw* output,
+  which is the one thing an agent cannot reach once a command is auto-compressed.
+  The hint now teaches the raw escape (`lean-ctx raw "<command>"`) and forbids the
+  small-chunk re-read anti-pattern. The raw spellings (`lean-ctx raw`,
+  `lean-ctx -c --raw`) are reentrance-safe: the rewrite hook leaves any command
+  starting with `lean-ctx ` untouched, so the agent always reaches verbatim bytes.
 - **`ctx_search` no longer returns a false `No matches` for content edited after
   the index warmed (#624).** The resident trigram index treated itself as *fresh*
   for a fixed 15 s TTL with no per-file change detection, so in hybrid setups

--- a/LEAN-CTX.md
+++ b/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 3 -->
+<!-- version: 4 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 
@@ -52,6 +52,8 @@ ctx_compose bundles multiple lookups into one call; for anything it doesn't
 cover, batch independent reads/searches together.
 
 Auto: preload/dedup/compress run in background. ctx_session=memory, ctx_knowledge=facts, ctx_semantic_search=meaning search, ctx_shell raw=true=uncompressed. Details: LEAN-CTX.md
+
+RECOVER: compressed output is reversible — never re-read line-by-line. Need full/exact? Read the shown file path with any tool (no MCP), or ctx_read(mode=full|raw=true); [Archived]/tee/firewall → ctx_expand(id=...).
 
 CEP v1: 1.ACT FIRST 2.DELTA ONLY (Fn refs) 3.STRUCTURED (+/-/~) 4.ONE LINE PER ACTION 5.QUALITY ANCHOR
 

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -61,6 +61,7 @@ Top-level configuration keys
 - `proxy_require_token` (bool, default `false`) — Require lean-ctx Bearer token authentication and disable provider API key fallback
 - `proxy_timeout_ms` (u64?, default `null`) — Proxy reachability timeout in ms (default: 200). Override via LEAN_CTX_PROXY_TIMEOUT_MS
 - `read_only_roots` (string[], default `[]` — env `LEAN_CTX_READ_ONLY_ROOTS`) — Read-only sibling roots: reads allowed, writes always denied (edit/refactor/export)
+- `recovery_hints` (enum: off | minimal | full, default `minimal`) — Verbosity of the reactive recovery footer on compressed output (path-first, MCP-optional)
 - `redirect_exclude` (string[], default `[]`) — URL patterns to exclude from proxy redirection
 - `reference_results` (bool, default `false` — env `LEAN_CTX_REFERENCE_RESULTS`) — Store large tool outputs as references instead of inline content
 - `response_verbosity` (enum: normal | compact | minimal, default `normal` — env `LEAN_CTX_RESPONSE_VERBOSITY`) — Controls how verbose tool responses are
@@ -84,7 +85,7 @@ Top-level configuration keys
 - `team_auto_push` (bool, default `false`) — Opt-in: daemon periodically pushes your signed savings batch to team_url (off by default; requires team_url + team_token)
 - `team_token` (string?, default `null`) — Bearer token for the team server (push needs a member token; pull/auto-push needs the configured team token)
 - `team_url` (string?, default `null`) — Team server base URL for the opt-in savings roll-up (push/pull)
-- `tee_mode` (enum: never | failures | always, default `failures`) — Controls when shell output is tee'd to disk for later retrieval
+- `tee_mode` (enum: never | failures | highcompression | always, default `highcompression`) — Controls when shell output is tee'd to disk for later retrieval
 - `terse_agent` (enum: off | lite | full | ultra, default `off` — env `LEAN_CTX_TERSE_AGENT`) — Controls agent output verbosity via instructions injection
 - `theme` (string, default `default`) — Dashboard color theme
 - `tool_profile` (enum: minimal | standard | power, default `""`) — Tool visibility profile: minimal (5 tools), standard (15), power (all). Override via LEAN_CTX_TOOL_PROFILE

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -225,6 +225,8 @@ WORKFLOW: see [Archived:ID] → ctx_expand id=ID to restore full content.
 Supports head/tail/search to filter lines and save tokens on re-read.
 action=list browses all archives. action=search_all queries across archives.
 Zero-loss: original preserved.
+NO MCP? The same bytes are a real file — every [Archived]/tee/firewall hint
+shows its on-disk path; read that path directly with any tool instead.
 ANTIPATTERN: not for reading project files — use ctx_read or ctx_compose.
 
 Parameters: `action`, `end_line`, `head`, `id`, `json_keys`, `json_path`, `query`, `search`, `session_id`, `start_line`, `tail`
@@ -762,5 +764,5 @@ Output is compressed for token savings. For verbatim output pass raw=true.
 Use when your MCP client prefers shell/bash over ctx_shell — transparently
 delegates to ctx_shell internals.
 
-Parameters: `command`*, `cwd`
+Parameters: `command`*, `cwd`, `raw`
 

--- a/rust/LEAN-CTX.md
+++ b/rust/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 3 -->
+<!-- version: 4 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 
@@ -52,6 +52,8 @@ ctx_compose bundles multiple lookups into one call; for anything it doesn't
 cover, batch independent reads/searches together.
 
 Auto: preload/dedup/compress run in background. ctx_session=memory, ctx_knowledge=facts, ctx_semantic_search=meaning search, ctx_shell raw=true=uncompressed. Details: LEAN-CTX.md
+
+RECOVER: compressed output is reversible — never re-read line-by-line. Need full/exact? Read the shown file path with any tool (no MCP), or ctx_read(mode=full|raw=true); [Archived]/tee/firewall → ctx_expand(id=...).
 
 CEP v1: 1.ACT FIRST 2.DELTA ONLY (Fn refs) 3.STRUCTURED (+/-/~) 4.ONE LINE PER ACTION 5.QUALITY ANCHOR
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -553,8 +553,8 @@ lean-ctx init --agent codex
 This installs:
 
 - `~/.codex/AGENTS.md` + `~/.codex/LEAN-CTX.md`
-- a `SessionStart` hook that reminds Codex to prefer `lean-ctx -c "<command>"` for rewritable shell commands
-- a `PreToolUse` hook that blocks rewritable raw Bash commands and tells Codex exactly how to rerun them through `lean-ctx`
+- a `PreToolUse` hook that transparently rewrites rewritable Bash commands to `lean-ctx -c "<command>"` (allowed + `updatedInput`), so shell output is compressed with zero agent effort
+- a `SessionStart` hook that teaches Codex the raw escape hatch — `lean-ctx raw "<command>"` for the full, exact output — so it never re-reads a compressed view in small chunks
 
 ### Google Antigravity
 
@@ -802,3 +802,4 @@ lean-ctx is a **privacy-first** tool — no tracking, no analytics, no PII colle
 ## License
 
 Apache-2.0 — see [LICENSE](../LICENSE) for details.
+

--- a/rust/src/cli/cheatsheet_cmd.rs
+++ b/rust/src/cli/cheatsheet_cmd.rs
@@ -22,6 +22,7 @@ pub fn cmd_cheatsheet() {
   ctx_multi_read        \x1b[2m# read multiple files at once\x1b[0m
   ctx_search            \x1b[2m# search with compressed results (~70%)\x1b[0m
   ctx_shell             \x1b[2m# run CLI with compressed output (~60-90%)\x1b[0m
+  ctx_read raw=true     \x1b[2m# escape hatch: exact bytes (CLI: lean-ctx raw \"cmd\")\x1b[0m
 
 \x1b[1;35m━━━ AFTER CODING ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m
   ctx_session finding \"...\"       \x1b[2m# record what you discovered\x1b[0m

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -59,6 +59,7 @@ GETTING STARTED:
 
 EVERYDAY COMMANDS:
     lean-ctx -c \"command\"          Run a shell command with compressed output
+    lean-ctx raw \"command\"         Same, but full uncompressed output (escape hatch)
     lean-ctx read <file>           Read a file with compression
     lean-ctx grep <pattern>        Search with compressed output
     lean-ctx dashboard             Open the web dashboard (localhost:3333)
@@ -110,6 +111,7 @@ USAGE:
     lean-ctx -t \"command\"          Track command (full output + stats, no compression)
     lean-ctx -c \"command\"          Execute with compressed output (used by AI hooks)
     lean-ctx -c --raw \"command\"    Execute without compression (full output)
+    lean-ctx raw \"command\"         Raw escape hatch: full, exact output (alias: bypass)
     lean-ctx exec \"command\"        Same as -c
     lean-ctx shell                 Interactive shell with compression
 

--- a/rust/src/core/archive.rs
+++ b/rust/src/core/archive.rs
@@ -465,8 +465,19 @@ pub fn disk_usage_bytes() -> u64 {
     total
 }
 
+/// Filesystem path of an archived entry's verbatim content. Exposed so recovery
+/// hints can offer the MCP-free "read this file directly" route alongside
+/// `ctx_expand(id=...)` — the same content is reachable both ways.
+pub fn content_path_str(id: &str) -> String {
+    content_path(id).to_string_lossy().into_owned()
+}
+
 pub fn format_hint(id: &str, size_chars: usize, size_tokens: usize) -> String {
-    format!("[Archived: {size_chars} chars ({size_tokens} tok). Retrieve: ctx_expand(id=\"{id}\")]")
+    // Unified, non-MCP-first recovery grammar (see [`crate::core::recovery`]): the
+    // archived blob is a real file readable with any tool, and `ctx_expand(id)`
+    // reaches the same bytes for surgical slices.
+    let clause = crate::core::recovery::handle_clause(id, Some(&content_path_str(id)));
+    format!("[Archived: {size_chars} chars ({size_tokens} tok). {clause}]")
 }
 
 #[cfg(test)]

--- a/rust/src/core/config/enums.rs
+++ b/rust/src/core/config/enums.rs
@@ -59,14 +59,72 @@ impl Effort {
 }
 
 /// Controls when shell output is tee'd to disk for later retrieval.
+///
+/// Default is `HighCompression` (not `Failures`): a heavily compressed but
+/// *successful* command is exactly the case where an agent later needs the raw
+/// bytes, and teeing them guarantees the MCP-free recovery path (a real file the
+/// agent can read with any tool) always exists. The archive GC (TTL + size cap)
+/// covers the extra files.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum TeeMode {
     Never,
-    #[default]
     Failures,
+    #[default]
     HighCompression,
     Always,
+}
+
+/// Controls the reactive recovery footer surfaced on compressed tool output
+/// (`ctx_read`, archive/firewall/spill handles, `ctx_shell` tee).
+///
+/// The proactive `RECOVER` rule teaches the vocabulary once in the system
+/// prompt; this knob governs the per-output reminder that names the concrete
+/// file path / handle at point-of-need:
+/// * `Minimal` (default) — a single, non-MCP-first line on the *first* compressed
+///   view of a file/handle per session.
+/// * `Full` — the richer ladder (`mode=full` · `raw=true` · `ctx_retrieve` ·
+///   `ctx_expand`); used by the `exploration`/`review` profiles.
+/// * `Off` — suppresses the footer entirely (the proactive rule still ships, so
+///   reversibility is never undiscoverable).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RecoveryHints {
+    Off,
+    #[default]
+    Minimal,
+    Full,
+}
+
+impl RecoveryHints {
+    /// Parse a config/env token. Returns `None` for unrecognized input so a typo
+    /// falls back to the default rather than silently disabling the feature.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "false" => Some(Self::Off),
+            "minimal" | "min" | "on" | "true" => Some(Self::Minimal),
+            "full" => Some(Self::Full),
+            _ => None,
+        }
+    }
+
+    /// Reads the recovery-hint tier from `LEAN_CTX_RECOVERY_HINTS` (ops/test
+    /// override). Unset or unrecognized yields `None` (use the configured value).
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        Self::parse(&std::env::var("LEAN_CTX_RECOVERY_HINTS").ok()?)
+    }
+
+    /// Stable lowercase label (config display, schema, `/status`).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Minimal => "minimal",
+            Self::Full => "full",
+        }
+    }
 }
 
 /// Legacy: Controls agent output verbosity level injected into MCP instructions.

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -29,8 +29,8 @@ mod tests;
 
 pub(crate) use defaults_allowlist::{cloud_infra_commands, default_shell_allowlist};
 pub use enums::{
-    CompressionLevel, Effort, OutputDensity, PermissionInheritance, ResponseVerbosity,
-    RulesInjection, RulesScope, SessionDegrade, TeeMode, TerseAgent,
+    CompressionLevel, Effort, OutputDensity, PermissionInheritance, RecoveryHints,
+    ResponseVerbosity, RulesInjection, RulesScope, SessionDegrade, TeeMode, TerseAgent,
 };
 pub use memory::{MemoryCleanup, MemoryGuardConfig, MemoryProfile, SavingsFooter};
 pub use provenance::{ConfigProvenance, EnvOverride};
@@ -77,6 +77,10 @@ pub struct Config {
     pub ultra_compact: bool,
     #[serde(default, deserialize_with = "serde_defaults::deserialize_tee_mode")]
     pub tee_mode: TeeMode,
+    /// Verbosity of the reactive recovery footer on compressed output
+    /// (`off|minimal|full`, default `minimal`). See [`RecoveryHints`].
+    #[serde(default)]
+    pub recovery_hints: RecoveryHints,
     #[serde(default)]
     pub output_density: OutputDensity,
     pub checkpoint_interval: u32,
@@ -590,6 +594,7 @@ impl Default for Config {
         Self {
             ultra_compact: false,
             tee_mode: TeeMode::default(),
+            recovery_hints: RecoveryHints::default(),
             output_density: OutputDensity::default(),
             checkpoint_interval: 15,
             excluded_commands: Vec::new(),
@@ -1439,6 +1444,9 @@ impl Config {
         }
         if local.tee_mode != TeeMode::default() {
             self.tee_mode = local.tee_mode;
+        }
+        if local.recovery_hints != RecoveryHints::default() {
+            self.recovery_hints = local.recovery_hints;
         }
         if local.output_density != OutputDensity::default() {
             self.output_density = local.output_density;

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -20,9 +20,17 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
     root.insert(
         "tee_mode".into(),
         key_enum(
-            &["never", "failures", "always"],
-            "failures",
+            &["never", "failures", "highcompression", "always"],
+            "highcompression",
             "Controls when shell output is tee'd to disk for later retrieval",
+        ),
+    );
+    root.insert(
+        "recovery_hints".into(),
+        key_enum(
+            &["off", "minimal", "full"],
+            "minimal",
+            "Verbosity of the reactive recovery footer on compressed output (path-first, MCP-optional)",
         ),
     );
     root.insert(

--- a/rust/src/core/conformance.rs
+++ b/rust/src/core/conformance.rs
@@ -250,6 +250,14 @@ const MUST_KEEP_SYMBOLS: &[&str] = &["add_item", "total_count", "Inventory"];
 const MUST_DROP_BODIES: &[&str] = &["body_secret_alpha", "body_secret_beta"];
 
 fn render_mode(mode: &str) -> String {
+    render_mode_full(mode).0
+}
+
+/// Rendered view plus its pre-footer body token count. The compression-size
+/// invariant measures `.1` (the body), since the reactive recovery footer and the
+/// savings line are orthogonal affordances appended after compression, not part of
+/// the compressed content.
+fn render_mode_full(mode: &str) -> (String, usize) {
     crate::tools::ctx_read::render::process_mode(
         ACCURACY_FIXTURE,
         mode,
@@ -261,7 +269,6 @@ fn render_mode(mode: &str) -> String {
         "conformance/fixture.rs",
         None,
     )
-    .0
 }
 
 fn accuracy_checks() -> Vec<Check> {
@@ -302,7 +309,7 @@ fn accuracy_checks() -> Vec<Check> {
 
     let fixture_tokens = crate::core::tokens::count_tokens(ACCURACY_FIXTURE);
     for mode in ["map", "signatures", "aggressive"] {
-        let sent = crate::core::tokens::count_tokens(&render_mode(mode));
+        let sent = render_mode_full(mode).1;
         checks.push(Check::from_bool(
             "accuracy",
             format!("read_mode_compresses:{mode}"),

--- a/rust/src/core/context_overhead.rs
+++ b/rust/src/core/context_overhead.rs
@@ -180,15 +180,16 @@ mod tests {
         // (no rules block) must keep the fixed per-turn prefix tiny. This is the
         // regression guard for the "~3K tokens/turn injected" critique — if any
         // knob silently stops applying, the total balloons and this fails.
-        // macOS/Linux baseline is ~1774 after two reviewed navigation additions:
-        // the v3 agent-loop + navigation-paradox one-liner (#609, always-on in the
-        // COMPACT skeleton) and the ctx_search `handle` param (#608) — together
-        // ~+47 tok over the prior ~1727. Windows additionally carries
-        // `build_shell_hint()` — a ~5-tok PowerShell-cmdlet warning that is empty on
-        // POSIX. The budget covers that surface plus a small margin for
-        // `shell_name()` variance (#1051), and still sits ~1.2K under the ~3K balloon
-        // this guard exists to catch — it is not a license for silent creep.
-        const MINIMAL_ARM_PREFIX_BUDGET_TOKENS: usize = 1790;
+        // macOS/Linux baseline is ~1829 after three reviewed additions: the v3
+        // agent-loop + navigation-paradox one-liner (#609, always-on in the COMPACT
+        // skeleton), the ctx_search `handle` param (#608), and the proactive
+        // `RECOVER` recovery one-liner + the `ctx_read` `raw` schema param
+        // (premium-recovery-layer) — together ~+39 tok over the prior ~1790. Windows
+        // additionally carries `build_shell_hint()` — a ~5-tok PowerShell-cmdlet
+        // warning that is empty on POSIX. The budget covers that surface plus a small
+        // margin for `shell_name()` variance (#1051), and still sits ~1.1K under the
+        // ~3K balloon this guard exists to catch — it is not a license for silent creep.
+        const MINIMAL_ARM_PREFIX_BUDGET_TOKENS: usize = 1835;
 
         let _iso = crate::core::data_dir::isolated_data_dir();
         crate::test_env::set_var("LEAN_CTX_TOOL_PROFILE", "minimal");

--- a/rust/src/core/firewall.rs
+++ b/rust/src/core/firewall.rs
@@ -84,6 +84,12 @@ pub fn summarize(full: &str, archive_id: &str, tool: &str, output_tokens: usize)
     }
 
     out.push_str("--- retrieve full output ---\n");
+    // Non-MCP route first: the verbatim blob is a real file any tool can read,
+    // for agents/orgs where MCP is unavailable or forbidden.
+    out.push_str(&format!(
+        "Direct:  read {} directly (no MCP)\n",
+        crate::core::archive::content_path_str(archive_id)
+    ));
     out.push_str(&format!("Full:    ctx_expand(id=\"{archive_id}\")\n"));
     out.push_str(&format!(
         "Range:   ctx_expand(id=\"{archive_id}\", start_line=1, end_line=80)\n"

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -449,6 +449,7 @@ pub mod provider_bandit;
 pub mod provider_cache;
 pub mod providers;
 pub mod read_stub_index;
+pub mod recovery;
 pub mod redaction;
 pub mod reference_docs;
 pub mod roles;

--- a/rust/src/core/recovery.rs
+++ b/rust/src/core/recovery.rs
@@ -1,0 +1,162 @@
+//! Recovery-hint policy + grammar.
+//!
+//! lean-ctx compression is fully reversible, but agents only act on that if we
+//! *show* the escape hatch — otherwise they re-read compressed output
+//! line-by-line (the "too compressed" complaint). The proactive `RECOVER` rule
+//! ([`crate::core::rules_canonical::RECOVER`]) teaches the vocabulary once in the
+//! system prompt; this module is the reactive half: it resolves the effective
+//! [`RecoveryHints`] tier and owns the canonical, **non-MCP-first** phrasings so
+//! every compressed-output site (`ctx_read`, `ctx_shell` tee, archive / firewall
+//! / spill handles) renders identical, byte-stable wording.
+//!
+//! Determinism (#498): the tier is a pure function of profile + config + env,
+//! never of per-call session state, and every phrasing is a pure function of its
+//! inputs (paths/ids are content-addressed). The footer is therefore "deduped by
+//! mode" — only lossy/compressed views carry it; escalating to `full`/`raw` (the
+//! recovery action itself) drops it — rather than by fragile session state that
+//! would break the byte-stability guards.
+
+use crate::core::config::{Config, RecoveryHints};
+
+/// Header line of the `Full`-tier compressed-view footer. Single source of truth:
+/// also surfaced verbatim in `tdd_schema` so the published schema and the runtime
+/// affordance can never drift.
+pub const COMPACT_VIEW_HEADER: &str =
+    "[lean-ctx: compact view — nothing lost, full source on request]";
+
+/// Resolve the effective recovery tier for the current call.
+///
+/// Resolution order:
+/// 1. `LEAN_CTX_RECOVERY_HINTS` env (`off|minimal|full`) — ops / test override.
+/// 2. Active profile: `output_hints.compressed_hint = Some(true)` →
+///    [`RecoveryHints::Full`] (the `exploration` / `review` profiles);
+///    `Some(false)` → [`RecoveryHints::Off`] (explicit profile opt-out).
+/// 3. Global `config.recovery_hints` (default [`RecoveryHints::Minimal`]).
+#[must_use]
+pub fn tier() -> RecoveryHints {
+    if let Some(t) = RecoveryHints::from_env() {
+        return t;
+    }
+    match crate::core::profiles::active_profile()
+        .output_hints
+        .compressed_hint
+    {
+        Some(true) => RecoveryHints::Full,
+        Some(false) => RecoveryHints::Off,
+        None => Config::load().recovery_hints,
+    }
+}
+
+/// Footer appended to a compressed `ctx_read` view. Leads with the MCP-free path
+/// ("read the file directly") so orgs that forbid MCP still have a route, then
+/// the `ctx_*` shortcuts. `None` when the tier is `Off`.
+#[must_use]
+pub fn read_footer(file_path: &str) -> Option<String> {
+    match tier() {
+        RecoveryHints::Off => None,
+        RecoveryHints::Minimal => Some(format!(
+            "[lean-ctx] full source: read \"{file_path}\" directly (no MCP)  ·  or ctx_read(\"{file_path}\", mode=\"full\")"
+        )),
+        // The header line is the SSOT [`COMPACT_VIEW_HEADER`] (also in `tdd_schema`);
+        // the ladder now leads with the native path before the MCP shortcuts.
+        RecoveryHints::Full => Some(format!(
+            "{COMPACT_VIEW_HEADER}\n  full: read \"{file_path}\" directly (no MCP)  ·  ctx_read(\"{file_path}\", mode=\"full\")  ·  exact bytes: ctx_read(\"{file_path}\", raw=true)  ·  recover: ctx_retrieve(\"{file_path}\")"
+        )),
+    }
+}
+
+/// Canonical recovery clause for a content-addressed handle (archive / firewall /
+/// spill / `ctx_shell` tee). Always names the on-disk path first (MCP-free), then
+/// the `ctx_expand(id=...)` shortcut. Unlike [`read_footer`] this is *functional*
+/// (it points at where the bytes live), so it is not tier-gated — but `Off`
+/// collapses it to the bare path so a `recovery_hints=off` operator still gets the
+/// pointer without the coaching.
+#[must_use]
+pub fn handle_clause(id: &str, on_disk_path: Option<&str>) -> String {
+    match (tier(), on_disk_path) {
+        (RecoveryHints::Off, Some(p)) => format!("full: {p}"),
+        (RecoveryHints::Off, None) => format!("full: ctx_expand(id=\"{id}\")"),
+        (_, Some(p)) => format!("full: read {p} directly (no MCP)  ·  or ctx_expand(id=\"{id}\")"),
+        (_, None) => format!("full: ctx_expand(id=\"{id}\")  ·  or read the shown path"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::data_dir::test_env_lock;
+
+    /// The env override forces a tier regardless of profile/config — the knob ops
+    /// and tests use to pin behaviour.
+    #[test]
+    fn env_override_pins_tier() {
+        let _lock = test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "off");
+        assert_eq!(tier(), RecoveryHints::Off);
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "full");
+        assert_eq!(tier(), RecoveryHints::Full);
+        crate::test_env::remove_var("LEAN_CTX_RECOVERY_HINTS");
+    }
+
+    #[test]
+    fn read_footer_leads_with_native_path_and_respects_off() {
+        let _lock = test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "off");
+        assert!(
+            read_footer("src/x.rs").is_none(),
+            "off suppresses the footer"
+        );
+
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "minimal");
+        let minimal = read_footer("src/x.rs").expect("minimal emits a footer");
+        assert!(minimal.lines().count() == 1, "minimal is a single line");
+        // Non-MCP path must come before the MCP shortcut.
+        let native = minimal.find("read \"src/x.rs\" directly").unwrap();
+        let mcp = minimal.find("ctx_read(").unwrap();
+        assert!(native < mcp, "native path must precede the MCP route");
+
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "full");
+        let full = read_footer("src/x.rs").expect("full emits a footer");
+        assert!(full.contains("raw=true") && full.contains("ctx_retrieve"));
+        assert!(
+            full.find("read \"src/x.rs\" directly").unwrap() < full.find("raw=true").unwrap(),
+            "full ladder still leads with the native path"
+        );
+        crate::test_env::remove_var("LEAN_CTX_RECOVERY_HINTS");
+    }
+
+    /// Determinism (#498): the footer/clause are pure functions of their inputs,
+    /// so repeated calls are byte-identical (provider prompt caching depends on it).
+    #[test]
+    fn footer_and_clause_are_byte_stable() {
+        let _lock = test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "minimal");
+        assert_eq!(read_footer("src/a.rs"), read_footer("src/a.rs"));
+        assert_eq!(
+            handle_clause("id1", Some("/tmp/t.log")),
+            handle_clause("id1", Some("/tmp/t.log"))
+        );
+        crate::test_env::remove_var("LEAN_CTX_RECOVERY_HINTS");
+    }
+
+    #[test]
+    fn handle_clause_is_non_mcp_first() {
+        let _lock = test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "minimal");
+        let with_path = handle_clause("abc123", Some("/tmp/tee/run.log"));
+        assert!(
+            with_path.find("/tmp/tee/run.log").unwrap() < with_path.find("ctx_expand").unwrap(),
+            "on-disk path must precede ctx_expand"
+        );
+        let no_path = handle_clause("abc123", None);
+        assert!(no_path.contains("ctx_expand(id=\"abc123\")"));
+
+        crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "off");
+        assert_eq!(
+            handle_clause("abc123", Some("/tmp/tee/run.log")),
+            "full: /tmp/tee/run.log",
+            "off keeps the bare functional pointer, drops the coaching"
+        );
+        crate::test_env::remove_var("LEAN_CTX_RECOVERY_HINTS");
+    }
+}

--- a/rust/src/core/rules_canonical.rs
+++ b/rust/src/core/rules_canonical.rs
@@ -64,9 +64,10 @@ pub const COMPRESSION_BLOCK_END: &str = "<!-- /lean-ctx-compression -->";
 /// injection layer can parse it and decide whether a file is up-to-date.
 ///
 /// History: v3 (#609) adds the `AGENT_LOOP` taxonomy + `NAV_PARADOX` guidance to
-/// the FULL profile and a compact one-liner to COMPACT. v4 adds the `RECOVER`
-/// section to FULL + COMPACT so agents learn the (MCP-optional) decompression
-/// paths proactively instead of re-reading compressed output line-by-line.
+/// the FULL profile and a compact one-liner to COMPACT. v4 adds recovery guidance
+/// so agents learn the (MCP-optional) decompression paths proactively instead of
+/// re-reading compressed output line-by-line — verbose [`RECOVER`] in FULL and the
+/// terse one-liner [`RECOVER_COMPACT`] in COMPACT (the cold-handshake budget).
 /// Bumping it forces every committed `LEAN-CTX.md` artifact to be regenerated
 /// (see `tests/rules_drift.rs`).
 pub const RULES_VERSION: usize = 4;
@@ -168,15 +169,27 @@ pub const AUTO: &str = "Auto: preload/dedup/compress run in background. \
     ctx_session=memory, ctx_knowledge=facts, ctx_semantic_search=meaning search, \
     ctx_shell raw=true=uncompressed. Details: LEAN-CTX.md";
 
-/// Recovery vocabulary. lean-ctx compression is fully reversible (CCR), but agents
-/// otherwise only discover the escape hatch reactively from output hints — so they
-/// re-read compressed files line-by-line instead of expanding (the "too compressed"
-/// complaint). Teaching it proactively here (FULL + COMPACT/Bare) fixes that, and
-/// the MCP-free path ("read the shown file path with any tool") covers orgs that
-/// forbid MCP. Mirrors the reactive footers in `ctx_read`/`archive`/`ctx_shell`.
+/// Recovery vocabulary (verbose, FULL profile). lean-ctx compression is fully
+/// reversible (CCR), but agents otherwise only discover the escape hatch reactively
+/// from output hints — so they re-read compressed files line-by-line instead of
+/// expanding (the "too compressed" complaint). Teaching it proactively in the
+/// dedicated rule files fixes that, and the MCP-free path ("read the shown file
+/// path with any tool") covers orgs that forbid MCP. The COMPACT/Bare channel
+/// carries the terser [`RECOVER_COMPACT`] instead. Mirrors the reactive footers in
+/// `ctx_read`/`archive`/`ctx_shell`.
 pub const RECOVER: &str = "RECOVER: compressed output is reversible — never re-read line-by-line. \
     Need full/exact? Read the shown file path with any tool (no MCP), or \
     ctx_read(mode=full|raw=true); [Archived]/tee/firewall → ctx_expand(id=...).";
+
+/// Terse COMPACT/Bare variant of [`RECOVER`]. The cold first-contact handshake
+/// renders the COMPACT profile, so it carries this one-liner to stay within the
+/// static char/token budget (`tests/intensive_benchmarks.rs`, `instructions.rs`)
+/// — the verbose block ships in the FULL dedicated rule files. Keeps the two
+/// primary MCP-optional paths and the "never line-by-line" rule; the
+/// `[Archived]`/tee → `ctx_expand` path is still taught reactively by the output
+/// footers. Must keep the `(no MCP)` clause (asserted in tests).
+pub const RECOVER_COMPACT: &str = "RECOVER: compression is reversible — read the shown path \
+    (no MCP) or ctx_read(raw=true), never re-read line-by-line.";
 
 /// Context Engineering Protocol version reference.
 pub const CEP: &str = "CEP v1: 1.ACT FIRST 2.DELTA ONLY (Fn refs) 3.STRUCTURED (+/-/~) \
@@ -270,7 +283,7 @@ const COMPACT_NON_SHADOW: &[&str] = &[
     LOOP_NAV_COMPACT,
     ANTI,
     PARALLEL,
-    RECOVER,
+    RECOVER_COMPACT,
 ];
 
 const COMPACT_SHADOW: &[&str] = &[SHADOW_MINIMAL];
@@ -626,25 +639,38 @@ mod tests {
     #[test]
     fn recover_reaches_every_non_shadow_carrier() {
         // The recovery vocabulary must reach FULL *and* COMPACT/Bare so agents
-        // never re-read compressed output line-by-line, and must lead with the
-        // MCP-free path ("read the shown path with any tool") for orgs that ban
-        // MCP. Bare resolves to COMPACT, so it carries RECOVER too.
-        for wrapper in [Wrapper::Dedicated, Wrapper::Shared, Wrapper::Bare] {
+        // never re-read compressed output line-by-line, and every carrier must
+        // keep the MCP-free path ("read the shown path") for orgs that ban MCP.
+        // FULL carries the verbose RECOVER; COMPACT/Bare carry the terse
+        // RECOVER_COMPACT one-liner (cold-handshake budget).
+        let full = render(false, Wrapper::Dedicated, CompressionLevel::Off);
+        assert!(
+            full.contains(RECOVER),
+            "FULL non-shadow must carry the verbose RECOVER verbatim"
+        );
+        for wrapper in [Wrapper::Shared, Wrapper::Bare] {
             let out = render(false, wrapper, CompressionLevel::Off);
             assert!(
-                out.contains(RECOVER),
-                "{wrapper:?} non-shadow must carry RECOVER verbatim"
+                out.contains(RECOVER_COMPACT),
+                "{wrapper:?} (COMPACT) must carry RECOVER_COMPACT verbatim"
             );
             assert!(
-                out.contains("(no MCP)"),
-                "{wrapper:?} RECOVER must lead with the MCP-free path"
+                !out.contains(RECOVER),
+                "{wrapper:?} (COMPACT) must not inline the verbose RECOVER block"
+            );
+        }
+        for wrapper in [Wrapper::Dedicated, Wrapper::Shared, Wrapper::Bare] {
+            assert!(
+                render(false, wrapper, CompressionLevel::Off).contains("(no MCP)"),
+                "{wrapper:?} recovery line must keep the MCP-free path"
             );
         }
         // Shadow stays minimal; the reactive footers still cover recovery there.
         for wrapper in [Wrapper::Dedicated, Wrapper::Shared] {
+            let out = render(true, wrapper, CompressionLevel::Off);
             assert!(
-                !render(true, wrapper, CompressionLevel::Off).contains(RECOVER),
-                "{wrapper:?} shadow drops RECOVER"
+                !out.contains(RECOVER) && !out.contains(RECOVER_COMPACT),
+                "{wrapper:?} shadow drops all RECOVER guidance"
             );
         }
     }

--- a/rust/src/core/rules_canonical.rs
+++ b/rust/src/core/rules_canonical.rs
@@ -64,9 +64,12 @@ pub const COMPRESSION_BLOCK_END: &str = "<!-- /lean-ctx-compression -->";
 /// injection layer can parse it and decide whether a file is up-to-date.
 ///
 /// History: v3 (#609) adds the `AGENT_LOOP` taxonomy + `NAV_PARADOX` guidance to
-/// the FULL profile and a compact one-liner to COMPACT; bumping it forces every
-/// committed `LEAN-CTX.md` artifact to be regenerated (see `tests/rules_drift.rs`).
-pub const RULES_VERSION: usize = 3;
+/// the FULL profile and a compact one-liner to COMPACT. v4 adds the `RECOVER`
+/// section to FULL + COMPACT so agents learn the (MCP-optional) decompression
+/// paths proactively instead of re-reading compressed output line-by-line.
+/// Bumping it forces every committed `LEAN-CTX.md` artifact to be regenerated
+/// (see `tests/rules_drift.rs`).
+pub const RULES_VERSION: usize = 4;
 
 /// Banner placed at the top of dedicated rule files (non-shadow only).
 pub const CRITICAL: &str = "CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. \
@@ -165,6 +168,16 @@ pub const AUTO: &str = "Auto: preload/dedup/compress run in background. \
     ctx_session=memory, ctx_knowledge=facts, ctx_semantic_search=meaning search, \
     ctx_shell raw=true=uncompressed. Details: LEAN-CTX.md";
 
+/// Recovery vocabulary. lean-ctx compression is fully reversible (CCR), but agents
+/// otherwise only discover the escape hatch reactively from output hints — so they
+/// re-read compressed files line-by-line instead of expanding (the "too compressed"
+/// complaint). Teaching it proactively here (FULL + COMPACT/Bare) fixes that, and
+/// the MCP-free path ("read the shown file path with any tool") covers orgs that
+/// forbid MCP. Mirrors the reactive footers in `ctx_read`/`archive`/`ctx_shell`.
+pub const RECOVER: &str = "RECOVER: compressed output is reversible — never re-read line-by-line. \
+    Need full/exact? Read the shown file path with any tool (no MCP), or \
+    ctx_read(mode=full|raw=true); [Archived]/tee/firewall → ctx_expand(id=...).";
+
 /// Context Engineering Protocol version reference.
 pub const CEP: &str = "CEP v1: 1.ACT FIRST 2.DELTA ONLY (Fn refs) 3.STRUCTURED (+/-/~) \
      4.ONE LINE PER ACTION 5.QUALITY ANCHOR";
@@ -237,6 +250,7 @@ const FULL_NON_SHADOW: &[&str] = &[
     NAV_PARADOX,
     PARALLEL,
     AUTO,
+    RECOVER,
     CEP,
     INTELLIGENCE,
     LITM_END,
@@ -256,6 +270,7 @@ const COMPACT_NON_SHADOW: &[&str] = &[
     LOOP_NAV_COMPACT,
     ANTI,
     PARALLEL,
+    RECOVER,
 ];
 
 const COMPACT_SHADOW: &[&str] = &[SHADOW_MINIMAL];
@@ -604,6 +619,32 @@ mod tests {
             assert!(
                 !out.contains("NAVIGATION PARADOX"),
                 "{wrapper:?} shadow drops paradox"
+            );
+        }
+    }
+
+    #[test]
+    fn recover_reaches_every_non_shadow_carrier() {
+        // The recovery vocabulary must reach FULL *and* COMPACT/Bare so agents
+        // never re-read compressed output line-by-line, and must lead with the
+        // MCP-free path ("read the shown path with any tool") for orgs that ban
+        // MCP. Bare resolves to COMPACT, so it carries RECOVER too.
+        for wrapper in [Wrapper::Dedicated, Wrapper::Shared, Wrapper::Bare] {
+            let out = render(false, wrapper, CompressionLevel::Off);
+            assert!(
+                out.contains(RECOVER),
+                "{wrapper:?} non-shadow must carry RECOVER verbatim"
+            );
+            assert!(
+                out.contains("(no MCP)"),
+                "{wrapper:?} RECOVER must lead with the MCP-free path"
+            );
+        }
+        // Shadow stays minimal; the reactive footers still cover recovery there.
+        for wrapper in [Wrapper::Dedicated, Wrapper::Shared] {
+            assert!(
+                !render(true, wrapper, CompressionLevel::Off).contains(RECOVER),
+                "{wrapper:?} shadow drops RECOVER"
             );
         }
     }

--- a/rust/src/core/tdd_schema.rs
+++ b/rust/src/core/tdd_schema.rs
@@ -52,7 +52,7 @@ pub fn tdd_schema_value() -> Value {
                 "api": "  API:\\n    <signature>"
             },
             "file_ref_format": "F<idx>=<short-path> <line-count>L",
-            "compressed_hint": "[lean-ctx: compact view — nothing lost, full source on request]"
+            "compressed_hint": crate::core::recovery::COMPACT_VIEW_HEADER
         },
         "stability": {
             "determinism": [

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -1240,6 +1240,24 @@ pub(crate) fn emit_session_start_additional_context(additional_context: &str) {
     );
 }
 
+/// Codex SessionStart guidance for the shell-hook surface (GH #625).
+///
+/// The Codex `PreToolUse` hook already rewrites every rewritable Bash command to
+/// `lean-ctx -c "<cmd>"` automatically (`codex_rewrite_output`: `allow` +
+/// `updatedInput`), so the old "prefer `lean-ctx -c`" line was redundant *and*
+/// taught nothing about getting raw output back — the one thing an agent cannot
+/// reach on its own once a command is auto-compressed. That gap is the shell-side
+/// twin of the MCP "too compressed" complaint: lacking an escape hatch, agents
+/// re-read the compressed view in tiny chunks instead of asking for raw bytes.
+///
+/// This hint mirrors the MCP `RECOVER` rule
+/// ([`crate::core::rules_canonical::RECOVER`]) on the non-MCP CLI surface: it
+/// names the **reversible** nature of the compression and the concrete raw escape
+/// (`lean-ctx raw "<command>"`), which the rewrite hook leaves untouched (it
+/// already starts with `lean-ctx `, so `rewrite_candidate` returns `None`). The
+/// blocked-command sentence still covers the allowlist gate.
+pub(crate) const CODEX_SHELL_RECOVERY_HINT: &str = "lean-ctx auto-compresses shell output, and the compression is fully reversible: when you need the complete, exact output, re-run the command as `lean-ctx raw \"<command>\"` instead of reading it back in small chunks. If a Bash call is blocked, rerun it with the exact command the hook suggests.";
+
 pub fn handle_codex_session_start() {
     if is_quiet() {
         return;
@@ -1250,9 +1268,7 @@ pub fn handle_codex_session_start() {
     if crate::core::config::Config::load().dedicated_session_context_active() {
         return;
     }
-    emit_session_start_additional_context(
-        "For shell commands matched by lean-ctx compression rules, prefer `lean-ctx -c \"<command>\"`. If a Bash call is blocked, rerun it with the exact command suggested by the hook.",
-    );
+    emit_session_start_additional_context(CODEX_SHELL_RECOVERY_HINT);
 }
 
 /// Dedicated Copilot PreToolUse handler (dispatched via `hook copilot`).

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -405,6 +405,22 @@ fn rewrite_candidate_returns_none_for_existing_lean_ctx_command() {
 }
 
 #[test]
+fn rewrite_candidate_leaves_raw_escape_hatch_untouched() {
+    // GH #625: the raw escape hatch the SessionStart hint teaches must not be
+    // re-wrapped back into a compressing `lean-ctx -c "…"`, or the agent could
+    // never actually reach raw bytes. Both spellings already start with
+    // `lean-ctx `, so the rewrite hook leaves them as-is (reentrance-safe).
+    assert_eq!(
+        rewrite_candidate("lean-ctx raw \"git diff\"", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_candidate("lean-ctx -c --raw \"git diff\"", "lean-ctx"),
+        None
+    );
+}
+
+#[test]
 fn rewrite_candidate_wraps_single_command() {
     assert_eq!(
         rewrite_candidate("git status", "lean-ctx"),
@@ -834,6 +850,39 @@ fn session_start_uses_codex_additional_context_channel() {
             .as_str()
             .unwrap_or_default(),
         "prefer lean-ctx -c"
+    );
+}
+
+#[test]
+fn codex_session_start_hint_teaches_the_raw_escape_hatch() {
+    // GH #625: the PreToolUse hook already auto-compresses every Bash command, so
+    // the SessionStart hint's job is to teach the *raw* escape — otherwise agents
+    // re-read the compressed view in small chunks (the shell-side "too compressed"
+    // complaint). It must name the reversible compression, the concrete raw CLI
+    // (`lean-ctx raw "<command>"`), and forbid the small-chunk anti-pattern; the
+    // redundant "prefer `lean-ctx -c`" coaching is gone (compression is automatic).
+    let hint = CODEX_SHELL_RECOVERY_HINT;
+    assert!(
+        hint.contains("lean-ctx raw \"<command>\""),
+        "names the raw CLI: {hint}"
+    );
+    assert!(hint.contains("reversible"), "states reversibility: {hint}");
+    assert!(
+        hint.contains("small chunks"),
+        "forbids chunked re-reads: {hint}"
+    );
+    assert!(
+        !hint.contains("prefer `lean-ctx -c`"),
+        "drops the redundant prefer-c coaching (auto-rewrite handles it): {hint}"
+    );
+    // The hint must survive the additionalContext JSON channel byte-for-byte.
+    let json = session_start_additional_context_json(hint);
+    let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(
+        v["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap_or_default(),
+        hint
     );
 }
 

--- a/rust/src/instructions.rs
+++ b/rust/src/instructions.rs
@@ -11,13 +11,16 @@ const INSTRUCTION_CAP_TOKENS: usize = 800;
 /// so the budget is deterministic across dev machines, not just clean CI (#498).
 /// Raised in reviewed steps: 520→540 / 600→640 for the sharpened ctx_* redirects
 /// (#1030), then 540→590 / 640→680 for the v3 agent-loop + navigation-paradox
-/// one-liner now carried in the COMPACT profile (#609). Both stay far under the
+/// one-liner now carried in the COMPACT profile (#609), then 590→615 / 680→712 for
+/// the proactive `RECOVER` recovery one-liner now carried in COMPACT_NON_SHADOW
+/// (premium-recovery-layer): it teaches the MCP-optional decompression paths so
+/// agents stop re-reading compressed output line-by-line. All stay far under the
 /// 800-token runtime cap (`INSTRUCTION_CAP_TOKENS`), so the guidance ships in
 /// full without truncating anything live.
 #[cfg(test)]
-const STATIC_INSTRUCTION_BUDGET_TOKENS: usize = 590;
+const STATIC_INSTRUCTION_BUDGET_TOKENS: usize = 615;
 #[cfg(test)]
-const STATIC_INSTRUCTION_BUDGET_TDD_TOKENS: usize = 680;
+const STATIC_INSTRUCTION_BUDGET_TDD_TOKENS: usize = 712;
 /// Windows carries a one-line SHELL hint inside the skeleton.
 #[cfg(all(test, windows))]
 const STATIC_INSTRUCTION_SHELL_HINT_TOKENS: usize = 25;

--- a/rust/src/proxy/compress.rs
+++ b/rust/src/proxy/compress.rs
@@ -55,7 +55,7 @@ fn attach_ccr(original: &str, result: String) -> String {
             ),
             // Shared-filesystem default: the path handle (native read or slice).
             None => format!(
-                "{result}\n[lean-ctx: full original at {handle} — read it, or \
+                "{result}\n[lean-ctx: full original at {handle} — read it directly (no MCP), or \
                  ctx_expand(id=\"{handle}\", head=N|search=\"…\"|json_path=\"…\") for a slice]"
             ),
         },

--- a/rust/src/shell/tee_policy.rs
+++ b/rust/src/shell/tee_policy.rs
@@ -17,8 +17,11 @@ use crate::core::config::TeeMode;
 /// - `Never` never tees.
 /// - `Always` tees any non-blank output.
 /// - `Failures` tees exactly when the command failed (`exit_code != 0`).
-/// - `HighCompression` tees when compression removed >70% of a sizable output,
-///   so a heavily-digested *successful* run stays recoverable.
+/// - `HighCompression` (the default) is a *superset* of `Failures`: it tees on
+///   failure **and** when compression removed >70% of a sizable output. As the
+///   default it guarantees the MCP-free recovery path — a real raw file — exists
+///   for both the cases an agent actually re-reads: failures and heavily-digested
+///   successful runs.
 pub(crate) fn should_tee(
     mode: &TeeMode,
     exit_code: i32,
@@ -34,7 +37,8 @@ pub(crate) fn should_tee(
         TeeMode::Always => true,
         TeeMode::Failures => exit_code != 0,
         TeeMode::HighCompression => {
-            original_tokens > 100 && savings_pct(original_tokens, compressed_tokens) > 70.0
+            exit_code != 0
+                || (original_tokens > 100 && savings_pct(original_tokens, compressed_tokens) > 70.0)
         }
     }
 }
@@ -84,6 +88,22 @@ mod tests {
         assert!(!should_tee(&TeeMode::HighCompression, 0, false, 1000, 900));
         // Savings high but the output is too small to bother.
         assert!(!should_tee(&TeeMode::HighCompression, 0, false, 80, 1));
+    }
+
+    #[test]
+    fn high_compression_is_a_superset_of_failures() {
+        // As the default tee mode, HighCompression must still tee failures (so the
+        // raw-file recovery path exists for them) even when output is tiny and
+        // barely compressed — exactly the case `Failures` covered before.
+        assert!(should_tee(&TeeMode::HighCompression, 1, false, 5, 5));
+        assert!(should_tee(&TeeMode::HighCompression, 127, false, 5, 5));
+        // A blank failure still has nothing worth saving.
+        assert!(!should_tee(&TeeMode::HighCompression, 1, true, 0, 0));
+    }
+
+    #[test]
+    fn default_tee_mode_is_high_compression() {
+        assert_eq!(TeeMode::default(), TeeMode::HighCompression);
     }
 
     #[test]

--- a/rust/src/tool_defs/granular.rs
+++ b/rust/src/tool_defs/granular.rs
@@ -33,7 +33,8 @@ pub fn unified_tool_defs() -> Vec<Tool> {
                     "start_line": { "type": "integer", "description": "Read from this 1-based line on (alias: offset)" },
                     "offset": { "type": "integer", "description": "Alias for start_line (1-based first line)" },
                     "limit": { "type": "integer", "description": "Max number of lines to read from start_line/offset" },
-                    "fresh": { "type": "boolean" }
+                    "fresh": { "type": "boolean" },
+                    "raw": { "type": "boolean", "description": "Exact bytes, unframed — skips compression (verbatim escape hatch)" }
                 },
                 "required": ["path"]
             }),

--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -31,8 +31,6 @@ pub struct ReadOutput {
     pub output_tokens: usize,
 }
 
-const COMPRESSED_HINT: &str = "[lean-ctx: compact view — nothing lost, full source on request]";
-
 /// SSOT via [`ReadMode`] (#528): the `map`/`signatures` summaries whose rendered
 /// body is stored per-file in `compressed_outputs`. Unknown modes are not
 /// cacheable, matching the prior `["map","signatures"].contains(mode)`.
@@ -102,16 +100,16 @@ fn compressed_cache_key(
     key
 }
 
+/// Appends the reactive recovery footer to a compressed view, leading with the
+/// MCP-free "read the path directly" route. Tier (`off|minimal|full`) and wording
+/// are resolved centrally in [`crate::core::recovery`] so `ctx_read`, the shell
+/// tee and archive handles all speak the same grammar. Only lossy/compressed
+/// modes reach this helper, so the footer is naturally absent from `full`/`raw`.
 fn append_compressed_hint(output: &str, file_path: &str) -> String {
-    if !crate::core::profiles::active_profile()
-        .output_hints
-        .compressed_hint()
-    {
-        return output.to_string();
+    match crate::core::recovery::read_footer(file_path) {
+        Some(footer) => format!("{output}\n{footer}"),
+        None => output.to_string(),
     }
-    format!(
-        "{output}\n{COMPRESSED_HINT}\n  full: ctx_read(\"{file_path}\", mode=\"full\")  ·  exact bytes: ctx_read(\"{file_path}\", raw=true)  ·  recover: ctx_retrieve(\"{file_path}\")"
-    )
 }
 
 /// Reads a file as UTF-8 with lossy fallback, enforcing binary detection and max read size limit.

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -772,6 +772,60 @@ fn process_mode_output_is_byte_stable_across_calls() {
     }
 }
 
+/// The reactive recovery footer (#premium-recovery): present on compressed views,
+/// leading with the MCP-free native path; absent from verbatim views and when the
+/// `recovery_hints` tier is `off`; and byte-stable across calls (#498).
+#[test]
+fn recovery_footer_is_compressed_only_and_togglable() {
+    // `isolated_data_dir()` already holds `test_env_lock` for its lifetime; taking
+    // the lock again here would self-deadlock (the mutex is non-reentrant).
+    let _iso = crate::core::data_dir::isolated_data_dir();
+    let content: String = (0..120)
+        .map(|i| format!("pub fn handler_{i}(x: u32) -> u32 {{ x * {i} }}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tokens = count_tokens(&content);
+    let run = |mode: &str| {
+        render::process_mode(
+            &content,
+            mode,
+            "F1",
+            "rec.rs",
+            "rs",
+            tokens,
+            CrpMode::Off,
+            "/tmp/rec.rs",
+            None,
+        )
+        .0
+    };
+
+    // Default tier (minimal): a compressed view leads its footer with the native,
+    // MCP-free path so an agent needing the full source never reads line-by-line.
+    crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "minimal");
+    let sigs = run("signatures");
+    assert!(
+        sigs.contains("read \"/tmp/rec.rs\" directly (no MCP)"),
+        "compressed view must surface the MCP-free recovery path: {sigs}"
+    );
+    // Determinism (#498): byte-stable across calls.
+    assert_eq!(sigs, run("signatures"), "footer must be byte-stable");
+
+    // The verbatim escape hatch itself carries no footer (nothing to recover).
+    assert!(
+        !run("raw").contains("(no MCP)"),
+        "raw view needs no recovery footer"
+    );
+
+    // The off switch suppresses the footer cleanly.
+    crate::test_env::set_var("LEAN_CTX_RECOVERY_HINTS", "off");
+    assert!(
+        !run("signatures").contains("(no MCP)"),
+        "recovery_hints=off must drop the footer"
+    );
+    crate::test_env::remove_var("LEAN_CTX_RECOVERY_HINTS");
+}
+
 #[test]
 fn raw_mode_no_savings_footer() {
     let _lock = crate::core::data_dir::test_env_lock();

--- a/rust/src/tools/registered/ctx_expand.rs
+++ b/rust/src/tools/registered/ctx_expand.rs
@@ -20,6 +20,8 @@ impl McpTool for CtxExpandTool {
              Supports head/tail/search to filter lines and save tokens on re-read.\n\
              action=list browses all archives. action=search_all queries across archives.\n\
              Zero-loss: original preserved.\n\
+             NO MCP? The same bytes are a real file — every [Archived]/tee/firewall hint\n\
+             shows its on-disk path; read that path directly with any tool instead.\n\
              ANTIPATTERN: not for reading project files — use ctx_read or ctx_compose.",
             json!({
                 "type": "object",

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -186,14 +186,16 @@ impl McpTool for CtxShellTool {
                             if matches!(cfg.tee_mode, crate::core::config::TeeMode::HighCompression)
                             {
                                 let pct = crate::shell::tee_policy::savings_pct(original, sent);
-                                // The tee is in the shared content-addressed store, so
-                                // ctx_expand can slice it surgically (head/search/json_path)
-                                // instead of re-reading the whole original (#936).
+                                // Recovery grammar (path-first, MCP-optional): the raw
+                                // bytes are a real file the agent can read with any tool
+                                // (no MCP needed) — for orgs that forbid it — and the same
+                                // path doubles as the ctx_expand id for surgical slices
+                                // (head/search/json_path) without re-reading it all (#936).
                                 format!(
-                                    "\n[compressed {pct:.0}%: full output at {p} — ctx_expand(id=\"{p}\", search=\"…\"|head=N|json_path=\"…\") for a slice]"
+                                    "\n[compressed {pct:.0}%: full output at {p} — read it directly (no MCP), or ctx_expand(id=\"{p}\", search=\"…\"|head=N|json_path=\"…\") for a slice]"
                                 )
                             } else {
-                                format!("\n[full output: {p}]")
+                                format!("\n[full output: {p} — read it directly (no MCP), or ctx_expand(id=\"{p}\")]")
                             }
                         })
                         .unwrap_or_default()

--- a/rust/src/tools/registered/shell_alias.rs
+++ b/rust/src/tools/registered/shell_alias.rs
@@ -39,6 +39,10 @@ impl McpTool for ShellAliasTool {
                     "cwd": {
                         "type": "string",
                         "description": "Working dir"
+                    },
+                    "raw": {
+                        "type": "boolean",
+                        "description": "Return verbatim output (skip compression). Default false — pass true for the exact bytes."
                     }
                 },
                 "required": ["command"]
@@ -64,13 +68,16 @@ impl McpTool for ShellAliasTool {
 
         tokio::task::block_in_place(|| {
             let cwd = get_str(args, "cwd");
+            // Compressed by default (the point of this alias), but honor an explicit
+            // raw=true so clients restricted to "shell"/"bash" still have the verbatim
+            // escape the description advertises — no MCP-specific tool required.
+            let raw = args.get("raw").and_then(Value::as_bool).unwrap_or(false);
             let mut shell_args = Map::new();
             shell_args.insert("command".to_string(), Value::String(command));
             if let Some(dir) = cwd {
                 shell_args.insert("cwd".to_string(), Value::String(dir));
             }
-            // raw=false → always compress (the whole point of this alias)
-            shell_args.insert("raw".to_string(), Value::Bool(false));
+            shell_args.insert("raw".to_string(), Value::Bool(raw));
 
             crate::tools::registered::ctx_shell::CtxShellTool.handle(&shell_args, ctx)
         })


### PR DESCRIPTION
## Summary

Closes #625.

Agents (Codex especially) re-read compressed views line-by-line because nothing teaches them how to get the raw bytes back — the real cause behind the "too compressed" reports. This makes lean-ctx's (already reversible) compression **discoverable and consistent**, with the **non-MCP path treated as first-class** (many orgs forbid MCP).

### Added — a first-class recovery layer on every surface
- **`core::recovery` module**: single source of truth for the path-first recovery grammar (`read_footer`, `handle_clause`, tier resolution). All channels (archive, firewall, spill, tee, `ctx_shell`) speak the same non-MCP-first sentence.
- **Proactive `RECOVER` rule** (`rules_canonical` v4) in FULL + COMPACT profiles: compressed output is reversible — never re-read line-by-line; read the shown path with any tool (no MCP), or `ctx_read(mode=full|raw=true)`; `[Archived]`/tee/firewall → `ctx_expand(id=...)`.
- **Reactive `ctx_read` footer** leading with the native file path, plus an explicit **`raw`** param (verbatim bytes, unframed escape hatch). `full`/`raw` views carry no footer (deduped by mode).
- **`tee_mode` default → `high-compression`** (now a superset of `failures`) so a verbatim copy always exists; new **`recovery_hints`** config (`off|minimal|full`).
- **CLI**: surface `lean-ctx raw "<command>"` in `help`, `help all` and the cheatsheet (the dispatch already existed).

### Fixed — the Codex `lean-ctx -c` SessionStart nag (#625)
The `PreToolUse` hook already rewrites every rewritable Bash command to `lean-ctx -c "<cmd>"` transparently, so the old "prefer `lean-ctx -c`" line taught nothing — and nothing about getting raw output. The hint now teaches the raw escape (`lean-ctx raw "<command>"`), which is reentrance-safe.

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib` (recovery, tee_policy, rules_canonical, ctx_read footer, hook_handlers #625, budgets/conformance) — green
- [x] `cargo test --test rules_drift --test reference_docs_drift --test rules_consistency --test rules_template_tool_names` — green (RULES_VERSION 4 artifacts current)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`

## Notes
- Determinism (#498): all recovery output is a pure function of its inputs (byte-stable); regression tests assert it.
- Generated reference docs + `LEAN-CTX.md` regenerated for RULES_VERSION 4; static instruction / per-turn budgets raised in reviewed steps.

Made with [Cursor](https://cursor.com)