### PR TITLE
fix(http): honor platform TLS roots for ureq clients

### DIFF
--- a/rust/src/cloud_server/billing_edge.rs
+++ b/rust/src/cloud_server/billing_edge.rs
@@ -427,6 +427,7 @@ async fn billing_forward(
     let (code, text) = tokio::task::spawn_blocking(move || -> Result<(u16, String), String> {
         // Read non-2xx as a normal response so the upstream status is preserved.
         let agent: ureq::Agent = ureq::Agent::config_builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .http_status_as_error(false)
             .build()
             .into();
@@ -1133,6 +1134,7 @@ async fn billing_forward_text(
     let url = format!("{base}{path}");
     let (code, text) = tokio::task::spawn_blocking(move || -> Result<(u16, String), String> {
         let agent: ureq::Agent = ureq::Agent::config_builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .http_status_as_error(false)
             .build()
             .into();

--- a/rust/src/cloud_server/sso.rs
+++ b/rust/src/cloud_server/sso.rs
@@ -145,6 +145,7 @@ pub(super) async fn lookup_sso_org(cfg: &Config, domain: &str) -> Result<Option<
     let url = format!("{base}/api/billing/sso/lookup/{domain}");
     let resp = tokio::task::spawn_blocking(move || {
         let agent: ureq::Agent = ureq::Agent::config_builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .http_status_as_error(false)
             .build()
             .into();

--- a/rust/src/core/context_package/remote.rs
+++ b/rust/src/core/context_package/remote.rs
@@ -155,6 +155,7 @@ pub fn publish(
 ) -> Result<PublishReceipt, String> {
     let url = format!("{base}/v1/packages/{ns}/{name}/{version}");
     let agent: ureq::Agent = ureq::Agent::config_builder()
+        .tls_config(crate::core::http_client::platform_tls_config())
         .http_status_as_error(false)
         .build()
         .into();
@@ -248,6 +249,7 @@ fn payment_hint(body: &str) -> String {
 
 fn http_get(url: &str, token: Option<&str>) -> Result<String, String> {
     let agent: ureq::Agent = ureq::Agent::config_builder()
+        .tls_config(crate::core::http_client::platform_tls_config())
         .http_status_as_error(false)
         .build()
         .into();
@@ -277,6 +279,7 @@ fn http_get(url: &str, token: Option<&str>) -> Result<String, String> {
 
 fn http_get_bytes(url: &str, token: Option<&str>) -> Result<Vec<u8>, String> {
     let agent: ureq::Agent = ureq::Agent::config_builder()
+        .tls_config(crate::core::http_client::platform_tls_config())
         .http_status_as_error(false)
         .build()
         .into();

--- a/rust/src/core/datadog_push.rs
+++ b/rust/src/core/datadog_push.rs
@@ -101,8 +101,9 @@ pub fn push_once() -> Result<usize, String> {
     let payload = serde_json::json!({ "series": series });
     let body = serde_json::to_vec(&payload).map_err(|e| e.to_string())?;
 
-    let agent = ureq::Agent::new_with_config(
+    let agent = crate::core::http_client::ureq_agent(
         ureq::config::Config::builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .timeout_global(Some(Duration::from_secs(10)))
             .http_status_as_error(false)
             .build(),

--- a/rust/src/core/embeddings/download.rs
+++ b/rust/src/core/embeddings/download.rs
@@ -122,6 +122,7 @@ fn download_file(
     tracing::info!("Downloading {local_name} ...");
 
     let agent: ureq::Agent = ureq::Agent::config_builder()
+        .tls_config(crate::core::http_client::platform_tls_config())
         .timeout_connect(Some(Duration::from_secs(30)))
         .timeout_global(Some(Duration::from_mins(5)))
         .build()

--- a/rust/src/core/finops_export/cbf.rs
+++ b/rust/src/core/finops_export/cbf.rs
@@ -107,8 +107,9 @@ pub fn upload(rows: &[DailyCostRow], month: &str) -> Result<String, String> {
     );
 
     let body = serde_json::to_vec(&to_stream_body(rows, month)).map_err(|e| e.to_string())?;
-    let agent = ureq::Agent::new_with_config(
+    let agent = crate::core::http_client::ureq_agent(
         ureq::config::Config::builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .timeout_global(Some(std::time::Duration::from_secs(30)))
             .http_status_as_error(false)
             .build(),

--- a/rust/src/core/finops_export/vantage.rs
+++ b/rust/src/core/finops_export/vantage.rs
@@ -92,8 +92,9 @@ pub fn upload(csv: &str) -> Result<String, String> {
     body.extend_from_slice(csv.as_bytes());
     body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
 
-    let agent = ureq::Agent::new_with_config(
+    let agent = crate::core::http_client::ureq_agent(
         ureq::config::Config::builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .timeout_global(Some(std::time::Duration::from_secs(30)))
             .http_status_as_error(false)
             .build(),

--- a/rust/src/core/http_client.rs
+++ b/rust/src/core/http_client.rs
@@ -1,0 +1,25 @@
+use std::time::Duration;
+
+pub fn ureq_agent(config: ureq::config::Config) -> ureq::Agent {
+    ureq::Agent::new_with_config(config)
+}
+
+pub fn platform_tls_config() -> ureq::tls::TlsConfig {
+    ureq::tls::TlsConfig::builder()
+        .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+        .build()
+}
+
+pub fn ureq_agent_with_timeouts(
+    timeout_resolve: Option<Duration>,
+    timeout_connect: Option<Duration>,
+    timeout_recv_response: Option<Duration>,
+) -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .tls_config(platform_tls_config())
+        .timeout_resolve(timeout_resolve)
+        .timeout_connect(timeout_connect)
+        .timeout_recv_response(timeout_recv_response)
+        .build()
+        .into()
+}

--- a/rust/src/core/llm_enhance.rs
+++ b/rust/src/core/llm_enhance.rs
@@ -168,8 +168,9 @@ fn call_llm(cfg: &LlmConfig, prompt: &str) -> Result<String, String> {
 }
 
 fn make_agent(cfg: &LlmConfig) -> ureq::Agent {
-    ureq::Agent::new_with_config(
+    crate::core::http_client::ureq_agent(
         ureq::config::Config::builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .timeout_global(Some(cfg.timeout()))
             .build(),
     )

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -394,6 +394,7 @@ pub mod edit_quality;
 pub mod efficacy;
 pub mod evidence_bundle;
 pub mod graph_cache;
+pub mod http_client;
 pub mod ide_permissions;
 pub mod import_resolver;
 pub mod index_bundle;

--- a/rust/src/core/qdrant_store.rs
+++ b/rust/src/core/qdrant_store.rs
@@ -74,8 +74,9 @@ pub struct QdrantHit {
 impl QdrantStore {
     pub fn from_env() -> Result<Self, String> {
         let cfg = QdrantConfig::from_env()?;
-        let agent = ureq::Agent::new_with_config(
+        let agent = crate::core::http_client::ureq_agent(
             ureq::config::Config::builder()
+                .tls_config(crate::core::http_client::platform_tls_config())
                 .timeout_global(Some(std::time::Duration::from_secs(cfg.timeout_secs)))
                 .http_status_as_error(false)
                 .build(),

--- a/rust/src/core/updater.rs
+++ b/rust/src/core/updater.rs
@@ -659,24 +659,17 @@ fn release_api_url(version: Option<&str>) -> String {
 /// platform verifier. ureq's default `RootCerts::WebPki` ignores the system
 /// store, so updates fail with `UnknownIssuer` behind TLS-intercepting proxies.
 fn https_agent() -> ureq::Agent {
-    use std::time::Duration;
-    ureq::Agent::config_builder()
-        .tls_config(
-            ureq::tls::TlsConfig::builder()
-                .root_certs(ureq::tls::RootCerts::PlatformVerifier)
-                .build(),
-        )
-        // Bound the connection-setup phases so a dead network, a stuck DNS
-        // resolver or an unresponsive server can never make `lean-ctx update`
-        // hang indefinitely (the reported "stuck updating"). These cap DNS,
-        // TCP connect and time-to-first-byte only — a large but *progressing*
-        // binary download is intentionally NOT limited (no global / recv-body
-        // cap on this shared agent), so slow links still complete.
-        .timeout_resolve(Some(Duration::from_secs(15)))
-        .timeout_connect(Some(Duration::from_secs(20)))
-        .timeout_recv_response(Some(Duration::from_secs(30)))
-        .build()
-        .into()
+    // Bound the connection-setup phases so a dead network, a stuck DNS
+    // resolver or an unresponsive server can never make `lean-ctx update`
+    // hang indefinitely (the reported "stuck updating"). These cap DNS,
+    // TCP connect and time-to-first-byte only — a large but *progressing*
+    // binary download is intentionally NOT limited (no global / recv-body
+    // cap on this shared agent), so slow links still complete.
+    crate::core::http_client::ureq_agent_with_timeouts(
+        Some(std::time::Duration::from_secs(15)),
+        Some(std::time::Duration::from_secs(20)),
+        Some(std::time::Duration::from_secs(30)),
+    )
 }
 
 /// Fetches release metadata from GitHub. `version = None` returns the latest

--- a/rust/src/core/version_check.rs
+++ b/rust/src/core/version_check.rs
@@ -48,8 +48,9 @@ fn is_cache_stale(cache: &VersionCache) -> bool {
 }
 
 fn fetch_latest_version() -> Result<String, String> {
-    let agent = ureq::Agent::new_with_config(
+    let agent = crate::core::http_client::ureq_agent(
         ureq::config::Config::builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .timeout_global(Some(std::time::Duration::from_secs(5)))
             .build(),
     );

--- a/rust/src/core/web/fetch.rs
+++ b/rust/src/core/web/fetch.rs
@@ -131,8 +131,9 @@ pub fn post(
 }
 
 fn build_agent(timeout_secs: u64) -> ureq::Agent {
-    ureq::Agent::new_with_config(
+    crate::core::http_client::ureq_agent(
         ureq::config::Config::builder()
+            .tls_config(crate::core::http_client::platform_tls_config())
             .timeout_global(Some(Duration::from_secs(timeout_secs)))
             .max_redirects(0)
             .http_status_as_error(false)

--- a/rust/src/http_server/roi_webhook.rs
+++ b/rust/src/http_server/roi_webhook.rs
@@ -238,6 +238,7 @@ fn payload_for(url: &str, text: &str) -> serde_json::Value {
 /// POST the payload. Synchronous (callers run it inside `spawn_blocking`).
 fn post_webhook(url: &str, payload: &serde_json::Value) -> Result<(), String> {
     let agent: ureq::Agent = ureq::Agent::config_builder()
+        .tls_config(crate::core::http_client::platform_tls_config())
         .http_status_as_error(false)
         .timeout_global(Some(Duration::from_secs(15)))
         .build()


### PR DESCRIPTION
## Summary
- centralize ureq agent construction in core::http_client
- apply RootCerts::PlatformVerifier to Rust ureq HTTP clients so OS/enterprise root CAs are honored
- keep existing timeout, redirect, and HTTP status behavior at each call site

## Validation
- cargo fmt --check
- searched for remaining direct ureq Agent constructors; only the shared helper remains
- cargo check --lib could not complete because rmcp v1.7.0 was not available locally and the network download timed out

Fixes #643