### PR TITLE
feat(ctx_shell): per-call timeout_ms + heavy tier for task runners (#676)

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -629,7 +629,7 @@ raw=true for verbatim output.
 [exit:N] on errors (lossless).
 ANTIPATTERN: multi-line scripts → ctx_execute.
 
-Parameters: `command`*, `cwd`, `env`, `raw`
+Parameters: `command`*, `cwd`, `env`, `raw`, `timeout_ms`
 
 ## `ctx_skillify`
 

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -7,13 +7,14 @@ const READER_RESULT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[cfg(test)]
 pub(crate) fn execute_command_in(command: &str, cwd: &str) -> (String, i32) {
-    execute_command_with_env(command, cwd, &std::collections::HashMap::new())
+    execute_command_with_env(command, cwd, &std::collections::HashMap::new(), None)
 }
 
 pub(crate) fn execute_command_with_env(
     command: &str,
     cwd: &str,
     extra_env: &std::collections::HashMap<String, String>,
+    timeout_ms: Option<u64>,
 ) -> (String, i32) {
     let (shell, flag) = crate::shell::shell_and_flag();
     let normalized_cmd = crate::tools::ctx_shell::normalize_command_for_shell(command);
@@ -83,7 +84,7 @@ pub(crate) fn execute_command_with_env(
     let (out_buf, out_done) = spawn_capture(child.stdout.take(), cap);
     let (err_buf, err_done) = spawn_capture(child.stderr.take(), cap);
 
-    let timeout = command_timeout(command);
+    let timeout = command_timeout(command, timeout_ms);
     let start = Instant::now();
     let (code, timed_out) = loop {
         match child.try_wait() {
@@ -229,11 +230,11 @@ fn ensure_utf8_locale(
     crate::shell::platform::apply_utf8_locale(cmd);
 }
 
-fn command_timeout(command: &str) -> Duration {
-    // Single source of truth: env (MS / per-tier SECS) > config > built-in
-    // heavy/normal ceilings. Keeps this path identical to `ctx_shell` and the
-    // interactive hook (`shell::exec::shell_timeout`).
-    crate::shell::shell_timeout(command)
+fn command_timeout(command: &str, timeout_ms: Option<u64>) -> Duration {
+    // Single source of truth: operator env pin > per-call `timeout_ms` >
+    // per-tier env/config > built-in heavy/normal ceilings. Keeps this path
+    // identical to the interactive hook (`shell::exec::shell_timeout`).
+    crate::shell::shell_timeout_with_override(command, timeout_ms)
 }
 
 #[cfg(test)]
@@ -249,15 +250,17 @@ mod tests {
         let saved = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
         crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
 
-        assert!(command_timeout("cargo install --path .") > command_timeout("git status"));
+        assert!(
+            command_timeout("cargo install --path .", None) > command_timeout("git status", None)
+        );
 
         crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", "5000");
         assert_eq!(
-            command_timeout("cargo install --path ."),
+            command_timeout("cargo install --path .", None),
             std::time::Duration::from_secs(5)
         );
         assert_eq!(
-            command_timeout("git status"),
+            command_timeout("git status", None),
             std::time::Duration::from_secs(5)
         );
 
@@ -378,6 +381,24 @@ mod tests {
         assert!(
             output.contains("TID=thread-from-hook"),
             "captured agent runtime var must be forwarded, got: {output}"
+        );
+    }
+
+    /// Per-call `timeout_ms` must reach the kill loop: a command that sleeps
+    /// past its 200ms budget is killed with the timeout exit code and message.
+    #[test]
+    #[cfg_attr(windows, ignore)] // POSIX sleep
+    fn per_call_timeout_kills_long_command() {
+        let (output, code) = super::execute_command_with_env(
+            "sleep 3",
+            ".",
+            &std::collections::HashMap::new(),
+            Some(200),
+        );
+        assert_eq!(code, 124, "timed-out command must exit 124: {output}");
+        assert!(
+            output.contains("timed out after 200ms"),
+            "timeout message must carry the per-call budget, got: {output}"
         );
     }
 

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -190,8 +190,28 @@ fn exec_limits(command: &str) -> (usize, std::time::Duration) {
 ///    `shell_timeout_secs`, else [`DEFAULT_TIMEOUT`].
 #[must_use]
 pub(crate) fn shell_timeout(command: &str) -> std::time::Duration {
+    shell_timeout_with_override(command, None)
+}
+
+/// Hard ceiling for a per-call `timeout_ms` override: generous enough for any
+/// legitimate build/release job, low enough that a typo'd value cannot wedge
+/// the executor for days.
+const MAX_CALL_TIMEOUT_MS: u64 = 3_600_000; // 1 hour
+
+/// [`shell_timeout`] with an optional per-call override (ctx_shell's
+/// `timeout_ms` arg). Precedence: operator env pin (`LEAN_CTX_SHELL_TIMEOUT_MS`)
+/// > per-call override (clamped to [`MAX_CALL_TIMEOUT_MS`], zero ignored)
+/// > per-tier env/config > built-in heavy/normal ceilings.
+#[must_use]
+pub(crate) fn shell_timeout_with_override(
+    command: &str,
+    override_ms: Option<u64>,
+) -> std::time::Duration {
     if let Some(ms) = env_u64("LEAN_CTX_SHELL_TIMEOUT_MS") {
         return std::time::Duration::from_millis(ms);
+    }
+    if let Some(ms) = override_ms.filter(|n| *n > 0) {
+        return std::time::Duration::from_millis(ms.min(MAX_CALL_TIMEOUT_MS));
     }
     if is_heavy_command(command) {
         if let Some(secs) = env_u64("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS")
@@ -269,6 +289,11 @@ fn is_heavy_command(command: &str) -> bool {
         // because the prefix is the full `git <verb>`.
         "git commit",
         "git push",
+        // Task runners wrap builds/test gates; the underlying job is what's
+        // heavy, so the wrapper gets the same ceiling. A fast subcommand
+        // (`mise ls`) merely inherits a longer kill deadline — harmless.
+        "mise ",
+        "just ",
     ];
     HEAVY_PREFIXES.iter().any(|p| lower.starts_with(p))
 }
@@ -1105,6 +1130,70 @@ mod exec_tests {
             if let Some(v) = saved {
                 crate::test_env::set_var(var, v);
             }
+        }
+    }
+
+    // Task runners (mise/just) wrap builds and test gates that routinely run
+    // past the 2-minute default; killing them mid-run loses the whole job.
+    // They get the heavy ceiling like the underlying build tools they invoke.
+    #[test]
+    fn task_runners_get_heavy_ceiling() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved_ms = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
+        let saved_heavy = std::env::var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS").ok();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        crate::test_env::remove_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS");
+
+        assert_eq!(super::shell_timeout("mise gate"), super::HEAVY_TIMEOUT);
+        assert_eq!(super::shell_timeout("mise run gate"), super::HEAVY_TIMEOUT);
+        assert_eq!(super::shell_timeout("just build"), super::HEAVY_TIMEOUT);
+
+        if let Some(v) = saved_ms {
+            crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);
+        }
+        if let Some(v) = saved_heavy {
+            crate::test_env::set_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS", v);
+        }
+    }
+
+    // Per-call `timeout_ms` (ctx_shell tool arg): explicit caller intent beats
+    // the built-in tiers in both directions, absurd values clamp to the 1h
+    // ceiling, zero is ignored, and the operator's universal env pin stays top.
+    #[test]
+    fn per_call_timeout_override_resolves_and_clamps() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved_ms = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(300_000)),
+            std::time::Duration::from_secs(300)
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("cargo build", Some(30_000)),
+            std::time::Duration::from_secs(30)
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(999_000_000)),
+            std::time::Duration::from_millis(super::MAX_CALL_TIMEOUT_MS)
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(0)),
+            super::DEFAULT_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("git status", None),
+            super::DEFAULT_TIMEOUT
+        );
+
+        crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", "5000");
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(300_000)),
+            std::time::Duration::from_secs(5)
+        );
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        if let Some(v) = saved_ms {
+            crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);
         }
     }
 

--- a/rust/src/shell/mod.rs
+++ b/rust/src/shell/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod reentry;
 pub(crate) mod tee_policy;
 
 pub use compress::compress_if_beneficial_pub;
-pub(crate) use exec::shell_timeout;
+pub(crate) use exec::shell_timeout_with_override;
 pub(crate) use exec::{STDERR_LABEL, combine_streams};
 pub use exec::{exec, exec_argv};
 pub use interactive::interactive;

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -3,7 +3,7 @@ use rmcp::model::Tool;
 use serde_json::{Map, Value, json};
 
 use crate::server::tool_trait::{
-    McpTool, ShellOutcome, ToolContext, ToolOutput, get_bool, get_str,
+    McpTool, ShellOutcome, ToolContext, ToolOutput, get_bool, get_int, get_str,
 };
 use crate::tool_defs::tool_def;
 
@@ -27,6 +27,7 @@ impl McpTool for CtxShellTool {
                     "command": { "type": "string", "description": "Shell command" },
                     "raw": { "type": "boolean", "description": "Skip compression (verbatim)" },
                     "cwd": { "type": "string", "description": "Working dir (persists across calls)" },
+                    "timeout_ms": { "type": "integer", "description": "Per-call timeout in ms (max 3600000). Overridden by LEAN_CTX_SHELL_TIMEOUT_MS." },
                     "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } }
                 },
                 "required": ["command"]
@@ -41,6 +42,7 @@ impl McpTool for CtxShellTool {
     ) -> Result<ToolOutput, ErrorData> {
         let command = get_str(args, "command")
             .ok_or_else(|| ErrorData::invalid_params("command is required", None))?;
+        let timeout_ms = get_int(args, "timeout_ms").and_then(|n| u64::try_from(n).ok());
 
         // The write-doctrine check (no `>`, `tee`, heredoc-to-file, curl -o, …)
         // is an MCP-payload-safety convention, not a security boundary, so it is
@@ -108,7 +110,7 @@ impl McpTool for CtxShellTool {
                         })
                         .unwrap_or_default();
                     let (raw_output, exit_code) = crate::server::execute::execute_command_with_env(
-                        &cmd_clone, &cwd_clone, &extra_env,
+                        &cmd_clone, &cwd_clone, &extra_env, timeout_ms,
                     );
                     let output = redact_shell_output_secrets(&raw_output);
                     // Keep failure reporting consistent on this degraded path:
@@ -161,7 +163,7 @@ impl McpTool for CtxShellTool {
                 .unwrap_or_default();
 
             let (raw_output, exit_code) = crate::server::execute::execute_command_with_env(
-                &cmd_clone, &cwd_clone, &extra_env,
+                &cmd_clone, &cwd_clone, &extra_env, timeout_ms,
             );
 
             // Structured diagnostics (#499) — same hook as the CLI path.


### PR DESCRIPTION
Closes #676.

## What

- Optional `timeout_ms` on the `ctx_shell` tool, threaded through `execute_command_with_env` into the kill loop.
  - Clamped to 1h (`MAX_CALL_TIMEOUT_MS`) so a typo'd value can't wedge the blocking pool; zero/negative ignored.
  - Precedence unchanged at the top: `LEAN_CTX_SHELL_TIMEOUT_MS` operator pin > per-call `timeout_ms` > per-tier env/config > built-in heavy/normal ceilings. Single source of truth stays `shell::exec` (`shell_timeout` is now a thin wrapper over `shell_timeout_with_override`), so the MCP path and the interactive hook keep resolving identically.
- `mise ` / `just ` added to `HEAVY_PREFIXES`: task runners wrap builds/test gates, so the wrapper gets the same 10-min ceiling as the tools it invokes. A fast subcommand (`mise ls`) merely inherits a longer kill deadline.

## Why

`mise gate` / `just build` pipelines (4-5 min) were classified normal and killed at 120s, forcing agents to fall back to their native shell tool — bypassing lean-ctx compression. Details + audit numbers in #676.

## Tests

- `task_runners_get_heavy_ceiling` — mise/just resolve to `HEAVY_TIMEOUT`
- `per_call_timeout_override_resolves_and_clamps` — override beats tiers both directions, 1h clamp, zero ignored, env pin still wins
- `per_call_timeout_kills_long_command` — `sleep 3` with `timeout_ms: 200` exits 124 with the per-call budget in the message (POSIX-gated, ignored on Windows)
- Existing `command_timeout_delegates_to_shell_timeout` updated for the new signature; full lib suite + clippy pedantic clean on touched files

## Not covered

`ctx_execute` has its own execution path and doesn't gain `timeout_ms` here — can follow up if wanted.