### PR TITLE
fix(shell): surface project-root jail rejection in ctx_shell cwd (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   small-chunk re-read anti-pattern. The raw spellings (`lean-ctx raw`,
   `lean-ctx -c --raw`) are reentrance-safe: the rewrite hook leaves any command
   starting with `lean-ctx ` untouched, so the agent always reaches verbatim bytes.
+- **`ctx_shell` now surfaces when a requested `cwd` was rejected by the project-root
+  jail (#629).** A `cwd` resolving outside the session's `project_root` is rejected
+  by the path jail and silently replaced with the project root — correct sandboxing
+  (it stops MCP clients escaping the workspace), but the *silent* fallback made the
+  parameter look ignored: a caller running `pwd && ls` in what they thought was dir
+  A actually ran in the root with no indication why. The jail is untouched;
+  `effective_cwd_checked` now returns the rejection reason and `ctx_shell` appends a
+  one-line `[cwd: …]` hint naming the reason and the directory it ran in instead.
+  Thanks to @mahmoudps for the report and the original patch (#630).
 - **`ctx_search` no longer returns a false `No matches` for content edited after
   the index warmed (#624).** The resident trigram index treated itself as *fresh*
   for a fixed 15 s TTL with no per-file change detection, so in hybrid setups

--- a/rust/src/core/session/mod.rs
+++ b/rust/src/core/session/mod.rs
@@ -191,6 +191,37 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    /// The checked variant must report *why* a jailed cwd was rejected, so
+    /// `ctx_shell` can surface it instead of silently swapping in the root (#629).
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn effective_cwd_checked_reports_jail_rejection_reason() {
+        let tmp = std::env::temp_dir().join("lean-ctx-test-cwd-checked");
+        let _ = std::fs::create_dir_all(&tmp);
+        let root_canon = crate::core::pathutil::safe_canonicalize_or_self(&tmp)
+            .to_string_lossy()
+            .to_string();
+
+        let mut session = SessionState::new();
+        session.project_root = Some(root_canon.clone());
+
+        // Rejected: falls back to the root AND surfaces a non-empty reason.
+        let (path, reason) = session.effective_cwd_checked(Some("/nonexistent-outside-path"));
+        assert_eq!(path, root_canon);
+        let reason = reason.expect("a jailed cwd must report a rejection reason");
+        assert!(!reason.is_empty(), "the rejection reason must not be empty");
+
+        // Accepted (no explicit cwd): no reason, path is the project root.
+        let (accepted, none_reason) = session.effective_cwd_checked(None);
+        assert_eq!(accepted, root_canon);
+        assert!(
+            none_reason.is_none(),
+            "a non-jailed path must not report a reason"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     #[test]
     fn effective_cwd_shell_cwd_second_priority() {
         let mut session = SessionState::new();

--- a/rust/src/core/session/state.rs
+++ b/rust/src/core/session/state.rs
@@ -411,6 +411,21 @@ impl SessionState {
     /// Explicit CWD and stored shell_cwd are jail-checked against the project root
     /// to prevent MCP clients from escaping the workspace.
     pub fn effective_cwd(&self, explicit_cwd: Option<&str>) -> String {
+        self.effective_cwd_checked(explicit_cwd).0
+    }
+
+    /// Like [`Self::effective_cwd`], but also reports *why* an explicit `cwd`
+    /// request was rejected by the project-root jail and silently replaced with
+    /// the project root (#629).
+    ///
+    /// The jail itself is deliberate sandboxing (it stops MCP clients escaping
+    /// the workspace) and must stay — the only gap was that the substitution was
+    /// silent, so a caller running `pwd && ls` in what they think is dir A
+    /// actually ran in the project root with no indication why. Callers that
+    /// surface output to a human/agent (e.g. `ctx_shell`) use the returned
+    /// `Option<String>` reason to append a one-line hint instead of letting the
+    /// swap pass unnoticed; `effective_cwd` keeps the original lossless behaviour.
+    pub fn effective_cwd_checked(&self, explicit_cwd: Option<&str>) -> (String, Option<String>) {
         let root = self.project_root.as_deref().unwrap_or(".");
         if let Some(cwd) = explicit_cwd
             && !cwd.is_empty()
@@ -419,22 +434,29 @@ impl SessionState {
             return Self::jail_cwd(cwd, root);
         }
         if let Some(ref cwd) = self.shell_cwd {
-            return cwd.clone();
+            return (cwd.clone(), None);
         }
         if let Some(ref r) = self.project_root {
-            return r.clone();
+            return (r.clone(), None);
         }
-        std::env::current_dir()
-            .map_or_else(|_| ".".to_string(), |p| p.to_string_lossy().to_string())
+        (
+            std::env::current_dir()
+                .map_or_else(|_| ".".to_string(), |p| p.to_string_lossy().to_string()),
+            None,
+        )
     }
 
     /// Verifies that `candidate` is within the project jail.
-    /// Falls back to `fallback_root` if the candidate escapes.
-    fn jail_cwd(candidate: &str, fallback_root: &str) -> String {
+    ///
+    /// Falls back to `fallback_root` if the candidate escapes, returning the
+    /// jail-rejection reason as the second tuple element so callers can surface
+    /// it instead of silently substituting the root (#629). `None` means the
+    /// candidate was accepted as-is.
+    fn jail_cwd(candidate: &str, fallback_root: &str) -> (String, Option<String>) {
         let p = std::path::Path::new(candidate);
         match crate::core::pathjail::jail_path(p, std::path::Path::new(fallback_root)) {
-            Ok(jailed) => jailed.to_string_lossy().to_string(),
-            Err(_) => fallback_root.to_string(),
+            Ok(jailed) => (jailed.to_string_lossy().to_string(), None),
+            Err(reason) => (fallback_root.to_string(), Some(reason)),
         }
     }
 

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -73,13 +73,22 @@ impl McpTool for CtxShellTool {
                 .ok_or_else(|| ErrorData::internal_error("session not available", None))?;
 
             let explicit_cwd = get_str(args, "cwd");
-            let effective_cwd = {
+            let (effective_cwd, cwd_jail_reason) = {
                 let guard = crate::server::bounded_lock::read(session_lock, "ctx_shell_cwd");
                 match guard {
-                    Some(session) => session.effective_cwd(explicit_cwd.as_deref()),
-                    None => explicit_cwd.unwrap_or_else(|| ".".to_string()),
+                    Some(session) => session.effective_cwd_checked(explicit_cwd.as_deref()),
+                    None => (explicit_cwd.unwrap_or_else(|| ".".to_string()), None),
                 }
             };
+            // A `cwd` rejected by the project-root jail is silently replaced with
+            // the root (deliberate sandboxing). Surface that swap as a one-line
+            // hint so the caller does not mistake the run dir for the requested
+            // one (#629); appended at the end of the output like the other hints.
+            let cwd_jail_hint = cwd_jail_reason.map_or_else(String::new, |reason| {
+                format!(
+                    "\n[cwd: requested path rejected by project-root jail ({reason}) \u{2014} ran in {effective_cwd} instead]"
+                )
+            });
 
             {
                 let Some(mut session) =
@@ -226,7 +235,8 @@ impl McpTool for CtxShellTool {
             } else {
                 String::new()
             };
-            let final_out = format!("{result_out}{tee_hint}{shell_mismatch}{exit_suffix}");
+            let final_out =
+                format!("{result_out}{tee_hint}{shell_mismatch}{cwd_jail_hint}{exit_suffix}");
 
             Ok(ToolOutput {
                 text: final_out,


### PR DESCRIPTION
## Summary
Closes #629. Reimplementation of #630 (blocked on CLA) — credit to @mahmoudps
for the report and original patch.

When `ctx_shell` receives a `cwd` that resolves outside the session's
`project_root`, the path jail rejects it and falls back to the project root.
That sandboxing is correct and stays — but the fallback was **silent**, so the
`cwd` parameter looked ignored (a caller running `pwd && ls` in what they think
is dir A actually runs in the project root, with no indication why).

### Changes
- `core/session/state.rs`: add `effective_cwd_checked()` returning
  `(String, Option<String>)` — the effective path plus the jail-rejection reason.
  `effective_cwd()` keeps its lossless behaviour by delegating to `.0`; `jail_cwd`
  now propagates the `jail_path` error string as the reason.
- `tools/registered/ctx_shell.rs`: when a `cwd` was jailed, append a one-line
  `[cwd: requested path rejected by project-root jail (<reason>) — ran in <dir>
  instead]` hint at the end of the output, alongside the existing hints.
- Test `effective_cwd_checked_reports_jail_rejection_reason`.
- `CHANGELOG.md`: entry under `[Unreleased] → Fixed`.

The jail logic itself is untouched — this only makes the existing, deliberate
substitution visible.

## Test plan
- [x] `cargo test --lib -- effective_cwd`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI green

Made with [Cursor](https://cursor.com)