### PR TITLE
fix: respect explicit index roots

### DIFF
--- a/rust/src/cli/common.rs
+++ b/rust/src/cli/common.rs
@@ -165,25 +165,49 @@ pub(crate) fn detect_project_root(args: &[String]) -> String {
         if let Some(v) = a.strip_prefix("--root=")
             && !v.trim().is_empty()
         {
-            return promote_to_git_root(v);
+            return normalize_explicit_root(v);
         }
         if let Some(v) = a.strip_prefix("--project-root=")
             && !v.trim().is_empty()
         {
-            return promote_to_git_root(v);
+            return normalize_explicit_root(v);
         }
         if (a == "--root" || a == "--project-root")
             && let Some(v) = it.peek()
             && !v.starts_with("--")
             && !v.trim().is_empty()
         {
-            return promote_to_git_root(v);
+            return normalize_explicit_root(v);
         }
+    }
+    if let Ok(root) = std::env::var("LEAN_CTX_PROJECT_ROOT")
+        && !root.trim().is_empty()
+    {
+        return normalize_explicit_root(&root);
     }
     let cwd = std::env::current_dir()
         .ok()
         .map_or_else(|| ".".to_string(), |p| p.to_string_lossy().to_string());
     promote_to_git_root(&cwd)
+}
+
+fn normalize_explicit_root(path: &str) -> String {
+    let expanded = expand_home(path.trim());
+    crate::core::index_paths::normalize_project_root(&expanded)
+}
+
+fn expand_home(path: &str) -> String {
+    if path == "~" {
+        return dirs::home_dir()
+            .map(|home| home.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.to_string());
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        return dirs::home_dir()
+            .map(|home| home.join(rest).to_string_lossy().to_string())
+            .unwrap_or_else(|| path.to_string());
+    }
+    path.to_string()
 }
 
 fn promote_to_git_root(path: &str) -> String {
@@ -201,7 +225,7 @@ fn promote_to_git_root(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::format_tokens_cli;
+    use super::{detect_project_root, format_tokens_cli, normalize_explicit_root};
 
     #[test]
     fn format_tokens_cli_scales_through_billions() {
@@ -211,5 +235,28 @@ mod tests {
         // Must read as billions once a heavy user crosses 1B, not "1310.0M".
         assert_eq!(format_tokens_cli(1_310_000_000), "1.31B");
         assert_eq!(format_tokens_cli(1_500_000_000_000), "1.50T");
+    }
+
+    #[test]
+    fn explicit_root_is_not_promoted_to_parent_git_root() {
+        let args = vec![
+            "build".to_string(),
+            "--root".to_string(),
+            "/home/example/travail".to_string(),
+        ];
+
+        assert_eq!(detect_project_root(&args), "/home/example/travail");
+    }
+
+    #[test]
+    fn explicit_root_expands_home_prefix() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+
+        assert_eq!(
+            normalize_explicit_root("~/travail"),
+            home.join("travail").to_string_lossy().to_string()
+        );
     }
 }

--- a/rust/src/cli/common.rs
+++ b/rust/src/cli/common.rs
@@ -198,14 +198,16 @@ fn normalize_explicit_root(path: &str) -> String {
 
 fn expand_home(path: &str) -> String {
     if path == "~" {
-        return dirs::home_dir()
-            .map(|home| home.to_string_lossy().to_string())
-            .unwrap_or_else(|| path.to_string());
+        return dirs::home_dir().map_or_else(
+            || path.to_string(),
+            |home| home.to_string_lossy().to_string(),
+        );
     }
     if let Some(rest) = path.strip_prefix("~/") {
-        return dirs::home_dir()
-            .map(|home| home.join(rest).to_string_lossy().to_string())
-            .unwrap_or_else(|| path.to_string());
+        return dirs::home_dir().map_or_else(
+            || path.to_string(),
+            |home| home.join(rest).to_string_lossy().to_string(),
+        );
     }
     path.to_string()
 }


### PR DESCRIPTION
## Summary

- Respect explicit `--root` / `--project-root` values without promoting them to an ancestor git root.
- Honor `LEAN_CTX_PROJECT_ROOT` in CLI project-root detection.
- Expand `~` for explicit CLI/env roots and keep git promotion only for implicit cwd fallback.

Fixes #638

## Validation

- `cargo fmt --check`
- `git diff --check`
- Focused tests are added for explicit root preservation and `~/` expansion.
- Full `cargo test` was not run locally because `rmcp v1.7.0` downloads from crates.io timed out in this environment.
