### PR TITLE
feat(mcp): migrate RMCP SDK 1.7 -> 2.0 (MCP 2025-11-25 alignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   mental model; covered by a CLI characterization test.
 
 ### Changed
+- **RMCP SDK upgraded `1.7 → 2.0` (MCP `2025-11-25` alignment, #656).** The MCP
+  server/client stack now builds on rmcp 2.0: `Content` is the spec-unified
+  `ContentBlock`, prompt roles use the shared `Role`, resources are plain
+  `Resource` structs, and progress notifications use the new constructor API.
+  Pulls in rmcp 2.0's security fixes (OAuth resource-spoofing/metadata-SSRF
+  hardening, streamable-HTTP session-leak fix) and unlocks 2025-11-25 protocol
+  features (tool icons, URL-mode elicitation, tasks) for future releases.
+  Protocol negotiation with older clients (`2025-06-18` and earlier) is
+  unchanged — verified end-to-end over stdio against the 1.7 baseline (identical
+  tool surface, identical negotiated protocol). Client-facing roots-based
+  project-root auto-detection stays in place (SEP-2577 deprecation
+  acknowledged upstream, still fully functional).
 - Refreshed bundled addon pins to current upstream: Headroom `0.27.0 → 0.28.0`,
   Repomix `1.15.0 → 1.16.0`.
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4049,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64",
@@ -4082,9 +4082,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -150,7 +150,7 @@ tree-sitter = [
 wasm = ["dep:wasmi"]
 
 [dependencies]
-rmcp = { version = "1.7", features = [
+rmcp = { version = "2", features = [
   "server",
   "client",
   "transport-io",

--- a/rust/src/server/call_tool.rs
+++ b/rust/src/server/call_tool.rs
@@ -82,7 +82,7 @@ impl LeanCtxServer {
                 if let Some(reason) = active.egress.check_content(&payload, &active.redaction) {
                     tracing::warn!(tool = name, %reason, "agent egress blocked by policy");
                     policy_guard::audit_egress(name, &reason);
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "[POLICY BLOCKED] {kind} blocked by context policy pack egress rule \
                          ({reason}). Adjust .lean-ctx/policy.toml to proceed."
                     ))]));
@@ -92,7 +92,7 @@ impl LeanCtxServer {
                 {
                     tracing::warn!(tool = name, max, "agent egress rate limit exceeded");
                     policy_guard::audit_egress(name, "rate-limit");
-                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                    return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                         "[POLICY BLOCKED] {kind} rate limit exceeded ({max}/min) by context \
                          policy pack. Slow agent writes/actions or adjust .lean-ctx/policy.toml."
                     ))]));
@@ -116,7 +116,7 @@ impl LeanCtxServer {
                         let mut shown = allowed.clone();
                         shown.sort();
                         shown.truncate(30);
-                        return Ok(CallToolResult::success(vec![Content::text(format!(
+                        return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                             "Tool '{name}' blocked by workflow '{}' (state: {}). Allowed: {}. Use ctx_workflow(action=\"stop\") to exit.",
                             run.spec.name,
                             run.current,
@@ -244,7 +244,7 @@ impl LeanCtxServer {
 
         if throttle_result.level == crate::core::loop_detection::ThrottleLevel::Blocked {
             let msg = throttle_result.message.unwrap_or_default();
-            return Ok(CallToolResult::success(vec![Content::text(msg)]));
+            return Ok(CallToolResult::success(vec![ContentBlock::text(msg)]));
         }
 
         let throttle_warning =
@@ -282,7 +282,7 @@ impl LeanCtxServer {
 
         if let Some(msg) = post_process::budget_exhausted_message(name) {
             tracing::warn!(tool = name, "{msg}");
-            return Ok(CallToolResult::success(vec![Content::text(msg)]));
+            return Ok(CallToolResult::success(vec![ContentBlock::text(msg)]));
         }
 
         if is_shell_tool_name(name) {
@@ -1001,6 +1001,10 @@ impl LeanCtxServer {
     /// Resolve project root from MCP client roots (once per session).
     /// Called on the first tool call. If the client supports `roots/list`,
     /// we query it and pick the best root with project markers.
+    ///
+    /// Roots is SEP-2577-deprecated in rmcp 2.0 but still fully functional; we
+    /// keep it for client-driven project-root auto-detection until MCP removes it.
+    #[expect(deprecated)]
     async fn resolve_roots_once(&self) {
         use std::sync::atomic::Ordering;
         if !self.has_client_roots.load(Ordering::Relaxed) {
@@ -1087,7 +1091,7 @@ fn finalize_call_result(
     result_text: String,
     shell_outcome: Option<crate::server::tool_trait::ShellOutcome>,
 ) -> CallToolResult {
-    let mut result = CallToolResult::success(vec![Content::text(result_text)]);
+    let mut result = CallToolResult::success(vec![ContentBlock::text(result_text)]);
     if let Some(outcome) = shell_outcome {
         if outcome.is_error() {
             result.is_error = Some(true);

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -26,7 +26,7 @@ use futures::FutureExt;
 use rmcp::ErrorData;
 use rmcp::handler::server::ServerHandler;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, Implementation, InitializeRequestParams,
+    CallToolRequestParams, CallToolResult, ContentBlock, Implementation, InitializeRequestParams,
     InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};

--- a/rust/src/server/permission_inheritance.rs
+++ b/rust/src/server/permission_inheritance.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::sync::{Mutex, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 use serde_json::{Map, Value};
 
 use crate::core::config::{Config, PermissionInheritance};
@@ -223,7 +223,7 @@ fn load_policy(client_id: &str, project_root: Option<&str>) -> IdePermissionPoli
 #[must_use]
 pub fn into_call_tool_result(check: &PermissionCheck) -> Option<CallToolResult> {
     if check.blocked {
-        Some(CallToolResult::success(vec![Content::text(
+        Some(CallToolResult::success(vec![ContentBlock::text(
             check
                 .message
                 .clone()

--- a/rust/src/server/policy_guard.rs
+++ b/rust/src/server/policy_guard.rs
@@ -11,7 +11,7 @@
 //! - **No self-lockout:** the `EXEMPT_TOOLS` meta tools can never be
 //!   policy-denied, so an operator can always switch roles/policies back out.
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use crate::core::policy::runtime::{self, ActivePolicy};
 
@@ -91,7 +91,7 @@ fn evaluate(active: Option<&ActivePolicy>, tool_name: &str) -> PolicyCheckResult
 
 pub fn into_call_tool_result(check: &PolicyCheckResult) -> Option<CallToolResult> {
     check.blocked.then(|| {
-        CallToolResult::success(vec![Content::text(
+        CallToolResult::success(vec![ContentBlock::text(
             check
                 .message
                 .as_deref()

--- a/rust/src/server/progress.rs
+++ b/rust/src/server/progress.rs
@@ -15,12 +15,14 @@ impl ProgressSender {
     }
 
     pub fn send(&self, progress: f64, total: Option<f64>, message: Option<String>) {
-        let params = ProgressNotificationParam {
-            progress_token: self.token.clone(),
-            progress,
-            total,
-            message,
-        };
+        // ProgressNotificationParam is #[non_exhaustive] since rmcp 2.0 — build via ctor.
+        let mut params = ProgressNotificationParam::new(self.token.clone(), progress);
+        if let Some(total) = total {
+            params = params.with_total(total);
+        }
+        if let Some(message) = message {
+            params = params.with_message(message);
+        }
         let peer = self.peer.clone();
         tokio::spawn(async move {
             if let Err(e) = peer.notify_progress(params).await {

--- a/rust/src/server/prompts.rs
+++ b/rust/src/server/prompts.rs
@@ -1,6 +1,5 @@
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, Prompt, PromptArgument, PromptMessage,
-    PromptMessageRole,
+    GetPromptRequestParams, GetPromptResult, Prompt, PromptArgument, PromptMessage, Role,
 };
 
 fn required_arg(name: &str, desc: &str) -> PromptArgument {
@@ -93,10 +92,7 @@ fn get_context_focus(
         ledger.entries.len(),
         pressure.utilization * 100.0,
     );
-    GetPromptResult::new(vec![PromptMessage::new_text(
-        PromptMessageRole::Assistant,
-        msg,
-    )])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::Assistant, msg)])
 }
 
 fn get_context_review(ledger: &crate::core::context_ledger::ContextLedger) -> GetPromptResult {
@@ -110,15 +106,12 @@ fn get_context_review(ledger: &crate::core::context_ledger::ContextLedger) -> Ge
         "Context Review:\n{summary}\nAdjusted savings: {adjusted} tokens\n{bounce_info}\n\n\
          Use ctx_metrics() for detailed breakdown or ctx_plan(task=\"review context state\") for mode recommendations.",
     );
-    GetPromptResult::new(vec![PromptMessage::new_text(
-        PromptMessageRole::Assistant,
-        msg,
-    )])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::Assistant, msg)])
 }
 
 fn get_context_reset() -> GetPromptResult {
     GetPromptResult::new(vec![PromptMessage::new_text(
-        PromptMessageRole::Assistant,
+        Role::Assistant,
         "Reset context: Use ctx_control(action=\"reset\") to clear all overlays and reset ledger states.",
     )])
 }
@@ -127,10 +120,7 @@ fn get_context_pin(path: &str) -> GetPromptResult {
     let msg = format!(
         "Pin file: Use ctx_control(action=\"pin\", target=\"{path}\") to keep this file in full context regardless of pressure."
     );
-    GetPromptResult::new(vec![PromptMessage::new_text(
-        PromptMessageRole::Assistant,
-        msg,
-    )])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::Assistant, msg)])
 }
 
 fn get_context_budget(tokens: &str) -> GetPromptResult {
@@ -138,10 +128,7 @@ fn get_context_budget(tokens: &str) -> GetPromptResult {
         "Set budget: Configure the context window to {tokens} tokens. \
          Use ctx_session(action=\"budget\", value=\"{tokens}\") or set LCTX_CONTEXT_BUDGET={tokens} in your environment."
     );
-    GetPromptResult::new(vec![PromptMessage::new_text(
-        PromptMessageRole::Assistant,
-        msg,
-    )])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::Assistant, msg)])
 }
 
 #[cfg(test)]

--- a/rust/src/server/resources.rs
+++ b/rust/src/server/resources.rs
@@ -1,4 +1,4 @@
-use rmcp::model::{Annotated, RawResource, Resource, ResourceContents};
+use rmcp::model::{Resource, ResourceContents};
 
 const URI_SUMMARY: &str = "lean-ctx://context/summary";
 const URI_PINNED: &str = "lean-ctx://context/pinned";
@@ -51,10 +51,9 @@ pub fn read_resource(
 }
 
 fn make_resource(uri: &str, name: &str, desc: &str) -> Resource {
-    let raw = RawResource::new(uri, name)
+    Resource::new(uri, name)
         .with_description(desc)
-        .with_mime_type("text/plain");
-    Annotated::new(raw, None)
+        .with_mime_type("text/plain")
 }
 
 fn build_summary(ledger: &crate::core::context_ledger::ContextLedger) -> String {

--- a/rust/src/server/role_guard.rs
+++ b/rust/src/server/role_guard.rs
@@ -3,7 +3,7 @@
 //! Checks the active role's tool policy before dispatching a tool call.
 //! Returns `Some(CallToolResult)` with a denial message if blocked, `None` if allowed.
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use crate::core::roles;
 
@@ -120,7 +120,7 @@ pub fn check_tool_access(tool_name: &str) -> RoleCheckResult {
 
 pub fn into_call_tool_result(check: &RoleCheckResult) -> Option<CallToolResult> {
     if check.blocked {
-        Some(CallToolResult::success(vec![Content::text(
+        Some(CallToolResult::success(vec![ContentBlock::text(
             check.message.as_deref().unwrap_or("Blocked by role policy"),
         )]))
     } else {

--- a/rust/src/server/server_handler.rs
+++ b/rust/src/server/server_handler.rs
@@ -562,7 +562,7 @@ impl ServerHandler for LeanCtxServer {
                     detector.record_error_outcome(&tool_name_for_panic, &args_fp_for_panic);
                 }
 
-                Ok(CallToolResult::error(vec![Content::text(
+                Ok(CallToolResult::error(vec![ContentBlock::text(
                     "ERROR: lean-ctx internal error. The MCP server is still running. \
                      Please retry or use a different approach."
                         .to_string(),

--- a/rust/tests/gateway_e2e.rs
+++ b/rust/tests/gateway_e2e.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
+    CallToolRequestParams, CallToolResult, ContentBlock, ListToolsResult, PaginatedRequestParams,
     ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
@@ -86,7 +86,7 @@ impl ServerHandler for EchoServer {
         std::future::ready(match request.name.as_ref() {
             "echo" => {
                 let text = args.get("text").and_then(|v| v.as_str()).unwrap_or("");
-                Ok(CallToolResult::success(vec![Content::text(format!(
+                Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                     "echo:{text}"
                 ))]))
             }
@@ -99,7 +99,7 @@ impl ServerHandler for EchoServer {
                     .get("b")
                     .and_then(serde_json::Value::as_i64)
                     .unwrap_or(0);
-                Ok(CallToolResult::success(vec![Content::text(
+                Ok(CallToolResult::success(vec![ContentBlock::text(
                     (a + b).to_string(),
                 )]))
             }


### PR DESCRIPTION
Closes #656. Implements the migration decided in the #640 evaluation.

## Summary
- Bump `rmcp`/`rmcp-macros` `1.7.0 -> 2.0.0`.
- Adapt to the MCP `2025-11-25` model API: `Content` -> unified `ContentBlock`, `PromptMessageRole` -> shared `Role`, resources as plain `Resource` structs (no more `Annotated<RawResource>`), progress notifications via the non-exhaustive-safe constructor, SEP-2577 roots deprecation acknowledged at our single call site (roots-based project-root auto-detection stays — still fully functional).
- Pulls in rmcp 2.0 security fixes: OAuth resource spoofing (#937), OAuth metadata SSRF (#935), streamable-HTTP session leak (#934) — we ship both streamable-HTTP transports.
- Unlocks 2025-11-25 features for future work: tool icons (SEP-973), URL-mode elicitation (SEP-1036), tasks.

## Verification (all done locally before this PR)
- `cargo build`: clean, 0 warnings.
- `cargo clippy --all-targets -- -D warnings`: clean.
- Full `cargo test`: **132 suites, 8122 tests, 0 failed**.
- **Real MCP stdio E2E**, run against both the 1.7 baseline (same base commit) and the 2.0 build, with isolated `$HOME`:
  - `initialize` with older protocol `2025-06-18` -> negotiated identically on both,
  - `tools/list` -> **byte-identical JSON** between 1.7 and 2.0,
  - real `tools/call ctx_read` -> identical content.

## Risk / rollback
Single squash commit; revert restores rmcp 1.7 wholesale. No config, no persisted-state, and no wire-format changes (proven by the baseline diff).

Made with [Cursor](https://cursor.com)