### PR TITLE
Fix MCP reroot from markerless client cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   Repomix `1.15.0 → 1.16.0`.
 
 ### Fixed
+- **MCP PathJail auto-corrects a stale markerless root instead of rejecting the
+  workspace (#649).** An MCP server launched by VS Code/WSL could adopt a
+  markerless client cwd (e.g. `/mnt/c/Users/<user>`) as its jail root; the first
+  absolute path into the real workspace on another mount was then rejected with
+  `path escapes project root`, breaking `ctx_compose` / `ctx_read` / `ctx_patch`.
+  `resolve_path` now reroots opt-in-free from such a markerless root to the
+  marker-bearing project derived from the requested path — the same rationale as
+  the agent-config-dir case (#580) — while a markerless target with no derivable
+  project stays blocked, so PathJail enforcement is unchanged.
 - **Enterprise/OS TLS roots are honored by every HTTP client (#643).** All ureq
   clients are now built through `core::http_client`, which injects
   `RootCerts::PlatformVerifier` so requests trust the system/enterprise trust store

--- a/rust/src/tools/mod.rs
+++ b/rust/src/tools/mod.rs
@@ -234,6 +234,48 @@ mod resolve_path_tests {
     #[cfg(not(feature = "no-jail"))]
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
+    async fn resolve_path_auto_reroots_from_markerless_client_cwd_without_opt_in() {
+        // VS Code/WSL can launch the MCP server from /mnt/c/Users while the
+        // workspace lives under /mnt/d. That markerless cwd must not become a
+        // permanent PathJail root when the request points at a real project.
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        crate::test_env::remove_var("LEAN_CTX_ALLOW_REROOT");
+        let tmp = tempfile::tempdir().unwrap();
+        let client_cwd = tmp.path().join("Users").join("user");
+        let real = tmp.path().join("workspaces").join("lean-ctx");
+        std::fs::create_dir_all(&client_cwd).unwrap();
+        let real_root = create_git_root(&real);
+        std::fs::write(real.join("rust.rs"), "ok").unwrap();
+
+        let server = LeanCtxServer::new_with_startup(
+            None,
+            None,
+            SessionMode::Personal,
+            "default",
+            "default",
+        );
+        {
+            let mut session = server.session.write().await;
+            session.project_root = Some(client_cwd.to_string_lossy().to_string());
+            session.shell_cwd = Some(client_cwd.to_string_lossy().to_string());
+        }
+
+        let out = server
+            .resolve_path(&real.join("rust.rs").to_string_lossy())
+            .await
+            .unwrap();
+        assert!(
+            out.ends_with("/rust.rs"),
+            "markerless client cwd must auto-correct: {out}"
+        );
+
+        let session = server.session.read().await;
+        assert_eq!(session.project_root.as_deref(), Some(real_root.as_str()));
+    }
+
+    #[cfg(not(feature = "no-jail"))]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn resolve_path_agent_dir_still_blocks_markerless_escape() {
         // The agent-dir bypass only reroots to a *real* project (one carrying a
         // marker). A markerless absolute path outside the jail stays blocked —

--- a/rust/src/tools/mod.rs
+++ b/rust/src/tools/mod.rs
@@ -276,6 +276,48 @@ mod resolve_path_tests {
     #[cfg(not(feature = "no-jail"))]
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
+    async fn resolve_path_markerless_root_still_blocks_markerless_escape() {
+        // #649 must not weaken PathJail: from a markerless client cwd, an absolute
+        // path that derives NO project marker stays blocked and the root is
+        // unchanged. Only rerooting *to a real project* is permitted.
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        crate::test_env::remove_var("LEAN_CTX_ALLOW_REROOT");
+        let tmp = tempfile::tempdir().unwrap();
+        let client_cwd = tmp.path().join("Users").join("user");
+        let loose = tmp.path().join("workspaces").join("loose");
+        std::fs::create_dir_all(&client_cwd).unwrap();
+        std::fs::create_dir_all(&loose).unwrap();
+        std::fs::write(loose.join("data.txt"), "no").unwrap();
+
+        let server = LeanCtxServer::new_with_startup(
+            None,
+            None,
+            SessionMode::Personal,
+            "default",
+            "default",
+        );
+        {
+            let mut session = server.session.write().await;
+            session.project_root = Some(client_cwd.to_string_lossy().to_string());
+            session.shell_cwd = Some(client_cwd.to_string_lossy().to_string());
+        }
+
+        let err = server
+            .resolve_path(&loose.join("data.txt").to_string_lossy())
+            .await
+            .unwrap_err();
+        assert!(err.contains("path escapes project root"), "got: {err}");
+
+        let session = server.session.read().await;
+        assert_eq!(
+            session.project_root.as_deref(),
+            Some(client_cwd.to_string_lossy().as_ref())
+        );
+    }
+
+    #[cfg(not(feature = "no-jail"))]
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn resolve_path_agent_dir_still_blocks_markerless_escape() {
         // The agent-dir bypass only reroots to a *real* project (one carrying a
         // marker). A markerless absolute path outside the jail stays blocked —

--- a/rust/src/tools/server_paths.rs
+++ b/rust/src/tools/server_paths.rs
@@ -75,16 +75,20 @@ impl LeanCtxServer {
                             |v| v == "1" || v == "true",
                         );
                         let candidate_under_jail = resolved.starts_with(jail_root_path);
-                        // #580: when the server was launched from an agent/IDE
-                        // config dir (e.g. ~/.copilot), that jail is never a real
-                        // project boundary. `maybe_derive_project_root_from_absolute`
-                        // already guarantees the new root carries a real project
-                        // marker, so correcting to it is a root *fix*, not a jail
-                        // weakening — allow it without the `allow_auto_reroot`
-                        // opt-in. Non-agent weak roots keep the conservative gate.
+                        // #580/#649: when the MCP server was launched from an
+                        // agent/IDE config dir (e.g. ~/.copilot) or a markerless
+                        // client cwd (e.g. WSL VS Code starting in /mnt/c/Users),
+                        // that jail is not a real project boundary. The derived
+                        // root already carries a project marker, so correcting to
+                        // it is a root fix, not a jail weakening. Real project
+                        // roots and trusted startup roots still keep the
+                        // conservative gate.
                         let allow_reroot = if candidate_under_jail {
                             false
-                        } else if is_suspicious_root(jail_root_path) {
+                        } else if is_suspicious_root(jail_root_path)
+                            || (self.startup_project_root.is_none()
+                                && !has_project_marker(jail_root_path))
+                        {
                             true
                         } else if !cfg_allow {
                             false


### PR DESCRIPTION
## Summary
- allow MCP path resolution to auto-correct from a markerless client cwd to the project root derived from an absolute request
- keep the conservative reroot gate for real project roots and trusted startup roots
- add a regression test for VS Code/WSL-style markerless client cwd launches

Refs #649

> Maintainer note: linked as `Refs` (not `Fixes`) so the issue stays open as `status: integrated` + milestone `v3.8.19` until release, per our issue-label lifecycle. The merged fix ships in v3.8.19.

## Tests (author)
- cargo fmt --manifest-path rust/Cargo.toml --check
- Targeted cargo test could not start locally because rmcp v1.7.0 was not cached and crates.io download timed out
- cargo test --offline confirmed the same missing cached crate: rmcp v1.7.0

## Maintainer additions
- Added regression test `resolve_path_markerless_root_still_blocks_markerless_escape` proving PathJail stays intact (a markerless root still blocks a markerless escape; root unchanged).
- Added `CHANGELOG.md` entry under `[Unreleased] → Fixed`.
- Ran full local gates: `cargo fmt --check`, `cargo test resolve_path` (15/15 incl. both reroot tests), `cargo clippy --all-targets -- -D warnings`, plus a security review of the PathJail change — no findings.

Thanks @cedric013 for the fix!