### PR TITLE
fix(proxy): keep source reads with decorative comments lossless (#628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
     non-MCP-first sentence.
 
 ### Fixed
+- **Source reads are no longer silently stripped of decorative separator comments,
+  which had broken follow-up edits (#628).** A file read carries lossless-only
+  intent — the model edits exactly what it sees — so the proxy never lossy-
+  compresses a recognized file read. The safety net for reads routed through an
+  *unrecognized* tool (the content heuristic) under-counted real source, though: a
+  decorative separator comment (`// ————`, `// ----`) and the call-shaped
+  scaffolding of a test file (`describe(…) {`, `});`) scored as non-code, so a
+  genuine `.test.ts` could be compressed on the wire and lose those separator
+  lines — after which `ctx_edit` failed on a whitespace mismatch against the
+  on-disk file. The heuristic now treats comment lines as neutral (they never
+  dilute the code ratio) and recognizes top-level call/closer shapes as code, so
+  real source is protected regardless of the originating tool. Regression tests
+  pin the verbatim `ctx_read` modes (`full`/`raw`/`lines:N-M`) to reproduce every
+  source line, including decorative comments.
 - **The Codex `lean-ctx -c` SessionStart hook is no longer a redundant nag (#625).**
   Codex's `PreToolUse` hook already rewrites every rewritable Bash command to
   `lean-ctx -c "<command>"` transparently (`permissionDecision: allow` +

--- a/rust/src/proxy/tool_kind.rs
+++ b/rust/src/proxy/tool_kind.rs
@@ -202,6 +202,15 @@ pub fn should_protect(kind: ToolResultKind, content: &str) -> bool {
 /// Deliberately conservative — it only returns `true` when code signals clearly
 /// dominate and shell/log signals are essentially absent, so genuine logs and
 /// build output are still compressed. Used only when the tool name is unknown.
+///
+/// GH #628: the previous version under-counted real source — a decorative
+/// separator comment (`// ————`, `// ====`) and the call-shaped scaffolding of a
+/// test file (`describe(…) {`, `});`) scored as non-code, so a genuine source
+/// read routed through an unrecognized tool was lossy-compressed and silently
+/// lost those separator lines, breaking the model's subsequent exact-match edit.
+/// The fix: comment lines are *neutral* (never dilute the ratio) and top-level
+/// call/closer shapes count as code even at column 0. The shell-signal veto is
+/// untouched, so genuine logs and build output are still compressed.
 pub fn looks_like_source_code(content: &str) -> bool {
     let mut code_signals = 0usize;
     let mut shell_signals = 0usize;
@@ -213,6 +222,22 @@ pub fn looks_like_source_code(content: &str) -> bool {
         if trimmed.is_empty() {
             continue;
         }
+
+        // Comment lines are part of source but carry no compress-vs-keep signal
+        // on their own, and a decorative separator (`// ————`, `// ====`) or a
+        // doc-block continuation (` * @param`) must never *dilute* the code ratio
+        // — that false-negative is what let the proxy strip those lines (#628).
+        // Treat C-style comments as neutral: skip without counting. `#` is
+        // deliberately excluded (ambiguous with shell prompts / log levels /
+        // Python) so genuine shell output is still detected and compressed.
+        if trimmed.starts_with("//")
+            || trimmed.starts_with("/*")
+            || trimmed.starts_with("*/")
+            || trimmed.starts_with("* ")
+        {
+            continue;
+        }
+
         considered += 1;
 
         // Command/log markers — strong evidence this is NOT a file read.
@@ -242,6 +267,15 @@ pub fn looks_like_source_code(content: &str) -> bool {
             || trimmed.ends_with("=>")
             || trimmed.ends_with("->")
             || trimmed.ends_with(':');
+        // Top-level declarations, call statements and block closers carry code
+        // punctuation even at column 0 (`describe("x", () => {`, `});`), so the
+        // bare `is_indented && has_code_punct` test missed them — the exact
+        // test-DSL shape (`describe`/`it`/`expect`) behind the #628 false-negative.
+        // A call/closer *shape* with code punctuation is a strong code signal
+        // regardless of indentation.
+        let is_call_or_closer = (trimmed.contains('(') && trimmed.contains(')'))
+            || trimmed.starts_with('}')
+            || trimmed.starts_with(')');
         let has_keyword = [
             "fn ",
             "def ",
@@ -268,7 +302,10 @@ pub fn looks_like_source_code(content: &str) -> bool {
         .iter()
         .any(|k| trimmed.starts_with(k) || trimmed.contains(k));
 
-        if (is_indented && has_code_punct) || has_keyword {
+        // Code punctuation counts when the line is indented (a statement in a
+        // block) OR is a top-level call/closer shape (`describe(…) {`, `});`).
+        let has_code_shape = has_code_punct && (is_indented || is_call_or_closer);
+        if has_code_shape || has_keyword {
             code_signals += 1;
         }
     }
@@ -402,5 +439,71 @@ mod tests {
     fn plain_prose_not_code() {
         let prose = "This is a normal paragraph of text.\nIt has several sentences.\nNone of them are code.\nThey are just words on lines.\nMore words follow here.";
         assert!(!looks_like_source_code(prose));
+    }
+
+    /// Regression for GH #628: a real test file whose only "non-code-shaped"
+    /// lines are decorative separator comments must be recognized as source, so
+    /// the proxy protects it (when routed through an unrecognized tool) instead
+    /// of lossy-compressing it and silently dropping the `// ————` separators —
+    /// the exact divergence that made the model's `ctx_edit` fail on a whitespace
+    /// mismatch.
+    #[test]
+    fn test_file_with_separator_comments_is_source() {
+        let code = "import { describe, it, expect } from \"vitest\";\n\
+            \n\
+            // ————————————————————————————————————————————————————————\n\
+            // Section: arithmetic\n\
+            // ————————————————————————————————————————————————————————\n\
+            describe(\"add\", () => {\n\
+            \x20 it(\"adds\", () => {\n\
+            \x20   expect(1 + 1).toBe(2);\n\
+            \x20 });\n\
+            });\n\
+            \n\
+            // ----------------------------------------------------------\n\
+            // Section: strings\n\
+            // ----------------------------------------------------------\n\
+            describe(\"concat\", () => {\n\
+            \x20 it(\"joins\", () => {\n\
+            \x20   expect(\"a\" + \"b\").toBe(\"ab\");\n\
+            \x20 });\n\
+            });\n";
+        assert!(
+            looks_like_source_code(code),
+            "a .test.ts with decorative separator comments must read as source"
+        );
+        assert!(
+            should_protect(ToolResultKind::Other, code),
+            "an unrecognized tool returning this source must still be protected"
+        );
+    }
+
+    /// A comment-heavy source file (license header, doc block) is still source:
+    /// the neutral-comment rule must not let comments dilute the code ratio.
+    #[test]
+    fn comment_heavy_source_still_detected() {
+        let code = "/*\n\
+            \x20* Copyright (c) 2026. All rights reserved.\n\
+            \x20* This module wires the request pipeline.\n\
+            \x20*/\n\
+            export function build(cfg) {\n\
+            \x20 const app = create();\n\
+            \x20 app.use(cfg);\n\
+            \x20 return app;\n\
+            }\n";
+        assert!(looks_like_source_code(code));
+    }
+
+    /// The loosened call/closer signal must NOT start treating parenthesized log
+    /// output as code — the shell-signal veto and the punctuation requirement keep
+    /// genuine command output compressible.
+    #[test]
+    fn parenthesized_log_output_still_not_code() {
+        let log = "INFO  starting worker (pid=4211)\n\
+            processing batch (size=128) ok\n\
+            processing batch (size=64) ok\n\
+            WARN  slow response (842ms) from upstream\n\
+            done in 3.2s (0 errors)\n";
+        assert!(!looks_like_source_code(log));
     }
 }

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -714,6 +714,66 @@ fn raw_mode_returns_exact_file_content() {
     assert!(!output.contains("deps"), "raw mode must not contain deps");
 }
 
+/// Regression for GH #628: the verbatim views (`full`, `raw`, `lines:N-M`) must
+/// reproduce every source line — including decorative separator comments
+/// (`// ————`, `// ----`) — so the content the model edits never diverges from
+/// disk. The original report saw these silently stripped, which then broke
+/// `ctx_edit` on a whitespace mismatch.
+#[test]
+fn verbatim_modes_preserve_decorative_comment_lines() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let sep_em = "// ————————————————————————————————————————";
+    let sep_dash = "// ------------------------------------------";
+    let content = format!(
+        "import {{ describe, it, expect }} from \"vitest\";\n\
+         \n\
+         {sep_em}\n\
+         // Section: arithmetic\n\
+         {sep_em}\n\
+         describe(\"add\", () => {{\n  it(\"adds\", () => expect(1 + 1).toBe(2));\n}});\n\
+         \n\
+         {sep_dash}\n\
+         // Section: strings\n\
+         {sep_dash}\n"
+    );
+
+    for mode in ["full", "raw"] {
+        let (output, _) = render::process_mode(
+            &content,
+            mode,
+            "F1",
+            "math.test.ts",
+            "ts",
+            count_tokens(&content),
+            CrpMode::Off,
+            "/tmp/math.test.ts",
+            None,
+        );
+        assert!(
+            output.contains(sep_em) && output.contains(sep_dash),
+            "{mode} mode must keep every separator comment verbatim:\n{output}"
+        );
+        // Every source line is present (modes may add a header/footer, never drop).
+        for line in content.lines().filter(|l| !l.is_empty()) {
+            assert!(
+                output.contains(line),
+                "{mode} mode dropped a source line: {line:?}"
+            );
+        }
+    }
+
+    // A `lines:` window must keep separators too, with original line numbering.
+    let window = render::extract_line_range(&content, "1-5");
+    assert!(
+        window.contains(sep_em),
+        "lines: window dropped the separator comment:\n{window}"
+    );
+    assert!(
+        window.contains("   3| ") && window.contains("   5| "),
+        "lines: window must number the separator lines (3 and 5):\n{window}"
+    );
+}
+
 /// Determinism contract (#498): tool output must be a pure function of
 /// (content, mode, crp_mode, task). Timestamps, counters or random hints in
 /// the body would make otherwise-identical outputs unique and defeat


### PR DESCRIPTION
## Summary
Fixes #628 — a source read routed through an *unrecognized* tool could be
lossy-compressed on the wire and silently lose decorative separator comment
lines (`// ————`, `// ----`), after which an exact-match `ctx_edit` failed on a
whitespace mismatch against the on-disk file.

A recognized file read is always protected (`ToolResultKind::FileRead`). The gap
was the content heuristic (`looks_like_source_code`) used as the fallback for
unknown/custom tools: it under-counted real source because

- decorative separator comments diluted the code-vs-text ratio, and
- top-level call/closer scaffolding of a test file (`describe(…) {`, `});`)
  scored as non-code at column 0.

### Changes
- `rust/src/proxy/tool_kind.rs`: comment lines are now **neutral** (skipped, never
  dilute the ratio); top-level **call/closer shapes** count as code regardless of
  indentation. The shell-signal veto is untouched, so genuine logs/build output
  still compress.
- Regression tests: `.test.ts` with separators reads as source (+ `should_protect`),
  comment-heavy source still detected, parenthesized log output still **not** code,
  and the verbatim `ctx_read` modes (`full`/`raw`/`lines:N-M`) reproduce every
  source line including decorative comments.
- `CHANGELOG.md`: entry under `[Unreleased] → Fixed`.

## Test plan
- [x] `cargo test --lib -- proxy::tool_kind verbatim_modes_preserve_decorative_comment_lines`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI green

Made with [Cursor](https://cursor.com)