### PR TITLE
fix: use dashboard API client for context Apply

### DIFF
--- a/rust/src/dashboard/static/components/cockpit-commander.js
+++ b/rust/src/dashboard/static/components/cockpit-commander.js
@@ -557,18 +557,16 @@ class CockpitCommander extends HTMLElement {
     if (value !== undefined) body.value = value;
 
     try {
-      await fetch('/api/context-overlay', {
+      await fetchJson('/api/context-overlay', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer ' + (window.__LEAN_CTX_TOKEN__ || ''),
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        timeoutMs: 15000,
       });
       toast(action + ': ' + shortenPath(path), 'success');
       this.loadData();
     } catch (e) {
-      toast('Failed: ' + String(e), 'error');
+      toast('Failed: ' + (e?.error || String(e)), 'error');
     }
   }
 }


### PR DESCRIPTION
## Summary
- route Context Triage Apply actions through the dashboard apiFetch helper
- keep auth, timeout, and non-2xx error handling consistent with Context Contents overlay actions
- preserve the existing success reload path after successful overlay mutation

Fixes #678

## Validation
- cd rust && cargo fmt --check
- cd rust && cargo test dashboard -q

Note: cargo test dashboard -q completed successfully, but the filter matched no concrete tests in the emitted test binaries; it reported filtered-out suites only.