### PR TITLE
feat(signatures): PowerShell support via tree-sitter-powershell (#679)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Your AI agent reads files and runs commands. LeanCTX compresses both automatical
 - **Target density** (`density:0.4`): SDE-style budget compression — keeps the highest-entropy lines until ~40% of the original tokens remain, deterministic
 - **JIT disclosure**: `signatures` carries line spans and points at `lines:N-M` for targeted expansion — outline first, bodies on demand
 - **Shell output**: 95+ shell-output patterns compress git, npm, cargo, docker, kubectl, terraform and more (270 passthrough rules)
-- **Tree-sitter AST**: structural understanding for 26 languages — not just text compression
+- **Tree-sitter AST**: structural understanding for 27 languages — not just text compression
 - **Reversible by design (CCR)**: compression never *discards* content — pruned or truncated payloads move to a content-addressed store with a deterministic handle, so the model can pull the original bytes back on demand via `ctx_expand`, `ctx_retrieve`, an in-band marker, or `GET /v1/references/{id}`. [Five recovery paths →](docs/comparisons/vs-headroom.md#reversibility)
 
 ### 2. Routing — the right fidelity per read

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -389,7 +389,7 @@ Parameters: `action`*, `alias`, `max_results`, `mode`, `path`, `query`, `roots`
 
 WORKFLOW: call BEFORE ctx_read to map code structure (a syntax-aware table of contents).
 Accepts a FILE or a DIRECTORY (folder surface — per-file symbols). Symbols come from
-tree-sitter (26 languages, real line spans); a conservative regex fallback covers the rest.
+tree-sitter (27 languages, real line spans); a conservative regex fallback covers the rest.
 kind=fn|struct|class|trait|enum|impl|all filters by kind; match=<substr> filters by name
 (case-insensitive); format=json emits deterministic JSON labelling the backend per file.
 ANTIPATTERN: NOT for file content (use ctx_read) or deep understanding (use ctx_compose).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2477,6 +2477,7 @@ dependencies = [
  "tree-sitter-nix",
  "tree-sitter-ocaml",
  "tree-sitter-php",
+ "tree-sitter-powershell",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -5732,6 +5733,16 @@ name = "tree-sitter-php"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -166,6 +166,7 @@ tree-sitter = [
   "dep:tree-sitter-julia",
   "dep:tree-sitter-solidity",
   "dep:tree-sitter-nix",
+  "dep:tree-sitter-powershell",
 ]
 wasm = ["dep:wasmi"]
 
@@ -251,6 +252,7 @@ tree-sitter-haskell = { version = "0.23", optional = true }
 tree-sitter-julia = { version = "0.23", optional = true }
 tree-sitter-solidity = { version = "1.2", optional = true }
 tree-sitter-nix = { version = "0.3", optional = true }
+tree-sitter-powershell = { version = "0.26", optional = true }
 # Exact pin: `ort` 2.0 is still in its release-candidate phase (no stable 2.0.0
 # yet; rc.12 is the upstream-recommended production build). RCs can carry breaking
 # API changes between candidates, so `=` prevents `cargo update` from silently

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -271,7 +271,7 @@ READ MODES:
     auto                           Auto-select optimal mode (default)
     full                           Full content (cached re-reads = 13 tokens)
     map                            Dependency graph + API signatures
-    signatures                     tree-sitter AST extraction (26 languages)
+    signatures                     tree-sitter AST extraction (27 languages)
     task                           Task-relevant filtering (requires ctx_session task)
     reference                      One-line reference stub (cheap cache key)
     aggressive                     Syntax-stripped content

--- a/rust/src/core/benchmark_compare/report.rs
+++ b/rust/src/core/benchmark_compare/report.rs
@@ -286,7 +286,7 @@ fn write_feature_matrix(out: &mut Vec<String>, report: &CompareReport) {
         ("Repo map generation", [false, true, true, false, true]),
         ("Knowledge base", [false, false, false, true, true]),
         (
-            "Tree-sitter AST (26 langs)",
+            "Tree-sitter AST (27 langs)",
             [false, true, true, false, true],
         ),
         ("MCP server", [false, false, false, true, true]),

--- a/rust/src/core/signatures.rs
+++ b/rust/src/core/signatures.rs
@@ -3,7 +3,7 @@
 //! IMPORTANT for readers skimming the repo: this file is the *fallback*, not the
 //! primary engine. The default build extracts signatures with **tree-sitter** via
 //! declarative per-language queries in [`crate::core::signatures_ts`] (real ASTs,
-//! real multi-line spans, ~26 languages). [`extract_signatures`] tries that path
+//! real multi-line spans, ~27 languages). [`extract_signatures`] tries that path
 //! first and only drops to the line-oriented regex extractors here when the
 //! `tree-sitter` feature is off or a parse yields nothing usable for a file.
 //!
@@ -690,6 +690,10 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
     let re_func = static_regex!(
         r"^\s*(?:(?:public|private|protected|static|async|abstract|virtual|override|final|def|func|fun|fn)\s+)+(\w+)\s*\("
     );
+    // PowerShell-style declarations: `function Verb-Noun {` — no paren required,
+    // hyphens allowed in the name. Also catches bash-like dialects the keyword+
+    // paren pattern above misses.
+    let re_ps_func = static_regex!(r"^\s*function\s+([\w-]+)");
     let re_class = static_regex!(
         r"^\s*(?:(?:public|private|protected|abstract|final|sealed|partial)\s+)*(?:class|struct|enum|interface|trait|module|object|record)\s+(\w+)"
     );
@@ -725,6 +729,18 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
                 params: String::new(),
                 return_type: String::new(),
                 is_async: trimmed.contains("async"),
+                is_exported: true,
+                indent: 0,
+                start_line: Some(line_no),
+                end_line: Some(line_no),
+            });
+        } else if let Some(caps) = re_ps_func.captures(trimmed) {
+            sigs.push(Signature {
+                kind: "fn",
+                name: caps[1].to_string(),
+                params: String::new(),
+                return_type: String::new(),
+                is_async: false,
                 is_exported: true,
                 indent: 0,
                 start_line: Some(line_no),
@@ -837,5 +853,21 @@ mod tests {
         let run = sigs.iter().find(|s| s.name == "run").unwrap();
         assert_eq!(run.start_line, Some(4));
         assert_eq!(run.end_line, Some(4));
+    }
+
+    // PowerShell in the generic regex fallback: `function Verb-Noun {` has no
+    // paren and a hyphenated name, which the old keyword+paren pattern missed
+    // entirely (limitation audit 2026-07-03). Covers non-tree-sitter builds.
+    #[test]
+    fn regex_fallback_matches_powershell_functions() {
+        let src = "function Get-CargoBinDir {\n}\nfunction Install($x) {\n}\n# function Commented-Out {\n";
+        let sigs = extract_generic_signatures(src);
+        let names: Vec<&str> = sigs.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Get-CargoBinDir"), "got {names:?}");
+        assert!(names.contains(&"Install"), "got {names:?}");
+        assert!(
+            !names.contains(&"Commented-Out"),
+            "comment must be skipped; got {names:?}"
+        );
     }
 }

--- a/rust/src/core/signatures_ts/extract.rs
+++ b/rust/src/core/signatures_ts/extract.rs
@@ -230,10 +230,14 @@ fn functional_signature(kind: &str, name: &str) -> Option<Signature> {
         | "function" | "bind"                                   // Haskell
         | "assignment"                                          // Julia short-form `f(x) = …`
         | "modifier_definition"                                 // Solidity
+        | "function_statement"                                  // PowerShell
         | "binding" => "fn",                                    // Nix function binding
+        "class_method_definition" => "method",                  // PowerShell
+        "enum_statement" => "enum",                             // PowerShell
         "data_type" | "newtype" | "type_synomym"                // Haskell
         | "abstract_definition" => "type",                      // Julia `abstract type`
-        "contract_declaration" | "library_declaration" => "class", // Solidity
+        "contract_declaration" | "library_declaration"          // Solidity
+        | "class_statement" => "class",                         // PowerShell
         "module_definition" => "module",                        // OCaml / Julia
         "module_type_definition" => "interface",                // OCaml signature
         "struct_definition" => "struct",                        // Julia

--- a/rust/src/core/signatures_ts/mod.rs
+++ b/rust/src/core/signatures_ts/mod.rs
@@ -826,7 +826,7 @@ end
         let langs: &[&str] = &[
             "rs", "ts", "js", "py", "go", "java", "c", "cpp", "rb", "cs", "kt", "swift", "php",
             "sh", "dart", "scala", "ex", "zig", "gd", "lua", "luau", "ml", "mli", "hs", "jl",
-            "sol", "nix",
+            "sol", "nix", "ps1",
         ];
         let mut failures = Vec::new();
         for ext in langs {
@@ -1033,5 +1033,42 @@ library SafeMath {
             !names.contains(&"plainValue"),
             "non-function binding must be skipped; got {names:?}"
         );
+    }
+
+    #[test]
+    fn test_powershell_signatures() {
+        let src = r#"
+function Get-CargoBinDir {
+    param([string]$Path)
+    return $Path
+}
+
+function Stop-RunningLeanCtx() {
+    Write-Host 'stopping'
+}
+
+class BuildResult {
+    [string]$Name
+    [void] Publish($target) {
+    }
+}
+
+enum BuildKind {
+    Debug
+    Release
+}
+"#;
+        let sigs = extract_signatures_ts(src, "ps1").unwrap();
+        let names: Vec<&str> = sigs.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Get-CargoBinDir"), "got {names:?}");
+        assert!(names.contains(&"Stop-RunningLeanCtx"), "got {names:?}");
+        assert!(names.contains(&"BuildResult"), "got {names:?}");
+        assert!(names.contains(&"BuildKind"), "got {names:?}");
+        assert!(names.contains(&"Publish"), "got {names:?}");
+
+        let cls = sigs.iter().find(|s| s.name == "BuildResult").unwrap();
+        assert_eq!(cls.kind, "class");
+        let f = sigs.iter().find(|s| s.name == "Get-CargoBinDir").unwrap();
+        assert_eq!(f.kind, "fn");
     }
 }

--- a/rust/src/core/signatures_ts/queries.rs
+++ b/rust/src/core/signatures_ts/queries.rs
@@ -294,6 +294,18 @@ const QUERY_NIX: &str = r"
 (binding attrpath: (attrpath) @name expression: (function_expression)) @def
 ";
 
+/// Queries [tree-sitter-powershell](https://crates.io/crates/tree-sitter-powershell)
+/// (airbus-cert grammar). Names are carried by child nodes (`function_name`,
+/// `simple_name`), not named fields. `(A (B) @name)` matches direct children
+/// only, so enum members (wrapped in their own nodes) and method parameters
+/// (`variable` nodes) never leak into the capture.
+const QUERY_POWERSHELL: &str = r"
+(function_statement (function_name) @name) @def
+(class_statement (simple_name) @name) @def
+(class_method_definition (simple_name) @name) @def
+(enum_statement (simple_name) @name) @def
+";
+
 pub(super) fn get_language(ext: &str) -> Option<Language> {
     Some(match ext {
         "rs" => tree_sitter_rust::LANGUAGE.into(),
@@ -324,6 +336,7 @@ pub(super) fn get_language(ext: &str) -> Option<Language> {
         "jl" => tree_sitter_julia::LANGUAGE.into(),
         "sol" => tree_sitter_solidity::LANGUAGE.into(),
         "nix" => tree_sitter_nix::LANGUAGE.into(),
+        "ps1" | "psm1" => tree_sitter_powershell::LANGUAGE.into(),
         _ => return None,
     })
 }
@@ -357,6 +370,7 @@ pub(super) fn get_query(ext: &str) -> Option<&'static str> {
         "jl" => QUERY_JULIA,
         "sol" => QUERY_SOLIDITY,
         "nix" => QUERY_NIX,
+        "ps1" | "psm1" => QUERY_POWERSHELL,
         _ => return None,
     })
 }

--- a/rust/src/core/signatures_ts/query_cache.rs
+++ b/rust/src/core/signatures_ts/query_cache.rs
@@ -13,7 +13,8 @@ pub(crate) fn get_cached_sig_query(file_ext: &str) -> Option<&'static Query> {
         let exts: &[&str] = &[
             "rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "c", "h", "cpp", "cc", "cxx",
             "hpp", "rb", "cs", "kt", "kts", "swift", "php", "sh", "bash", "dart", "scala", "sc",
-            "ex", "exs", "zig", "gd", "lua", "luau", "ml", "mli", "hs", "jl", "sol", "nix",
+            "ex", "exs", "zig", "gd", "lua", "luau", "ml", "mli", "hs", "jl", "sol", "nix", "ps1",
+            "psm1",
         ];
         for &ext in exts {
             if let (Some(lang), Some(src)) = (get_language(ext), get_query(ext))

--- a/rust/src/templates/SKILL.md
+++ b/rust/src/templates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lean-ctx
-description: Context Engineering for AI Agents — 81 MCP tools, 10 read modes, 95+ shell patterns, tree-sitter AST for 26 languages. Compresses LLM context by up to 99%. Use when reading files, running shell commands, searching code, or exploring directories. Auto-installs if not present.
+description: Context Engineering for AI Agents — 81 MCP tools, 10 read modes, 95+ shell patterns, tree-sitter AST for 27 languages. Compresses LLM context by up to 99%. Use when reading files, running shell commands, searching code, or exploring directories. Auto-installs if not present.
 ---
 
 # lean-ctx — Context Engineering for AI Agents

--- a/rust/src/tools/registered/ctx_outline.rs
+++ b/rust/src/tools/registered/ctx_outline.rs
@@ -18,7 +18,7 @@ impl McpTool for CtxOutlineTool {
             "ctx_outline",
             "WORKFLOW: call BEFORE ctx_read to map code structure (a syntax-aware table of contents).\n\
             Accepts a FILE or a DIRECTORY (folder surface — per-file symbols). Symbols come from\n\
-            tree-sitter (26 languages, real line spans); a conservative regex fallback covers the rest.\n\
+            tree-sitter (27 languages, real line spans); a conservative regex fallback covers the rest.\n\
             kind=fn|struct|class|trait|enum|impl|all filters by kind; match=<substr> filters by name\n\
             (case-insensitive); format=json emits deterministic JSON labelling the backend per file.\n\
             ANTIPATTERN: NOT for file content (use ctx_read) or deep understanding (use ctx_compose).",


### PR DESCRIPTION
Closes #679.

## What

- Wire [tree-sitter-powershell 0.26](https://crates.io/crates/tree-sitter-powershell) (airbus-cert, MIT) for `.ps1`/`.psm1`: functions, classes, methods, enums with real line spans.
  - Query matches the grammar's name-carrying child nodes (`function_name`, `simple_name`); direct-child matching keeps enum members and method parameters out of the capture.
  - Kind labels routed through `functional_signature` per repo convention (`class_statement` merged into the existing `class` group to satisfy `clippy::match_same_arms`).
- Generic regex fallback learns `function [\w-]+` — PowerShell's `function Verb-Noun {` (no paren, hyphenated name) previously matched nothing; also covers other shell dialects on non-tree-sitter builds. Comment lines still skipped.
- Coverage guard `every_supported_ext_has_a_compiling_query` now includes `ps1`; query pre-compile cache includes `ps1`/`psm1`; docs/tool descriptions bumped 26 → 27 languages.

## Why

`.ps1` map/signatures reads carried zero information and degraded to full-file verbatim delivery (0 saved, no marker) — details and repro in #679. Windows-heavy repos lose structural reads entirely.

## Result (this repo's own install.ps1, 102L ~900 tok)

```
install.ps1 [102L]
  API:
    fn pub Get-CargoBinDir() @L25-31
    fn pub Stop-RunningLeanCtx() @L33-43
```

## Cost

+937,984 bytes measured on the debug binary (+0.58%); parser-table const data, same league as tree-sitter-rust (rlib 1.46 MB vs 1.47 MB).

## Tests

- `test_powershell_signatures` — functions (hyphenated names), class, method, enum, kind labels
- `regex_fallback_matches_powershell_functions` — fallback path incl. comment-line exclusion
- `every_supported_ext_has_a_compiling_query` — ps1 grammar+query compile guard
- Full lib suite: no new failures; clippy pedantic clean on touched files

## Not covered (deliberate)

`psd1` (data files, no functions); PowerShell `Import-Module` deps extraction — follow-up if callgraph for ps1 ever matters.