### PR TITLE
fix(install): resolve cargo target dir in install.sh source build (#671 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   shell script fails loudly when the binary is absent instead of planting a
   dead symlink on PATH, the Rust path gained the same resolution plus the
   Windows `.exe` suffix, and `tests/pre_release_check.sh` follows suit.
+  Follow-up: `install.sh`'s source-build path (served at
+  `leanctx.com/install.sh`) had the same hardcode and could link a stale
+  binary from an earlier default-layout build — it now resolves via
+  `cargo metadata` identically and names the override in its error hint.
   Thanks [@getappz](https://github.com/getappz) for the report and the initial
   fix (#672)!
 - **pi-lean-ctx ships with zero runtime npm dependencies (GH #670).** pi

--- a/install.sh
+++ b/install.sh
@@ -211,7 +211,16 @@ install_from_source() {
 
   if [ -d "$RUST_DIR" ]; then
     (cd "$RUST_DIR" && cargo build --release)
-    binary="$RUST_DIR/target/release/lean-ctx"
+    # Honour CARGO_TARGET_DIR / a config.toml [build] target-dir override
+    # (GH #671): with a hardcoded ./target, a stale binary from an earlier
+    # default-layout build gets linked instead of the one just built.
+    # `|| true` keeps a failing `cargo metadata` on the fallback path.
+    target_dir=$( (cd "$RUST_DIR" && cargo metadata --no-deps --format-version=1 2>/dev/null) \
+        | grep -o '"target_directory":"[^"]*"' \
+        | head -1 \
+        | sed -E 's/^"target_directory":"(.*)"$/\1/' \
+        | sed 's/\\\\/\//g' || true)
+    binary="${target_dir:-$RUST_DIR/target}/release/lean-ctx"
   else
     cargo install lean-ctx
     echo ""
@@ -220,7 +229,8 @@ install_from_source() {
   fi
 
   if [ ! -x "$binary" ]; then
-    echo "Error: build failed — binary not found"
+    echo "Error: build failed — binary not found at $binary"
+    echo "Hint: is CARGO_TARGET_DIR or ~/.cargo/config.toml [build] target-dir pointing elsewhere?"
     exit 1
   fi
   echo "Built: $binary"


### PR DESCRIPTION
## Summary
- `install_from_source()` in `install.sh` (served at leanctx.com/install.sh) hardcoded `$RUST_DIR/target/release/lean-ctx` — the same class of bug fixed for `dev-install` in #672. With `CARGO_TARGET_DIR` or a `~/.cargo/config.toml` `[build] target-dir` override, a **stale** binary from an earlier default-layout build passes the `-x` check and gets symlinked onto PATH.
- Resolves the target dir via `cargo metadata` with the identical extraction/fallback used in `rust/dev-install.sh` (incl. `|| true` so the fallback is reachable under failure), and the error hint now names the override.

Completes #671 across all three install surfaces (dev-install.sh, `lean-ctx dev-install`, install.sh).

## Test
- Sandboxed e2e (cargo stubbed, HOME/PATH shimmed): override honoured **with a stale `./target` decoy present**; metadata failure → `./target` fallback; missing binary → exit 1 with hint. 4/4 pass.
- `sh -n` clean.