### PR TITLE
feat(compression): add deterministic markdown and log folding

### DIFF
--- a/rust/eval/testbench/recording.json
+++ b/rust/eval/testbench/recording.json
@@ -12,7 +12,7 @@
     }
   },
   "entries": {
-    "1311831e8bd7baab4338a41c47bf1cfaecebc44997060b1ca2c7c299ae7efd13": {
+    "13deefd8cdb0a1b372b7750d83a6a3963df119122d1b4e28bf713f4b9f8898a4": {
       "text": "The PaymentGateway retries failed charges with exponential backoff: a base delay of 200ms that doubles each attempt, up to a maximum of 5 attempts before the charge is marked permanently failed."
     },
     "1aaa8fd672e05f9a6db2c6537d0f1a405bc4decf4c099397880a779e92af895a": {

--- a/rust/eval/testbench/recording.json
+++ b/rust/eval/testbench/recording.json
@@ -12,7 +12,7 @@
     }
   },
   "entries": {
-    "13deefd8cdb0a1b372b7750d83a6a3963df119122d1b4e28bf713f4b9f8898a4": {
+    "1311831e8bd7baab4338a41c47bf1cfaecebc44997060b1ca2c7c299ae7efd13": {
       "text": "The PaymentGateway retries failed charges with exponential backoff: a base delay of 200ms that doubles each attempt, up to a maximum of 5 attempts before the charge is marked permanently failed."
     },
     "1aaa8fd672e05f9a6db2c6537d0f1a405bc4decf4c099397880a779e92af895a": {

--- a/rust/src/core/compressor.rs
+++ b/rust/src/core/compressor.rs
@@ -46,7 +46,14 @@ pub fn aggressive_compress(content: &str, ext: Option<&str>) -> String {
     // Structured data (JSON/JSONL) carries no comments and barely compresses via
     // the line-based path below (~0% measured). Strip insignificant whitespace
     // losslessly instead — key order, numbers, and string contents are preserved.
-    if matches!(ext, Some("md" | "markdown" | "mdown" | "txt"))
+    // Markdown-family files opt into the lossy structural compactor by
+    // extension alone; a plain `.txt` must additionally show a real ATX
+    // heading — hyphen lists or wrapped prose are not enough to treat a text
+    // file as a structured document (#655).
+    let markdown_family = matches!(ext, Some("md" | "markdown" | "mdown"));
+    let structured_txt =
+        matches!(ext, Some("txt")) && crate::core::markdown_compact::has_markdown_headings(content);
+    if (markdown_family || structured_txt)
         && let Some(compacted) = crate::core::markdown_compact::compact_markdown(content)
     {
         return compacted;

--- a/rust/src/core/compressor.rs
+++ b/rust/src/core/compressor.rs
@@ -46,6 +46,11 @@ pub fn aggressive_compress(content: &str, ext: Option<&str>) -> String {
     // Structured data (JSON/JSONL) carries no comments and barely compresses via
     // the line-based path below (~0% measured). Strip insignificant whitespace
     // losslessly instead — key order, numbers, and string contents are preserved.
+    if matches!(ext, Some("md" | "markdown" | "mdown" | "txt"))
+        && let Some(compacted) = crate::core::markdown_compact::compact_markdown(content)
+    {
+        return compacted;
+    }
     if let Some(compacted) = crate::core::structured_compact::compact_structured(content, ext) {
         return compacted;
     }

--- a/rust/src/core/markdown_compact.rs
+++ b/rust/src/core/markdown_compact.rs
@@ -5,6 +5,9 @@
 
 use std::collections::{HashMap, HashSet};
 
+const SECTION_BODY_FRACTION: f64 = 0.35;
+const MIN_SECTION_BODY_LINES: usize = 2;
+
 const STOP_WORDS: &[&str] = &[
     "the", "and", "for", "with", "that", "this", "from", "into", "your", "you", "are", "can",
     "will", "not", "all", "use", "using", "used", "lean", "ctx", "context", "agent", "agents",
@@ -21,37 +24,20 @@ pub fn compact_markdown(content: &str) -> Option<String> {
         return None;
     }
 
-    let docs = token_sets(&lines);
-    let df = document_frequency(&docs);
-    let mut scored: Vec<(usize, f64)> = lines
-        .iter()
-        .enumerate()
-        .map(|(idx, line)| (idx, score_line(idx, line, &docs[idx], lines.len(), &df)))
-        .collect();
-    scored.sort_by(|a, b| {
-        b.1.partial_cmp(&a.1)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.0.cmp(&b.0))
-    });
-
-    // ~45% line budget from the measured prototype, with all headings forced in.
-    let target = ((lines.len() as f64) * 0.45).ceil() as usize;
-    let mut keep: HashSet<usize> = lines
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, line)| is_heading(line).then_some(idx))
-        .collect();
-    for (idx, _) in scored.into_iter().take(target) {
-        keep.insert(idx);
-    }
+    let keep = section_keep_set(&lines);
 
     let mut out = String::new();
+    let mut omitted = 0usize;
     for (idx, line) in lines.iter().enumerate() {
         if keep.contains(&idx) {
+            flush_omission(&mut out, &mut omitted);
             out.push_str(line.trim_end());
             out.push('\n');
+        } else {
+            omitted += 1;
         }
     }
+    flush_omission(&mut out, &mut omitted);
 
     let kept_lines = out.lines().count();
     if kept_lines >= lines.len() || out.len() >= content.len() {
@@ -59,6 +45,73 @@ pub fn compact_markdown(content: &str) -> Option<String> {
     } else {
         Some(out)
     }
+}
+
+fn section_keep_set(lines: &[&str]) -> HashSet<usize> {
+    let docs = token_sets(lines);
+    let df = document_frequency(&docs);
+    let mut keep = HashSet::new();
+    let mut section_body = Vec::new();
+
+    for (idx, line) in lines.iter().enumerate() {
+        if is_heading(line) {
+            select_section_body(&mut keep, &section_body, lines, &docs, &df);
+            section_body.clear();
+            keep.insert(idx);
+        } else {
+            section_body.push(idx);
+        }
+    }
+    select_section_body(&mut keep, &section_body, lines, &docs, &df);
+    keep
+}
+
+fn select_section_body(
+    keep: &mut HashSet<usize>,
+    body: &[usize],
+    lines: &[&str],
+    docs: &[HashSet<String>],
+    df: &HashMap<String, usize>,
+) {
+    if body.is_empty() {
+        return;
+    }
+
+    let target = section_body_budget(body.len());
+    let mut scored: Vec<(usize, f64)> = body
+        .iter()
+        .map(|idx| {
+            (
+                *idx,
+                score_line(*idx, lines[*idx], &docs[*idx], lines.len(), df),
+            )
+        })
+        .collect();
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    if let Some(first) = body.first() {
+        keep.insert(*first);
+    }
+    for (idx, _) in scored.into_iter().take(target) {
+        keep.insert(idx);
+    }
+}
+
+fn section_body_budget(line_count: usize) -> usize {
+    let fractional = ((line_count as f64) * SECTION_BODY_FRACTION).ceil() as usize;
+    fractional.max(MIN_SECTION_BODY_LINES).min(line_count)
+}
+
+fn flush_omission(out: &mut String, omitted: &mut usize) {
+    if *omitted == 0 {
+        return;
+    }
+    out.push_str(&format!("... [lean-ctx: omitted {} lines]\n", *omitted));
+    *omitted = 0;
 }
 
 fn looks_like_markdown(content: &str) -> bool {
@@ -178,6 +231,33 @@ mod tests {
         assert!(compacted.contains("## Safety"));
         assert!(compacted.contains("ctx_read"));
         assert!(compacted.contains("MUST preserve"));
+        assert!(compacted.contains("[lean-ctx: omitted"));
+    }
+
+    #[test]
+    fn keeps_body_lines_from_each_section() {
+        let mut doc = String::from("# Root\n\nRoot intro.\n");
+        for section in 0..8 {
+            doc.push_str(&format!("\n## Section {section}\n\n"));
+            doc.push_str(&format!("Section {section} overview line.\n"));
+            for item in 0..12 {
+                doc.push_str(&format!(
+                    "- repeated filler item {item} for section {section}.\n"
+                ));
+            }
+            doc.push_str(&format!(
+                "BLOCKING section {section} exact requirement with `ctx_read`.\n"
+            ));
+        }
+
+        let compacted = compact_markdown(&doc).expect("markdown should compact");
+        assert!(compacted.len() < doc.len());
+        for section in 0..8 {
+            assert!(compacted.contains(&format!("## Section {section}")));
+            assert!(compacted.contains(&format!("Section {section} overview line.")));
+            assert!(compacted.contains(&format!("BLOCKING section {section}")));
+        }
+        assert!(compacted.contains("[lean-ctx: omitted"));
     }
 
     #[test]

--- a/rust/src/core/markdown_compact.rs
+++ b/rust/src/core/markdown_compact.rs
@@ -1,68 +1,190 @@
 //! Deterministic Markdown/documentation compaction for LLM-agent reads.
 //!
-//! Keeps heading topology intact and selects high-signal body lines with a small
-//! IDF-style scorer. This is intentionally std-only and byte-stable (#498).
+//! Keeps heading topology intact, treats fenced code blocks as atomic units, and
+//! selects high-signal body units with a small IDF-style scorer. Intentionally
+//! std-only and byte-stable (#498): per-line token sets are ordered
+//! (`BTreeSet`), so the f64 score summation order — and therefore the selected
+//! lines and omission markers — are a pure function of the input bytes.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt::Write as _;
 
 const SECTION_BODY_FRACTION: f64 = 0.35;
 const MIN_SECTION_BODY_LINES: usize = 2;
+/// Documents with fewer content (non-blank) lines pass through untouched.
+const MIN_CONTENT_LINES: usize = 24;
 
 const STOP_WORDS: &[&str] = &[
     "the", "and", "for", "with", "that", "this", "from", "into", "your", "you", "are", "can",
     "will", "not", "all", "use", "using", "used", "lean", "ctx", "context", "agent", "agents",
 ];
 
-/// Compact Markdown while preserving all headings and high-signal details.
+/// One compaction unit: a heading line, a prose line, or an atomic fenced block.
+///
+/// Fenced blocks are kept or dropped only as a whole, so the output never
+/// contains an unbalanced fence or an omission marker inside a code example.
+struct Unit {
+    /// Raw line range `[start, end)` covered by this unit.
+    start: usize,
+    end: usize,
+    kind: UnitKind,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UnitKind {
+    Heading,
+    Prose,
+    Fence,
+}
+
+impl Unit {
+    /// Non-blank lines covered by this unit (blank interior fence lines are
+    /// emitted verbatim but carry no "content" weight in budgets or markers).
+    fn content_lines(&self, lines: &[&str]) -> usize {
+        lines[self.start..self.end]
+            .iter()
+            .filter(|l| !l.trim().is_empty())
+            .count()
+    }
+}
+
+/// Compact Markdown while preserving all headings, whole fenced code blocks,
+/// and high-signal details. Returns `None` when the document is too small, not
+/// markdown-shaped, or compaction would not actually shrink it.
 pub fn compact_markdown(content: &str) -> Option<String> {
     if content.trim().is_empty() || !looks_like_markdown(content) {
         return None;
     }
 
-    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
-    if lines.len() < 24 {
+    let lines: Vec<&str> = content.lines().collect();
+    let units = parse_units(&lines);
+    let content_total: usize = units.iter().map(|u| u.content_lines(&lines)).sum();
+    if content_total < MIN_CONTENT_LINES {
         return None;
     }
 
-    let keep = section_keep_set(&lines);
+    let keep = select_units(&lines, &units, content_total);
 
     let mut out = String::new();
     let mut omitted = 0usize;
-    for (idx, line) in lines.iter().enumerate() {
-        if keep.contains(&idx) {
+    for (uidx, unit) in units.iter().enumerate() {
+        if keep.contains(&uidx) {
             flush_omission(&mut out, &mut omitted);
-            out.push_str(line.trim_end());
-            out.push('\n');
+            for line in &lines[unit.start..unit.end] {
+                out.push_str(line.trim_end());
+                out.push('\n');
+            }
         } else {
-            omitted += 1;
+            omitted += unit.content_lines(&lines);
         }
     }
     flush_omission(&mut out, &mut omitted);
 
-    let kept_lines = out.lines().count();
-    if kept_lines >= lines.len() || out.len() >= content.len() {
+    let kept_content = out.lines().filter(|l| !l.trim().is_empty()).count();
+    if kept_content >= content_total || out.len() >= content.len() {
         None
     } else {
         Some(out)
     }
 }
 
-fn section_keep_set(lines: &[&str]) -> HashSet<usize> {
+/// True when the document carries at least one ATX heading — the structural
+/// signal a plain `.txt` file must show before the lossy compactor may touch it
+/// (hyphen lists alone are not enough to call a text file "markdown").
+pub fn has_markdown_headings(content: &str) -> bool {
+    content.lines().any(is_heading)
+}
+
+/// Splits raw lines into units. Blank lines outside fences belong to no unit:
+/// they carry no signal and are dropped silently (not counted as "omitted"),
+/// matching the compact typography of the output. Lines inside a fence — blank
+/// or not — always travel with their block.
+fn parse_units(lines: &[&str]) -> Vec<Unit> {
+    let mut units = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.is_empty() {
+            i += 1;
+            continue;
+        }
+        if let Some(marker) = fence_marker(trimmed) {
+            let mut end = i + 1;
+            while end < lines.len() && !is_closing_fence(lines[end], marker) {
+                end += 1;
+            }
+            // Include the closing fence; an unterminated block runs to EOF.
+            let end = (end + 1).min(lines.len());
+            units.push(Unit {
+                start: i,
+                end,
+                kind: UnitKind::Fence,
+            });
+            i = end;
+            continue;
+        }
+        let kind = if is_heading(lines[i]) {
+            UnitKind::Heading
+        } else {
+            UnitKind::Prose
+        };
+        units.push(Unit {
+            start: i,
+            end: i + 1,
+            kind,
+        });
+        i += 1;
+    }
+    units
+}
+
+/// Returns the fence character when `trimmed` opens a code fence (``` or ~~~).
+fn fence_marker(trimmed: &str) -> Option<char> {
+    ['`', '~']
+        .into_iter()
+        .find(|&marker| trimmed.chars().take_while(|c| *c == marker).count() >= 3)
+}
+
+/// A closing fence is a run of >=3 fence characters with nothing but whitespace
+/// after it (an info string like ```rust only ever opens a block).
+fn is_closing_fence(line: &str, marker: char) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.chars().take_while(|c| *c == marker).count() >= 3
+        && trimmed.chars().all(|c| c == marker || c.is_whitespace())
+}
+
+fn select_units(lines: &[&str], units: &[Unit], content_total: usize) -> HashSet<usize> {
     let docs = token_sets(lines);
     let df = document_frequency(&docs);
     let mut keep = HashSet::new();
-    let mut section_body = Vec::new();
+    let mut section_body: Vec<usize> = Vec::new();
 
-    for (idx, line) in lines.iter().enumerate() {
-        if is_heading(line) {
-            select_section_body(&mut keep, &section_body, lines, &docs, &df);
+    for (uidx, unit) in units.iter().enumerate() {
+        if unit.kind == UnitKind::Heading {
+            select_section_body(
+                &mut keep,
+                &section_body,
+                lines,
+                units,
+                &docs,
+                &df,
+                content_total,
+            );
             section_body.clear();
-            keep.insert(idx);
+            keep.insert(uidx);
         } else {
-            section_body.push(idx);
+            section_body.push(uidx);
         }
     }
-    select_section_body(&mut keep, &section_body, lines, &docs, &df);
+    select_section_body(
+        &mut keep,
+        &section_body,
+        lines,
+        units,
+        &docs,
+        &df,
+        content_total,
+    );
     keep
 }
 
@@ -70,20 +192,24 @@ fn select_section_body(
     keep: &mut HashSet<usize>,
     body: &[usize],
     lines: &[&str],
-    docs: &[HashSet<String>],
+    units: &[Unit],
+    docs: &[BTreeSet<String>],
     df: &HashMap<String, usize>,
+    content_total: usize,
 ) {
     if body.is_empty() {
         return;
     }
 
-    let target = section_body_budget(body.len());
+    let body_lines: usize = body.iter().map(|u| units[*u].content_lines(lines)).sum();
+    let target = section_body_budget(body_lines);
+
     let mut scored: Vec<(usize, f64)> = body
         .iter()
-        .map(|idx| {
+        .map(|uidx| {
             (
-                *idx,
-                score_line(*idx, lines[*idx], &docs[*idx], lines.len(), df),
+                *uidx,
+                score_unit(&units[*uidx], lines, docs, content_total, df),
             )
         })
         .collect();
@@ -93,11 +219,19 @@ fn select_section_body(
             .then_with(|| a.0.cmp(&b.0))
     });
 
+    // The first body unit anchors the section (usually its intro sentence).
     if let Some(first) = body.first() {
         keep.insert(*first);
     }
-    for (idx, _) in scored.into_iter().take(target) {
-        keep.insert(idx);
+    // Greedy by content lines so a large fenced block spends its real size of
+    // the budget instead of counting as one line.
+    let mut taken = 0usize;
+    for (uidx, _) in scored {
+        if taken >= target {
+            break;
+        }
+        keep.insert(uidx);
+        taken += units[uidx].content_lines(lines);
     }
 }
 
@@ -110,7 +244,7 @@ fn flush_omission(out: &mut String, omitted: &mut usize) {
     if *omitted == 0 {
         return;
     }
-    out.push_str(&format!("... [lean-ctx: omitted {} lines]\n", *omitted));
+    let _ = writeln!(out, "... [lean-ctx: omitted {omitted} lines]");
     *omitted = 0;
 }
 
@@ -121,19 +255,26 @@ fn looks_like_markdown(content: &str) -> bool {
         || content.lines().any(|l| l.trim_start().starts_with("| "))
 }
 
+/// ATX heading per CommonMark: 1–6 `#` followed by a space (or end of line).
+/// The space requirement keeps shebangs (`#!/usr/bin/env`) and `#pragma`-style
+/// lines from masquerading as document structure.
 fn is_heading(line: &str) -> bool {
     let trimmed = line.trim_start();
-    trimmed.starts_with('#') && trimmed.chars().take_while(|c| *c == '#').count() <= 6
+    let hashes = trimmed.chars().take_while(|c| *c == '#').count();
+    (1..=6).contains(&hashes) && (trimmed.len() == hashes || trimmed[hashes..].starts_with(' '))
 }
 
-fn token_sets(lines: &[&str]) -> Vec<HashSet<String>> {
+/// Per-line token sets. `BTreeSet` (not `HashSet`) is load-bearing: the score
+/// is an f64 sum over these tokens, and f64 addition is not associative, so the
+/// iteration order must be fixed for the output to be byte-stable (#498).
+fn token_sets(lines: &[&str]) -> Vec<BTreeSet<String>> {
     lines
         .iter()
         .map(|line| tokens(line).into_iter().collect())
         .collect()
 }
 
-fn document_frequency(docs: &[HashSet<String>]) -> HashMap<String, usize> {
+fn document_frequency(docs: &[BTreeSet<String>]) -> HashMap<String, usize> {
     let mut df = HashMap::new();
     for doc in docs {
         for token in doc {
@@ -143,23 +284,43 @@ fn document_frequency(docs: &[HashSet<String>]) -> HashMap<String, usize> {
     df
 }
 
+fn score_unit(
+    unit: &Unit,
+    lines: &[&str],
+    docs: &[BTreeSet<String>],
+    content_total: usize,
+    df: &HashMap<String, usize>,
+) -> f64 {
+    match unit.kind {
+        UnitKind::Fence => {
+            // A block is one unit of meaning: score the union of its tokens
+            // once, with the same code bonus a backticked prose line gets.
+            let mut tokens = BTreeSet::new();
+            for doc in &docs[unit.start..unit.end] {
+                tokens.extend(doc.iter().cloned());
+            }
+            idf_sum(&tokens, content_total, df) + 10.0 + position_bonus(unit.start)
+        }
+        _ => score_line(
+            unit.start,
+            lines[unit.start],
+            &docs[unit.start],
+            content_total,
+            df,
+        ),
+    }
+}
+
 fn score_line(
     idx: usize,
     line: &str,
-    tokens: &HashSet<String>,
+    tokens: &BTreeSet<String>,
     line_count: usize,
     df: &HashMap<String, usize>,
 ) -> f64 {
-    let mut score = 0.0;
-    for token in tokens {
-        let freq = *df.get(token).unwrap_or(&1) as f64;
-        score += ((line_count as f64 + 1.0) / (freq + 1.0)).ln();
-    }
+    let mut score = idf_sum(tokens, line_count, df);
 
     let trimmed = line.trim_start();
-    if is_heading(line) {
-        score += 20.0;
-    }
     if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("| ") {
         score += 2.0;
     }
@@ -173,7 +334,21 @@ fn score_line(
     {
         score += 10.0;
     }
-    score + (1.0 / (idx + 1) as f64)
+    score + position_bonus(idx)
+}
+
+/// IDF-style sum; iterating a `BTreeSet` keeps the f64 summation order fixed.
+fn idf_sum(tokens: &BTreeSet<String>, line_count: usize, df: &HashMap<String, usize>) -> f64 {
+    let mut score = 0.0;
+    for token in tokens {
+        let freq = *df.get(token).unwrap_or(&1) as f64;
+        score += ((line_count as f64 + 1.0) / (freq + 1.0)).ln();
+    }
+    score
+}
+
+fn position_bonus(idx: usize) -> f64 {
+    1.0 / (idx + 1) as f64
 }
 
 fn tokens(line: &str) -> Vec<String> {
@@ -207,7 +382,7 @@ fn push_token(out: &mut Vec<String>, token: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::compact_markdown;
+    use super::{compact_markdown, has_markdown_headings};
 
     #[test]
     fn keeps_all_headings_and_shrinks() {
@@ -263,5 +438,95 @@ mod tests {
     #[test]
     fn short_docs_pass_through() {
         assert!(compact_markdown("# Title\n\nSmall.\n").is_none());
+    }
+
+    #[test]
+    fn output_is_deterministic_across_calls() {
+        // #498 regression guard: the score is an f64 sum over per-line token
+        // sets. With unordered sets, near-tied lines could flip across calls
+        // (each std HashSet instance iterates in its own random order), moving
+        // omission markers and changing bytes. Mixed token frequencies below
+        // engineer many near-ties on purpose.
+        let mut doc = String::from("# Determinism\n\nIntro line for the document.\n");
+        for section in 0..4 {
+            doc.push_str(&format!("\n## Section {section}\n\n"));
+            for i in 0..30 {
+                doc.push_str(&format!(
+                    "candidate_{i} shared_token_{} another_token_{} overlapping detail item.\n",
+                    i % 3,
+                    i % 7,
+                ));
+            }
+        }
+
+        let first = compact_markdown(&doc).expect("doc should compact");
+        for _ in 0..16 {
+            let next = compact_markdown(&doc).expect("doc should compact");
+            assert_eq!(first, next, "compaction must be byte-stable across calls");
+        }
+    }
+
+    #[test]
+    fn fenced_blocks_stay_atomic() {
+        let filler = "Ordinary explanatory filler sentence repeated for volume.\n";
+        let mut doc = String::from("# Guide\n\nIntro line.\n\n## Usage\n\n");
+        for _ in 0..30 {
+            doc.push_str(filler);
+        }
+        doc.push_str("Run the exact `ctx_read` command below:\n\n");
+        doc.push_str(
+            "```bash\nlean-ctx read src/lib.rs\n\nlean-ctx search \"ctx_read\" src/\n```\n",
+        );
+        for _ in 0..30 {
+            doc.push_str(filler);
+        }
+
+        let compacted = compact_markdown(&doc).expect("doc should compact");
+
+        // The fence must never be split: fences stay balanced and no omission
+        // marker may appear inside a block.
+        let mut in_fence = false;
+        for line in compacted.lines() {
+            if line.trim_start().starts_with("```") {
+                in_fence = !in_fence;
+            } else if in_fence {
+                assert!(
+                    !line.starts_with("... [lean-ctx:"),
+                    "omission marker inside a fenced block:\n{compacted}"
+                );
+            }
+        }
+        assert!(!in_fence, "unbalanced code fences:\n{compacted}");
+
+        // This block is high-signal, so it must survive whole — including its
+        // blank interior line (kept fences are verbatim).
+        assert!(compacted.contains(
+            "```bash\nlean-ctx read src/lib.rs\n\nlean-ctx search \"ctx_read\" src/\n```"
+        ));
+        assert!(compacted.contains("[lean-ctx: omitted"));
+    }
+
+    #[test]
+    fn heading_inside_fence_is_not_structure() {
+        // A `# comment` inside a code block is code, not a heading: it must not
+        // be force-kept or start a new section.
+        let mut doc = String::from("# Real Heading\n\nIntro.\n\n");
+        doc.push_str("```sh\n# just a shell comment\necho done\n```\n");
+        for i in 0..30 {
+            doc.push_str(&format!("Body filler sentence number {i} for volume.\n"));
+        }
+
+        let compacted = compact_markdown(&doc).expect("doc should compact");
+        let fences = compacted.matches("```").count();
+        assert_eq!(fences % 2, 0, "fences must stay balanced:\n{compacted}");
+    }
+
+    #[test]
+    fn has_markdown_headings_requires_atx_space() {
+        assert!(has_markdown_headings("# Title\nbody\n"));
+        assert!(has_markdown_headings("###\nempty heading is valid\n"));
+        assert!(!has_markdown_headings("#!/usr/bin/env bash\necho hi\n"));
+        assert!(!has_markdown_headings("#pragma once\nplain text\n"));
+        assert!(!has_markdown_headings("- a list\n- alone\n"));
     }
 }

--- a/rust/src/core/markdown_compact.rs
+++ b/rust/src/core/markdown_compact.rs
@@ -1,0 +1,187 @@
+//! Deterministic Markdown/documentation compaction for LLM-agent reads.
+//!
+//! Keeps heading topology intact and selects high-signal body lines with a small
+//! IDF-style scorer. This is intentionally std-only and byte-stable (#498).
+
+use std::collections::{HashMap, HashSet};
+
+const STOP_WORDS: &[&str] = &[
+    "the", "and", "for", "with", "that", "this", "from", "into", "your", "you", "are", "can",
+    "will", "not", "all", "use", "using", "used", "lean", "ctx", "context", "agent", "agents",
+];
+
+/// Compact Markdown while preserving all headings and high-signal details.
+pub fn compact_markdown(content: &str) -> Option<String> {
+    if content.trim().is_empty() || !looks_like_markdown(content) {
+        return None;
+    }
+
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.len() < 24 {
+        return None;
+    }
+
+    let docs = token_sets(&lines);
+    let df = document_frequency(&docs);
+    let mut scored: Vec<(usize, f64)> = lines
+        .iter()
+        .enumerate()
+        .map(|(idx, line)| (idx, score_line(idx, line, &docs[idx], lines.len(), &df)))
+        .collect();
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    // ~45% line budget from the measured prototype, with all headings forced in.
+    let target = ((lines.len() as f64) * 0.45).ceil() as usize;
+    let mut keep: HashSet<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, line)| is_heading(line).then_some(idx))
+        .collect();
+    for (idx, _) in scored.into_iter().take(target) {
+        keep.insert(idx);
+    }
+
+    let mut out = String::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if keep.contains(&idx) {
+            out.push_str(line.trim_end());
+            out.push('\n');
+        }
+    }
+
+    let kept_lines = out.lines().count();
+    if kept_lines >= lines.len() || out.len() >= content.len() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn looks_like_markdown(content: &str) -> bool {
+    content.lines().any(is_heading)
+        || content.lines().any(|l| l.trim_start().starts_with("- "))
+        || content.lines().any(|l| l.trim_start().starts_with("* "))
+        || content.lines().any(|l| l.trim_start().starts_with("| "))
+}
+
+fn is_heading(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('#') && trimmed.chars().take_while(|c| *c == '#').count() <= 6
+}
+
+fn token_sets(lines: &[&str]) -> Vec<HashSet<String>> {
+    lines
+        .iter()
+        .map(|line| tokens(line).into_iter().collect())
+        .collect()
+}
+
+fn document_frequency(docs: &[HashSet<String>]) -> HashMap<String, usize> {
+    let mut df = HashMap::new();
+    for doc in docs {
+        for token in doc {
+            *df.entry(token.clone()).or_insert(0) += 1;
+        }
+    }
+    df
+}
+
+fn score_line(
+    idx: usize,
+    line: &str,
+    tokens: &HashSet<String>,
+    line_count: usize,
+    df: &HashMap<String, usize>,
+) -> f64 {
+    let mut score = 0.0;
+    for token in tokens {
+        let freq = *df.get(token).unwrap_or(&1) as f64;
+        score += ((line_count as f64 + 1.0) / (freq + 1.0)).ln();
+    }
+
+    let trimmed = line.trim_start();
+    if is_heading(line) {
+        score += 20.0;
+    }
+    if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("| ") {
+        score += 2.0;
+    }
+    if line.contains('`')
+        || line.contains("MUST")
+        || line.contains("SHOULD")
+        || line.contains("BLOCKING")
+        || line.contains("WARNING")
+        || line.contains("ctx_")
+        || line.contains("lean-ctx")
+    {
+        score += 10.0;
+    }
+    score + (1.0 / (idx + 1) as f64)
+}
+
+fn tokens(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    for ch in line.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '/' | '.' | ':') {
+            cur.push(ch);
+        } else if !cur.is_empty() {
+            push_token(&mut out, &cur);
+            cur.clear();
+        }
+    }
+    if !cur.is_empty() {
+        push_token(&mut out, &cur);
+    }
+    out
+}
+
+fn push_token(out: &mut Vec<String>, token: &str) {
+    let t = token
+        .trim_matches(|c: char| matches!(c, '.' | ',' | ':' | ';' | '(' | ')' | '[' | ']'))
+        .to_ascii_lowercase();
+    if t.len() < 3 || STOP_WORDS.contains(&t.as_str()) {
+        return;
+    }
+    if t.len() >= 8 || t.chars().any(|c| matches!(c, '_' | '-' | '/' | '.' | ':')) {
+        out.push(t);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compact_markdown;
+
+    #[test]
+    fn keeps_all_headings_and_shrinks() {
+        let input = "# Title\n\nIntro paragraph with ordinary words.\n\n## Setup\n\n";
+        let body = "- `ctx_read` keeps important details for agents.\n";
+        let repeated = "This sentence is useful once but repeated many times for filler.\n";
+        let mut doc = input.to_string();
+        for _ in 0..20 {
+            doc.push_str(repeated);
+        }
+        doc.push_str(body);
+        doc.push_str("## Safety\n\nMUST preserve warnings and exact commands.\n");
+        for _ in 0..20 {
+            doc.push_str(repeated);
+        }
+
+        let compacted = compact_markdown(&doc).expect("markdown should compact");
+        assert!(compacted.len() < doc.len());
+        assert!(compacted.contains("# Title"));
+        assert!(compacted.contains("## Setup"));
+        assert!(compacted.contains("## Safety"));
+        assert!(compacted.contains("ctx_read"));
+        assert!(compacted.contains("MUST preserve"));
+    }
+
+    #[test]
+    fn short_docs_pass_through() {
+        assert!(compact_markdown("# Title\n\nSmall.\n").is_none());
+    }
+}

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -21,6 +21,7 @@ pub mod extractive;
 pub mod finops_export;
 pub mod information_bottleneck;
 pub mod json_crush;
+pub mod markdown_compact;
 pub mod output_sanitizer;
 pub mod policy;
 pub mod pop_pruning;

--- a/rust/src/shell/compress/engine.rs
+++ b/rust/src/shell/compress/engine.rs
@@ -255,22 +255,25 @@ pub(crate) fn compress_if_beneficial(command: &str, output: &str) -> String {
     // CRITICAL: Never compress error output from build/check/lint tools.
     // Compiler errors, type errors, lint findings etc. must be preserved verbatim
     // so the agent can see file paths, line numbers, and full diagnostics.
+    // Folding compiler/test-runner *progress* noise composes with — never
+    // replaces — the verbatim token cap: diagnostics stay verbatim, and a log
+    // whose diagnostics alone exceed the budget is still head/tail-truncated
+    // with safety-needle preservation (#655).
     if is_error_output_from_build_tool(command, output) {
-        if let Some(folded) = maybe_fold_progress(output, count_tokens(output)) {
-            return folded;
-        }
-        return truncate_verbatim(output, count_tokens(output));
+        let base =
+            maybe_fold_progress(output, count_tokens(output)).unwrap_or_else(|| output.to_string());
+        return truncate_verbatim(&base, count_tokens(&base));
     }
 
     // CRITICAL: Test-runner output is kept verbatim (only head/tail truncated
     // when huge, and even then middle test-result/failure lines are preserved).
     // This holds for fully-passing runs too, so pass/fail summaries can never be
     // semantically compressed or deduplicated away — on any OS or client.
+    // Same composition as above: progress folding first, cap always (#655).
     if is_test_runner_command(command) {
-        if let Some(folded) = maybe_fold_progress(output, count_tokens(output)) {
-            return folded;
-        }
-        return truncate_verbatim(output, count_tokens(output));
+        let base =
+            maybe_fold_progress(output, count_tokens(output)).unwrap_or_else(|| output.to_string());
+        return truncate_verbatim(&base, count_tokens(&base));
     }
 
     if !is_search_output(command) && crate::tools::ctx_shell::contains_auth_flow(output) {
@@ -763,9 +766,11 @@ fn classify_foldable_progress(line: &str) -> Option<ProgressKind> {
     None
 }
 
+/// Pure dot-run lines (pytest/unittest progress) of any length. Lines with any
+/// other character (e.g. `....F...`, which encodes a failure) are never folded.
 fn is_low_signal_progress(line: &str) -> bool {
     let trimmed = line.trim();
-    trimmed == "." || trimmed == ".." || trimmed == "..." || trimmed == "...."
+    !trimmed.is_empty() && trimmed.bytes().all(|b| b == b'.')
 }
 
 fn flush_progress_run(out: &mut Vec<String>, kind: Option<ProgressKind>, lines: &[&str]) {

--- a/rust/src/shell/compress/engine.rs
+++ b/rust/src/shell/compress/engine.rs
@@ -256,6 +256,9 @@ pub(crate) fn compress_if_beneficial(command: &str, output: &str) -> String {
     // Compiler errors, type errors, lint findings etc. must be preserved verbatim
     // so the agent can see file paths, line numbers, and full diagnostics.
     if is_error_output_from_build_tool(command, output) {
+        if let Some(folded) = maybe_fold_progress(output, count_tokens(output)) {
+            return folded;
+        }
         return truncate_verbatim(output, count_tokens(output));
     }
 
@@ -264,6 +267,9 @@ pub(crate) fn compress_if_beneficial(command: &str, output: &str) -> String {
     // This holds for fully-passing runs too, so pass/fail summaries can never be
     // semantically compressed or deduplicated away — on any OS or client.
     if is_test_runner_command(command) {
+        if let Some(folded) = maybe_fold_progress(output, count_tokens(output)) {
+            return folded;
+        }
         return truncate_verbatim(output, count_tokens(output));
     }
 
@@ -690,7 +696,127 @@ fn truncate_with_safety_scan(lines: &[&str], original_tokens: usize) -> Option<S
     Some(shell_savings_footer(&compressed, original_tokens, ct))
 }
 
-/// Public wrapper for integration tests to exercise the compression pipeline.
+fn fold_repetitive_progress(output: &str) -> Option<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut pending_kind: Option<ProgressKind> = None;
+    let mut pending: Vec<&str> = Vec::new();
+    let mut omitted_low_signal = 0usize;
+
+    for line in output.lines() {
+        if is_low_signal_progress(line) {
+            omitted_low_signal += 1;
+            continue;
+        }
+
+        let kind = classify_foldable_progress(line);
+        if kind.is_some() && kind == pending_kind {
+            pending.push(line);
+            continue;
+        }
+
+        flush_progress_run(&mut out, pending_kind, &pending);
+        pending.clear();
+        pending_kind = kind;
+        if kind.is_some() {
+            pending.push(line);
+        } else {
+            out.push(line.to_string());
+        }
+    }
+
+    flush_progress_run(&mut out, pending_kind, &pending);
+    if omitted_low_signal > 0 {
+        out.push(format!(
+            "[{omitted_low_signal} low-signal progress lines omitted]"
+        ));
+    }
+
+    let folded = out.join("\n") + "\n";
+    (folded.len() < output.len()).then_some(folded)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProgressKind {
+    CargoCompile,
+    CargoFresh,
+    PytestPassed,
+    NpmProgress,
+}
+
+fn classify_foldable_progress(line: &str) -> Option<ProgressKind> {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("Compiling ") || trimmed.starts_with("Checking ") {
+        return Some(ProgressKind::CargoCompile);
+    }
+    if trimmed.starts_with("Fresh ")
+        || trimmed.starts_with("Downloaded ")
+        || trimmed.starts_with("Downloading ")
+    {
+        return Some(ProgressKind::CargoFresh);
+    }
+    if line.contains(" PASSED [") {
+        return Some(ProgressKind::PytestPassed);
+    }
+    if trimmed.starts_with('[') && trimmed.contains('%') && trimmed.contains('/') {
+        return Some(ProgressKind::NpmProgress);
+    }
+    None
+}
+
+fn is_low_signal_progress(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed == "." || trimmed == ".." || trimmed == "..." || trimmed == "...."
+}
+
+fn flush_progress_run(out: &mut Vec<String>, kind: Option<ProgressKind>, lines: &[&str]) {
+    let Some(kind) = kind else {
+        return;
+    };
+    if lines.is_empty() {
+        return;
+    }
+    let threshold = match kind {
+        ProgressKind::CargoCompile | ProgressKind::PytestPassed => 8,
+        ProgressKind::CargoFresh | ProgressKind::NpmProgress => 12,
+    };
+    if lines.len() < threshold {
+        out.extend(lines.iter().map(|line| (*line).to_string()));
+        return;
+    }
+
+    out.push(format!(
+        "[{} {} lines folded]",
+        lines.len(),
+        match kind {
+            ProgressKind::CargoCompile => "cargo compile/check",
+            ProgressKind::CargoFresh => "cargo download/fresh",
+            ProgressKind::PytestPassed => "pytest PASSED",
+            ProgressKind::NpmProgress => "package-manager progress",
+        }
+    ));
+    for line in lines.iter().take(3) {
+        out.push((*line).to_string());
+    }
+    if lines.len() > 5 {
+        out.push("…".to_string());
+    }
+    for line in lines
+        .iter()
+        .rev()
+        .take(2)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+    {
+        out.push((*line).to_string());
+    }
+}
+
+fn maybe_fold_progress(output: &str, original_tokens: usize) -> Option<String> {
+    let folded = fold_repetitive_progress(output)?;
+    (count_tokens(&folded) < original_tokens).then_some(folded)
+}
+
 pub fn compress_if_beneficial_pub(command: &str, output: &str) -> String {
     compress_if_beneficial(command, output)
 }

--- a/rust/tests/compression_improvements.rs
+++ b/rust/tests/compression_improvements.rs
@@ -71,3 +71,127 @@ fn pytest_success_output_folds_passed_lines_and_preserves_summary() {
     assert!(compressed.contains("pytest PASSED lines folded"));
     assert!(compressed.contains("80 passed"));
 }
+
+#[test]
+fn markdown_compaction_is_deterministic_across_calls() {
+    // #498: aggressive compaction must be a pure function of the input bytes.
+    // Mixed token frequencies engineer near-tied line scores on purpose — with
+    // unordered per-line token sets the f64 summation order could flip the
+    // selected lines between calls.
+    let mut doc = String::from("# Stability\n\nIntro line for the document.\n");
+    for section in 0..4 {
+        doc.push_str(&format!("\n## Section {section}\n\n"));
+        for i in 0..30 {
+            doc.push_str(&format!(
+                "candidate_{i} shared_token_{} another_token_{} overlapping detail item.\n",
+                i % 3,
+                i % 7,
+            ));
+        }
+    }
+
+    let first = aggressive_compress(&doc, Some("md"));
+    for _ in 0..16 {
+        assert_eq!(
+            first,
+            aggressive_compress(&doc, Some("md")),
+            "markdown compaction must be byte-stable across calls"
+        );
+    }
+}
+
+#[test]
+fn verbatim_token_cap_survives_progress_folding() {
+    // Folding progress noise must compose with — not replace — the verbatim
+    // token cap: a build log whose *diagnostics alone* exceed the budget is
+    // still head/tail-truncated with safety-needle preservation.
+    let mut output = String::new();
+    for i in 0..200 {
+        output.push_str(&format!(
+            "   Compiling crate_{i:03} v0.1.0 (/tmp/ws/crate_{i:03})\n"
+        ));
+    }
+    output.push_str("error[E0308]: mismatched types\n");
+    output.push_str("  --> crates/demo/src/lib.rs:7:5\n");
+    // A diagnostic body far above MAX_VERBATIM_TOKENS (8000) that is neither
+    // foldable progress nor low-signal, so only the cap can bound it.
+    for i in 0..4000 {
+        output.push_str(&format!(
+            "note: required because of the expansion trace frame {i} in `deeply::nested::module_{i}`\n"
+        ));
+    }
+    output.push_str("error: aborting due to 1 previous error\n");
+
+    let compressed = compress_if_beneficial_pub("cargo build", &output);
+    assert!(
+        compressed.contains("cargo compile/check lines folded"),
+        "progress noise must still fold"
+    );
+    assert!(
+        compressed.contains("lines omitted"),
+        "oversized diagnostics must still hit the verbatim cap"
+    );
+    assert!(
+        compressed.contains("error[E0308]: mismatched types"),
+        "the head diagnostic must survive"
+    );
+    assert!(
+        compressed.contains("aborting due to 1 previous error"),
+        "the tail diagnostic must survive"
+    );
+    assert!(
+        count_tokens(&compressed) < count_tokens(&output) / 4,
+        "capped output must be a fraction of the raw log"
+    );
+}
+
+#[test]
+fn plain_txt_without_headings_is_not_structurally_compacted() {
+    // A `.txt` with hyphen lists but no ATX heading is ordinary prose — the
+    // lossy structural compactor must not touch it (no omitted-lines markers).
+    let mut doc = String::from("Shopping notes\n\n");
+    for i in 0..40 {
+        doc.push_str(&format!("- item number {i} with a longer description\n"));
+    }
+
+    let compressed = aggressive_compress(&doc, Some("txt"));
+    assert!(
+        !compressed.contains("[lean-ctx: omitted"),
+        "txt without headings must not be structurally compacted: {compressed}"
+    );
+
+    // The same content as `.md` (heading added) opts in.
+    let md = format!("# Notes\n\n{doc}");
+    let compacted = aggressive_compress(&md, Some("md"));
+    assert!(compacted.contains("[lean-ctx: omitted"));
+}
+
+#[test]
+fn markdown_compaction_never_splits_code_fences() {
+    let mut doc = String::from("# Guide\n\nIntro line.\n\n## Usage\n\n");
+    for i in 0..40 {
+        doc.push_str(&format!("Filler prose sentence number {i} for volume.\n"));
+    }
+    doc.push_str("```bash\nlean-ctx read src/lib.rs\n\nlean-ctx search \"ctx_read\" src/\n```\n");
+    for i in 0..40 {
+        doc.push_str(&format!("More filler prose sentence number {i}.\n"));
+    }
+
+    let compressed = aggressive_compress(&doc, Some("md"));
+    assert_eq!(
+        compressed.matches("```").count() % 2,
+        0,
+        "code fences must stay balanced: {compressed}"
+    );
+    let mut in_fence = false;
+    for line in compressed.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+        } else if in_fence {
+            assert!(
+                !line.starts_with("... [lean-ctx:"),
+                "omission marker inside a fenced block: {compressed}"
+            );
+        }
+    }
+}

--- a/rust/tests/compression_improvements.rs
+++ b/rust/tests/compression_improvements.rs
@@ -1,0 +1,73 @@
+use lean_ctx::core::compressor::aggressive_compress;
+use lean_ctx::core::tokens::count_tokens;
+use lean_ctx::shell::compress::compress_if_beneficial_pub;
+
+#[test]
+fn markdown_aggressive_keeps_headings_and_saves_tokens() {
+    let mut doc =
+        String::from("# Context Engine\n\nIntro text with stable overview.\n\n## Setup\n\n");
+    for i in 0..60 {
+        doc.push_str(&format!(
+            "Repeated explanatory prose line {i} about background concepts and examples.\n"
+        ));
+    }
+    doc.push_str("- `ctx_read` keeps exact source references for agent tasks.\n");
+    doc.push_str("## Safety\n\nMUST preserve diagnostics, commands, and recovery notes.\n");
+    for i in 0..60 {
+        doc.push_str(&format!(
+            "Additional explanatory prose line {i} about operational background.\n"
+        ));
+    }
+
+    let compressed = aggressive_compress(&doc, Some("md"));
+    assert!(count_tokens(&compressed) < count_tokens(&doc));
+    assert!(compressed.contains("# Context Engine"));
+    assert!(compressed.contains("## Setup"));
+    assert!(compressed.contains("## Safety"));
+    assert!(compressed.contains("ctx_read"));
+    assert!(compressed.contains("MUST preserve"));
+}
+
+#[test]
+fn cargo_warning_output_folds_progress_and_preserves_diagnostics() {
+    let mut output = String::new();
+    for i in 0..80 {
+        output.push_str(&format!(
+            "   Compiling crate_{i:03} v0.1.0 (/tmp/ws/crate_{i:03})\n"
+        ));
+    }
+    output.push_str("warning: unused variable: `tmp`\n");
+    output.push_str("  --> crates/demo/src/lib.rs:42:9\n");
+    output.push_str("   |\n42 |     let tmp = 1;\n   |         ^^^\n");
+    output.push_str("warning: `demo` generated 1 warning\n");
+    output.push_str("    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.23s\n");
+
+    let compressed = compress_if_beneficial_pub("cargo build", &output);
+    assert!(count_tokens(&compressed) < count_tokens(&output));
+    assert!(compressed.contains("cargo compile/check lines folded"));
+    assert!(compressed.contains("warning: unused variable"));
+    assert!(compressed.contains("crates/demo/src/lib.rs:42:9"));
+    assert!(compressed.contains("generated 1 warning"));
+}
+
+#[test]
+fn pytest_success_output_folds_passed_lines_and_preserves_summary() {
+    let mut output = String::from(
+        "============================= test session starts =============================\n",
+    );
+    for i in 0..80 {
+        output.push_str(&format!(
+            "tests/test_mod_{:02}.py::test_case_{i:03} PASSED [ {:02}%]\n",
+            i / 10,
+            i % 100
+        ));
+    }
+    output.push_str(
+        "======================= 80 passed, 0 warnings in 2.34s =======================\n",
+    );
+
+    let compressed = compress_if_beneficial_pub("pytest", &output);
+    assert!(count_tokens(&compressed) < count_tokens(&output));
+    assert!(compressed.contains("pytest PASSED lines folded"));
+    assert!(compressed.contains("80 passed"));
+}


### PR DESCRIPTION
## Summary

  Add a std-only Markdown compactor for aggressive reads that preserves heading
  topology while selecting high-signal body lines with deterministic IDF scoring.
  Wire it ahead of generic structured compaction for md/txt inputs.

  Fold repetitive shell progress output for cargo/pytest/package-manager logs while
  preserving warnings, errors, file spans, and final summaries.

  Benchmarks:
  - AGENTS.md: 29.4% smaller
  - README.md: 22.0% smaller
  - cargo sample: 254 → 163 tok, 35.8% saved

## Test plan

- [x] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

 - Risk areas / edge cases:
    - Markdown aggressive reads now route through the new deterministic compactor
      before generic structured compaction for `md/txt`; review heading/detail
      preservation on large docs.
    - Shell compression now folds repetitive cargo/pytest/progress lines; diagnostics,
      file spans, warnings/errors, and final summaries should remain intact.
    - Folding intentionally skips small runs to avoid noisy/inflating output.

  - Backwards compatibility:
    - No external dependencies added; pure Rust/std-only.
    - Verbatim/full/lines read modes unchanged.
    - Existing shell safety/adversarial tests pass; diagnostic preservation remains
      enforced.

  - Docs updated (links/files):
    - No user-facing docs updated.
    - Added test coverage in `rust/tests/compression_improvements.rs`.