### PR TITLE
fix: pi-lean-ctx zero-dep vendor bundle (#670) + MCP fast-initialize (#669)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,9 @@ jobs:
             echo "npm already has pi-lean-ctx@${PKG_VERSION} — skipping publish."
             exit 0
           fi
+          # prepack builds the self-contained vendor bundle (esbuild devDep),
+          # so the published package ships with zero runtime dependencies (#670).
+          npm ci
           npm publish --access public
 
   update-homebrew:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   (C2 — Managed) is surfaced from the README security section and Journey 13.
 
 ### Fixed
+- **pi-lean-ctx ships with zero runtime npm dependencies (GH #670).** pi
+  installs every package into one shared npm prefix and re-reifies the whole
+  tree on each `pi install`/`pi remove`; an interrupted rewrite (Windows
+  AV/file locks) stranded `zod/v3/locales/en.js` and the extension failed to
+  load — unrepairable by reinstalling, because npm never re-extracts a package
+  whose version matches. The MCP SDK (incl. zod) is now vendored as one
+  self-contained bundle (`extensions/vendor/mcp-sdk.cjs`, built at `prepack`),
+  so no corruptible dependency tree exists in the first place. Verified by an
+  isolation smoke: bundle in an empty dir, real initialize + tools/list
+  roundtrip, plus a jiti-loaded co-install with `pi-markdown-preview`.
+- **MCP server answers `initialize` before doing housekeeping (GH #669).**
+  Orphan-process sweep (one `ps` per running lean-ctx), proxy autostart (TCP
+  probe + detached spawn) and the throttled savings-recap publish ran in front
+  of the stdio transport bind — on a cold WSL2 / VS Code Server start this
+  widened the window in which VS Code's start-on-demand first tool call races
+  server readiness and dies with `Cannot read properties of undefined
+  (reading 'invoke')` (upstream: microsoft/vscode#321150). That work is now
+  deferred onto the blocking pool, concurrent with the handshake; a
+  `time_to_initialize_ms` log line makes the span measurable, `lean-ctx
+  doctor` surfaces the upstream race on WSL2 + VS Code setups, and a
+  regression test drives the exact race pattern (tools/call immediately after
+  the initialized notification) against the real binary.
 - **Zero-config golden path: `onboard --yes` now leaves `doctor` fully green.**
   Three healers that silently disagreed are aligned: the session-start heal
   installs the agent `SKILL.md` files alongside rules (previously `doctor`

--- a/packages/pi-lean-ctx/.gitignore
+++ b/packages/pi-lean-ctx/.gitignore
@@ -1,0 +1,4 @@
+# Generated at prepack/pretest by scripts/build-vendor.mjs — never committed.
+# (npm pack still includes it: the package.json "files" whitelist wins.)
+extensions/vendor/*.cjs
+dist/

--- a/packages/pi-lean-ctx/README.md
+++ b/packages/pi-lean-ctx/README.md
@@ -127,6 +127,12 @@ Or use the automated setup:
 lean-ctx init --agent pi
 ```
 
+The published package has **zero runtime npm dependencies**: the MCP SDK
+(incl. zod) is shipped as a self-contained vendor bundle
+(`extensions/vendor/mcp-sdk.cjs`). This makes the extension immune to pi's
+shared npm prefix rewriting `node_modules` on every `pi install`/`pi remove`
+(which previously corrupted zod's locale files — GH #670).
+
 ## How it works
 
 ### ctx_ tools (CLI-backed)

--- a/packages/pi-lean-ctx/extensions/mcp-bridge.ts
+++ b/packages/pi-lean-ctx/extensions/mcp-bridge.ts
@@ -1,5 +1,9 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+// The MCP SDK (incl. zod) is consumed through a self-contained vendor bundle
+// instead of node_modules: pi's shared npm prefix rewrites every installed
+// package on each `pi install`/`remove`, and an interrupted rewrite corrupted
+// zod beyond repair (GH #670). scripts/build-vendor.mjs generates the bundle
+// at prepack; extensions/vendor/mcp-sdk.d.cts carries its types.
+import { Client, StdioClientTransport } from "./vendor/mcp-sdk.cjs";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { type TSchema, Type } from "typebox";
 import type { McpBridgeRetryState, McpBridgeStatus } from "./types.js";

--- a/packages/pi-lean-ctx/extensions/vendor/mcp-sdk.d.cts
+++ b/packages/pi-lean-ctx/extensions/vendor/mcp-sdk.d.cts
@@ -1,0 +1,6 @@
+// Hand-written declarations for the generated vendor bundle (mcp-sdk.cjs,
+// built by scripts/build-vendor.mjs — see GH #670). Typecheck resolves the
+// real SDK types from devDependencies; at runtime the self-contained bundle
+// is used so the published package has zero npm dependencies.
+export { Client } from "@modelcontextprotocol/sdk/client/index.js";
+export { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";

--- a/packages/pi-lean-ctx/package-lock.json
+++ b/packages/pi-lean-ctx/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "pi-lean-ctx",
-  "version": "3.8.9",
+  "version": "3.8.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-lean-ctx",
-      "version": "3.8.9",
+      "version": "3.8.18",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.79.3",
         "@earendil-works/pi-tui": "^0.79.3",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "esbuild": "^0.28.1",
         "typebox": "^1.2.9",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
@@ -557,7 +556,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -680,9 +679,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -700,9 +696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -720,9 +713,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +730,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -760,9 +747,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2457,6 +2441,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -2476,6 +2461,7 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -3011,6 +2997,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -3024,6 +3011,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3040,6 +3028,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3067,6 +3056,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -3091,6 +3081,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3100,6 +3091,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3113,6 +3105,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3139,6 +3132,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3152,6 +3146,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3168,6 +3163,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3177,6 +3173,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -3186,6 +3183,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -3203,6 +3201,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3217,6 +3216,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3234,6 +3234,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3243,6 +3244,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3257,12 +3259,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3272,6 +3276,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3281,6 +3286,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3297,6 +3303,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3351,6 +3358,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/estree-walker": {
@@ -3367,6 +3375,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3376,6 +3385,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -3388,6 +3398,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -3407,6 +3418,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -3450,6 +3462,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -3468,12 +3481,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3508,6 +3523,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -3529,6 +3545,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3538,6 +3555,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3562,6 +3580,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3584,6 +3603,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3608,6 +3628,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3621,6 +3642,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3633,6 +3655,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3645,6 +3668,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3657,6 +3681,7 @@
       "version": "4.12.25",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3666,6 +3691,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -3686,6 +3712,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3702,12 +3729,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3717,6 +3746,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -3726,18 +3756,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3747,12 +3780,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/magic-string": {
@@ -3782,6 +3817,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3791,6 +3827,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3800,6 +3837,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3812,6 +3850,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3821,6 +3860,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -3837,6 +3877,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3862,6 +3903,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3871,6 +3913,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3880,6 +3923,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3906,6 +3950,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -3918,6 +3963,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3927,6 +3973,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3936,6 +3983,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3945,6 +3993,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3982,6 +4031,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -4020,6 +4070,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -4033,6 +4084,7 @@
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4048,6 +4100,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4057,6 +4110,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -4072,6 +4126,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4126,6 +4181,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -4142,12 +4198,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -4174,6 +4232,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -4193,12 +4252,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -4211,6 +4272,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4220,6 +4282,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4239,6 +4302,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4255,6 +4319,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4273,6 +4338,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4316,6 +4382,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4376,6 +4443,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -4385,6 +4453,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -4403,6 +4472,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4437,6 +4507,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4446,6 +4517,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4620,6 +4692,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4652,12 +4725,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -4667,6 +4742,7 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/packages/pi-lean-ctx/package.json
+++ b/packages/pi-lean-ctx/package.json
@@ -22,11 +22,11 @@
     "url": "https://github.com/yvgude/lean-ctx/issues"
   },
   "scripts": {
+    "build:vendor": "node scripts/build-vendor.mjs",
+    "prepack": "npm run build:vendor",
+    "pretest": "npm run build:vendor",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
-  },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0",
@@ -45,6 +45,8 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.79.3",
     "@earendil-works/pi-tui": "^0.79.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "esbuild": "^0.28.1",
     "typebox": "^1.2.9",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"

--- a/packages/pi-lean-ctx/scripts/build-vendor.mjs
+++ b/packages/pi-lean-ctx/scripts/build-vendor.mjs
@@ -1,0 +1,44 @@
+// Builds extensions/vendor/mcp-sdk.js — a self-contained bundle of the MCP
+// SDK client (incl. zod) so the published package needs ZERO runtime npm
+// dependencies.
+//
+// Why (GH #670): pi installs every package into one shared npm prefix
+// (~/.pi/agent/npm). Each `pi install`/`remove` re-reifies the whole tree and
+// physically rewrites unrelated packages; an interrupted extraction (Windows
+// AV/file locks) strands files like zod/v3/locales/en.js, and npm never
+// repairs a package whose package.json version matches. Bundling removes the
+// failure class: there is no zod left on disk to corrupt.
+//
+// The bundle is generated at publish time (`prepack`) and before tests; it is
+// NOT committed. Node built-ins stay external (platform: node).
+import { build } from "esbuild";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outfile = resolve(here, "..", "extensions", "vendor", "mcp-sdk.cjs");
+mkdirSync(dirname(outfile), { recursive: true });
+
+const result = await build({
+  entryPoints: [resolve(here, "vendor-entry.mjs")],
+  outfile,
+  bundle: true,
+  platform: "node",
+  target: "node18",
+  // CJS on purpose: pi loads extensions through jiti, which transpiles every
+  // module to CJS — an ESM bundle would need a createRequire banner that
+  // collides with the CJS wrapper's own `require` binding. As CJS the bundle
+  // requires node built-ins natively under jiti, and native ESM importers
+  // (vitest, plain `node`) still get named exports via esbuild's
+  // cjs-module-lexer annotation.
+  format: "cjs",
+  sourcemap: false,
+  minify: false,
+  legalComments: "inline",
+  logLevel: "warning",
+  metafile: true,
+});
+
+const bytes = Object.values(result.metafile.outputs)[0]?.bytes ?? 0;
+console.log(`vendor bundle: ${outfile} (${(bytes / 1024).toFixed(0)} KB)`);

--- a/packages/pi-lean-ctx/scripts/vendor-entry.mjs
+++ b/packages/pi-lean-ctx/scripts/vendor-entry.mjs
@@ -1,0 +1,5 @@
+// Entry point for the vendored MCP SDK bundle (see build-vendor.mjs).
+// Re-exports exactly the SDK surface mcp-bridge.ts consumes, so esbuild
+// tree-shakes the server/HTTP/OAuth halves of the SDK out of the bundle.
+export { Client } from "@modelcontextprotocol/sdk/client/index.js";
+export { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";

--- a/packages/pi-lean-ctx/test/vendor-bundle.test.ts
+++ b/packages/pi-lean-ctx/test/vendor-bundle.test.ts
@@ -1,0 +1,48 @@
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression guards for GH #670: the package must stay free of runtime npm
+// dependencies (pi's shared-prefix reification corrupted zod beyond repair),
+// with the MCP SDK vendored as one self-contained CJS bundle. `pretest`
+// builds the bundle, so these run against the exact artifact npm pack ships.
+
+const require = createRequire(import.meta.url);
+const pkgRoot = resolve(__dirname, "..");
+const bundlePath = resolve(pkgRoot, "extensions", "vendor", "mcp-sdk.cjs");
+
+describe("vendor bundle (zero runtime deps, #670)", () => {
+  it("package.json declares NO runtime dependencies", () => {
+    const pkg = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf8"));
+    expect(pkg.dependencies).toBeUndefined();
+  });
+
+  it("bundle exposes Client + StdioClientTransport via CJS require (jiti path)", () => {
+    const bundle = require(bundlePath);
+    expect(typeof bundle.Client).toBe("function");
+    expect(typeof bundle.StdioClientTransport).toBe("function");
+  });
+
+  it("bundle exposes named exports via native ESM import", async () => {
+    const bundle = await import(bundlePath);
+    expect(typeof bundle.Client).toBe("function");
+    expect(typeof bundle.StdioClientTransport).toBe("function");
+  });
+
+  it("bundle is self-contained — only node built-ins left as requires", () => {
+    const source = readFileSync(bundlePath, "utf8");
+    // esbuild leaves `require("<builtin>")` for externals (platform: node).
+    // Any bare package specifier here would mean an unbundled runtime dep
+    // that resolves from the corruptible shared prefix again.
+    const builtins = new Set<string>(require("node:module").builtinModules);
+    const externals = [...source.matchAll(/\brequire\("([^"./][^"]*)"\)/g)]
+      .map((m) => m[1])
+      // ajv embeds require() calls inside *generated-code string templates*
+      // (standalone codegen, never executed at runtime); real requires never
+      // carry a dist/ subpath of ajv.
+      .filter((spec) => !spec.startsWith("ajv/dist/") && !spec.startsWith("ajv-formats/dist/"))
+      .filter((spec) => !builtins.has(spec.replace(/^node:/, "")));
+    expect(externals).toEqual([]);
+  });
+});

--- a/rust/src/cli/dispatch/server.rs
+++ b/rust/src/cli/dispatch/server.rs
@@ -8,18 +8,22 @@ use anyhow::Result;
 pub(super) fn run_mcp_server() -> Result<()> {
     use rmcp::ServiceExt;
 
+    // Time-to-initialize is the metric that decides whether a client's
+    // start-on-demand first tool call races us (GH #669) — measured from
+    // process entry to the completed MCP initialize handshake.
+    let started_at = std::time::Instant::now();
+
     // SAFETY: set once at MCP server startup, before the Tokio runtime is built
     // and any worker/blocking threads exist (runtime is constructed below).
     unsafe { std::env::set_var("LEAN_CTX_MCP_SERVER", "1") };
 
     crate::core::startup_guard::crash_loop_backoff(crate::core::startup_guard::MCP_PROCESS_NAME);
 
-    cleanup_orphan_mcp_processes();
-
     // Commit to the XDG layout (and drain any residual ~/.lean-ctx) once per
     // server start, so a stray marker can never re-collapse config/data/state/
     // cache while the server runs (GL #623). Every other process honors the pin
-    // through the same resolver once it exists.
+    // through the same resolver once it exists. Stays synchronous: everything
+    // below resolves paths through this pin, and it is a no-op once pinned.
     crate::core::layout_pin::heal();
 
     // Concurrency hardening:
@@ -75,20 +79,13 @@ pub(super) fn run_mcp_server() -> Result<()> {
     let server = tools::create_server();
     drop(startup_lock);
 
-    // Auto-start proxy in background so the dashboard gets exact token data.
-    spawn_proxy_if_needed();
-
-    // Throttled (24h), opt-in background publish of the savings recap so the public
-    // leaderboard/hero stay fresh without the user ever running `lean-ctx gain`.
-    // Silent + detached: must not touch stdout (MCP protocol channel) or block startup.
-    crate::cli::wrapped_publish::maybe_auto_publish_background();
-
     rt.block_on(async {
         core::logging::init_mcp_logging();
         core::protocol::set_mcp_context(true);
 
         // Activate the plugin registry once per server process, then announce the
         // session. `notify` is a no-op unless a plugin listens for the hook.
+        // Stays ahead of serve(): a plugin may hook the very first tool call.
         core::plugins::PluginManager::init();
         core::plugins::PluginManager::notify(core::plugins::executor::HookPoint::OnSessionStart);
 
@@ -104,6 +101,22 @@ pub(super) fn run_mcp_server() -> Result<()> {
         // Orphan watchdog: if our parent process dies (IDE crashed/closed without
         // closing stdin), we exit cleanly instead of hanging forever.
         spawn_parent_watchdog();
+
+        // Deferred housekeeping (GH #669): none of this is needed to answer
+        // `initialize`, but each item spawns processes or opens sockets — on a
+        // cold WSL2 / VS Code Server start that widened the window in which the
+        // client's start-on-demand first tool call races server readiness
+        // (microsoft/vscode#321150). Run it on the blocking pool, concurrent
+        // with the handshake, instead of in front of it.
+        let _housekeeping = tokio::task::spawn_blocking(|| {
+            // Kill orphan MCP processes whose parent IDE died (one `ps` per
+            // lean-ctx pid). Auto-start the proxy so the dashboard gets exact
+            // token data. Then the throttled (24h), opt-in publish of the
+            // savings recap — silent + detached, never touches stdout.
+            cleanup_orphan_mcp_processes();
+            spawn_proxy_if_needed();
+            crate::cli::wrapped_publish::maybe_auto_publish_background();
+        });
 
         let transport =
             mcp_stdio::HybridStdioTransport::new_server(tokio::io::stdin(), tokio::io::stdout());
@@ -122,6 +135,12 @@ pub(super) fn run_mcp_server() -> Result<()> {
                 return Err(e.into());
             }
         };
+        // serve() resolves once the client's initialize/initialized handshake
+        // completed — the span a start-on-demand client actually waits on.
+        tracing::info!(
+            time_to_initialize_ms = started_at.elapsed().as_millis() as u64,
+            "MCP server initialized"
+        );
         match service.waiting().await {
             Ok(reason) => {
                 tracing::info!("MCP server stopped: {reason:?}");

--- a/rust/src/doctor/checks/environment.rs
+++ b/rust/src/doctor/checks/environment.rs
@@ -198,6 +198,28 @@ pub(crate) fn mcp_config_outcome() -> Outcome {
         }
     }
 }
+/// WSL2 + VS Code (GH #669): VS Code's start-on-demand MCP lifecycle has a
+/// known client-side race — the first tool call of a fresh conversation can
+/// fire against cached tool metadata before the server's implementation is
+/// bound, failing with `Cannot read properties of undefined (reading 'invoke')`
+/// (microsoft/vscode#321150). Cold starts on WSL2 widen that window. Purely
+/// informational (ok: true): the defect is upstream, a retry always succeeds.
+pub(crate) fn wsl_vscode_mcp_outcome() -> Option<Outcome> {
+    if !crate::core::io_health::is_wsl() {
+        return None;
+    }
+    let home = dirs::home_dir()?;
+    if !lean_ctx_mcp_location_names(&home).contains("VS Code") {
+        return None;
+    }
+    Some(Outcome {
+        ok: true,
+        line: format!(
+            "{BOLD}WSL2 + VS Code{RST}  {YELLOW}known first-call race in VS Code's MCP client{RST}  {DIM}(a fresh conversation's first ctx_* call may fail with \"reading 'invoke'\" — retry succeeds; upstream: microsoft/vscode#321150. Mitigation: run the MCP server once via \"MCP: List Servers\" → lean-ctx → Start){RST}"
+        ),
+    })
+}
+
 pub(crate) fn port_3333_outcome() -> Outcome {
     match TcpListener::bind("127.0.0.1:3333") {
         Ok(_listener) => Outcome {

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -337,6 +337,11 @@ pub fn run() -> u32 {
         .map(|home| lean_ctx_mcp_location_names(&home))
         .unwrap_or_default();
 
+    // 7b) WSL2 + VS Code: surface the upstream first-call invoke race (GH #669)
+    if let Some(wsl_hint) = wsl_vscode_mcp_outcome() {
+        board.check(&wsl_hint);
+    }
+
     // 8) Workspace-scope MCP (optional; only when a project-local config exists)
     let workspace_scope = workspace_scope::workspace_scope_outcome(&user_scope_mcp_locations);
     if let Some(ref ws) = workspace_scope {

--- a/rust/tests/mcp_fast_initialize_669.rs
+++ b/rust/tests/mcp_fast_initialize_669.rs
@@ -1,0 +1,166 @@
+//! Fast-initialize contract (GH #669).
+//!
+//! VS Code's start-on-demand MCP lifecycle races the first tool call of a
+//! fresh conversation against server startup (microsoft/vscode#321150). The
+//! server-side mitigation: nothing that spawns processes or opens sockets may
+//! run in front of the `initialize` handshake — housekeeping (orphan sweep,
+//! proxy autostart, publish throttle) is deferred onto the blocking pool.
+//!
+//! Two guards, real binary over real stdio JSON-RPC in an isolated HOME:
+//!   1. spawn → initialize-response stays under a conservative wall-clock
+//!      bound (catches a future re-introduction of synchronous pre-serve work
+//!      such as a crash-backoff sleep or a network wait),
+//!   2. a tools/call fired IMMEDIATELY after the initialized notification —
+//!      the exact VS Code race pattern — succeeds on the first attempt.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+/// Generous for CI (debug binary, cold cache, shared runners) yet far below
+/// the pathological regressions this guards against (30s crash-loop backoff,
+/// TCP timeouts, N×ps orphan sweeps in front of the handshake).
+const INITIALIZE_DEADLINE: Duration = Duration::from_secs(10);
+
+struct TestEnv {
+    _tmp: tempfile::TempDir,
+    home: std::path::PathBuf,
+    data: std::path::PathBuf,
+    project: std::path::PathBuf,
+}
+
+fn test_env() -> TestEnv {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let data = tmp.path().join("data");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::write(project.join("hello.txt"), "hello fast init\n").unwrap();
+    TestEnv {
+        _tmp: tmp,
+        home,
+        data,
+        project,
+    }
+}
+
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "HOME-override isolation is Unix-only (dirs::home_dir uses the Win32 API)"
+)]
+fn initialize_answers_fast_and_first_call_succeeds() {
+    let bin = env!("CARGO_BIN_EXE_lean-ctx");
+    let env = test_env();
+
+    let spawn_at = Instant::now();
+    let mut child: Child = Command::new(bin)
+        .arg("mcp")
+        .current_dir(&env.project)
+        .env("HOME", &env.home)
+        .env("LEAN_CTX_DATA_DIR", &env.data)
+        .env("CODEX_HOME", env.home.join(".codex"))
+        .env("LEAN_CTX_HEADLESS", "1")
+        // Root detection must derive from the temp project's cwd. When the
+        // suite itself runs inside an IDE/agent session these carry the HOST
+        // workspace and would hijack the project root (→ path-jail rejects
+        // the temp file).
+        .env_remove("LEAN_CTX_PROJECT_ROOT")
+        .env_remove("CLAUDE_PROJECT_DIR")
+        .env_remove("WORKSPACE_FOLDER_PATHS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("mcp server spawn");
+
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout = child.stdout.take().expect("child stdout");
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader = std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            match line {
+                Ok(l) => {
+                    if tx.send(l).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let recv_response = |id: u64, deadline: Duration| -> serde_json::Value {
+        let needle = format!("\"id\":{id}");
+        let until = Instant::now() + deadline;
+        loop {
+            let remaining = until
+                .checked_duration_since(Instant::now())
+                .unwrap_or_else(|| panic!("timeout waiting for JSON-RPC response id={id}"));
+            let line = rx
+                .recv_timeout(remaining)
+                .unwrap_or_else(|e| panic!("no response id={id} within deadline: {e}"));
+            if line.contains(&needle) {
+                return serde_json::from_str(&line)
+                    .unwrap_or_else(|e| panic!("invalid JSON-RPC line: {e}\n{line}"));
+            }
+        }
+    };
+
+    let init = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "vscode", "version": "1.109.0" }
+        }
+    });
+    writeln!(stdin, "{init}").expect("write initialize");
+    let init_res = recv_response(1, INITIALIZE_DEADLINE);
+    let elapsed = spawn_at.elapsed();
+    assert!(
+        init_res["result"]["serverInfo"]["name"].is_string(),
+        "initialize must return serverInfo; got: {init_res}"
+    );
+    assert!(
+        elapsed < INITIALIZE_DEADLINE,
+        "spawn → initialize-response took {elapsed:?} (bound {INITIALIZE_DEADLINE:?}) — \
+         synchronous pre-serve work crept back in front of the handshake (#669)"
+    );
+
+    // The VS Code race pattern: initialized notification and the first tool
+    // call back-to-back, no grace period. It must succeed first try.
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" })
+    )
+    .expect("write initialized");
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {
+            "name": "ctx_read",
+            "arguments": { "path": env.project.join("hello.txt").to_string_lossy() }
+        }
+    });
+    writeln!(stdin, "{call}").expect("write tools/call");
+    let call_res = recv_response(2, Duration::from_secs(30));
+    assert!(
+        call_res["error"].is_null(),
+        "first tools/call immediately after initialized must succeed; got: {call_res}"
+    );
+    let text = call_res["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        text.contains("hello fast init"),
+        "ctx_read must deliver the file on the first post-initialize call; got: {call_res}"
+    );
+
+    drop(stdin); // EOF → clean server shutdown
+    let _ = child.wait();
+    let _ = reader.join();
+}


### PR DESCRIPTION
## Summary

Two release-blocking fixes from this week's field reports, one commit each:

### 1. `fix(pi)` — pi-lean-ctx ships with **zero runtime npm dependencies** (closes #670, GL#1142)

pi installs every package into one shared npm prefix (`~/.pi/agent/npm`) and re-reifies the whole tree on each `pi install`/`pi remove` — unrelated packages are physically deleted and re-extracted even when their version is unchanged. An interrupted rewrite (Windows AV/file locks) strands files (`zod/v3/locales/en.js`, alphabetically last in its dir), and npm never repairs a package whose `package.json` version matches — the extension stays broken until the prefix is wiped by hand.

Instead of patching around the corruption, the failure class is removed: the MCP SDK (incl. zod) is bundled at `prepack` into `extensions/vendor/mcp-sdk.cjs` (esbuild, platform=node, CJS for pi's jiti loader, 554 KB tree-shaken to the `Client` + `StdioClientTransport` surface). `package.json` has **no `dependencies` block anymore**.

- `scripts/build-vendor.mjs` + `scripts/vendor-entry.mjs`: generator (prepack/pretest); bundle is gitignored, `files` whitelist ships it in the tarball
- `extensions/vendor/mcp-sdk.d.cts`: hand-written declarations (typecheck resolves real SDK types from devDependencies)
- `test/vendor-bundle.test.ts`: guards no-runtime-deps, CJS require + native ESM import loadability, bundle self-containment (only node built-ins left as `require()`)
- `release.yml`: `npm ci` before `npm publish` so prepack has esbuild

Verified locally: isolation smoke (bundle alone in an empty dir → real `initialize` + `tools/list` roundtrip against the lean-ctx binary, via CJS require, native ESM import **and** jiti-loaded TS import), co-install with `pi-markdown-preview` leaves no `@modelcontextprotocol/sdk` anywhere in the shared tree.

### 2. `fix(mcp)` — answer `initialize` before housekeeping (mitigates #669, GL#1143)

VS Code starts MCP servers on demand and has a known client-side race: the first tool call of a fresh conversation can fire against cached tool metadata before the server implementation is bound → `TypeError: Cannot read properties of undefined (reading 'invoke')` (upstream microsoft/vscode#321150; first call per conversation, retry always works). Our pre-serve work — orphan-process sweep (one `ps` per running lean-ctx), proxy autostart (TCP probe + spawn), publish throttle — sat inside that window, and cold WSL2/VS Code Server starts made it wide.

- Housekeeping now runs on the blocking pool, spawned right before `serve()` (concurrent with the handshake); crash-loop backoff, layout-pin heal, startup lock and server construction stay synchronous (correctness-ordered, cheap steady-state)
- `time_to_initialize_ms` INFO log after the handshake completes — makes the race span measurable in field reports
- `doctor`: informational WSL2 + VS Code check pointing at the upstream issue and the "MCP: List Servers → Start" warm-up mitigation
- `tests/mcp_fast_initialize_669.rs`: real-binary regression — initialize under a 10s wall bound AND a `tools/call` fired back-to-back with the `initialized` notification (the exact VS Code pattern) must succeed first try

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets` clean (0 warnings)
- [x] `cargo test --lib` — 7009 passed
- [x] `cargo test --test mcp_fast_initialize_669` — new regression passes
- [x] `cargo test --test live_smoke_client_instructions` — 5 passed
- [x] pi-lean-ctx: `npm run typecheck` + `npm test` — 26 tests passed (incl. 4 new vendor guards)
- [x] `npm pack` tarball inspected: 8 files, vendor bundle + d.cts included, no `dependencies`
- [x] Isolation + co-install smokes (see above)
- [ ] CI green on this PR
