### PR TITLE
feat(dense): pgvector backend — vectors in your own PostgreSQL (GL#1136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   asserts every runnable bundled addon carries a capability block.
 
 ### Added
+- **pgvector dense backend (Context Hub, GL#1136).** Teams that already operate
+  PostgreSQL can point the dense half of hybrid retrieval at it:
+  `LEANCTX_PGVECTOR_URL=postgres://…` (or `LEANCTX_DENSE_BACKEND=pgvector`)
+  stores embeddings in per-project, per-dimension `vector(N)` tables — same
+  namespacing, point-id scheme and delete-by-file incremental sync as the
+  qdrant backend, so switching backends never mixes identities. Implemented
+  through the `psql` CLI (zero new crate dependencies, mirrors the postgres
+  provider); rows return as per-line JSON for robust parsing; identifiers and
+  literals are strictly validated/escaped. The `qdrant` + `pgvector` features
+  join the default feature set, so release binaries support all three backends
+  out of the box; a live end-to-end test (`pgvector_e2e_round_trip`, `--ignored`)
+  verifies table creation, cosine search, incremental replace and quote-escaping
+  against a real pgvector container. Guide: `docs/guides/dense-backends.md`.
 - **Addon registry: `qmd` + `memgraph-ingester` (Context Hub, GL#1134).** Two
   community tools from the Discord retrieval thread are now 1-command installs:
   `qmd` (on-device Markdown/notes search — BM25 + vectors + reranking, via

--- a/docs/guides/dense-backends.md
+++ b/docs/guides/dense-backends.md
@@ -9,6 +9,7 @@ delegate dense search to it instead.
 |---|---|---|---|
 | **local** (default) | inside the lean-ctx process, persisted next to the BM25 index | none | individuals and most teams — zero-ops, deterministic |
 | **qdrant** | your [Qdrant](https://qdrant.tech) server (self-hosted or cloud) | `LEANCTX_QDRANT_URL` | fleets sharing one index, corpora beyond one machine's RAM |
+| **pgvector** | your PostgreSQL with the [pgvector](https://github.com/pgvector/pgvector) extension | `LEANCTX_PGVECTOR_URL` + `psql` client | orgs that already operate Postgres and want vectors under existing backup/HA/access policies |
 
 Both backends consume the **same embedding pipeline** — the local ONNX model
 selected via [`[embedding].model`](custom-embeddings.md) produces the vectors;
@@ -21,9 +22,12 @@ and reranking are unaffected by the backend choice.
 # Explicit
 export LEANCTX_DENSE_BACKEND=local    # default
 export LEANCTX_DENSE_BACKEND=qdrant
+export LEANCTX_DENSE_BACKEND=pgvector
 
-# Implicit: setting a Qdrant URL selects the qdrant backend automatically
+# Implicit: setting a backend URL selects that backend automatically
 export LEANCTX_QDRANT_URL=http://127.0.0.1:6333
+export LEANCTX_PGVECTOR_URL=postgres://user:pass@127.0.0.1:5432/leanctx
+# (if both URLs are set, qdrant wins — set LEANCTX_DENSE_BACKEND to override)
 ```
 
 An unknown value fails fast with a clear error rather than silently falling
@@ -44,15 +48,46 @@ export LEANCTX_QDRANT_COLLECTION_PREFIX=lctx_code_ # optional, default shown
 - **Sync is incremental.** On each dense search lean-ctx upserts only chunks of
   files that changed since the last sync (delete-by-file, then re-upsert). A
   fresh collection is populated once.
-- **The build stays quiet.** The `qdrant` build feature is enabled in release
-  binaries; requesting the backend without the feature produces an explicit
-  error, not a silent local fallback.
+- **The build stays quiet.** The `qdrant` and `pgvector` build features are part
+  of the default feature set (so release binaries have them); requesting a
+  backend whose feature was compiled out produces an explicit error, not a
+  silent local fallback.
 
 Run a local Qdrant for testing:
 
 ```bash
 docker run -p 6333:6333 qdrant/qdrant
 LEANCTX_QDRANT_URL=http://127.0.0.1:6333 lean-ctx search --semantic "auth flow"
+```
+
+## pgvector configuration
+
+```bash
+export LEANCTX_PGVECTOR_URL=postgres://user:pass@127.0.0.1:5432/leanctx  # required
+export LEANCTX_PGVECTOR_TIMEOUT_SECS=10                                  # optional, default 10
+export LEANCTX_PGVECTOR_TABLE_PREFIX=lctx_code_                          # optional, default shown
+```
+
+- **Talks through the `psql` CLI** — no native driver, no async runtime added to
+  lean-ctx. The PostgreSQL client tools must be on `PATH` (macOS:
+  `brew install libpq`, Debian/Ubuntu: `apt install postgresql-client`).
+- **Tables are per project and per model dimension** (same namespacing rule as
+  qdrant collections): `lctx_code_<namespace-hash>_d<dims>`, created on first
+  use together with `CREATE EXTENSION IF NOT EXISTS vector`. The database user
+  needs extension-create rights once (or a DBA pre-installs the extension).
+- **Same incremental sync** — delete-by-file then re-upsert for changed files,
+  one full upsert for a fresh table. Point ids are identical to the qdrant
+  scheme, so backend switches never mix identities.
+- **Search is exact** (`ORDER BY embedding <=> query`) — correct at any corpus
+  size, and you can add an HNSW/IVFFlat index in Postgres later without any
+  lean-ctx change.
+
+Run a local pgvector Postgres for testing:
+
+```bash
+docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=lctx pgvector/pgvector:pg16
+LEANCTX_PGVECTOR_URL=postgres://postgres:lctx@127.0.0.1:5432/postgres \
+  lean-ctx search --semantic "auth flow"
 ```
 
 ## What stays true regardless of backend

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -84,6 +84,10 @@ default = [
   "team-server",
   "secure-update",
   "jemalloc",
+  # Remote dense backends ship in release binaries so LEANCTX_QDRANT_URL /
+  # LEANCTX_PGVECTOR_URL work out of the box (both are env-gated at runtime).
+  "qdrant",
+  "pgvector",
 ]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 dev-tools = []
@@ -103,6 +107,7 @@ http-server = [
   "dep:rustls",
 ]
 qdrant = ["embeddings"]
+pgvector = ["embeddings"]
 team-server = ["http-server"]
 # Self-hostable org gateway (proxy remote-bind + usage store + admin API).
 # LOCAL_OPTIONAL: free, gated by compilation only — never by account/license/plan

--- a/rust/src/core/dense_backend.rs
+++ b/rust/src/core/dense_backend.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::core::bm25_index::BM25Index;
-#[cfg(feature = "qdrant")]
+#[cfg(any(feature = "qdrant", feature = "pgvector"))]
 use crate::core::bm25_index::ChunkKind;
 use crate::core::hnsw::FlatEmbeddings;
 use crate::core::hybrid_search::{DenseSearchResult, HybridConfig, HybridResult};
@@ -11,6 +11,8 @@ pub enum DenseBackendKind {
     Local,
     #[cfg(feature = "qdrant")]
     Qdrant,
+    #[cfg(feature = "pgvector")]
+    Pgvector,
 }
 
 impl DenseBackendKind {
@@ -22,8 +24,12 @@ impl DenseBackendKind {
 
         let inferred_qdrant =
             std::env::var("LEANCTX_QDRANT_URL").is_ok_and(|v| !v.trim().is_empty());
+        let inferred_pgvector =
+            std::env::var("LEANCTX_PGVECTOR_URL").is_ok_and(|v| !v.trim().is_empty());
 
-        let requested = explicit.or_else(|| inferred_qdrant.then_some("qdrant".to_string()));
+        let requested = explicit
+            .or_else(|| inferred_qdrant.then_some("qdrant".to_string()))
+            .or_else(|| inferred_pgvector.then_some("pgvector".to_string()));
 
         match requested.as_deref() {
             None | Some("local") => Ok(Self::Local),
@@ -37,8 +43,18 @@ impl DenseBackendKind {
                     Err("Dense backend 'qdrant' requested, but feature 'qdrant' is not enabled. Rebuild with --features qdrant.".to_string())
                 }
             }
+            Some("pgvector") => {
+                #[cfg(feature = "pgvector")]
+                {
+                    Ok(Self::Pgvector)
+                }
+                #[cfg(not(feature = "pgvector"))]
+                {
+                    Err("Dense backend 'pgvector' requested, but feature 'pgvector' is not enabled. Rebuild with --features pgvector.".to_string())
+                }
+            }
             Some(other) => Err(format!(
-                "Unknown LEANCTX_DENSE_BACKEND={other:?} (expected 'local' or 'qdrant')"
+                "Unknown LEANCTX_DENSE_BACKEND={other:?} (expected 'local', 'qdrant' or 'pgvector')"
             )),
         }
     }
@@ -48,6 +64,8 @@ impl DenseBackendKind {
             Self::Local => "local",
             #[cfg(feature = "qdrant")]
             Self::Qdrant => "qdrant",
+            #[cfg(feature = "pgvector")]
+            Self::Pgvector => "pgvector",
         }
     }
 }
@@ -129,41 +147,85 @@ pub fn hybrid_results(
             Ok(results)
         }
         #[cfg(feature = "qdrant")]
-        DenseBackendKind::Qdrant => {
-            let bm25_k = config.bm25_candidates.max(top_k);
-            let dense_k = config.dense_candidates.max(top_k);
-
-            let mut bm25 = index.search(query, bm25_k);
-            if let Some(pred) = filter {
-                bm25.retain(|r| pred(&r.file_path));
-            }
-
-            let dense = dense_results(
-                backend,
-                root,
-                index,
-                engine,
-                aligned_embeddings,
-                changed_files,
-                query,
-                dense_k,
-                filter,
-            )?;
-
-            let mut fused = crate::core::hybrid_search::reciprocal_rank_fusion(
-                &bm25,
-                &dense,
-                config,
-                top_k,
-                graph_file_ranks,
-            );
-            if let Some(pred) = filter {
-                fused.retain(|r| pred(&r.file_path));
-            }
-            fused.truncate(top_k);
-            Ok(fused)
-        }
+        DenseBackendKind::Qdrant => remote_hybrid_results(
+            backend,
+            root,
+            index,
+            engine,
+            aligned_embeddings,
+            changed_files,
+            query,
+            top_k,
+            config,
+            filter,
+            graph_file_ranks,
+        ),
+        #[cfg(feature = "pgvector")]
+        DenseBackendKind::Pgvector => remote_hybrid_results(
+            backend,
+            root,
+            index,
+            engine,
+            aligned_embeddings,
+            changed_files,
+            query,
+            top_k,
+            config,
+            filter,
+            graph_file_ranks,
+        ),
     }
+}
+
+/// Shared BM25+dense RRF pipeline for remote vector backends (qdrant, pgvector):
+/// the backends differ only in where `dense_results` fetches from.
+#[cfg(all(feature = "embeddings", any(feature = "qdrant", feature = "pgvector")))]
+#[allow(clippy::too_many_arguments)]
+fn remote_hybrid_results(
+    backend: DenseBackendKind,
+    root: &Path,
+    index: &BM25Index,
+    engine: &crate::core::embeddings::EmbeddingEngine,
+    aligned_embeddings: &FlatEmbeddings,
+    changed_files: &[String],
+    query: &str,
+    top_k: usize,
+    config: &HybridConfig,
+    filter: Option<&dyn Fn(&str) -> bool>,
+    graph_file_ranks: Option<&std::collections::HashMap<String, usize>>,
+) -> Result<Vec<HybridResult>, String> {
+    let bm25_k = config.bm25_candidates.max(top_k);
+    let dense_k = config.dense_candidates.max(top_k);
+
+    let mut bm25 = index.search(query, bm25_k);
+    if let Some(pred) = filter {
+        bm25.retain(|r| pred(&r.file_path));
+    }
+
+    let dense = dense_results(
+        backend,
+        root,
+        index,
+        engine,
+        aligned_embeddings,
+        changed_files,
+        query,
+        dense_k,
+        filter,
+    )?;
+
+    let mut fused = crate::core::hybrid_search::reciprocal_rank_fusion(
+        &bm25,
+        &dense,
+        config,
+        top_k,
+        graph_file_ranks,
+    );
+    if let Some(pred) = filter {
+        fused.retain(|r| pred(&r.file_path));
+    }
+    fused.truncate(top_k);
+    Ok(fused)
 }
 
 #[cfg(feature = "embeddings")]
@@ -190,6 +252,22 @@ fn dense_results(
                 .map(|i| aligned_embeddings.get_vec(i))
                 .collect();
             dense_results_qdrant(
+                root,
+                index,
+                engine,
+                &vecs,
+                changed_files,
+                query,
+                top_k,
+                filter,
+            )
+        }
+        #[cfg(feature = "pgvector")]
+        DenseBackendKind::Pgvector => {
+            let vecs: Vec<Vec<f32>> = (0..aligned_embeddings.n_vectors())
+                .map(|i| aligned_embeddings.get_vec(i))
+                .collect();
+            dense_results_pgvector(
                 root,
                 index,
                 engine,
@@ -350,7 +428,58 @@ fn dense_results_qdrant(
     Ok(out)
 }
 
-#[cfg(feature = "qdrant")]
+#[cfg(feature = "pgvector")]
+#[cfg(feature = "embeddings")]
+#[allow(clippy::too_many_arguments)]
+fn dense_results_pgvector(
+    root: &Path,
+    index: &BM25Index,
+    engine: &crate::core::embeddings::EmbeddingEngine,
+    aligned_embeddings: &[Vec<f32>],
+    changed_files: &[String],
+    query: &str,
+    top_k: usize,
+    filter: Option<&dyn Fn(&str) -> bool>,
+) -> Result<Vec<DenseSearchResult>, String> {
+    let store = crate::core::pgvector_store::PgvectorStore::from_env()?;
+    let table = store.table_name(root, engine.dimensions())?;
+    let created_new = store.ensure_table(&table, engine.dimensions())?;
+    store.sync_index(
+        &table,
+        index,
+        aligned_embeddings,
+        changed_files,
+        created_new,
+    )?;
+
+    let query_vec = engine
+        .embed_query(query)
+        .map_err(|e| format!("embedding failed: {e}"))?;
+
+    let hits = store.search(&table, &query_vec, top_k)?;
+    let mut out = Vec::with_capacity(hits.len());
+    for hit in hits {
+        if let Some(pred) = filter
+            && !pred(&hit.file_path)
+        {
+            continue;
+        }
+        let snippet = snippet_from_disk(root, &hit.file_path, hit.start_line, hit.end_line, 5);
+        out.push(DenseSearchResult {
+            chunk_idx: 0,
+            similarity: hit.score,
+            file_path: hit.file_path,
+            symbol_name: hit.symbol_name,
+            kind: hit.kind,
+            start_line: hit.start_line,
+            end_line: hit.end_line,
+            snippet,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(any(feature = "qdrant", feature = "pgvector"))]
 fn snippet_from_disk(
     root: &Path,
     rel_path: &str,
@@ -377,7 +506,7 @@ fn snippet_from_disk(
     slice.join("\n")
 }
 
-#[cfg(feature = "qdrant")]
+#[cfg(any(feature = "qdrant", feature = "pgvector"))]
 pub(crate) fn kind_to_str(kind: &ChunkKind) -> &'static str {
     match kind {
         ChunkKind::Function => "Function",
@@ -397,7 +526,7 @@ pub(crate) fn kind_to_str(kind: &ChunkKind) -> &'static str {
     }
 }
 
-#[cfg(feature = "qdrant")]
+#[cfg(any(feature = "qdrant", feature = "pgvector"))]
 pub(crate) fn kind_from_str(s: &str) -> ChunkKind {
     match s {
         "Function" => ChunkKind::Function,
@@ -420,10 +549,6 @@ pub(crate) fn kind_from_str(s: &str) -> ChunkKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
     fn set_env(key: &str, value: Option<&str>) -> Option<String> {
         let old = std::env::var(key).ok();
         match value {
@@ -442,20 +567,22 @@ mod tests {
 
     #[test]
     fn dense_backend_defaults_to_local() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::core::data_dir::test_env_lock();
         let old_backend = set_env("LEANCTX_DENSE_BACKEND", None);
         let old_url = set_env("LEANCTX_QDRANT_URL", None);
+        let old_pg = set_env("LEANCTX_PGVECTOR_URL", None);
 
         let got = DenseBackendKind::try_from_env().unwrap();
         assert_eq!(got, DenseBackendKind::Local);
 
         restore_env("LEANCTX_DENSE_BACKEND", old_backend);
         restore_env("LEANCTX_QDRANT_URL", old_url);
+        restore_env("LEANCTX_PGVECTOR_URL", old_pg);
     }
 
     #[test]
     fn dense_backend_unknown_value_errors() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::core::data_dir::test_env_lock();
         let old_backend = set_env("LEANCTX_DENSE_BACKEND", Some("wat"));
         let old_url = set_env("LEANCTX_QDRANT_URL", None);
 
@@ -469,26 +596,79 @@ mod tests {
     #[cfg(feature = "qdrant")]
     #[test]
     fn dense_backend_infers_qdrant_from_url() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::core::data_dir::test_env_lock();
         let old_backend = set_env("LEANCTX_DENSE_BACKEND", None);
         let old_url = set_env("LEANCTX_QDRANT_URL", Some("http://127.0.0.1:6333"));
+        let old_pg = set_env("LEANCTX_PGVECTOR_URL", None);
 
         let got = DenseBackendKind::try_from_env().unwrap();
         assert_eq!(got, DenseBackendKind::Qdrant);
 
         restore_env("LEANCTX_DENSE_BACKEND", old_backend);
         restore_env("LEANCTX_QDRANT_URL", old_url);
+        restore_env("LEANCTX_PGVECTOR_URL", old_pg);
+    }
+
+    #[cfg(feature = "pgvector")]
+    #[test]
+    fn dense_backend_infers_pgvector_from_url() {
+        let _g = crate::core::data_dir::test_env_lock();
+        let old_backend = set_env("LEANCTX_DENSE_BACKEND", None);
+        let old_url = set_env("LEANCTX_QDRANT_URL", None);
+        let old_pg = set_env("LEANCTX_PGVECTOR_URL", Some("postgres://localhost/lctx"));
+
+        let got = DenseBackendKind::try_from_env().unwrap();
+        assert_eq!(got, DenseBackendKind::Pgvector);
+
+        restore_env("LEANCTX_DENSE_BACKEND", old_backend);
+        restore_env("LEANCTX_QDRANT_URL", old_url);
+        restore_env("LEANCTX_PGVECTOR_URL", old_pg);
+    }
+
+    #[cfg(all(feature = "qdrant", feature = "pgvector"))]
+    #[test]
+    fn dense_backend_qdrant_wins_when_both_urls_set() {
+        let _g = crate::core::data_dir::test_env_lock();
+        let old_backend = set_env("LEANCTX_DENSE_BACKEND", None);
+        let old_url = set_env("LEANCTX_QDRANT_URL", Some("http://127.0.0.1:6333"));
+        let old_pg = set_env("LEANCTX_PGVECTOR_URL", Some("postgres://localhost/lctx"));
+
+        let got = DenseBackendKind::try_from_env().unwrap();
+        assert_eq!(got, DenseBackendKind::Qdrant);
+
+        // Explicit selection overrides inference order.
+        crate::test_env::set_var("LEANCTX_DENSE_BACKEND", "pgvector");
+        let got = DenseBackendKind::try_from_env().unwrap();
+        assert_eq!(got, DenseBackendKind::Pgvector);
+
+        restore_env("LEANCTX_DENSE_BACKEND", old_backend);
+        restore_env("LEANCTX_QDRANT_URL", old_url);
+        restore_env("LEANCTX_PGVECTOR_URL", old_pg);
     }
 
     #[cfg(not(feature = "qdrant"))]
     #[test]
     fn dense_backend_qdrant_requires_feature() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::core::data_dir::test_env_lock();
         let old_backend = set_env("LEANCTX_DENSE_BACKEND", Some("qdrant"));
         let old_url = set_env("LEANCTX_QDRANT_URL", None);
 
         let err = DenseBackendKind::try_from_env().unwrap_err();
         assert!(err.contains("feature 'qdrant' is not enabled"));
+
+        restore_env("LEANCTX_DENSE_BACKEND", old_backend);
+        restore_env("LEANCTX_QDRANT_URL", old_url);
+    }
+
+    #[cfg(not(feature = "pgvector"))]
+    #[test]
+    fn dense_backend_pgvector_requires_feature() {
+        let _g = crate::core::data_dir::test_env_lock();
+        let old_backend = set_env("LEANCTX_DENSE_BACKEND", Some("pgvector"));
+        let old_url = set_env("LEANCTX_QDRANT_URL", None);
+
+        let err = DenseBackendKind::try_from_env().unwrap_err();
+        assert!(err.contains("feature 'pgvector' is not enabled"));
 
         restore_env("LEANCTX_DENSE_BACKEND", old_backend);
         restore_env("LEANCTX_QDRANT_URL", old_url);

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -199,6 +199,8 @@ pub mod embedding_quant;
 pub mod embeddings;
 pub mod energy;
 pub mod hybrid_search;
+#[cfg(feature = "pgvector")]
+pub mod pgvector_store;
 #[cfg(feature = "qdrant")]
 pub mod qdrant_store;
 pub mod search_reranking;

--- a/rust/src/core/pgvector_store.rs
+++ b/rust/src/core/pgvector_store.rs
@@ -1,0 +1,536 @@
+//! Optional pgvector (PostgreSQL) backend for dense (embedding) search.
+//!
+//! This module is behind the `pgvector` feature flag. It mirrors the
+//! `qdrant_store` API (namespaced per-project tables, md5-derived point ids,
+//! delete-by-file + upsert incremental sync) but talks to a self-hosted
+//! PostgreSQL instance with the `vector` extension installed.
+//!
+//! Deliberately dependency-free: SQL is executed through the `psql` CLI —
+//! the same pattern the postgres context provider uses — so no async runtime
+//! or native driver enters the dependency tree. Row output is read as
+//! one JSON object per line (`json_build_object(...)::text`), which is robust
+//! against arbitrary characters in file paths and symbol names.
+
+use std::collections::HashSet;
+use std::io::Write as _;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::core::bm25_index::{BM25Index, CodeChunk};
+
+#[derive(Debug, Clone)]
+pub struct PgvectorConfig {
+    /// PostgreSQL connection string (postgres://user:pass@host:port/db).
+    pub url: String,
+    /// Connect timeout for each psql invocation (seconds).
+    pub timeout_secs: u64,
+    /// Table name prefix; the project namespace hash and dimensions are appended.
+    pub table_prefix: String,
+}
+
+impl PgvectorConfig {
+    pub fn from_env() -> Result<Self, String> {
+        let url = std::env::var("LEANCTX_PGVECTOR_URL")
+            .map_err(|_| "LEANCTX_PGVECTOR_URL is required for pgvector backend".to_string())?;
+        let url = url.trim().to_string();
+        if url.is_empty() {
+            return Err("LEANCTX_PGVECTOR_URL is required for pgvector backend".to_string());
+        }
+
+        let timeout_secs = std::env::var("LEANCTX_PGVECTOR_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(10);
+
+        let table_prefix = std::env::var("LEANCTX_PGVECTOR_TABLE_PREFIX")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "lctx_code_".to_string());
+        validate_pg_identifier_prefix(&table_prefix)?;
+
+        Ok(Self {
+            url,
+            timeout_secs,
+            table_prefix,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PgvectorStore {
+    cfg: PgvectorConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct PgvectorHit {
+    pub score: f32,
+    pub file_path: String,
+    pub symbol_name: String,
+    pub kind: crate::core::bm25_index::ChunkKind,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct PgRow {
+    score: f32,
+    file_path: String,
+    symbol_name: String,
+    kind: String,
+    start_line: usize,
+    end_line: usize,
+}
+
+impl PgvectorStore {
+    pub fn from_env() -> Result<Self, String> {
+        let cfg = PgvectorConfig::from_env()?;
+        Ok(Self { cfg })
+    }
+
+    /// Namespaced table name for a project root at given dimensionality.
+    /// Mirrors `QdrantStore::collection_name` (prefix + namespace hash + dims).
+    pub fn table_name(&self, root: &Path, dimensions: usize) -> Result<String, String> {
+        let ns = crate::core::index_namespace::namespace_hash(root);
+        let name = format!("{}{}_d{}", self.cfg.table_prefix, ns, dimensions);
+        if name.len() > 63 {
+            return Err(format!(
+                "pgvector table name exceeds PostgreSQL's 63-byte identifier limit: {name}"
+            ));
+        }
+        Ok(name)
+    }
+
+    /// Ensure the extension + table exist. Returns `true` if the table was created.
+    pub fn ensure_table(&self, table: &str, dimensions: usize) -> Result<bool, String> {
+        let existed = self.table_exists(table)?;
+        if existed {
+            return Ok(false);
+        }
+        let sql = format!(
+            "CREATE EXTENSION IF NOT EXISTS vector;\n\
+             CREATE TABLE IF NOT EXISTS {table} (\n\
+               id BIGINT PRIMARY KEY,\n\
+               file_path TEXT NOT NULL,\n\
+               symbol_name TEXT NOT NULL,\n\
+               kind TEXT NOT NULL,\n\
+               start_line BIGINT NOT NULL,\n\
+               end_line BIGINT NOT NULL,\n\
+               embedding vector({dimensions}) NOT NULL\n\
+             );\n\
+             CREATE INDEX IF NOT EXISTS {table}_file_idx ON {table} (file_path);"
+        );
+        self.run_sql(&sql)?;
+        Ok(true)
+    }
+
+    /// Same incremental semantics as the qdrant backend: fresh table gets a
+    /// full upsert; otherwise changed files are replaced (delete + upsert).
+    pub fn sync_index(
+        &self,
+        table: &str,
+        index: &BM25Index,
+        aligned_embeddings: &[Vec<f32>],
+        changed_files: &[String],
+        created_new: bool,
+    ) -> Result<(), String> {
+        if index.chunks.len() != aligned_embeddings.len() {
+            return Err("embedding alignment length mismatch".to_string());
+        }
+
+        if created_new {
+            return self.upsert_filtered(table, index, aligned_embeddings, None);
+        }
+
+        if changed_files.is_empty() {
+            return Ok(());
+        }
+
+        let mut unique: Vec<String> = changed_files.to_vec();
+        unique.sort();
+        unique.dedup();
+
+        for file in &unique {
+            self.delete_by_file(table, file)?;
+        }
+
+        let changed_set: HashSet<&str> = unique.iter().map(String::as_str).collect();
+        self.upsert_filtered(table, index, aligned_embeddings, Some(&changed_set))
+    }
+
+    pub fn search(
+        &self,
+        table: &str,
+        query_vec: &[f32],
+        limit: usize,
+    ) -> Result<Vec<PgvectorHit>, String> {
+        let vec_literal = vector_literal(query_vec);
+        // Cosine distance operator `<=>`: similarity = 1 - distance.
+        let sql = format!(
+            "SELECT json_build_object(\
+               'score', 1 - (embedding <=> '{vec_literal}'::vector), \
+               'file_path', file_path, \
+               'symbol_name', symbol_name, \
+               'kind', kind, \
+               'start_line', start_line, \
+               'end_line', end_line\
+             )::text \
+             FROM {table} \
+             ORDER BY embedding <=> '{vec_literal}'::vector \
+             LIMIT {limit};"
+        );
+        let stdout = self.run_sql(&sql)?;
+
+        let mut out = Vec::new();
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let row: PgRow = serde_json::from_str(line)
+                .map_err(|e| format!("invalid pgvector row json: {e}"))?;
+            out.push(PgvectorHit {
+                score: row.score,
+                file_path: row.file_path,
+                symbol_name: row.symbol_name,
+                kind: crate::core::dense_backend::kind_from_str(&row.kind),
+                start_line: row.start_line,
+                end_line: row.end_line,
+            });
+        }
+        Ok(out)
+    }
+
+    fn table_exists(&self, table: &str) -> Result<bool, String> {
+        let literal = sql_string_literal(table)?;
+        let out = self.run_sql(&format!("SELECT to_regclass({literal}) IS NOT NULL;"))?;
+        Ok(out.trim() == "t")
+    }
+
+    /// Upsert all chunks (or only those whose file is in `changed_set`),
+    /// batched to keep individual statements bounded.
+    fn upsert_filtered(
+        &self,
+        table: &str,
+        index: &BM25Index,
+        aligned_embeddings: &[Vec<f32>],
+        changed_set: Option<&HashSet<&str>>,
+    ) -> Result<(), String> {
+        let mut batch: Vec<String> = Vec::new();
+        for (i, chunk) in index.chunks.iter().enumerate() {
+            if let Some(set) = changed_set
+                && !set.contains(chunk.file_path.as_str())
+            {
+                continue;
+            }
+            let vec = aligned_embeddings
+                .get(i)
+                .ok_or_else(|| "embedding alignment missing".to_string())?;
+            batch.push(values_row_for_chunk(chunk, vec)?);
+            if batch.len() >= UPSERT_BATCH_ROWS {
+                self.upsert_rows(table, &batch)?;
+                batch.clear();
+            }
+        }
+        if !batch.is_empty() {
+            self.upsert_rows(table, &batch)?;
+        }
+        Ok(())
+    }
+
+    fn upsert_rows(&self, table: &str, rows: &[String]) -> Result<(), String> {
+        let sql = format!(
+            "INSERT INTO {table} (id, file_path, symbol_name, kind, start_line, end_line, embedding)\n\
+             VALUES\n{}\n\
+             ON CONFLICT (id) DO UPDATE SET\n\
+               file_path = EXCLUDED.file_path,\n\
+               symbol_name = EXCLUDED.symbol_name,\n\
+               kind = EXCLUDED.kind,\n\
+               start_line = EXCLUDED.start_line,\n\
+               end_line = EXCLUDED.end_line,\n\
+               embedding = EXCLUDED.embedding;",
+            rows.join(",\n")
+        );
+        self.run_sql(&sql).map(|_| ())
+    }
+
+    fn delete_by_file(&self, table: &str, file_path: &str) -> Result<(), String> {
+        let literal = sql_string_literal(file_path)?;
+        self.run_sql(&format!("DELETE FROM {table} WHERE file_path = {literal};"))
+            .map(|_| ())
+    }
+
+    /// Run SQL through `psql` via a temp file (`-f`) so statement size is not
+    /// limited by ARG_MAX. Returns stdout (tuples-only, unaligned).
+    fn run_sql(&self, sql: &str) -> Result<String, String> {
+        let mut tmp = tempfile::NamedTempFile::new()
+            .map_err(|e| format!("pgvector: temp file failed: {e}"))?;
+        tmp.write_all(sql.as_bytes())
+            .map_err(|e| format!("pgvector: temp write failed: {e}"))?;
+        tmp.flush()
+            .map_err(|e| format!("pgvector: temp flush failed: {e}"))?;
+
+        let output = std::process::Command::new("psql")
+            .arg(&self.cfg.url)
+            .args(["-X", "-q", "-v", "ON_ERROR_STOP=1", "-t", "-A", "-f"])
+            .arg(tmp.path())
+            .env("PGCONNECT_TIMEOUT", self.cfg.timeout_secs.to_string())
+            .output()
+            .map_err(|e| {
+                format!("pgvector: failed to run psql (is the PostgreSQL client installed?): {e}")
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("pgvector: psql error: {}", stderr.trim()));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+const UPSERT_BATCH_ROWS: usize = 256;
+
+/// One `(id, 'file', 'symbol', 'kind', start, end, '[...]'::vector)` row.
+fn values_row_for_chunk(chunk: &CodeChunk, vector: &[f32]) -> Result<String, String> {
+    let id = point_id_for_chunk(chunk) as i64; // BIGINT: deterministic wrap of the u64 hash
+    let file = sql_string_literal(&chunk.file_path)?;
+    let symbol = sql_string_literal(&chunk.symbol_name)?;
+    let kind = sql_string_literal(crate::core::dense_backend::kind_to_str(&chunk.kind))?;
+    Ok(format!(
+        "({id}, {file}, {symbol}, {kind}, {}, {}, '{}'::vector)",
+        chunk.start_line,
+        chunk.end_line,
+        vector_literal(vector)
+    ))
+}
+
+/// Identical id scheme to `qdrant_store::point_id_for_chunk` so a project can
+/// switch backends without changing point identity semantics.
+fn point_id_for_chunk(chunk: &CodeChunk) -> u64 {
+    use md5::{Digest, Md5};
+    let mut h = Md5::new();
+    h.update(chunk.file_path.as_bytes());
+    h.update(chunk.start_line.to_le_bytes());
+    h.update(chunk.end_line.to_le_bytes());
+    h.update(chunk.symbol_name.as_bytes());
+    h.update(crate::core::dense_backend::kind_to_str(&chunk.kind).as_bytes());
+    let out = h.finalize();
+    u64::from_le_bytes(out[0..8].try_into().unwrap_or([0u8; 8]))
+}
+
+/// pgvector input format: `[0.1,0.2,...]`.
+fn vector_literal(vector: &[f32]) -> String {
+    let mut s = String::with_capacity(vector.len() * 10 + 2);
+    s.push('[');
+    for (i, v) in vector.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        // `{v}` for f32 is locale-independent and round-trips through Postgres real parsing.
+        s.push_str(&format!("{v}"));
+    }
+    s.push(']');
+    s
+}
+
+/// Standard SQL single-quoted literal with `'` doubling. Rejects NUL bytes
+/// (PostgreSQL cannot store them in TEXT anyway) and backslashes are safe
+/// because standard_conforming_strings is on by default since PostgreSQL 9.1.
+fn sql_string_literal(s: &str) -> Result<String, String> {
+    if s.contains('\0') {
+        return Err("pgvector: NUL byte in string".to_string());
+    }
+    Ok(format!("'{}'", s.replace('\'', "''")))
+}
+
+/// The table prefix is interpolated into SQL identifiers; enforce the same
+/// whitelist the postgres provider uses for schema names.
+fn validate_pg_identifier_prefix(name: &str) -> Result<(), String> {
+    let valid_start = name
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
+    let valid_rest = name
+        .chars()
+        .skip(1)
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$');
+    if name.is_empty() || name.len() > 40 || !valid_start || !valid_rest {
+        return Err(format!(
+            "Invalid LEANCTX_PGVECTOR_TABLE_PREFIX: {name:?} (allowed: [A-Za-z_][A-Za-z0-9_$]*, max 40 chars)"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::bm25_index::ChunkKind;
+
+    fn chunk(file: &str, name: &str, start: usize, end: usize, kind: ChunkKind) -> CodeChunk {
+        CodeChunk {
+            file_path: file.to_string(),
+            symbol_name: name.to_string(),
+            kind,
+            start_line: start,
+            end_line: end,
+            content: "fn x() {}".to_string(),
+            tokens: vec![],
+            token_count: 0,
+        }
+    }
+
+    #[test]
+    fn point_id_matches_qdrant_scheme_and_is_stable() {
+        let c = chunk("src/main.rs", "main", 1, 10, ChunkKind::Function);
+        assert_eq!(point_id_for_chunk(&c), point_id_for_chunk(&c));
+        let c2 = chunk("src/main.rs", "main", 2, 10, ChunkKind::Function);
+        assert_ne!(point_id_for_chunk(&c), point_id_for_chunk(&c2));
+    }
+
+    #[test]
+    fn sql_string_literal_escapes_quotes() {
+        assert_eq!(sql_string_literal("a'b").unwrap(), "'a''b'");
+        assert_eq!(sql_string_literal("plain").unwrap(), "'plain'");
+        assert!(sql_string_literal("nul\0byte").is_err());
+    }
+
+    #[test]
+    fn vector_literal_is_bracketed_csv() {
+        assert_eq!(vector_literal(&[0.5, -1.0, 2.0]), "[0.5,-1,2]");
+        assert_eq!(vector_literal(&[]), "[]");
+    }
+
+    #[test]
+    fn values_row_contains_escaped_fields() {
+        let c = chunk("src/a'b.rs", "fn'x", 3, 9, ChunkKind::Method);
+        let row = values_row_for_chunk(&c, &[0.25, 0.75]).unwrap();
+        assert!(row.contains("'src/a''b.rs'"));
+        assert!(row.contains("'fn''x'"));
+        assert!(row.contains("'Method'"));
+        assert!(row.contains("'[0.25,0.75]'::vector"));
+    }
+
+    #[test]
+    fn table_prefix_validation() {
+        assert!(validate_pg_identifier_prefix("lctx_code_").is_ok());
+        assert!(validate_pg_identifier_prefix("with space").is_err());
+        assert!(validate_pg_identifier_prefix("1leading_digit").is_err());
+        assert!(validate_pg_identifier_prefix("drop;table").is_err());
+        assert!(validate_pg_identifier_prefix("").is_err());
+    }
+
+    #[test]
+    fn config_requires_url() {
+        let _env = crate::core::data_dir::test_env_lock();
+        crate::test_env::remove_var("LEANCTX_PGVECTOR_URL");
+        assert!(PgvectorConfig::from_env().is_err());
+
+        crate::test_env::set_var("LEANCTX_PGVECTOR_URL", "postgres://localhost/lctx");
+        crate::test_env::remove_var("LEANCTX_PGVECTOR_TABLE_PREFIX");
+        crate::test_env::remove_var("LEANCTX_PGVECTOR_TIMEOUT_SECS");
+        let cfg = PgvectorConfig::from_env().unwrap();
+        assert_eq!(cfg.url, "postgres://localhost/lctx");
+        assert_eq!(cfg.table_prefix, "lctx_code_");
+        assert_eq!(cfg.timeout_secs, 10);
+        crate::test_env::remove_var("LEANCTX_PGVECTOR_URL");
+    }
+
+    /// Real round-trip against a live PostgreSQL+pgvector instance.
+    /// Run explicitly (needs LEANCTX_PGVECTOR_URL + psql client on PATH):
+    ///   LEANCTX_PGVECTOR_URL=postgres://... cargo test --lib pgvector_e2e -- --ignored
+    #[test]
+    #[ignore = "requires live PostgreSQL with pgvector extension (set LEANCTX_PGVECTOR_URL)"]
+    fn pgvector_e2e_round_trip() {
+        let store = PgvectorStore::from_env().expect("LEANCTX_PGVECTOR_URL must be set");
+        let table = "lctx_e2e_round_trip_d3".to_string();
+        let _ = store.run_sql(&format!("DROP TABLE IF EXISTS {table};"));
+
+        // Fresh table + full upsert.
+        assert!(
+            store.ensure_table(&table, 3).unwrap(),
+            "table should be new"
+        );
+        assert!(
+            !store.ensure_table(&table, 3).unwrap(),
+            "second call sees it"
+        );
+
+        let mut index = BM25Index::new();
+        index
+            .chunks
+            .push(chunk("src/a.rs", "alpha", 1, 5, ChunkKind::Function));
+        index
+            .chunks
+            .push(chunk("src/b.rs", "beta", 10, 20, ChunkKind::Struct));
+        let embeddings = vec![vec![1.0, 0.0, 0.0], vec![0.0, 1.0, 0.0]];
+
+        store
+            .sync_index(&table, &index, &embeddings, &[], true)
+            .unwrap();
+
+        let hits = store.search(&table, &[1.0, 0.0, 0.0], 2).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].file_path, "src/a.rs");
+        assert_eq!(hits[0].symbol_name, "alpha");
+        assert!(hits[0].score > 0.99, "cosine sim of identical vec ~ 1.0");
+        assert_eq!(hits[0].kind, ChunkKind::Function);
+
+        // Incremental: b.rs changes (chunk moves), delete-by-file + re-upsert.
+        index.chunks[1] = chunk("src/b.rs", "beta", 30, 40, ChunkKind::Struct);
+        store
+            .sync_index(
+                &table,
+                &index,
+                &embeddings,
+                &["src/b.rs".to_string()],
+                false,
+            )
+            .unwrap();
+
+        let hits = store.search(&table, &[0.0, 1.0, 0.0], 2).unwrap();
+        assert_eq!(hits[0].file_path, "src/b.rs");
+        assert_eq!(hits[0].start_line, 30, "stale row was replaced");
+        assert_eq!(hits[0].end_line, 40);
+
+        // Escaping survives the round trip.
+        index
+            .chunks
+            .push(chunk("src/it's.rs", "q'uote", 2, 3, ChunkKind::Method));
+        let embeddings = vec![
+            vec![1.0, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0],
+        ];
+        store
+            .sync_index(
+                &table,
+                &index,
+                &embeddings,
+                &["src/it's.rs".to_string()],
+                false,
+            )
+            .unwrap();
+        let hits = store.search(&table, &[0.0, 0.0, 1.0], 1).unwrap();
+        assert_eq!(hits[0].file_path, "src/it's.rs");
+        assert_eq!(hits[0].symbol_name, "q'uote");
+
+        store.run_sql(&format!("DROP TABLE {table};")).unwrap();
+    }
+
+    #[test]
+    fn table_name_is_namespaced_and_bounded() {
+        let _env = crate::core::data_dir::test_env_lock();
+        crate::test_env::set_var("LEANCTX_PGVECTOR_URL", "postgres://localhost/lctx");
+        let store = PgvectorStore::from_env().unwrap();
+        let name = store
+            .table_name(Path::new("/tmp/some-project"), 384)
+            .unwrap();
+        assert!(name.starts_with("lctx_code_"));
+        assert!(name.ends_with("_d384"));
+        assert!(name.len() <= 63);
+        crate::test_env::remove_var("LEANCTX_PGVECTOR_URL");
+    }
+}


### PR DESCRIPTION
## Summary

Closes GL#1136 (Context Hub epic GL#1131, T5) — third dense backend next to `local` and `qdrant`.

- **`LEANCTX_PGVECTOR_URL=postgres://…`** (or `LEANCTX_DENSE_BACKEND=pgvector`) stores embeddings in per-project, per-dimension `vector(N)` tables inside an existing PostgreSQL with the [pgvector](https://github.com/pgvector/pgvector) extension.
- **Mirrors `qdrant_store` deliberately**: same namespace-hash table naming, same md5 point-id scheme (backend switches never mix identities), same delete-by-file + upsert incremental sync.
- **Zero new dependencies**: SQL goes through the `psql` CLI (same pattern as the postgres provider); rows return as per-line `json_build_object` — robust against arbitrary path/symbol characters. Identifiers whitelist-validated, literals quote-escaped, NUL rejected.
- **Shared hybrid arm**: `remote_hybrid_results()` now carries qdrant *and* pgvector (BM25 + remote dense + RRF).
- **`qdrant` + `pgvector` join default features** so release binaries support all three backends out of the box (env-gated at runtime; previously the docs claimed qdrant was in release binaries but it was not — now true).
- Guide: `docs/guides/dense-backends.md` (+ selection precedence when both URLs are set).

## Test plan

- [x] Unit: env/config parsing, backend selection precedence (qdrant wins on both URLs, explicit override), SQL literal escaping, vector literal, table-name bounds, id-scheme parity
- [x] Live E2E `pgvector_e2e_round_trip` (`--ignored`) against `pgvector/pgvector:pg16` container: extension+table creation, exact cosine ranking, incremental replace (delete-by-file), quote-escape round-trip — **ran locally, green**
- [x] `cargo test --lib` full suite: 6987 passed
- [x] `cargo clippy --all-features --lib --tests -- -D warnings` clean
