### PR TITLE
fix: detect running dashboard in doctor port check

### DIFF
--- a/rust/src/doctor/checks.rs
+++ b/rust/src/doctor/checks.rs
@@ -3,7 +3,9 @@
 #[allow(clippy::wildcard_imports)]
 use super::common::*;
 use super::{BOLD, DIM, GREEN, Outcome, RED, RST, YELLOW};
-use std::net::TcpListener;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
 
 /// Reports the shell allowlist exactly as the MCP tools enforce it — and, crucially,
 /// flags when `config.toml` fails to parse (the silent-default trap behind #341,
@@ -473,11 +475,57 @@ pub(super) fn port_3333_outcome() -> Outcome {
             ok: true,
             line: format!("{BOLD}Dashboard port 3333{RST}  {GREEN}available on 127.0.0.1{RST}"),
         },
+        Err(_) if dashboard_responding_on_port(3333) => Outcome {
+            ok: true,
+            line: format!(
+                "{BOLD}Dashboard port 3333{RST}  {GREEN}already serving lean-ctx dashboard{RST}  {DIM}(http://localhost:3333){RST}"
+            ),
+        },
         Err(e) => Outcome {
             ok: false,
             line: format!("{BOLD}Dashboard port 3333{RST}  {RED}not available: {e}{RST}"),
         },
     }
+}
+fn dashboard_responding_on_port(port: u16) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(
+        &std::net::SocketAddr::from(([127, 0, 0, 1], port)),
+        Duration::from_millis(150),
+    ) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(150)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(150)));
+
+    let auth_header = saved_dashboard_token()
+        .map(|token| format!("Authorization: Bearer {token}\r\n"))
+        .unwrap_or_default();
+    let req = format!(
+        "GET /api/version HTTP/1.1\r\nHost: localhost:{port}\r\n{auth_header}Connection: close\r\n\r\n"
+    );
+    if stream.write_all(req.as_bytes()).is_err() {
+        return false;
+    }
+
+    let mut buf = [0u8; 1024];
+    let Ok(n) = stream.read(&mut buf) else {
+        return false;
+    };
+    let response = String::from_utf8_lossy(&buf[..n]);
+    (response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200"))
+        && response.contains(r#""current":"#)
+        && response.contains(r#""latest":"#)
+        && response.contains(r#""update_available":"#)
+}
+
+fn saved_dashboard_token() -> Option<String> {
+    let path = crate::core::paths::state_dir()
+        .ok()?
+        .join("dashboard.token");
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 pub(super) fn pi_outcome() -> Option<Outcome> {

--- a/rust/src/doctor/checks_tests.rs
+++ b/rust/src/doctor/checks_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::core::config::{RulesInjection, RulesScope};
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::Path;
 
 fn write(home: &Path, rel: &str, content: &str) {
@@ -25,6 +27,41 @@ fn capacity_hint_is_actionable_for_both_states() {
     assert!(crit.contains("memory.*"));
 
     assert_ne!(warn, crit);
+}
+#[test]
+fn dashboard_probe_recognizes_lean_ctx_version_endpoint() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut req = [0u8; 512];
+        let n = stream.read(&mut req).unwrap();
+        let req = String::from_utf8_lossy(&req[..n]);
+        assert!(req.starts_with("GET /api/version HTTP/1.1"));
+        let body = r#"{"current":"3.8.18","latest":"3.8.18","update_available":false,"checked_age_secs":null}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+
+    assert!(dashboard_responding_on_port(port));
+    handle.join().unwrap();
+}
+
+#[test]
+fn dashboard_probe_rejects_non_dashboard_http_service() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+
+    assert!(!dashboard_responding_on_port(port));
+    handle.join().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #644

## Summary
- Treat port `3333` as healthy when it is already serving the lean-ctx dashboard.
- Probe `/api/version` after bind failure and recognize lean-ctx dashboard version JSON.
- Preserve the existing conflict error for unrelated services on the same port.
- Add regression coverage for a dashboard-like endpoint and a non-dashboard HTTP service.

## Tests
- `cargo fmt --check`
- Isolated Rust probe validation passed locally.

Full `cargo test` / `cargo build` could not complete in this environment because Cargo could not download `rmcp v1.7.0` from crates.io due network timeout.