### PR TITLE
feat(sessions): Added alias "new" for "lean-ctx session reset".

### DIFF
--- a/rust/src/cli/session_cmd.rs
+++ b/rust/src/cli/session_cmd.rs
@@ -126,7 +126,7 @@ pub fn cmd_session_action(args: &[String]) {
             let _ = session.save();
             println!("{out}");
         }
-        Some("reset") => {
+        Some("reset" | "new") => {
             #[cfg(unix)]
             {
                 #[cfg(unix)]
@@ -192,7 +192,7 @@ Usage:
   lean-ctx session save                 Save current session
   lean-ctx session load [session-id]    Load a session (latest if no ID)
   lean-ctx session status               Show session status
-  lean-ctx session reset                Reset session
+  lean-ctx session reset|new            Reset session
 
 Examples:
   lean-ctx session task \"implement JWT authentication\"

--- a/rust/tests/cli_characterization.rs
+++ b/rust/tests/cli_characterization.rs
@@ -314,6 +314,12 @@ fn session_no_args_exits_cleanly() {
 }
 
 #[test]
+fn session_new_alias_resets_session() {
+    let out = run(&["session", "new"]);
+    assert_eq!(exit_code(&out), 0, "stderr: {}", stderr(&out));
+}
+
+#[test]
 fn knowledge_no_args_exits_cleanly() {
     let out = run(&["knowledge"]);
     let code = exit_code(&out);


### PR DESCRIPTION
## Summary

Added alias `new` for `lean-ctx session reset" - it looks more clear.

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`


## Notes for reviewers

- Risk areas / edge cases: No risk areas.
- Backwards compatibility: True
- Docs updated (links/files): Yes
