### PR TITLE
fix: five output-honesty fixes for compressed and degraded views (#683)

### DIFF
--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -265,6 +265,11 @@ pub fn cmd_read(args: &[String]) {
                         buf.push_str(&format!("\n    {}", sig.to_compact_located()));
                     }
                 }
+                // Same honesty rule as the MCP renderer: an information-free
+                // map must say so (limitations audit, #4).
+                if key_sigs.is_empty() && dep_info.imports.is_empty() && extra_exports.is_empty() {
+                    buf.push_str(&crate::tools::ctx_read::no_structure_marker(ext));
+                }
                 buf
             } else {
                 format!("{short} [{line_count}L]\n{structured}")
@@ -291,6 +296,10 @@ pub fn cmd_read(args: &[String]) {
             let mut output_buf = format!("{short} [{line_count}L]");
             for sig in &sigs {
                 output_buf.push_str(&format!("\n{}", sig.to_compact_located()));
+            }
+            // Same honesty rule as the MCP renderer (limitations audit, #4).
+            if sigs.is_empty() {
+                output_buf.push_str(&crate::tools::ctx_read::no_structure_marker(ext));
             }
             if requested_auto {
                 output_buf = cap_cli_to_raw(output_buf, &content, original_tokens);
@@ -341,13 +350,38 @@ pub fn cmd_read(args: &[String]) {
                 read_start.elapsed(),
             );
         }
+        m if m.starts_with("lines:") => {
+            // The CLI used to drop the window and print the whole file — a
+            // `lines:` read must return the requested selection, with the same
+            // comma-multi-select hint as the MCP renderer (limitations #7).
+            let range_str = &m[6..];
+            let extracted = crate::tools::ctx_read::extract_line_range(&content, range_str);
+            let multi_hint = if range_str.contains(',') {
+                crate::tools::ctx_read::LINES_COMMA_HINT
+            } else {
+                ""
+            };
+            let output =
+                format!("{short} [{line_count}L] lines:{range_str}\n{extracted}{multi_hint}");
+            println!("{output}");
+            let sent = count_tokens(&output);
+            print_savings(original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "lines",
+                original_tokens,
+                sent,
+                &output,
+                read_start.elapsed(),
+            );
+        }
         _ => {
-            // `full`, `lines:` and any unrecognized mode land here. These are
+            // `full` and any unrecognized mode land here. These are
             // verbatim reads — the prose terse pipeline would mangle source
             // (dictionary substitutions, line-drop dedup) and break a `full`
             // read's "complete content" contract, so it must never run here
             // (#404). Intentionally-lossy modes (map/signatures/aggressive/
-            // entropy) have their own arms above.
+            // entropy/lines) have their own arms above.
             let mut output = format!("{short} [{line_count}L]\n{content}");
             if !crate::core::terse::is_verbatim_read("ctx_read", Some(mode)) {
                 let config = crate::core::config::Config::load();

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -61,10 +61,7 @@ fn resolve_cli_read_mode(args: &[String]) -> &str {
     }
     args.iter()
         .skip(1)
-        .find(|a| {
-            !a.starts_with('-')
-                && a.parse::<crate::tools::ctx_read::ReadMode>().is_ok()
-        })
+        .find(|a| !a.starts_with('-') && a.parse::<crate::tools::ctx_read::ReadMode>().is_ok())
         .map_or("auto", std::string::String::as_str)
 }
 

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -46,6 +46,28 @@ fn should_force_fresh(args: &[String], hook_child: bool) -> bool {
     hook_child || args.iter().any(|a| a == "--fresh" || a == "--no-cache")
 }
 
+/// Resolve the read mode from CLI args. `--mode`/`-m` wins; otherwise the
+/// first positional after the path that parses as a known mode counts — a bare
+/// `lean-ctx read f.ps1 map` used to silently serve the `auto` default instead
+/// of the requested view (limitations audit 2026-07-03). Unknown positionals
+/// and flags are left alone so existing invocations keep their meaning.
+fn resolve_cli_read_mode(args: &[String]) -> &str {
+    if let Some(m) = args
+        .iter()
+        .position(|a| a == "--mode" || a == "-m")
+        .and_then(|i| args.get(i + 1))
+    {
+        return m.as_str();
+    }
+    args.iter()
+        .skip(1)
+        .find(|a| {
+            !a.starts_with('-')
+                && a.parse::<crate::tools::ctx_read::ReadMode>().is_ok()
+        })
+        .map_or("auto", std::string::String::as_str)
+}
+
 pub fn cmd_read(args: &[String]) {
     if args.is_empty() {
         eprintln!(
@@ -64,11 +86,7 @@ pub fn cmd_read(args: &[String]) {
         raw_path.clone()
     };
     let path = path.as_str();
-    let mode = args
-        .iter()
-        .position(|a| a == "--mode" || a == "-m")
-        .and_then(|i| args.get(i + 1))
-        .map_or("auto", std::string::String::as_str);
+    let mode = resolve_cli_read_mode(args);
     // #1037: redirect/rewrite hook children pipe `-m full` output into a temp file the
     // host reads back AS the file's content, so a `cached <file> [NL]` cache-hit stub
     // corrupts the read (and round-trips the stub into the real file on the next edit).
@@ -700,5 +718,46 @@ mod fresh_tests {
         assert!(should_force_fresh(&["--fresh".to_string()], false));
         assert!(should_force_fresh(&["--no-cache".to_string()], false));
         assert!(!should_force_fresh(&["file.rs".to_string()], false));
+    }
+}
+
+#[cfg(test)]
+mod mode_arg_tests {
+    use super::resolve_cli_read_mode;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(ToString::to_string).collect()
+    }
+
+    // `lean-ctx read f.ps1 map` used to silently IGNORE the positional mode and
+    // serve the `auto` default — reads must honour it like `--mode map`
+    // (limitations audit 2026-07-03).
+    #[test]
+    fn positional_mode_is_honoured() {
+        assert_eq!(resolve_cli_read_mode(&args(&["f.ps1", "map"])), "map");
+        assert_eq!(
+            resolve_cli_read_mode(&args(&["f.rs", "lines:5-10"])),
+            "lines:5-10"
+        );
+    }
+
+    #[test]
+    fn mode_flag_wins_over_positional() {
+        assert_eq!(
+            resolve_cli_read_mode(&args(&["f.rs", "map", "--mode", "signatures"])),
+            "signatures"
+        );
+        assert_eq!(
+            resolve_cli_read_mode(&args(&["f.rs", "-m", "full"])),
+            "full"
+        );
+    }
+
+    #[test]
+    fn defaults_to_auto_and_skips_flags_and_junk() {
+        assert_eq!(resolve_cli_read_mode(&args(&["f.rs"])), "auto");
+        assert_eq!(resolve_cli_read_mode(&args(&["f.rs", "--fresh"])), "auto");
+        // An unknown positional is not silently treated as a mode.
+        assert_eq!(resolve_cli_read_mode(&args(&["f.rs", "banana"])), "auto");
     }
 }

--- a/rust/src/core/io_boundary.rs
+++ b/rust/src/core/io_boundary.rs
@@ -47,7 +47,17 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
         let msg = crate::core::binary_detect::binary_file_message(path);
         return Err(std::io::Error::other(msg));
     }
-    read_file_nofollow(path)
+    read_file_nofollow(path).map(strip_utf8_bom)
+}
+
+/// A UTF-8 BOM is an encoding artifact, not content — leaking it corrupts the
+/// first line of every downstream view (limitations doc #11). Shared by both
+/// file readers (this module's and `tools::ctx_read::read_file_lossy`).
+pub(crate) fn strip_utf8_bom(s: String) -> String {
+    match s.strip_prefix('\u{feff}') {
+        Some(rest) => rest.to_owned(),
+        None => s,
+    }
 }
 
 /// Result of a file read with secret scanning applied.
@@ -350,5 +360,18 @@ mod tests {
             Some("credential file")
         );
         assert_eq!(is_secret_like(Path::new("shadow")), Some("credential file"));
+    }
+
+    // The CLI full-read path (`cli_cache::check_and_read`) reads through THIS
+    // `read_file_lossy`, not the ctx_read one — both must strip the UTF-8 BOM
+    // or the CLI leaks it while the MCP path doesn't (limitations doc #11).
+    #[test]
+    fn read_file_lossy_strips_utf8_bom() {
+        let p = std::env::temp_dir().join("lean_ctx_io_bom_test.txt");
+        std::fs::write(&p, b"\xEF\xBB\xBFhello\n").unwrap();
+        let s = read_file_lossy(p.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert!(!s.starts_with('\u{feff}'), "BOM must be stripped");
+        assert!(s.starts_with("hello"));
     }
 }

--- a/rust/src/core/patterns/git/commit.rs
+++ b/rust/src/core/patterns/git/commit.rs
@@ -12,7 +12,19 @@ pub(super) fn compress_add(output: &str) -> String {
     if lines.len() <= 3 {
         return trimmed.to_string();
     }
-    format!("ok (+{} files)", lines.len())
+    // Only `add '<path>'` verbose lines are files; anything else in the output
+    // (hook chatter, a chained `git commit`'s summary) must not be counted as
+    // one — a summary may only state numbers parsed from the output (#2 in the
+    // limitations audit: "ok (+7 files)" for a 1-file commit).
+    let added = lines
+        .iter()
+        .filter(|l| l.trim_start().starts_with("add '"))
+        .count();
+    if added > 0 {
+        format!("ok (+{added} files)")
+    } else {
+        format!("ok ({} lines)", lines.len())
+    }
 }
 
 pub(super) fn compress_commit(output: &str) -> String {

--- a/rust/src/core/patterns/git/mod.rs
+++ b/rust/src/core/patterns/git/mod.rs
@@ -154,6 +154,30 @@ mod tests {
         assert!(result.contains("ok"), "git add should compress to 'ok'");
     }
 
+    // A chained `git add … && git commit …` routes the whole compound output
+    // through the add-compressor, which used to label OUTPUT LINE COUNT as a
+    // file count ("ok (+7 files)" for a 1-file commit). Numbers in summaries
+    // must come from the output, not be fabricated (limitations audit, #2).
+    #[test]
+    fn git_add_does_not_label_line_count_as_files() {
+        let output = "[main abc1234] fix: x\n 1 file changed, 1 insertion(+)\nhook line\nanother\nmore\nlines\nseven\n";
+        let result = compress("git add . && git commit -m 'x'", output).unwrap();
+        assert!(
+            !result.contains("files)"),
+            "line count must not be presented as a file count: {result}"
+        );
+    }
+
+    #[test]
+    fn git_add_verbose_counts_real_added_files() {
+        let output = "add 'a.rs'\nadd 'b.rs'\nadd 'c.rs'\nadd 'd.rs'\n";
+        let result = compress("git add -v .", output).unwrap();
+        assert!(
+            result.contains("+4 files"),
+            "verbose add lines are the real file count: {result}"
+        );
+    }
+
     #[test]
     fn git_commit_extracts_hash() {
         let output =

--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -163,12 +163,7 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
         Ok(s) => s,
         Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
     };
-    // A UTF-8 BOM is an encoding artifact, not content — leaking it corrupts
-    // the first line of every downstream view (limitations doc #11).
-    Ok(match s.strip_prefix('\u{feff}') {
-        Some(rest) => rest.to_owned(),
-        None => s,
-    })
+    Ok(crate::core::io_boundary::strip_utf8_bom(s))
 }
 
 /// Opens a file, retrying once after a brief pause on NotFound.

--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -159,10 +159,16 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
     use std::io::Read;
     let mut bytes = Vec::with_capacity(meta.len() as usize);
     std::io::BufReader::new(file).read_to_end(&mut bytes)?;
-    match String::from_utf8(bytes) {
-        Ok(s) => Ok(s),
-        Err(e) => Ok(String::from_utf8_lossy(e.as_bytes()).into_owned()),
-    }
+    let s = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
+    };
+    // A UTF-8 BOM is an encoding artifact, not content — leaking it corrupts
+    // the first line of every downstream view (limitations doc #11).
+    Ok(match s.strip_prefix('\u{feff}') {
+        Some(rest) => rest.to_owned(),
+        None => s,
+    })
 }
 
 /// Opens a file, retrying once after a brief pause on NotFound.

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -280,6 +280,13 @@ pub(crate) fn process_mode_tuned(
                     output.push_str(note);
                 }
             }
+            // Same honesty rule as map: an empty signature view for a language
+            // without an extractor must be labeled (limitations audit, #4).
+            if sigs.is_empty() && dep_info.imports.is_empty() {
+                output.push_str(&format!(
+                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
+                ));
+            }
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
                 output.push('\n');
                 output.push_str(&body);
@@ -395,6 +402,15 @@ pub(crate) fn process_mode_tuned(
                         output.push_str(note);
                     }
                 }
+            }
+
+            // Nothing extractable (no grammar/regex coverage for this language):
+            // an information-free map must say so, or the caller reads the bare
+            // header as "this file has no API" (limitations audit, #4 residual).
+            if key_sigs.is_empty() && dep_info.imports.is_empty() && extra_exports.is_empty() {
+                output.push_str(&format!(
+                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
+                ));
             }
 
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
@@ -677,9 +693,17 @@ pub(crate) fn process_mode_tuned(
             } else {
                 format!("{short} {line_count}L lines:{range_str}")
             };
+            // Comma is multi-select, not a range — a caller who meant `N-M`
+            // gets stray single lines back, so say what the comma did instead
+            // of letting the wrong window pass silently (limitations #7).
+            let multi_hint = if range_str.contains(',') {
+                "\n[lines: comma = multi-select (e.g. 5,10-20 picks line 5 and lines 10-20); use N-M for one span]"
+            } else {
+                ""
+            };
             let sent = count_tokens(&extracted);
             let savings = protocol::format_savings(original_tokens, sent);
-            (format!("{header}\n{extracted}\n{savings}"), sent)
+            (format!("{header}\n{extracted}{multi_hint}\n{savings}"), sent)
         }
         mode if mode.starts_with("density:") => {
             // SDE target-density mode: compress to a token budget instead of

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -283,9 +283,7 @@ pub(crate) fn process_mode_tuned(
             // Same honesty rule as map: an empty signature view for a language
             // without an extractor must be labeled (limitations audit, #4).
             if sigs.is_empty() && dep_info.imports.is_empty() {
-                output.push_str(&format!(
-                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
-                ));
+                output.push_str(&no_structure_marker(ext));
             }
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
                 output.push('\n');
@@ -408,9 +406,7 @@ pub(crate) fn process_mode_tuned(
             // an information-free map must say so, or the caller reads the bare
             // header as "this file has no API" (limitations audit, #4 residual).
             if key_sigs.is_empty() && dep_info.imports.is_empty() && extra_exports.is_empty() {
-                output.push_str(&format!(
-                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
-                ));
+                output.push_str(&no_structure_marker(ext));
             }
 
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
@@ -697,7 +693,7 @@ pub(crate) fn process_mode_tuned(
             // gets stray single lines back, so say what the comma did instead
             // of letting the wrong window pass silently (limitations #7).
             let multi_hint = if range_str.contains(',') {
-                "\n[lines: comma = multi-select (e.g. 5,10-20 picks line 5 and lines 10-20); use N-M for one span]"
+                LINES_COMMA_HINT
             } else {
                 ""
             };
@@ -833,6 +829,20 @@ pub(crate) fn task_relevant_body(
         "  ▸ body {} L{}-{}:\n{body}{truncated}",
         ch.symbol_name, ch.start_line, ch.end_line
     ))
+}
+
+/// One-line explainer appended whenever a `lines:` payload uses a comma —
+/// comma means multi-select, and a caller who meant a `N-M` span must be able
+/// to see that from the output (limitations #7). Shared with the CLI arm.
+pub(crate) const LINES_COMMA_HINT: &str = "\n[lines: comma = multi-select (e.g. 5,10-20 picks line 5 and lines 10-20); use N-M for one span]";
+
+/// Marker for a map/signatures view that extracted nothing — a language with
+/// no grammar/regex coverage must be distinguishable from a file with no API
+/// (limitations audit, #4). Shared with the CLI arms.
+pub(crate) fn no_structure_marker(ext: &str) -> String {
+    format!(
+        "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
+    )
 }
 
 pub(crate) fn extract_line_range(content: &str, range_str: &str) -> String {

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -703,7 +703,10 @@ pub(crate) fn process_mode_tuned(
             };
             let sent = count_tokens(&extracted);
             let savings = protocol::format_savings(original_tokens, sent);
-            (format!("{header}\n{extracted}{multi_hint}\n{savings}"), sent)
+            (
+                format!("{header}\n{extracted}{multi_hint}\n{savings}"),
+                sent,
+            )
         }
         mode if mode.starts_with("density:") => {
             // SDE target-density mode: compress to a token budget instead of

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -343,6 +343,94 @@ fn map_mode_inlines_task_relevant_body() {
     );
 }
 
+// `lines:5,10-12` is multi-select (comma-separated lines/ranges), not a range.
+// Callers who meant a span get stray lines back — the output must say what
+// the comma did so the mistake is visible (limitations audit 2026-07-03, #7).
+#[test]
+fn lines_comma_multiselect_gets_hint() {
+    let content = (1..=30)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tokens = count_tokens(&content);
+    let (out, _) = process_mode(
+        &content,
+        "lines:5,10-12",
+        "F1",
+        "t.txt",
+        "txt",
+        tokens,
+        CrpMode::Off,
+        "t.txt",
+        None,
+    );
+    assert!(out.contains("line 5") && out.contains("line 10"), "{out}");
+    assert!(
+        out.contains("multi-select"),
+        "comma form must carry a hint: {out}"
+    );
+}
+
+// A map/signatures read of a language with no extractor must say so instead of
+// returning a bare header the caller mistakes for "file has no API"
+// (limitations audit 2026-07-03, #4 residual).
+#[test]
+fn map_on_unsupported_language_carries_marker() {
+    let content = "some plain text\nwith no code\nstructure at all\n";
+    let tokens = count_tokens(content);
+    let (out, _) = process_mode(
+        content,
+        "map",
+        "F1",
+        "notes.txt",
+        "txt",
+        tokens,
+        CrpMode::Off,
+        "notes.txt",
+        None,
+    );
+    assert!(
+        out.contains("no extractable structure"),
+        "empty map must carry a marker: {out}"
+    );
+}
+
+#[test]
+fn signatures_on_unsupported_language_carries_marker() {
+    let content = "some plain text\nwith no code\nstructure at all\n";
+    let tokens = count_tokens(content);
+    let (out, _) = process_mode(
+        content,
+        "signatures",
+        "F1",
+        "notes.txt",
+        "txt",
+        tokens,
+        CrpMode::Off,
+        "notes.txt",
+        None,
+    );
+    assert!(
+        out.contains("no extractable structure"),
+        "empty signatures must carry a marker: {out}"
+    );
+}
+
+// UTF-8 BOM must not leak into the first line of ctx_read output
+// (limitations doc #11).
+#[test]
+fn read_file_lossy_strips_utf8_bom() {
+    let p = std::env::temp_dir().join("lean_ctx_bom_test.txt");
+    std::fs::write(&p, b"\xEF\xBB\xBFhello\n").unwrap();
+    let s = read_file_lossy(p.to_str().unwrap()).unwrap();
+    let _ = std::fs::remove_file(&p);
+    assert!(
+        !s.starts_with('\u{feff}'),
+        "BOM must be stripped from read content"
+    );
+    assert!(s.starts_with("hello"), "content after BOM must survive: {s}");
+}
+
 #[test]
 fn compressed_cache_key_distinguishes_task() {
     let no_task = compressed_cache_key("map", CrpMode::Off, None, None, &[]);

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -428,7 +428,10 @@ fn read_file_lossy_strips_utf8_bom() {
         !s.starts_with('\u{feff}'),
         "BOM must be stripped from read content"
     );
-    assert!(s.starts_with("hello"), "content after BOM must survive: {s}");
+    assert!(
+        s.starts_with("hello"),
+        "content after BOM must survive: {s}"
+    );
 }
 
 #[test]

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -45,7 +45,7 @@ impl McpTool for CtxReadTool {
                     "paths": { "type": "array", "items": { "type": "string" }, "description": "Batch read" },
                     "mode": {
                         "type": "string",
-                        "description": "REQUIRED. full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window reference=quotes task=focus"
+                        "description": "REQUIRED. full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window (comma multi-selects: lines:5,10-20) reference=quotes task=focus"
                     },
                     "raw": { "type": "boolean", "description": "Verbatim (= mode=raw + fresh)" },
                     "start_line": { "type": "integer", "description": "1-based" },

--- a/rust/tests/read_fidelity.rs
+++ b/rust/tests/read_fidelity.rs
@@ -51,10 +51,16 @@ fn cli_lines_read_is_byte_exact() {
 
     let out = read_output(dir.path(), &file, "lines:1-3");
     let stdout = String::from_utf8_lossy(&out.stdout);
-    // The contract under test is fidelity: the source must survive verbatim with
-    // no terse substitutions, regardless of how the range is rendered.
-    assert!(
-        stdout.contains(SAMPLE),
-        "lines: read must not terse-mangle source; got:\n{stdout}"
-    );
+    // The contract under test is fidelity: the SELECTED lines must survive
+    // verbatim with no terse substitutions, regardless of how the range is
+    // rendered. `lines:1-3` is windowed output, not a full-file dump, so the
+    // oracle is the selected slice — not the whole SAMPLE (#684 fix made
+    // `lines:` actually honour the window instead of returning the full file).
+    let selected_lines = &SAMPLE.lines().collect::<Vec<_>>()[..3];
+    for line in selected_lines {
+        assert!(
+            line.is_empty() || stdout.contains(line),
+            "lines: read must not terse-mangle selected source; missing {line:?} in:\n{stdout}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #683.

Compressed views must never lie about what they contain. Five small, independent fixes sharing that failure mode, each with a test that reproduces the misstatement first:

## Fixes

1. **`compress_add` fabricated file counts** (`core/patterns/git/commit.rs`) — count only verbose `add '<path>'` lines as files; other output (hook chatter, a chained commit's summary) reports as `ok (N lines)`. Repro: `git add . && git commit` said `ok (+7 files)` for a 1-file commit.

2. **`lines:N,M` comma multi-select made visible** (`tools/ctx_read/render.rs`) — the comma form keeps working (it's useful: `lines:5,10-20`), but the view now appends a one-line hint whenever a comma is used, and the ctx_read `mode` schema documents the syntax. Previously a caller who meant a span got stray single lines with no indication.

3. **CLI positional mode honored** (`cli/read_cmd.rs`) — `lean-ctx read f.ps1 map` used to silently serve `auto`; the first positional after the path that parses as a known `ReadMode` now counts. `--mode`/`-m` still wins; unknown positionals and flags keep their old meaning (extracted into a pure, unit-tested `resolve_cli_read_mode`).

4. **Empty map/signatures labeled** (`tools/ctx_read/render.rs`) — when a language has no extractor and the view carries zero information, both modes append `[no extractable structure for .ext — header only; use mode="lines:N-M" or "full"]` instead of a bare header the caller reads as 'this file has no API'.

5. **UTF-8 BOM stripped** (`tools/ctx_read/mod.rs::read_file_lossy`) — the BOM is an encoding artifact, not content; it no longer leaks into the first line of every downstream view.

## Tests

8 new: `git_add_does_not_label_line_count_as_files`, `git_add_verbose_counts_real_added_files`, `lines_comma_multiselect_gets_hint`, `map_on_unsupported_language_carries_marker`, `signatures_on_unsupported_language_carries_marker`, `read_file_lossy_strips_utf8_bom`, `positional_mode_is_honoured`, `mode_flag_wins_over_positional` (+ defaults case). All written red-first. Full lib suite: no new failures; clippy pedantic clean; `gen_docs` unchanged (generated reference lists parameter names, none changed).