### PR TITLE
fix(hook): Codex still read by chunks. Proposed different hook.

### DIFF
--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -1272,22 +1272,20 @@ pub(crate) fn emit_session_start_additional_context(additional_context: &str) {
 ///
 /// This hint mirrors the MCP `RECOVER` rule
 /// ([`crate::core::rules_canonical::RECOVER`]) on the non-MCP CLI surface: it
-/// names the **reversible** nature of the compression and the concrete raw escape
-/// (`lean-ctx raw "<command>"`), which the rewrite hook leaves untouched (it
+/// states that the compressed view is not exact evidence and names the raw escape
+/// (`lean-ctx raw "<exact command>"`), which the rewrite hook leaves untouched (it
 /// already starts with `lean-ctx `, so `rewrite_candidate` returns `None`). The
 /// blocked-command sentence still covers the allowlist gate.
-pub(crate) const CODEX_SHELL_RECOVERY_HINT: &str = r#"RAW OUTPUT RULE — HARD
+pub(crate) const CODEX_SHELL_RECOVERY_HINT: &str = r#"RAW OUTPUT RULE (shell)
 
-  Compressed shell output != exact evidence.
+Compressed shell output is not exact evidence. When you need exact content
+(file text, log lines, quotes, counts, line numbers), you MUST re-run the
+command as `lean-ctx raw "<exact command>"` — never reconstruct it from the
+compressed view with chunked reads (`cat`/`sed`/`head`/`tail`), and never quote
+compressed output as if it were exact. If a Bash call is blocked, re-run the
+exact command the hook suggests.
 
-  Need exact file/log/text/quotes/line content? MUST rerun:
-  `lean-ctx raw "<exact command>"`
-
-  Never reconstruct exact output via chunks (`cat|sed|head|tail`).
-  Never quote compressed output as exact.
-  If hook blocks Bash, rerun exact suggested command.
-
-  Final check: exact claim -> `lean-ctx raw` evidence."#;
+Rule of thumb: back every exact claim with `lean-ctx raw` output."#;
 pub fn handle_codex_session_start() {
     if is_quiet() {
         return;

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -1276,8 +1276,18 @@ pub(crate) fn emit_session_start_additional_context(additional_context: &str) {
 /// (`lean-ctx raw "<command>"`), which the rewrite hook leaves untouched (it
 /// already starts with `lean-ctx `, so `rewrite_candidate` returns `None`). The
 /// blocked-command sentence still covers the allowlist gate.
-pub(crate) const CODEX_SHELL_RECOVERY_HINT: &str = "lean-ctx auto-compresses shell output, and the compression is fully reversible: when you need the complete, exact output, re-run the command as `lean-ctx raw \"<command>\"` instead of reading it back in small chunks. If a Bash call is blocked, rerun it with the exact command the hook suggests.";
+pub(crate) const CODEX_SHELL_RECOVERY_HINT: &str = r#"RAW OUTPUT RULE — HARD
 
+  Compressed shell output != exact evidence.
+
+  Need exact file/log/text/quotes/line content? MUST rerun:
+  `lean-ctx raw "<exact command>"`
+
+  Never reconstruct exact output via chunks (`cat|sed|head|tail`).
+  Never quote compressed output as exact.
+  If hook blocks Bash, rerun exact suggested command.
+
+  Final check: exact claim -> `lean-ctx raw` evidence."#;
 pub fn handle_codex_session_start() {
     if is_quiet() {
         return;

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -858,20 +858,21 @@ fn codex_session_start_hint_teaches_the_raw_escape_hatch() {
     // GH #625: the PreToolUse hook already auto-compresses every Bash command, so
     // the SessionStart hint's job is to teach the *raw* escape — otherwise agents
     // re-read the compressed view in small chunks (the shell-side "too compressed"
-    // complaint). It must name exact evidence, the concrete raw CLI
-    // (`lean-ctx raw "<exact command>"`), and forbid the chunk anti-pattern; the
-    // redundant "prefer `lean-ctx -c`" coaching is gone (compression is automatic).
+    // complaint). It must state that compressed output is not exact evidence, name
+    // the concrete raw CLI (`lean-ctx raw "<exact command>"`), and forbid the
+    // chunked-read anti-pattern; the redundant "prefer `lean-ctx -c`" coaching is
+    // gone (compression is automatic).
     let hint = CODEX_SHELL_RECOVERY_HINT;
     assert!(
         hint.contains("lean-ctx raw \"<exact command>\""),
         "names the raw CLI: {hint}"
     );
     assert!(
-        hint.contains("Compressed shell output != exact evidence"),
+        hint.contains("is not exact evidence"),
         "states compressed output is not exact evidence: {hint}"
     );
     assert!(
-        hint.contains("via chunks"),
+        hint.contains("chunked reads"),
         "forbids chunk-based reconstruction: {hint}"
     );
     assert!(

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -858,18 +858,21 @@ fn codex_session_start_hint_teaches_the_raw_escape_hatch() {
     // GH #625: the PreToolUse hook already auto-compresses every Bash command, so
     // the SessionStart hint's job is to teach the *raw* escape — otherwise agents
     // re-read the compressed view in small chunks (the shell-side "too compressed"
-    // complaint). It must name the reversible compression, the concrete raw CLI
-    // (`lean-ctx raw "<command>"`), and forbid the small-chunk anti-pattern; the
+    // complaint). It must name exact evidence, the concrete raw CLI
+    // (`lean-ctx raw "<exact command>"`), and forbid the chunk anti-pattern; the
     // redundant "prefer `lean-ctx -c`" coaching is gone (compression is automatic).
     let hint = CODEX_SHELL_RECOVERY_HINT;
     assert!(
-        hint.contains("lean-ctx raw \"<command>\""),
+        hint.contains("lean-ctx raw \"<exact command>\""),
         "names the raw CLI: {hint}"
     );
-    assert!(hint.contains("reversible"), "states reversibility: {hint}");
     assert!(
-        hint.contains("small chunks"),
-        "forbids chunked re-reads: {hint}"
+        hint.contains("Compressed shell output != exact evidence"),
+        "states compressed output is not exact evidence: {hint}"
+    );
+    assert!(
+        hint.contains("via chunks"),
+        "forbids chunk-based reconstruction: {hint}"
     );
     assert!(
         !hint.contains("prefer `lean-ctx -c`"),


### PR DESCRIPTION
## Summary

What does this PR change and why?

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`

## Notes for reviewers

- Risk areas / edge cases: Session hook
- Backwards compatibility: Yes
- Docs updated (links/files): Not needed
