### PR TITLE
feat(addons,docs): qmd + memgraph-ingester installable; context-infrastructure docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   asserts every runnable bundled addon carries a capability block.
 
 ### Added
+- **Addon registry: `qmd` + `memgraph-ingester` (Context Hub, GL#1134).** Two
+  community tools from the Discord retrieval thread are now 1-command installs:
+  `qmd` (on-device Markdown/notes search — BM25 + vectors + reranking, via
+  `npx -y @tobilu/qmd@2.5.3 mcp`) and `memgraph-ingester` (structure-aware RAG
+  on a Memgraph code graph, via `uvx memgraph-ingester-mcp==0.6.6`; needs a
+  running Memgraph). Both ship scrubbed-env capability blocks; the memgraph
+  Bolt-URI/read-only toggles joined the reviewed env passthrough allowlist.
+- **Docs: the context-infrastructure map (GL#1135).** New
+  `docs/guides/context-infrastructure.md` (sources → one pipeline → hybrid
+  retrieval → OKF/ctxpkg portability → addons) and
+  `docs/guides/dense-backends.md` documenting the previously undocumented
+  Qdrant dense backend (`LEANCTX_DENSE_BACKEND`, `LEANCTX_QDRANT_URL`/`_API_KEY`
+  /`_TIMEOUT_SECS`/`_COLLECTION_PREFIX`) next to the default in-process store.
 - **Portable OKF knowledge export/import** (`knowledge export --format okf` /
   `knowledge import <dir>`, `ctx_knowledge`). Renders facts, patterns and typed
   relations from one shared `KnowledgeSnapshot` to the vendor-neutral Open

--- a/docs/comparisons/vs-naive-rag.md
+++ b/docs/comparisons/vs-naive-rag.md
@@ -110,5 +110,7 @@ different jobs; for coding agents, structure and the two-halves pipeline win.
 ---
 
 *See also: [How retrieval works](https://leanctx.com/docs/concepts/how-retrieval-works),
+[Context Infrastructure](../guides/context-infrastructure.md),
+[Dense Backends (local / Qdrant)](../guides/dense-backends.md),
 [Knowledge Formats](../guides/knowledge-formats.md),
 [lean-ctx vs Mem0](vs-mem0.md), [lean-ctx vs claude-context](vs-claude-context.md).*

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -117,11 +117,13 @@ lean-ctx setup
 
 ## More Resources
 
+- [Context Infrastructure — the big picture](context-infrastructure.md)
 - [Extending lean-ctx — which mechanism to use](extensions.md)
 - [Addons — Community Extensions](addons.md)
 - [Embed lean-ctx (Rust SDK)](embed-sdk.md)
 - [Monorepo Guide](monorepo.md)
 - [Custom Embedding Models](custom-embeddings.md)
+- [Dense Backends (local / Qdrant)](dense-backends.md)
 - [Context Policy Packs](policy-packs.md)
 - [Org Single Sign-On (OIDC) Setup](org-sso-setup.md)
 - [Getting Started](https://leanctx.com/docs/getting-started)

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -120,6 +120,8 @@ registry validator, so upstream can't change under you silently.
 |---|---|---|---|
 | `repomix` | **yes** (runner) | `npx -y repomix@1.15.0 --mcp` | — |
 | `serena` | **yes** (runner) | `uvx --from serena-agent==1.5.3 serena start-mcp-server` | — |
+| `qmd` | **yes** (runner) | `npx -y @tobilu/qmd@2.5.3 mcp` — register folders first (`qmd collection add`) | — |
+| `memgraph-ingester` | **yes** (runner) | `uvx --from memgraph-ingester-mcp==0.6.6 memgraph-ingester-mcp` | needs a running Memgraph (`MEMGRAPH_INGESTER_MCP_BOLT_URI`) |
 | `sequential-thinking` | **yes** (runner) | `npx -y @modelcontextprotocol/server-sequential-thinking@…` | — |
 | `everything` | **yes** (runner) | `npx -y @modelcontextprotocol/server-everything@…` | — |
 | `headroom` | **yes** (`[install]`) | `uv tool install headroom-ai[mcp]==0.27.0` → `headroom mcp serve` | — |

--- a/docs/guides/context-infrastructure.md
+++ b/docs/guides/context-infrastructure.md
@@ -1,0 +1,90 @@
+# lean-ctx as Context Infrastructure
+
+lean-ctx is more than a file-read compressor: it is the **infrastructure layer
+between your agents and everything they need to know**. This page is the map of
+that layer — which sources flow in, what one shared pipeline does with them, how
+retrieval gets them back out, and where the escape hatches are. Every capability
+below exists today; each section links to its reference.
+
+```text
+ SOURCES                    ONE PIPELINE                     RETRIEVAL
+ ─────────                  ────────────                     ─────────
+ repo files      ┐                                     ┌─ ctx_search (BM25)
+ linked repos    │   chunk → index → consolidate       ├─ ctx_search --semantic
+ docs/artifacts  ├──▶ BM25 + SPLADE + dense vectors ──▶├─   (hybrid: RRF + rerank)
+ GitHub/GitLab   │   + code graph + knowledge facts    ├─ ctx_multi_repo
+ Jira/Postgres   │                                     ├─ ctx_graph / ctx_callgraph
+ any MCP server  ┘                                     └─ ctx_knowledge
+                                                            │
+                          PORTABILITY: OKF (Markdown) · signed .ctxpkg
+                          EXTENSION:   addons behind the gateway
+```
+
+## Sources — what flows in
+
+| Source | How it enters | Reference |
+|---|---|---|
+| **The repo** | tree-sitter AST chunking (20+ languages), incremental BM25 + embedding index | [How retrieval works](https://leanctx.com/docs/concepts/how-retrieval-works) |
+| **More repos** | `ctx_multi_repo` roots, or linked workspace projects fused into one result list | [Monorepo guide](monorepo.md) |
+| **Docs & artifacts** | project doc folders declared in `.lean-ctx-artifacts.json`, indexed separately from code | `ctx_search action=semantic artifacts=true` |
+| **Issue trackers & DBs** | first-class providers: GitHub, GitLab, Jira, Postgres schema | `lean-ctx provider …`, `ctx_provider` |
+| **Any MCP server** | the MCP bridge provider + gateway addons | [Addons](addons.md) |
+
+Provider results don't just pass through: with `providers.auto_index = true`
+they are **consolidated** — chunked into the BM25 index, linked into the code
+graph, distilled into knowledge facts. An issue that references `src/auth.rs`
+becomes findable from the file, and vice versa.
+
+## Retrieval — one hybrid engine, not one signal
+
+Every retrieval surface runs the same engine: lexical **BM25** + learned-sparse
+**SPLADE** + **dense vectors** from a local ONNX model, fused with **Reciprocal
+Rank Fusion**, sharpened by code-aware reranking and graph spreading activation.
+No external embedding API, no index-build marathon — and each piece degrades
+gracefully (cold dense index → BM25 floor, never a failed query).
+
+Two dials matter in practice:
+
+- **The embedding model is swappable** — any HuggingFace ONNX export via
+  `[embedding].model = "hf:org/repo@rev"`, including code-specialized models.
+  See [Custom Embedding Models](custom-embeddings.md).
+- **The vector store is swappable** — in-process by default, or delegate dense
+  search to a self-hosted Qdrant. See [Dense Backends](dense-backends.md).
+
+The quality floor is measurable, not asserted: the benchmark scorecard
+(recall@5/10, MRR, determinism digest) ships with the repo.
+
+## Memory — what the layer learns
+
+Sessions distill into **knowledge**: facts, patterns, decisions and typed
+relations per project (`ctx_knowledge`, `ctx_session`). Retrieval consults this
+store alongside code — and it is never locked in:
+
+- **[OKF](okf-interop.md)** — export/import the knowledge base as vendor-neutral,
+  git-diffable Markdown (one concept per file, relations as links).
+- **[ctxpkg](knowledge-formats.md)** — the same snapshot as a signed, verifiable
+  bundle for distribution.
+
+## Extension — when you want more than the core
+
+The core stays local and lean on purpose. Heavier machinery — external RAG
+stacks, graph databases, specialized doc search — plugs in as
+**[addons](addons.md)** behind the gateway instead of bloating the binary:
+one `lean-ctx addon add <name>`, and the tool's MCP surface joins your agent's
+toolbox with scrubbed env, pinned versions and typed output adapters.
+
+Examples from the registry relevant to this page: `qmd` (local Markdown/notes
+search), `memgraph-ingester` (structure-aware RAG on a Memgraph code graph),
+`cognee` (GraphRAG knowledge graphs).
+
+## Design commitments
+
+1. **Local first.** Embeddings, indexes and knowledge live on your machine
+   unless you explicitly point them elsewhere.
+2. **Deterministic outputs.** Tool output is a pure function of content + mode,
+   which keeps provider prompt caches hot (#498).
+3. **The right half of the pipeline.** Compress what fits into the window;
+   retrieve only what doesn't. See [lean-ctx vs naive
+   RAG](../comparisons/vs-naive-rag.md) for when a dedicated vector DB is
+   genuinely the better tool.
+4. **No lock-in.** Everything the layer accumulates leaves as OKF or ctxpkg.

--- a/docs/guides/dense-backends.md
+++ b/docs/guides/dense-backends.md
@@ -1,0 +1,70 @@
+# Dense Backends — where your vectors live
+
+The dense (embedding) half of lean-ctx's hybrid retriever needs a vector store.
+By default that store is **in-process and on disk** — no service, no container,
+nothing to operate. For teams that already run a vector database, lean-ctx can
+delegate dense search to it instead.
+
+| Backend | Runs where | Setup | Best for |
+|---|---|---|---|
+| **local** (default) | inside the lean-ctx process, persisted next to the BM25 index | none | individuals and most teams — zero-ops, deterministic |
+| **qdrant** | your [Qdrant](https://qdrant.tech) server (self-hosted or cloud) | `LEANCTX_QDRANT_URL` | fleets sharing one index, corpora beyond one machine's RAM |
+
+Both backends consume the **same embedding pipeline** — the local ONNX model
+selected via [`[embedding].model`](custom-embeddings.md) produces the vectors;
+only the storage and the nearest-neighbor search move. BM25, SPLADE, RRF fusion
+and reranking are unaffected by the backend choice.
+
+## Selecting a backend
+
+```bash
+# Explicit
+export LEANCTX_DENSE_BACKEND=local    # default
+export LEANCTX_DENSE_BACKEND=qdrant
+
+# Implicit: setting a Qdrant URL selects the qdrant backend automatically
+export LEANCTX_QDRANT_URL=http://127.0.0.1:6333
+```
+
+An unknown value fails fast with a clear error rather than silently falling
+back — retrieval quality should never degrade without you noticing.
+
+## Qdrant configuration
+
+```bash
+export LEANCTX_QDRANT_URL=http://127.0.0.1:6333   # required
+export LEANCTX_QDRANT_API_KEY=…                   # optional (Qdrant Cloud / secured instances)
+export LEANCTX_QDRANT_TIMEOUT_SECS=10             # optional, default 10
+export LEANCTX_QDRANT_COLLECTION_PREFIX=lctx_code_ # optional, default shown
+```
+
+- **Collections are per project and per model dimension** — the collection name
+  is derived from the project root's namespace hash and the embedding model's
+  vector width, so switching models can never mix incompatible vectors.
+- **Sync is incremental.** On each dense search lean-ctx upserts only chunks of
+  files that changed since the last sync (delete-by-file, then re-upsert). A
+  fresh collection is populated once.
+- **The build stays quiet.** The `qdrant` build feature is enabled in release
+  binaries; requesting the backend without the feature produces an explicit
+  error, not a silent local fallback.
+
+Run a local Qdrant for testing:
+
+```bash
+docker run -p 6333:6333 qdrant/qdrant
+LEANCTX_QDRANT_URL=http://127.0.0.1:6333 lean-ctx search --semantic "auth flow"
+```
+
+## What stays true regardless of backend
+
+- Embeddings are produced **locally** (ONNX; swappable via
+  [`hf:org/repo`](custom-embeddings.md)) — no embedding API, no per-token fees.
+- The lexical BM25 floor is always available: if the dense backend is
+  unreachable, hybrid search degrades to BM25 with a warning instead of failing
+  the query.
+- Chunk identity is content-derived, so re-indexing an unchanged corpus is a
+  no-op on the store.
+
+*See also: [Context Infrastructure](context-infrastructure.md),
+[Custom Embedding Models](custom-embeddings.md),
+[lean-ctx vs naive RAG](../comparisons/vs-naive-rag.md).*

--- a/rust/data/addon_registry.json
+++ b/rust/data/addon_registry.json
@@ -188,6 +188,47 @@
     },
     {
       "addon": {
+        "name": "memgraph-ingester",
+        "display_name": "Memgraph Ingester",
+        "description": "Structure-aware RAG for 150+ languages: the memgraph-ingester CLI parses a codebase into a Memgraph code graph with project memory; this addon wires its MCP server (uvx memgraph-ingester-mcp) into the lean-ctx gateway for high-level graph queries. Needs a running Memgraph instance (e.g. Docker) plus a graph built with the ingester CLI — set MEMGRAPH_INGESTER_MCP_BOLT_URI to your Bolt endpoint.",
+        "author": "ousatov-ua",
+        "homepage": "https://github.com/ousatov-ua/memgraph-ingester",
+        "license": "MIT",
+        "categories": ["code-intelligence", "memory"],
+        "integration": "code-graph",
+        "keywords": ["knowledge-graph", "rag", "memgraph", "ast", "memory", "community", "mcp"],
+        "min_lean_ctx": "3.8.0"
+      },
+      "mcp": {
+        "transport": "stdio",
+        "command": "uvx",
+        "args": ["--from", "memgraph-ingester-mcp==0.6.6", "memgraph-ingester-mcp"],
+        "env": { "MEMGRAPH_INGESTER_MCP_BOLT_URI": "bolt://localhost:7687" }
+      },
+      "capabilities": { "network": "full", "filesystem": "read_write", "env": ["MEMGRAPH_INGESTER_MCP_BOLT_URI", "MEMGRAPH_INGESTER_MCP_READ_ONLY"] }
+    },
+    {
+      "addon": {
+        "name": "qmd",
+        "display_name": "QMD (Query Markup Documents)",
+        "description": "On-device search engine for markdown notes, meeting transcripts, docs and knowledge bases — BM25 + vector search + LLM re-ranking, fully local via node-llama-cpp GGUF models. Register folders as collections (qmd collection add), then agents search them through its MCP server (qmd mcp) wired into the lean-ctx gateway.",
+        "author": "tobi",
+        "homepage": "https://github.com/tobi/qmd",
+        "license": "MIT",
+        "categories": ["search", "memory"],
+        "integration": "none",
+        "keywords": ["markdown", "notes", "semantic-search", "bm25", "local", "community", "mcp"],
+        "min_lean_ctx": "3.8.0"
+      },
+      "mcp": {
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@tobilu/qmd@2.5.3", "mcp"]
+      },
+      "capabilities": { "network": "full", "filesystem": "read_write", "env": [] }
+    },
+    {
+      "addon": {
         "name": "claude-context",
         "display_name": "Claude Context",
         "description": "Semantic code search over an entire codebase (hybrid BM25 + dense vectors) via @zilliz/claude-context-mcp. Needs a Milvus/Zilliz vector database and an embedding API key to run, so it is listed rather than auto-installed.",

--- a/rust/src/core/addons/registry.rs
+++ b/rust/src/core/addons/registry.rs
@@ -242,7 +242,20 @@ mod tests {
         // (e.g. cognee needs `LLM_API_KEY`). Any name outside this allowlist must
         // be justified with an explicit review entry here, so a new addon can
         // never silently widen the host-secret surface.
-        const REVIEWED_ADDON_ENV: &[&str] = &["LLM_API_KEY"];
+        //
+        // Review log:
+        // - `LLM_API_KEY` — cognee BYO key (a secret, but explicitly the user's
+        //   own key for the addon to use).
+        // - `MEMGRAPH_INGESTER_MCP_BOLT_URI` / `MEMGRAPH_INGESTER_MCP_READ_ONLY`
+        //   — memgraph-ingester connection settings (a local Bolt endpoint URL
+        //   and a boolean toggle). Not host secrets; passing them through lets
+        //   users point the addon at a non-default Memgraph without editing the
+        //   installed gateway entry.
+        const REVIEWED_ADDON_ENV: &[&str] = &[
+            "LLM_API_KEY",
+            "MEMGRAPH_INGESTER_MCP_BOLT_URI",
+            "MEMGRAPH_INGESTER_MCP_READ_ONLY",
+        ];
         for m in bundled() {
             if !m.is_installable() {
                 continue; // listed-only entries are never spawned


### PR DESCRIPTION
Part of #664 (Context Hub epic; GL#1134 + GL#1135).

## Summary
- **Addon registry**: `qmd` 2.5.3 (on-device Markdown/notes search, `npx -y @tobilu/qmd@2.5.3 mcp`) and `memgraph-ingester` (structure-aware RAG on a Memgraph code graph, `uvx --from memgraph-ingester-mcp==0.6.6 memgraph-ingester-mcp`) become 1-command installs with scrubbed-env capability blocks. The two non-secret memgraph connection vars (`MEMGRAPH_INGESTER_MCP_BOLT_URI`, `…_READ_ONLY`) join the reviewed env passthrough allowlist with a review-log entry.
- **Docs**: new `docs/guides/context-infrastructure.md` (sources → one pipeline → hybrid retrieval → OKF/ctxpkg portability → addons) and `docs/guides/dense-backends.md` — first documentation of the Qdrant dense backend env surface (`LEANCTX_DENSE_BACKEND`, `LEANCTX_QDRANT_URL/_API_KEY/_TIMEOUT_SECS/_COLLECTION_PREFIX`). Cross-links from vs-naive-rag, guides index, addons wiring table.

## Test plan
- [x] `cargo test --lib addons::` — 143 passed (incl. env-scrub regression + registry security bar)
- [x] `cargo clippy --lib -- -D warnings` clean; pre-commit ran `--all-targets`
- [x] `scripts/check-addon-versions.py` — both pins resolve, 0 outdated (qmd 2.5.3 = npm latest, memgraph-ingester-mcp 0.6.6 = PyPI latest)

Made with [Cursor](https://cursor.com)