### PR TITLE
fix(dev-install): resolve cargo target dir dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (C2 — Managed) is surfaced from the README security section and Journey 13.
 
 ### Fixed
+- **`dev-install` honours redirected cargo target dirs (GH #671).** Both
+  `rust/dev-install.sh` and the `lean-ctx dev-install` command located the
+  built binary at a hardcoded `target/release/…`; with `CARGO_TARGET_DIR` or a
+  `~/.cargo/config.toml` `[build] target-dir` override (one shared build cache
+  across worktrees) they silently symlinked/installed a stale or missing
+  binary. The target dir is now resolved via `cargo metadata` (env, config
+  files and workspace settings all honoured) with a `./target` fallback, the
+  shell script fails loudly when the binary is absent instead of planting a
+  dead symlink on PATH, the Rust path gained the same resolution plus the
+  Windows `.exe` suffix, and `tests/pre_release_check.sh` follows suit.
+  Thanks [@getappz](https://github.com/getappz) for the report and the initial
+  fix (#672)!
 - **pi-lean-ctx ships with zero runtime npm dependencies (GH #670).** pi
   installs every package into one shared npm prefix and re-reifies the whole
   tree on each `pi install`/`pi remove`; an interrupted rewrite (Windows

--- a/rust/dev-install.sh
+++ b/rust/dev-install.sh
@@ -37,7 +37,16 @@ cargo build --release 2>&1 | tail -3
 
 # 3) Install
 mkdir -p "$INSTALL_DIR"
-TARGET="$(pwd)/target/release/lean-ctx"
+# Ask cargo for the real target dir — honours CARGO_TARGET_DIR and a
+# ~/.cargo/config.toml `[build] target-dir` override, not just the default
+# "./target" (a hardcoded path silently installed a stale binary here).
+TARGET_DIR=$(cargo metadata --no-deps --format-version=1 2>/dev/null \
+    | grep -o '"target_directory":"[^"]*"' \
+    | head -1 \
+    | sed -E 's/^"target_directory":"(.*)"$/\1/' \
+    | sed 's/\\\\/\//g')
+TARGET_DIR="${TARGET_DIR:-$(pwd)/target}"
+TARGET="${TARGET_DIR}/release/lean-ctx"
 TMP_LINK="${BINARY}.tmp.$$"
 ln -sf "$TARGET" "$TMP_LINK"
 mv -f "$TMP_LINK" "$BINARY"

--- a/rust/dev-install.sh
+++ b/rust/dev-install.sh
@@ -40,13 +40,21 @@ mkdir -p "$INSTALL_DIR"
 # Ask cargo for the real target dir — honours CARGO_TARGET_DIR and a
 # ~/.cargo/config.toml `[build] target-dir` override, not just the default
 # "./target" (a hardcoded path silently installed a stale binary here).
+# The `|| true` keeps `set -euo pipefail` from aborting before the fallback:
+# a failing `cargo metadata` (or unmatched grep) exits the pipeline non-zero.
 TARGET_DIR=$(cargo metadata --no-deps --format-version=1 2>/dev/null \
     | grep -o '"target_directory":"[^"]*"' \
     | head -1 \
     | sed -E 's/^"target_directory":"(.*)"$/\1/' \
-    | sed 's/\\\\/\//g')
+    | sed 's/\\\\/\//g' || true)
 TARGET_DIR="${TARGET_DIR:-$(pwd)/target}"
 TARGET="${TARGET_DIR}/release/lean-ctx"
+# Fail loudly instead of symlinking a missing/stale binary into PATH (#671).
+if [ ! -x "$TARGET" ]; then
+    printf "  error: built binary not found at %s\n" "$TARGET" >&2
+    printf "  hint: is CARGO_TARGET_DIR or ~/.cargo/config.toml [build] target-dir pointing elsewhere?\n" >&2
+    exit 1
+fi
 TMP_LINK="${BINARY}.tmp.$$"
 ln -sf "$TARGET" "$TMP_LINK"
 mv -f "$TMP_LINK" "$BINARY"

--- a/rust/src/cli/dispatch/lifecycle.rs
+++ b/rust/src/cli/dispatch/lifecycle.rs
@@ -151,11 +151,16 @@ pub(super) fn cmd_dev_install() {
         }
     }
 
-    let built_binary = cargo_root.join("target/release/lean-ctx");
+    let built_binary = resolve_cargo_target_dir(&cargo_root)
+        .join("release")
+        .join(format!("lean-ctx{}", std::env::consts::EXE_SUFFIX));
     if !built_binary.exists() {
         eprintln!(
             "  Error: Built binary not found at {}",
             built_binary.display()
+        );
+        eprintln!(
+            "  Hint: is CARGO_TARGET_DIR or a [build] target-dir override pointing elsewhere?"
         );
         std::process::exit(1);
     }
@@ -326,6 +331,39 @@ fn atomic_install_binary(src: &std::path::Path, dst: &std::path::Path) -> Result
     Ok(())
 }
 
+/// Resolve cargo's real target directory for the project at `cargo_root`.
+///
+/// A hardcoded `target/` breaks setups that redirect the target dir via
+/// `CARGO_TARGET_DIR` or a `~/.cargo/config.toml` `[build] target-dir`
+/// override (e.g. one shared build cache across worktrees, as recommended in
+/// CONTRIBUTING.md) — dev-install then silently installed a stale or missing
+/// binary (#671). `cargo metadata` is the canonical answer: it folds in env,
+/// config files and workspace settings. Runs under a hard timeout (cargo may
+/// touch the network lock) and falls back to `<root>/target` on any failure.
+fn resolve_cargo_target_dir(cargo_root: &std::path::Path) -> std::path::PathBuf {
+    use crate::ipc;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["metadata", "--no-deps", "--format-version=1"])
+        .current_dir(cargo_root);
+
+    ipc::process::run_with_timeout(cmd, std::time::Duration::from_secs(15))
+        .filter(|o| o.status.success())
+        .and_then(|o| target_dir_from_metadata(&String::from_utf8_lossy(&o.stdout)))
+        .unwrap_or_else(|| cargo_root.join("target"))
+}
+
+/// Extract `target_directory` from `cargo metadata` JSON. Split out from
+/// [`resolve_cargo_target_dir`] so the parsing is unit-testable without
+/// invoking cargo.
+fn target_dir_from_metadata(metadata_json: &str) -> Option<std::path::PathBuf> {
+    let value: serde_json::Value = serde_json::from_str(metadata_json).ok()?;
+    value
+        .get("target_directory")?
+        .as_str()
+        .map(std::path::PathBuf::from)
+}
+
 pub(super) fn find_cargo_project_root() -> Option<std::path::PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
     loop {
@@ -472,6 +510,48 @@ pub(super) fn spawn_proxy_if_needed() {
     match crate::ipc::process::spawn_detached(&mut cmd) {
         Ok(_) => tracing::info!("auto-started proxy on port {port}"),
         Err(e) => tracing::debug!("could not auto-start proxy: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod target_dir_tests {
+    use super::{resolve_cargo_target_dir, target_dir_from_metadata};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn extracts_target_directory_from_metadata_json() {
+        let json = r#"{"packages":[],"target_directory":"/shared/build/target","version":1}"#;
+        assert_eq!(
+            target_dir_from_metadata(json),
+            Some(PathBuf::from("/shared/build/target"))
+        );
+    }
+
+    #[test]
+    fn windows_paths_survive_json_unescaping() {
+        // serde_json decodes the escaped backslashes; no manual munging needed.
+        let json = r#"{"target_directory":"C:\\Users\\dev\\shared\\target"}"#;
+        assert_eq!(
+            target_dir_from_metadata(json),
+            Some(PathBuf::from(r"C:\Users\dev\shared\target"))
+        );
+    }
+
+    #[test]
+    fn malformed_or_incomplete_metadata_yields_none() {
+        assert_eq!(target_dir_from_metadata("not json"), None);
+        assert_eq!(target_dir_from_metadata("{}"), None);
+        assert_eq!(target_dir_from_metadata(r#"{"target_directory":42}"#), None);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_root_target_without_manifest() {
+        // No Cargo.toml at / — `cargo metadata` fails, the fallback must kick in.
+        let root = if cfg!(windows) { r"C:\" } else { "/" };
+        assert_eq!(
+            resolve_cargo_target_dir(Path::new(root)),
+            Path::new(root).join("target")
+        );
     }
 }
 

--- a/rust/tests/pre_release_check.sh
+++ b/rust/tests/pre_release_check.sh
@@ -4,7 +4,15 @@
 # Usage: cd rust && bash tests/pre_release_check.sh
 set -euo pipefail
 
-BIN="./target/release/lean-ctx"
+# Honour CARGO_TARGET_DIR / config.toml target-dir overrides (#671); fall back
+# to ./target when `cargo metadata` is unavailable. `|| true` keeps the
+# pipeline from tripping `set -euo pipefail` before the fallback applies.
+TARGET_DIR=$(cargo metadata --no-deps --format-version=1 2>/dev/null \
+    | grep -o '"target_directory":"[^"]*"' \
+    | head -1 \
+    | sed -E 's/^"target_directory":"(.*)"$/\1/' \
+    | sed 's/\\\\/\//g' || true)
+BIN="${TARGET_DIR:-./target}/release/lean-ctx"
 PASS=0
 FAIL=0
 


### PR DESCRIPTION
## Summary
- \`dev-install.sh\` hardcoded \`$(pwd)/target/release/lean-ctx\`, ignoring \`CARGO_TARGET_DIR\` / a \`~/.cargo/config.toml\` \`[build] target-dir\` override — silently installing a stale/missing binary on setups that redirect the target dir (e.g. sharing one build cache across worktrees, as noted in CONTRIBUTING.md's disk-usage section).
- Now resolves the real target dir via \`cargo metadata\` (honours env var, config.toml, and workspace settings), unescaping the JSON-escaped path for Windows-style paths. Falls back to \`./target\` if \`cargo metadata\` fails.

Fixes #671

## Test plan
- [x] \`bash -n dev-install.sh\` (syntax check)
- [x] Verified against a real \`~/.cargo/config.toml\` \`target-dir\` override on this machine — resolves to the configured dir and finds the built binary (previously would have pointed at a nonexistent \`./target/release/lean-ctx\`)
- [x] Confirmed the extracted path round-trips correctly with backslash-escaped (Windows) paths from \`cargo metadata\`'s JSON output