### PR TITLE
fix(dev-install): explain the Windows rename lock instead of retrying blind

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Your AI agent reads files and runs commands. LeanCTX compresses both automatical
 - **Target density** (`density:0.4`): SDE-style budget compression — keeps the highest-entropy lines until ~40% of the original tokens remain, deterministic
 - **JIT disclosure**: `signatures` carries line spans and points at `lines:N-M` for targeted expansion — outline first, bodies on demand
 - **Shell output**: 95+ shell-output patterns compress git, npm, cargo, docker, kubectl, terraform and more (270 passthrough rules)
-- **Tree-sitter AST**: structural understanding for 26 languages — not just text compression
+- **Tree-sitter AST**: structural understanding for 27 languages — not just text compression
 - **Reversible by design (CCR)**: compression never *discards* content — pruned or truncated payloads move to a content-addressed store with a deterministic handle, so the model can pull the original bytes back on demand via `ctx_expand`, `ctx_retrieve`, an in-band marker, or `GET /v1/references/{id}`. [Five recovery paths →](docs/comparisons/vs-headroom.md#reversibility)
 
 ### 2. Routing — the right fidelity per read

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -629,7 +629,7 @@ raw=true for verbatim output.
 [exit:N] on errors (lossless).
 ANTIPATTERN: multi-line scripts → ctx_execute.
 
-Parameters: `command`*, `cwd`, `env`, `raw`
+Parameters: `command`*, `cwd`, `env`, `raw`, `timeout_ms`
 
 ## `ctx_skillify`
 

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -389,7 +389,7 @@ Parameters: `action`*, `alias`, `max_results`, `mode`, `path`, `query`, `roots`
 
 WORKFLOW: call BEFORE ctx_read to map code structure (a syntax-aware table of contents).
 Accepts a FILE or a DIRECTORY (folder surface — per-file symbols). Symbols come from
-tree-sitter (26 languages, real line spans); a conservative regex fallback covers the rest.
+tree-sitter (27 languages, real line spans); a conservative regex fallback covers the rest.
 kind=fn|struct|class|trait|enum|impl|all filters by kind; match=<substr> filters by name
 (case-insensitive); format=json emits deterministic JSON labelling the backend per file.
 ANTIPATTERN: NOT for file content (use ctx_read) or deep understanding (use ctx_compose).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2477,6 +2477,7 @@ dependencies = [
  "tree-sitter-nix",
  "tree-sitter-ocaml",
  "tree-sitter-php",
+ "tree-sitter-powershell",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -5732,6 +5733,16 @@ name = "tree-sitter-php"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -166,6 +166,7 @@ tree-sitter = [
   "dep:tree-sitter-julia",
   "dep:tree-sitter-solidity",
   "dep:tree-sitter-nix",
+  "dep:tree-sitter-powershell",
 ]
 wasm = ["dep:wasmi"]
 
@@ -251,6 +252,7 @@ tree-sitter-haskell = { version = "0.23", optional = true }
 tree-sitter-julia = { version = "0.23", optional = true }
 tree-sitter-solidity = { version = "1.2", optional = true }
 tree-sitter-nix = { version = "0.3", optional = true }
+tree-sitter-powershell = { version = "0.26", optional = true }
 # Exact pin: `ort` 2.0 is still in its release-candidate phase (no stable 2.0.0
 # yet; rc.12 is the upstream-recommended production build). RCs can carry breaking
 # API changes between candidates, so `=` prevents `cargo update` from silently

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -271,7 +271,7 @@ READ MODES:
     auto                           Auto-select optimal mode (default)
     full                           Full content (cached re-reads = 13 tokens)
     map                            Dependency graph + API signatures
-    signatures                     tree-sitter AST extraction (26 languages)
+    signatures                     tree-sitter AST extraction (27 languages)
     task                           Task-relevant filtering (requires ctx_session task)
     reference                      One-line reference stub (cheap cache key)
     aggressive                     Syntax-stripped content

--- a/rust/src/cli/dispatch/lifecycle.rs
+++ b/rust/src/cli/dispatch/lifecycle.rs
@@ -316,10 +316,7 @@ fn atomic_install_binary(src: &std::path::Path, dst: &std::path::Path) -> Result
     #[cfg(target_os = "macos")]
     let _ = std::fs::remove_file(dst);
 
-    if let Err(e) = std::fs::rename(&staged, dst) {
-        let _ = std::fs::remove_file(&staged);
-        return Err(format!("atomic rename failed: {e}"));
-    }
+    rename_with_retry(&staged, dst)?;
 
     // #356: prefer the persistent identity (stable cdhash anchor → TCC grant
     // survives updates); ad-hoc fallback keeps the binary launchable regardless.
@@ -329,6 +326,63 @@ fn atomic_install_binary(src: &std::path::Path, dst: &std::path::Path) -> Result
     }
 
     Ok(())
+}
+
+/// Rename `staged` onto `dst`, retrying briefly on failure.
+///
+/// dev-install deliberately never SIGKILLs the IDE-owned MCP stdio server
+/// (#1036) — killing it would drop the editor's MCP connection for minutes,
+/// and the binary it respawns is the freshly installed one anyway. On Windows
+/// that still-running process's open handle to the old binary can make a
+/// single-shot rename fail with ACCESS_DENIED.
+///
+/// Field data (2026-07-03) ruled out a short timing race: a 2.25s retry
+/// budget failed, and so did 60s — the hold does not clear on any timer, it
+/// lasts for the connected MCP session's lifetime. No retry budget can
+/// out-wait that, so this keeps only a brief retry (catches a genuinely quick
+/// transient, e.g. AV/EDR scanning the freshly written exe) and instead makes
+/// the failure actionable: the error explains the likely cause and the real
+/// fix (reconnect the MCP client) instead of a bare OS error code.
+fn rename_with_retry(staged: &std::path::Path, dst: &std::path::Path) -> Result<(), String> {
+    rename_with_retry_within(
+        staged,
+        dst,
+        std::time::Duration::from_secs(5),
+        std::time::Duration::from_millis(300),
+    )
+}
+
+/// Core retry loop, parameterized so tests can use short budgets instead of
+/// waiting out the real production ceiling.
+fn rename_with_retry_within(
+    staged: &std::path::Path,
+    dst: &std::path::Path,
+    max_wait: std::time::Duration,
+    step: std::time::Duration,
+) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + max_wait;
+    let err = loop {
+        match std::fs::rename(staged, dst) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                if std::time::Instant::now() >= deadline {
+                    break e;
+                }
+                std::thread::sleep(step);
+            }
+        }
+    };
+
+    let _ = std::fs::remove_file(staged);
+    Err(format!(
+        "atomic rename failed after {:.0}s: {err}\n  \
+         This usually means another process still has the old binary open — \
+         most commonly an IDE/editor's MCP connection to lean-ctx, which \
+         dev-install deliberately does not kill (#1036). Disconnect and \
+         reconnect your MCP client (e.g. `/mcp` in Claude Code) and re-run \
+         `lean-ctx dev-install`.",
+        max_wait.as_secs_f64()
+    ))
 }
 
 /// Resolve cargo's real target directory for the project at `cargo_root`.
@@ -582,5 +636,167 @@ mod tests {
         )));
         assert!(!is_homebrew_cellar_link(Path::new("/usr/local/bin/other")));
         assert!(!is_homebrew_cellar_link(Path::new("lean-ctx")));
+    }
+}
+
+/// dev-install (#1036) deliberately leaves the IDE-owned MCP stdio server
+/// running rather than SIGKILLing it (killing it drops the editor's MCP
+/// connection for minutes). On Windows that process's still-open handle to
+/// the old binary can make a single-shot `rename` fail with ACCESS_DENIED
+/// even though the hold is transient. Retrying with backoff lets the install
+/// succeed once the handle clears, without ever killing the IDE's process.
+#[cfg(all(test, windows))]
+mod windows_rename_retry_tests {
+    use super::{rename_with_retry, rename_with_retry_within};
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::time::Duration;
+
+    const FILE_SHARE_READ: u32 = 0x1;
+
+    #[test]
+    fn recovers_from_transient_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let dst = dir.path().join("target.exe");
+        let staged = dir.path().join("target.exe.new");
+        std::fs::write(&dst, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        let locked_dst = dst.clone();
+        let locker = std::thread::spawn(move || {
+            let _handle = std::fs::OpenOptions::new()
+                .read(true)
+                .share_mode(FILE_SHARE_READ) // no FILE_SHARE_DELETE: blocks rename
+                .open(&locked_dst)
+                .unwrap();
+            std::thread::sleep(Duration::from_millis(400));
+        });
+        std::thread::sleep(Duration::from_millis(50)); // let the lock actually take
+
+        let result = rename_with_retry(&staged, &dst);
+        locker.join().unwrap();
+
+        assert!(
+            result.is_ok(),
+            "should recover once the lock clears: {result:?}"
+        );
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new");
+    }
+
+    #[test]
+    fn single_shot_rename_fails_during_the_same_lock() {
+        // Sanity check that the lock we simulate above is real: proves the
+        // retry loop is doing actual work, not passing by coincidence.
+        let dir = tempfile::tempdir().unwrap();
+        let dst = dir.path().join("target.exe");
+        let staged = dir.path().join("target.exe.new");
+        std::fs::write(&dst, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        let _lock = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ)
+            .open(&dst)
+            .unwrap();
+
+        assert!(std::fs::rename(&staged, &dst).is_err());
+    }
+
+    /// Live 2026-07-03 field failure: the first (2.25s-budget) version of this
+    /// retry loop still hit "atomic rename failed after 6 attempts" against a
+    /// real held-open binary — the hold outlasted a couple of seconds. Proves
+    /// a longer-than-that lock now succeeds given a longer configured budget.
+    #[test]
+    fn recovers_from_lock_longer_than_the_original_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let dst = dir.path().join("target.exe");
+        let staged = dir.path().join("target.exe.new");
+        std::fs::write(&dst, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        let locked_dst = dst.clone();
+        let locker = std::thread::spawn(move || {
+            let _handle = std::fs::OpenOptions::new()
+                .read(true)
+                .share_mode(FILE_SHARE_READ)
+                .open(&locked_dst)
+                .unwrap();
+            std::thread::sleep(Duration::from_millis(3000));
+        });
+        std::thread::sleep(Duration::from_millis(50));
+
+        let result = rename_with_retry_within(
+            &staged,
+            &dst,
+            Duration::from_secs(5),
+            Duration::from_millis(200),
+        );
+        locker.join().unwrap();
+
+        assert!(
+            result.is_ok(),
+            "should recover once the lock clears: {result:?}"
+        );
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new");
+    }
+
+    #[test]
+    fn gives_up_after_deadline_on_a_permanent_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let dst = dir.path().join("target.exe");
+        let staged = dir.path().join("target.exe.new");
+        std::fs::write(&dst, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        let _lock = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ)
+            .open(&dst)
+            .unwrap();
+
+        let result = rename_with_retry_within(
+            &staged,
+            &dst,
+            Duration::from_millis(300),
+            Duration::from_millis(50),
+        );
+
+        assert!(result.is_err(), "must not hang forever on a permanent lock");
+        assert!(
+            !staged.exists(),
+            "staged temp file must be cleaned up after giving up"
+        );
+    }
+
+    /// Live 2026-07-03 field failure #2: even a 60s retry budget still hit
+    /// ACCESS_DENIED — the lock is held for the connected MCP session's
+    /// lifetime, not cleared by any timer. A blind wait can never out-last
+    /// that, so the failure message must point the user at the actual fix
+    /// (reconnect the MCP client) instead of a bare OS error code.
+    #[test]
+    fn permanent_lock_error_explains_the_likely_cause() {
+        let dir = tempfile::tempdir().unwrap();
+        let dst = dir.path().join("target.exe");
+        let staged = dir.path().join("target.exe.new");
+        std::fs::write(&dst, b"old").unwrap();
+        std::fs::write(&staged, b"new").unwrap();
+
+        let _lock = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ)
+            .open(&dst)
+            .unwrap();
+
+        let result = rename_with_retry_within(
+            &staged,
+            &dst,
+            Duration::from_millis(100),
+            Duration::from_millis(20),
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("MCP") && err.contains("reconnect"),
+            "error should point at the MCP-connection cause and the fix, got: {err}"
+        );
     }
 }

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -265,6 +265,11 @@ pub fn cmd_read(args: &[String]) {
                         buf.push_str(&format!("\n    {}", sig.to_compact_located()));
                     }
                 }
+                // Same honesty rule as the MCP renderer: an information-free
+                // map must say so (limitations audit, #4).
+                if key_sigs.is_empty() && dep_info.imports.is_empty() && extra_exports.is_empty() {
+                    buf.push_str(&crate::tools::ctx_read::no_structure_marker(ext));
+                }
                 buf
             } else {
                 format!("{short} [{line_count}L]\n{structured}")
@@ -291,6 +296,10 @@ pub fn cmd_read(args: &[String]) {
             let mut output_buf = format!("{short} [{line_count}L]");
             for sig in &sigs {
                 output_buf.push_str(&format!("\n{}", sig.to_compact_located()));
+            }
+            // Same honesty rule as the MCP renderer (limitations audit, #4).
+            if sigs.is_empty() {
+                output_buf.push_str(&crate::tools::ctx_read::no_structure_marker(ext));
             }
             if requested_auto {
                 output_buf = cap_cli_to_raw(output_buf, &content, original_tokens);
@@ -341,13 +350,38 @@ pub fn cmd_read(args: &[String]) {
                 read_start.elapsed(),
             );
         }
+        m if m.starts_with("lines:") => {
+            // The CLI used to drop the window and print the whole file — a
+            // `lines:` read must return the requested selection, with the same
+            // comma-multi-select hint as the MCP renderer (limitations #7).
+            let range_str = &m[6..];
+            let extracted = crate::tools::ctx_read::extract_line_range(&content, range_str);
+            let multi_hint = if range_str.contains(',') {
+                crate::tools::ctx_read::LINES_COMMA_HINT
+            } else {
+                ""
+            };
+            let output =
+                format!("{short} [{line_count}L] lines:{range_str}\n{extracted}{multi_hint}");
+            println!("{output}");
+            let sent = count_tokens(&output);
+            print_savings(original_tokens, sent);
+            super::common::cli_track_read(
+                path,
+                "lines",
+                original_tokens,
+                sent,
+                &output,
+                read_start.elapsed(),
+            );
+        }
         _ => {
-            // `full`, `lines:` and any unrecognized mode land here. These are
+            // `full` and any unrecognized mode land here. These are
             // verbatim reads — the prose terse pipeline would mangle source
             // (dictionary substitutions, line-drop dedup) and break a `full`
             // read's "complete content" contract, so it must never run here
             // (#404). Intentionally-lossy modes (map/signatures/aggressive/
-            // entropy) have their own arms above.
+            // entropy/lines) have their own arms above.
             let mut output = format!("{short} [{line_count}L]\n{content}");
             if !crate::core::terse::is_verbatim_read("ctx_read", Some(mode)) {
                 let config = crate::core::config::Config::load();

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -61,10 +61,7 @@ fn resolve_cli_read_mode(args: &[String]) -> &str {
     }
     args.iter()
         .skip(1)
-        .find(|a| {
-            !a.starts_with('-')
-                && a.parse::<crate::tools::ctx_read::ReadMode>().is_ok()
-        })
+        .find(|a| !a.starts_with('-') && a.parse::<crate::tools::ctx_read::ReadMode>().is_ok())
         .map_or("auto", std::string::String::as_str)
 }
 

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -46,6 +46,28 @@ fn should_force_fresh(args: &[String], hook_child: bool) -> bool {
     hook_child || args.iter().any(|a| a == "--fresh" || a == "--no-cache")
 }
 
+/// Resolve the read mode from CLI args. `--mode`/`-m` wins; otherwise the
+/// first positional after the path that parses as a known mode counts — a bare
+/// `lean-ctx read f.ps1 map` used to silently serve the `auto` default instead
+/// of the requested view (limitations audit 2026-07-03). Unknown positionals
+/// and flags are left alone so existing invocations keep their meaning.
+fn resolve_cli_read_mode(args: &[String]) -> &str {
+    if let Some(m) = args
+        .iter()
+        .position(|a| a == "--mode" || a == "-m")
+        .and_then(|i| args.get(i + 1))
+    {
+        return m.as_str();
+    }
+    args.iter()
+        .skip(1)
+        .find(|a| {
+            !a.starts_with('-')
+                && a.parse::<crate::tools::ctx_read::ReadMode>().is_ok()
+        })
+        .map_or("auto", std::string::String::as_str)
+}
+
 pub fn cmd_read(args: &[String]) {
     if args.is_empty() {
         eprintln!(
@@ -64,11 +86,7 @@ pub fn cmd_read(args: &[String]) {
         raw_path.clone()
     };
     let path = path.as_str();
-    let mode = args
-        .iter()
-        .position(|a| a == "--mode" || a == "-m")
-        .and_then(|i| args.get(i + 1))
-        .map_or("auto", std::string::String::as_str);
+    let mode = resolve_cli_read_mode(args);
     // #1037: redirect/rewrite hook children pipe `-m full` output into a temp file the
     // host reads back AS the file's content, so a `cached <file> [NL]` cache-hit stub
     // corrupts the read (and round-trips the stub into the real file on the next edit).
@@ -700,5 +718,46 @@ mod fresh_tests {
         assert!(should_force_fresh(&["--fresh".to_string()], false));
         assert!(should_force_fresh(&["--no-cache".to_string()], false));
         assert!(!should_force_fresh(&["file.rs".to_string()], false));
+    }
+}
+
+#[cfg(test)]
+mod mode_arg_tests {
+    use super::resolve_cli_read_mode;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(ToString::to_string).collect()
+    }
+
+    // `lean-ctx read f.ps1 map` used to silently IGNORE the positional mode and
+    // serve the `auto` default — reads must honour it like `--mode map`
+    // (limitations audit 2026-07-03).
+    #[test]
+    fn positional_mode_is_honoured() {
+        assert_eq!(resolve_cli_read_mode(&args(&["f.ps1", "map"])), "map");
+        assert_eq!(
+            resolve_cli_read_mode(&args(&["f.rs", "lines:5-10"])),
+            "lines:5-10"
+        );
+    }
+
+    #[test]
+    fn mode_flag_wins_over_positional() {
+        assert_eq!(
+            resolve_cli_read_mode(&args(&["f.rs", "map", "--mode", "signatures"])),
+            "signatures"
+        );
+        assert_eq!(
+            resolve_cli_read_mode(&args(&["f.rs", "-m", "full"])),
+            "full"
+        );
+    }
+
+    #[test]
+    fn defaults_to_auto_and_skips_flags_and_junk() {
+        assert_eq!(resolve_cli_read_mode(&args(&["f.rs"])), "auto");
+        assert_eq!(resolve_cli_read_mode(&args(&["f.rs", "--fresh"])), "auto");
+        // An unknown positional is not silently treated as a mode.
+        assert_eq!(resolve_cli_read_mode(&args(&["f.rs", "banana"])), "auto");
     }
 }

--- a/rust/src/core/benchmark_compare/report.rs
+++ b/rust/src/core/benchmark_compare/report.rs
@@ -286,7 +286,7 @@ fn write_feature_matrix(out: &mut Vec<String>, report: &CompareReport) {
         ("Repo map generation", [false, true, true, false, true]),
         ("Knowledge base", [false, false, false, true, true]),
         (
-            "Tree-sitter AST (26 langs)",
+            "Tree-sitter AST (27 langs)",
             [false, true, true, false, true],
         ),
         ("MCP server", [false, false, false, true, true]),

--- a/rust/src/core/io_boundary.rs
+++ b/rust/src/core/io_boundary.rs
@@ -47,7 +47,17 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
         let msg = crate::core::binary_detect::binary_file_message(path);
         return Err(std::io::Error::other(msg));
     }
-    read_file_nofollow(path)
+    read_file_nofollow(path).map(strip_utf8_bom)
+}
+
+/// A UTF-8 BOM is an encoding artifact, not content — leaking it corrupts the
+/// first line of every downstream view (limitations doc #11). Shared by both
+/// file readers (this module's and `tools::ctx_read::read_file_lossy`).
+pub(crate) fn strip_utf8_bom(s: String) -> String {
+    match s.strip_prefix('\u{feff}') {
+        Some(rest) => rest.to_owned(),
+        None => s,
+    }
 }
 
 /// Result of a file read with secret scanning applied.
@@ -350,5 +360,18 @@ mod tests {
             Some("credential file")
         );
         assert_eq!(is_secret_like(Path::new("shadow")), Some("credential file"));
+    }
+
+    // The CLI full-read path (`cli_cache::check_and_read`) reads through THIS
+    // `read_file_lossy`, not the ctx_read one — both must strip the UTF-8 BOM
+    // or the CLI leaks it while the MCP path doesn't (limitations doc #11).
+    #[test]
+    fn read_file_lossy_strips_utf8_bom() {
+        let p = std::env::temp_dir().join("lean_ctx_io_bom_test.txt");
+        std::fs::write(&p, b"\xEF\xBB\xBFhello\n").unwrap();
+        let s = read_file_lossy(p.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert!(!s.starts_with('\u{feff}'), "BOM must be stripped");
+        assert!(s.starts_with("hello"));
     }
 }

--- a/rust/src/core/patterns/git/commit.rs
+++ b/rust/src/core/patterns/git/commit.rs
@@ -12,7 +12,19 @@ pub(super) fn compress_add(output: &str) -> String {
     if lines.len() <= 3 {
         return trimmed.to_string();
     }
-    format!("ok (+{} files)", lines.len())
+    // Only `add '<path>'` verbose lines are files; anything else in the output
+    // (hook chatter, a chained `git commit`'s summary) must not be counted as
+    // one — a summary may only state numbers parsed from the output (#2 in the
+    // limitations audit: "ok (+7 files)" for a 1-file commit).
+    let added = lines
+        .iter()
+        .filter(|l| l.trim_start().starts_with("add '"))
+        .count();
+    if added > 0 {
+        format!("ok (+{added} files)")
+    } else {
+        format!("ok ({} lines)", lines.len())
+    }
 }
 
 pub(super) fn compress_commit(output: &str) -> String {

--- a/rust/src/core/patterns/git/mod.rs
+++ b/rust/src/core/patterns/git/mod.rs
@@ -154,6 +154,30 @@ mod tests {
         assert!(result.contains("ok"), "git add should compress to 'ok'");
     }
 
+    // A chained `git add … && git commit …` routes the whole compound output
+    // through the add-compressor, which used to label OUTPUT LINE COUNT as a
+    // file count ("ok (+7 files)" for a 1-file commit). Numbers in summaries
+    // must come from the output, not be fabricated (limitations audit, #2).
+    #[test]
+    fn git_add_does_not_label_line_count_as_files() {
+        let output = "[main abc1234] fix: x\n 1 file changed, 1 insertion(+)\nhook line\nanother\nmore\nlines\nseven\n";
+        let result = compress("git add . && git commit -m 'x'", output).unwrap();
+        assert!(
+            !result.contains("files)"),
+            "line count must not be presented as a file count: {result}"
+        );
+    }
+
+    #[test]
+    fn git_add_verbose_counts_real_added_files() {
+        let output = "add 'a.rs'\nadd 'b.rs'\nadd 'c.rs'\nadd 'd.rs'\n";
+        let result = compress("git add -v .", output).unwrap();
+        assert!(
+            result.contains("+4 files"),
+            "verbose add lines are the real file count: {result}"
+        );
+    }
+
     #[test]
     fn git_commit_extracts_hash() {
         let output =

--- a/rust/src/core/signatures.rs
+++ b/rust/src/core/signatures.rs
@@ -3,7 +3,7 @@
 //! IMPORTANT for readers skimming the repo: this file is the *fallback*, not the
 //! primary engine. The default build extracts signatures with **tree-sitter** via
 //! declarative per-language queries in [`crate::core::signatures_ts`] (real ASTs,
-//! real multi-line spans, ~26 languages). [`extract_signatures`] tries that path
+//! real multi-line spans, ~27 languages). [`extract_signatures`] tries that path
 //! first and only drops to the line-oriented regex extractors here when the
 //! `tree-sitter` feature is off or a parse yields nothing usable for a file.
 //!
@@ -690,6 +690,10 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
     let re_func = static_regex!(
         r"^\s*(?:(?:public|private|protected|static|async|abstract|virtual|override|final|def|func|fun|fn)\s+)+(\w+)\s*\("
     );
+    // PowerShell-style declarations: `function Verb-Noun {` — no paren required,
+    // hyphens allowed in the name. Also catches bash-like dialects the keyword+
+    // paren pattern above misses.
+    let re_ps_func = static_regex!(r"^\s*function\s+([\w-]+)");
     let re_class = static_regex!(
         r"^\s*(?:(?:public|private|protected|abstract|final|sealed|partial)\s+)*(?:class|struct|enum|interface|trait|module|object|record)\s+(\w+)"
     );
@@ -725,6 +729,18 @@ fn extract_generic_signatures(content: &str) -> Vec<Signature> {
                 params: String::new(),
                 return_type: String::new(),
                 is_async: trimmed.contains("async"),
+                is_exported: true,
+                indent: 0,
+                start_line: Some(line_no),
+                end_line: Some(line_no),
+            });
+        } else if let Some(caps) = re_ps_func.captures(trimmed) {
+            sigs.push(Signature {
+                kind: "fn",
+                name: caps[1].to_string(),
+                params: String::new(),
+                return_type: String::new(),
+                is_async: false,
                 is_exported: true,
                 indent: 0,
                 start_line: Some(line_no),
@@ -837,5 +853,21 @@ mod tests {
         let run = sigs.iter().find(|s| s.name == "run").unwrap();
         assert_eq!(run.start_line, Some(4));
         assert_eq!(run.end_line, Some(4));
+    }
+
+    // PowerShell in the generic regex fallback: `function Verb-Noun {` has no
+    // paren and a hyphenated name, which the old keyword+paren pattern missed
+    // entirely (limitation audit 2026-07-03). Covers non-tree-sitter builds.
+    #[test]
+    fn regex_fallback_matches_powershell_functions() {
+        let src = "function Get-CargoBinDir {\n}\nfunction Install($x) {\n}\n# function Commented-Out {\n";
+        let sigs = extract_generic_signatures(src);
+        let names: Vec<&str> = sigs.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Get-CargoBinDir"), "got {names:?}");
+        assert!(names.contains(&"Install"), "got {names:?}");
+        assert!(
+            !names.contains(&"Commented-Out"),
+            "comment must be skipped; got {names:?}"
+        );
     }
 }

--- a/rust/src/core/signatures_ts/extract.rs
+++ b/rust/src/core/signatures_ts/extract.rs
@@ -230,10 +230,14 @@ fn functional_signature(kind: &str, name: &str) -> Option<Signature> {
         | "function" | "bind"                                   // Haskell
         | "assignment"                                          // Julia short-form `f(x) = …`
         | "modifier_definition"                                 // Solidity
+        | "function_statement"                                  // PowerShell
         | "binding" => "fn",                                    // Nix function binding
+        "class_method_definition" => "method",                  // PowerShell
+        "enum_statement" => "enum",                             // PowerShell
         "data_type" | "newtype" | "type_synomym"                // Haskell
         | "abstract_definition" => "type",                      // Julia `abstract type`
-        "contract_declaration" | "library_declaration" => "class", // Solidity
+        "contract_declaration" | "library_declaration"          // Solidity
+        | "class_statement" => "class",                         // PowerShell
         "module_definition" => "module",                        // OCaml / Julia
         "module_type_definition" => "interface",                // OCaml signature
         "struct_definition" => "struct",                        // Julia

--- a/rust/src/core/signatures_ts/mod.rs
+++ b/rust/src/core/signatures_ts/mod.rs
@@ -826,7 +826,7 @@ end
         let langs: &[&str] = &[
             "rs", "ts", "js", "py", "go", "java", "c", "cpp", "rb", "cs", "kt", "swift", "php",
             "sh", "dart", "scala", "ex", "zig", "gd", "lua", "luau", "ml", "mli", "hs", "jl",
-            "sol", "nix",
+            "sol", "nix", "ps1",
         ];
         let mut failures = Vec::new();
         for ext in langs {
@@ -1033,5 +1033,42 @@ library SafeMath {
             !names.contains(&"plainValue"),
             "non-function binding must be skipped; got {names:?}"
         );
+    }
+
+    #[test]
+    fn test_powershell_signatures() {
+        let src = r#"
+function Get-CargoBinDir {
+    param([string]$Path)
+    return $Path
+}
+
+function Stop-RunningLeanCtx() {
+    Write-Host 'stopping'
+}
+
+class BuildResult {
+    [string]$Name
+    [void] Publish($target) {
+    }
+}
+
+enum BuildKind {
+    Debug
+    Release
+}
+"#;
+        let sigs = extract_signatures_ts(src, "ps1").unwrap();
+        let names: Vec<&str> = sigs.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Get-CargoBinDir"), "got {names:?}");
+        assert!(names.contains(&"Stop-RunningLeanCtx"), "got {names:?}");
+        assert!(names.contains(&"BuildResult"), "got {names:?}");
+        assert!(names.contains(&"BuildKind"), "got {names:?}");
+        assert!(names.contains(&"Publish"), "got {names:?}");
+
+        let cls = sigs.iter().find(|s| s.name == "BuildResult").unwrap();
+        assert_eq!(cls.kind, "class");
+        let f = sigs.iter().find(|s| s.name == "Get-CargoBinDir").unwrap();
+        assert_eq!(f.kind, "fn");
     }
 }

--- a/rust/src/core/signatures_ts/queries.rs
+++ b/rust/src/core/signatures_ts/queries.rs
@@ -294,6 +294,18 @@ const QUERY_NIX: &str = r"
 (binding attrpath: (attrpath) @name expression: (function_expression)) @def
 ";
 
+/// Queries [tree-sitter-powershell](https://crates.io/crates/tree-sitter-powershell)
+/// (airbus-cert grammar). Names are carried by child nodes (`function_name`,
+/// `simple_name`), not named fields. `(A (B) @name)` matches direct children
+/// only, so enum members (wrapped in their own nodes) and method parameters
+/// (`variable` nodes) never leak into the capture.
+const QUERY_POWERSHELL: &str = r"
+(function_statement (function_name) @name) @def
+(class_statement (simple_name) @name) @def
+(class_method_definition (simple_name) @name) @def
+(enum_statement (simple_name) @name) @def
+";
+
 pub(super) fn get_language(ext: &str) -> Option<Language> {
     Some(match ext {
         "rs" => tree_sitter_rust::LANGUAGE.into(),
@@ -324,6 +336,7 @@ pub(super) fn get_language(ext: &str) -> Option<Language> {
         "jl" => tree_sitter_julia::LANGUAGE.into(),
         "sol" => tree_sitter_solidity::LANGUAGE.into(),
         "nix" => tree_sitter_nix::LANGUAGE.into(),
+        "ps1" | "psm1" => tree_sitter_powershell::LANGUAGE.into(),
         _ => return None,
     })
 }
@@ -357,6 +370,7 @@ pub(super) fn get_query(ext: &str) -> Option<&'static str> {
         "jl" => QUERY_JULIA,
         "sol" => QUERY_SOLIDITY,
         "nix" => QUERY_NIX,
+        "ps1" | "psm1" => QUERY_POWERSHELL,
         _ => return None,
     })
 }

--- a/rust/src/core/signatures_ts/query_cache.rs
+++ b/rust/src/core/signatures_ts/query_cache.rs
@@ -13,7 +13,8 @@ pub(crate) fn get_cached_sig_query(file_ext: &str) -> Option<&'static Query> {
         let exts: &[&str] = &[
             "rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "c", "h", "cpp", "cc", "cxx",
             "hpp", "rb", "cs", "kt", "kts", "swift", "php", "sh", "bash", "dart", "scala", "sc",
-            "ex", "exs", "zig", "gd", "lua", "luau", "ml", "mli", "hs", "jl", "sol", "nix",
+            "ex", "exs", "zig", "gd", "lua", "luau", "ml", "mli", "hs", "jl", "sol", "nix", "ps1",
+            "psm1",
         ];
         for &ext in exts {
             if let (Some(lang), Some(src)) = (get_language(ext), get_query(ext))

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -7,13 +7,14 @@ const READER_RESULT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[cfg(test)]
 pub(crate) fn execute_command_in(command: &str, cwd: &str) -> (String, i32) {
-    execute_command_with_env(command, cwd, &std::collections::HashMap::new())
+    execute_command_with_env(command, cwd, &std::collections::HashMap::new(), None)
 }
 
 pub(crate) fn execute_command_with_env(
     command: &str,
     cwd: &str,
     extra_env: &std::collections::HashMap<String, String>,
+    timeout_ms: Option<u64>,
 ) -> (String, i32) {
     let (shell, flag) = crate::shell::shell_and_flag();
     let normalized_cmd = crate::tools::ctx_shell::normalize_command_for_shell(command);
@@ -83,7 +84,7 @@ pub(crate) fn execute_command_with_env(
     let (out_buf, out_done) = spawn_capture(child.stdout.take(), cap);
     let (err_buf, err_done) = spawn_capture(child.stderr.take(), cap);
 
-    let timeout = command_timeout(command);
+    let timeout = command_timeout(command, timeout_ms);
     let start = Instant::now();
     let (code, timed_out) = loop {
         match child.try_wait() {
@@ -229,11 +230,11 @@ fn ensure_utf8_locale(
     crate::shell::platform::apply_utf8_locale(cmd);
 }
 
-fn command_timeout(command: &str) -> Duration {
-    // Single source of truth: env (MS / per-tier SECS) > config > built-in
-    // heavy/normal ceilings. Keeps this path identical to `ctx_shell` and the
-    // interactive hook (`shell::exec::shell_timeout`).
-    crate::shell::shell_timeout(command)
+fn command_timeout(command: &str, timeout_ms: Option<u64>) -> Duration {
+    // Single source of truth: operator env pin > per-call `timeout_ms` >
+    // per-tier env/config > built-in heavy/normal ceilings. Keeps this path
+    // identical to the interactive hook (`shell::exec::shell_timeout`).
+    crate::shell::shell_timeout_with_override(command, timeout_ms)
 }
 
 #[cfg(test)]
@@ -249,15 +250,17 @@ mod tests {
         let saved = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
         crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
 
-        assert!(command_timeout("cargo install --path .") > command_timeout("git status"));
+        assert!(
+            command_timeout("cargo install --path .", None) > command_timeout("git status", None)
+        );
 
         crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", "5000");
         assert_eq!(
-            command_timeout("cargo install --path ."),
+            command_timeout("cargo install --path .", None),
             std::time::Duration::from_secs(5)
         );
         assert_eq!(
-            command_timeout("git status"),
+            command_timeout("git status", None),
             std::time::Duration::from_secs(5)
         );
 
@@ -378,6 +381,24 @@ mod tests {
         assert!(
             output.contains("TID=thread-from-hook"),
             "captured agent runtime var must be forwarded, got: {output}"
+        );
+    }
+
+    /// Per-call `timeout_ms` must reach the kill loop: a command that sleeps
+    /// past its 200ms budget is killed with the timeout exit code and message.
+    #[test]
+    #[cfg_attr(windows, ignore)] // POSIX sleep
+    fn per_call_timeout_kills_long_command() {
+        let (output, code) = super::execute_command_with_env(
+            "sleep 3",
+            ".",
+            &std::collections::HashMap::new(),
+            Some(200),
+        );
+        assert_eq!(code, 124, "timed-out command must exit 124: {output}");
+        assert!(
+            output.contains("timed out after 200ms"),
+            "timeout message must carry the per-call budget, got: {output}"
         );
     }
 

--- a/rust/src/shell/compress/classification.rs
+++ b/rust/src/shell/compress/classification.rs
@@ -212,6 +212,14 @@ fn is_file_viewer(command: &str) -> bool {
     match first {
         "cat" | "bat" | "batcat" | "pygmentize" | "highlight" => true,
         "head" | "tail" => !command.contains("-f") && !command.contains("--follow"),
+        // #1: sed/awk are commonly used as range/pattern file viewers
+        // (`sed -n '10,50p' file`, `awk '{print}' file`). Their output must
+        // never enter the generic terse pipeline — the dictionary layer
+        // word-substitutes code identifiers with no code-awareness. In-place
+        // edit flags are excluded since they don't dump content to stdout.
+        "sed" | "awk" | "gawk" | "mawk" | "nawk" => {
+            !command.contains("-i") && !command.contains("--in-place")
+        }
         _ => false,
     }
 }

--- a/rust/src/shell/compress/tests.rs
+++ b/rust/src/shell/compress/tests.rs
@@ -418,6 +418,26 @@ mod verbatim_output_tests {
         assert!(!is_verbatim_output("tail --follow server.log"));
     }
 
+    /// #1 (severe): a `sed`/`awk` file dump must never enter the generic terse
+    /// pipeline — its dictionary layer word-substitutes code identifiers that
+    /// happen to match English words (`function`→`fn`, `return`→`ret`) with no
+    /// code-awareness, corrupting source read via a range-print instead of `cat`.
+    #[test]
+    fn sed_awk_file_dumps_are_verbatim() {
+        assert!(is_verbatim_output("sed -n '1,50p' build_windows.ps1"));
+        assert!(is_verbatim_output("sed -n '/start/,/end/p' file.rs"));
+        assert!(is_verbatim_output("sed 's/foo/bar/' file.txt"));
+        assert!(is_verbatim_output("awk '{print}' file.txt"));
+        assert!(is_verbatim_output("awk -F, '{print $1}' data.csv"));
+        assert!(is_verbatim_output("gawk '{print $0}' file.log"));
+    }
+
+    #[test]
+    fn sed_awk_in_place_not_verbatim() {
+        assert!(!is_verbatim_output("sed -i 's/foo/bar/' file.txt"));
+        assert!(!is_verbatim_output("sed --in-place 's/foo/bar/' file.txt"));
+    }
+
     #[test]
     fn data_format_tools_are_verbatim() {
         assert!(is_verbatim_output("jq '.items' data.json"));
@@ -906,6 +926,20 @@ mod verbatim_output_tests {
         assert!(
             result.contains(r#""version": "3.5.16""#),
             "cat output must be preserved, got: {result}"
+        );
+    }
+
+    /// #1 (severe) regression: a `sed -n` range-print of PowerShell source must
+    /// come back byte-exact. Before the classification fix, this fell through
+    /// to the generic terse pipeline, which word-substituted `function`->`fn`,
+    /// `return`->`ret` and dropped bare `else` lines as low-information.
+    #[test]
+    fn sed_dump_of_powershell_code_is_byte_exact() {
+        let content = "function Sign-File([string]$path) {\n    param(\n        [string]$certPath,\n        [string]$password\n    )\n    $env = [Environment]::GetEnvironmentVariable(\"CERT_PATH\")\n    if ($path -eq $env) {\n        Write-Host \"Signing $path with certificate\"\n        return $true\n    } else {\n        Write-Host \"Skipping unsigned file\"\n        return $false\n    }\n}\n";
+        let result = compress_if_beneficial("sed -n '1,13p' build_windows.ps1", content);
+        assert_eq!(
+            result, content,
+            "sed range-print of source must be byte-exact, got:\n{result}"
         );
     }
 

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -190,8 +190,28 @@ fn exec_limits(command: &str) -> (usize, std::time::Duration) {
 ///    `shell_timeout_secs`, else [`DEFAULT_TIMEOUT`].
 #[must_use]
 pub(crate) fn shell_timeout(command: &str) -> std::time::Duration {
+    shell_timeout_with_override(command, None)
+}
+
+/// Hard ceiling for a per-call `timeout_ms` override: generous enough for any
+/// legitimate build/release job, low enough that a typo'd value cannot wedge
+/// the executor for days.
+const MAX_CALL_TIMEOUT_MS: u64 = 3_600_000; // 1 hour
+
+/// [`shell_timeout`] with an optional per-call override (ctx_shell's
+/// `timeout_ms` arg). Precedence: operator env pin (`LEAN_CTX_SHELL_TIMEOUT_MS`)
+/// > per-call override (clamped to [`MAX_CALL_TIMEOUT_MS`], zero ignored)
+/// > per-tier env/config > built-in heavy/normal ceilings.
+#[must_use]
+pub(crate) fn shell_timeout_with_override(
+    command: &str,
+    override_ms: Option<u64>,
+) -> std::time::Duration {
     if let Some(ms) = env_u64("LEAN_CTX_SHELL_TIMEOUT_MS") {
         return std::time::Duration::from_millis(ms);
+    }
+    if let Some(ms) = override_ms.filter(|n| *n > 0) {
+        return std::time::Duration::from_millis(ms.min(MAX_CALL_TIMEOUT_MS));
     }
     if is_heavy_command(command) {
         if let Some(secs) = env_u64("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS")
@@ -269,6 +289,11 @@ fn is_heavy_command(command: &str) -> bool {
         // because the prefix is the full `git <verb>`.
         "git commit",
         "git push",
+        // Task runners wrap builds/test gates; the underlying job is what's
+        // heavy, so the wrapper gets the same ceiling. A fast subcommand
+        // (`mise ls`) merely inherits a longer kill deadline — harmless.
+        "mise ",
+        "just ",
     ];
     HEAVY_PREFIXES.iter().any(|p| lower.starts_with(p))
 }
@@ -1105,6 +1130,70 @@ mod exec_tests {
             if let Some(v) = saved {
                 crate::test_env::set_var(var, v);
             }
+        }
+    }
+
+    // Task runners (mise/just) wrap builds and test gates that routinely run
+    // past the 2-minute default; killing them mid-run loses the whole job.
+    // They get the heavy ceiling like the underlying build tools they invoke.
+    #[test]
+    fn task_runners_get_heavy_ceiling() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved_ms = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
+        let saved_heavy = std::env::var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS").ok();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        crate::test_env::remove_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS");
+
+        assert_eq!(super::shell_timeout("mise gate"), super::HEAVY_TIMEOUT);
+        assert_eq!(super::shell_timeout("mise run gate"), super::HEAVY_TIMEOUT);
+        assert_eq!(super::shell_timeout("just build"), super::HEAVY_TIMEOUT);
+
+        if let Some(v) = saved_ms {
+            crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);
+        }
+        if let Some(v) = saved_heavy {
+            crate::test_env::set_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS", v);
+        }
+    }
+
+    // Per-call `timeout_ms` (ctx_shell tool arg): explicit caller intent beats
+    // the built-in tiers in both directions, absurd values clamp to the 1h
+    // ceiling, zero is ignored, and the operator's universal env pin stays top.
+    #[test]
+    fn per_call_timeout_override_resolves_and_clamps() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved_ms = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(300_000)),
+            std::time::Duration::from_secs(300)
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("cargo build", Some(30_000)),
+            std::time::Duration::from_secs(30)
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(999_000_000)),
+            std::time::Duration::from_millis(super::MAX_CALL_TIMEOUT_MS)
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(0)),
+            super::DEFAULT_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout_with_override("git status", None),
+            super::DEFAULT_TIMEOUT
+        );
+
+        crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", "5000");
+        assert_eq!(
+            super::shell_timeout_with_override("git status", Some(300_000)),
+            std::time::Duration::from_secs(5)
+        );
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        if let Some(v) = saved_ms {
+            crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);
         }
     }
 

--- a/rust/src/shell/mod.rs
+++ b/rust/src/shell/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod reentry;
 pub(crate) mod tee_policy;
 
 pub use compress::compress_if_beneficial_pub;
-pub(crate) use exec::shell_timeout;
+pub(crate) use exec::shell_timeout_with_override;
 pub(crate) use exec::{STDERR_LABEL, combine_streams};
 pub use exec::{exec, exec_argv};
 pub use interactive::interactive;

--- a/rust/src/templates/SKILL.md
+++ b/rust/src/templates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lean-ctx
-description: Context Engineering for AI Agents — 81 MCP tools, 10 read modes, 95+ shell patterns, tree-sitter AST for 26 languages. Compresses LLM context by up to 99%. Use when reading files, running shell commands, searching code, or exploring directories. Auto-installs if not present.
+description: Context Engineering for AI Agents — 81 MCP tools, 10 read modes, 95+ shell patterns, tree-sitter AST for 27 languages. Compresses LLM context by up to 99%. Use when reading files, running shell commands, searching code, or exploring directories. Auto-installs if not present.
 ---
 
 # lean-ctx — Context Engineering for AI Agents

--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -163,12 +163,7 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
         Ok(s) => s,
         Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
     };
-    // A UTF-8 BOM is an encoding artifact, not content — leaking it corrupts
-    // the first line of every downstream view (limitations doc #11).
-    Ok(match s.strip_prefix('\u{feff}') {
-        Some(rest) => rest.to_owned(),
-        None => s,
-    })
+    Ok(crate::core::io_boundary::strip_utf8_bom(s))
 }
 
 /// Opens a file, retrying once after a brief pause on NotFound.

--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -159,10 +159,16 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
     use std::io::Read;
     let mut bytes = Vec::with_capacity(meta.len() as usize);
     std::io::BufReader::new(file).read_to_end(&mut bytes)?;
-    match String::from_utf8(bytes) {
-        Ok(s) => Ok(s),
-        Err(e) => Ok(String::from_utf8_lossy(e.as_bytes()).into_owned()),
-    }
+    let s = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
+    };
+    // A UTF-8 BOM is an encoding artifact, not content — leaking it corrupts
+    // the first line of every downstream view (limitations doc #11).
+    Ok(match s.strip_prefix('\u{feff}') {
+        Some(rest) => rest.to_owned(),
+        None => s,
+    })
 }
 
 /// Opens a file, retrying once after a brief pause on NotFound.

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -280,6 +280,13 @@ pub(crate) fn process_mode_tuned(
                     output.push_str(note);
                 }
             }
+            // Same honesty rule as map: an empty signature view for a language
+            // without an extractor must be labeled (limitations audit, #4).
+            if sigs.is_empty() && dep_info.imports.is_empty() {
+                output.push_str(&format!(
+                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
+                ));
+            }
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
                 output.push('\n');
                 output.push_str(&body);
@@ -395,6 +402,15 @@ pub(crate) fn process_mode_tuned(
                         output.push_str(note);
                     }
                 }
+            }
+
+            // Nothing extractable (no grammar/regex coverage for this language):
+            // an information-free map must say so, or the caller reads the bare
+            // header as "this file has no API" (limitations audit, #4 residual).
+            if key_sigs.is_empty() && dep_info.imports.is_empty() && extra_exports.is_empty() {
+                output.push_str(&format!(
+                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
+                ));
             }
 
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
@@ -677,9 +693,17 @@ pub(crate) fn process_mode_tuned(
             } else {
                 format!("{short} {line_count}L lines:{range_str}")
             };
+            // Comma is multi-select, not a range — a caller who meant `N-M`
+            // gets stray single lines back, so say what the comma did instead
+            // of letting the wrong window pass silently (limitations #7).
+            let multi_hint = if range_str.contains(',') {
+                "\n[lines: comma = multi-select (e.g. 5,10-20 picks line 5 and lines 10-20); use N-M for one span]"
+            } else {
+                ""
+            };
             let sent = count_tokens(&extracted);
             let savings = protocol::format_savings(original_tokens, sent);
-            (format!("{header}\n{extracted}\n{savings}"), sent)
+            (format!("{header}\n{extracted}{multi_hint}\n{savings}"), sent)
         }
         mode if mode.starts_with("density:") => {
             // SDE target-density mode: compress to a token budget instead of

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -283,9 +283,7 @@ pub(crate) fn process_mode_tuned(
             // Same honesty rule as map: an empty signature view for a language
             // without an extractor must be labeled (limitations audit, #4).
             if sigs.is_empty() && dep_info.imports.is_empty() {
-                output.push_str(&format!(
-                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
-                ));
+                output.push_str(&no_structure_marker(ext));
             }
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
                 output.push('\n');
@@ -408,9 +406,7 @@ pub(crate) fn process_mode_tuned(
             // an information-free map must say so, or the caller reads the bare
             // header as "this file has no API" (limitations audit, #4 residual).
             if key_sigs.is_empty() && dep_info.imports.is_empty() && extra_exports.is_empty() {
-                output.push_str(&format!(
-                    "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
-                ));
+                output.push_str(&no_structure_marker(ext));
             }
 
             if let Some(body) = task_relevant_body(content, file_path, ext, task) {
@@ -697,7 +693,7 @@ pub(crate) fn process_mode_tuned(
             // gets stray single lines back, so say what the comma did instead
             // of letting the wrong window pass silently (limitations #7).
             let multi_hint = if range_str.contains(',') {
-                "\n[lines: comma = multi-select (e.g. 5,10-20 picks line 5 and lines 10-20); use N-M for one span]"
+                LINES_COMMA_HINT
             } else {
                 ""
             };
@@ -833,6 +829,20 @@ pub(crate) fn task_relevant_body(
         "  ▸ body {} L{}-{}:\n{body}{truncated}",
         ch.symbol_name, ch.start_line, ch.end_line
     ))
+}
+
+/// One-line explainer appended whenever a `lines:` payload uses a comma —
+/// comma means multi-select, and a caller who meant a `N-M` span must be able
+/// to see that from the output (limitations #7). Shared with the CLI arm.
+pub(crate) const LINES_COMMA_HINT: &str = "\n[lines: comma = multi-select (e.g. 5,10-20 picks line 5 and lines 10-20); use N-M for one span]";
+
+/// Marker for a map/signatures view that extracted nothing — a language with
+/// no grammar/regex coverage must be distinguishable from a file with no API
+/// (limitations audit, #4). Shared with the CLI arms.
+pub(crate) fn no_structure_marker(ext: &str) -> String {
+    format!(
+        "\n  [no extractable structure for .{ext} — header only; use mode=\"lines:N-M\" or \"full\"]"
+    )
 }
 
 pub(crate) fn extract_line_range(content: &str, range_str: &str) -> String {

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -703,7 +703,10 @@ pub(crate) fn process_mode_tuned(
             };
             let sent = count_tokens(&extracted);
             let savings = protocol::format_savings(original_tokens, sent);
-            (format!("{header}\n{extracted}{multi_hint}\n{savings}"), sent)
+            (
+                format!("{header}\n{extracted}{multi_hint}\n{savings}"),
+                sent,
+            )
         }
         mode if mode.starts_with("density:") => {
             // SDE target-density mode: compress to a token budget instead of

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -343,6 +343,94 @@ fn map_mode_inlines_task_relevant_body() {
     );
 }
 
+// `lines:5,10-12` is multi-select (comma-separated lines/ranges), not a range.
+// Callers who meant a span get stray lines back — the output must say what
+// the comma did so the mistake is visible (limitations audit 2026-07-03, #7).
+#[test]
+fn lines_comma_multiselect_gets_hint() {
+    let content = (1..=30)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tokens = count_tokens(&content);
+    let (out, _) = process_mode(
+        &content,
+        "lines:5,10-12",
+        "F1",
+        "t.txt",
+        "txt",
+        tokens,
+        CrpMode::Off,
+        "t.txt",
+        None,
+    );
+    assert!(out.contains("line 5") && out.contains("line 10"), "{out}");
+    assert!(
+        out.contains("multi-select"),
+        "comma form must carry a hint: {out}"
+    );
+}
+
+// A map/signatures read of a language with no extractor must say so instead of
+// returning a bare header the caller mistakes for "file has no API"
+// (limitations audit 2026-07-03, #4 residual).
+#[test]
+fn map_on_unsupported_language_carries_marker() {
+    let content = "some plain text\nwith no code\nstructure at all\n";
+    let tokens = count_tokens(content);
+    let (out, _) = process_mode(
+        content,
+        "map",
+        "F1",
+        "notes.txt",
+        "txt",
+        tokens,
+        CrpMode::Off,
+        "notes.txt",
+        None,
+    );
+    assert!(
+        out.contains("no extractable structure"),
+        "empty map must carry a marker: {out}"
+    );
+}
+
+#[test]
+fn signatures_on_unsupported_language_carries_marker() {
+    let content = "some plain text\nwith no code\nstructure at all\n";
+    let tokens = count_tokens(content);
+    let (out, _) = process_mode(
+        content,
+        "signatures",
+        "F1",
+        "notes.txt",
+        "txt",
+        tokens,
+        CrpMode::Off,
+        "notes.txt",
+        None,
+    );
+    assert!(
+        out.contains("no extractable structure"),
+        "empty signatures must carry a marker: {out}"
+    );
+}
+
+// UTF-8 BOM must not leak into the first line of ctx_read output
+// (limitations doc #11).
+#[test]
+fn read_file_lossy_strips_utf8_bom() {
+    let p = std::env::temp_dir().join("lean_ctx_bom_test.txt");
+    std::fs::write(&p, b"\xEF\xBB\xBFhello\n").unwrap();
+    let s = read_file_lossy(p.to_str().unwrap()).unwrap();
+    let _ = std::fs::remove_file(&p);
+    assert!(
+        !s.starts_with('\u{feff}'),
+        "BOM must be stripped from read content"
+    );
+    assert!(s.starts_with("hello"), "content after BOM must survive: {s}");
+}
+
 #[test]
 fn compressed_cache_key_distinguishes_task() {
     let no_task = compressed_cache_key("map", CrpMode::Off, None, None, &[]);

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -428,7 +428,10 @@ fn read_file_lossy_strips_utf8_bom() {
         !s.starts_with('\u{feff}'),
         "BOM must be stripped from read content"
     );
-    assert!(s.starts_with("hello"), "content after BOM must survive: {s}");
+    assert!(
+        s.starts_with("hello"),
+        "content after BOM must survive: {s}"
+    );
 }
 
 #[test]

--- a/rust/src/tools/registered/ctx_outline.rs
+++ b/rust/src/tools/registered/ctx_outline.rs
@@ -18,7 +18,7 @@ impl McpTool for CtxOutlineTool {
             "ctx_outline",
             "WORKFLOW: call BEFORE ctx_read to map code structure (a syntax-aware table of contents).\n\
             Accepts a FILE or a DIRECTORY (folder surface — per-file symbols). Symbols come from\n\
-            tree-sitter (26 languages, real line spans); a conservative regex fallback covers the rest.\n\
+            tree-sitter (27 languages, real line spans); a conservative regex fallback covers the rest.\n\
             kind=fn|struct|class|trait|enum|impl|all filters by kind; match=<substr> filters by name\n\
             (case-insensitive); format=json emits deterministic JSON labelling the backend per file.\n\
             ANTIPATTERN: NOT for file content (use ctx_read) or deep understanding (use ctx_compose).",

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -45,7 +45,7 @@ impl McpTool for CtxReadTool {
                     "paths": { "type": "array", "items": { "type": "string" }, "description": "Batch read" },
                     "mode": {
                         "type": "string",
-                        "description": "REQUIRED. full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window reference=quotes task=focus"
+                        "description": "REQUIRED. full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window (comma multi-selects: lines:5,10-20) reference=quotes task=focus"
                     },
                     "raw": { "type": "boolean", "description": "Verbatim (= mode=raw + fresh)" },
                     "start_line": { "type": "integer", "description": "1-based" },

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -3,7 +3,7 @@ use rmcp::model::Tool;
 use serde_json::{Map, Value, json};
 
 use crate::server::tool_trait::{
-    McpTool, ShellOutcome, ToolContext, ToolOutput, get_bool, get_str,
+    McpTool, ShellOutcome, ToolContext, ToolOutput, get_bool, get_int, get_str,
 };
 use crate::tool_defs::tool_def;
 
@@ -27,6 +27,7 @@ impl McpTool for CtxShellTool {
                     "command": { "type": "string", "description": "Shell command" },
                     "raw": { "type": "boolean", "description": "Skip compression (verbatim)" },
                     "cwd": { "type": "string", "description": "Working dir (persists across calls)" },
+                    "timeout_ms": { "type": "integer", "description": "Per-call timeout in ms (max 3600000). Overridden by LEAN_CTX_SHELL_TIMEOUT_MS." },
                     "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } }
                 },
                 "required": ["command"]
@@ -41,6 +42,7 @@ impl McpTool for CtxShellTool {
     ) -> Result<ToolOutput, ErrorData> {
         let command = get_str(args, "command")
             .ok_or_else(|| ErrorData::invalid_params("command is required", None))?;
+        let timeout_ms = get_int(args, "timeout_ms").and_then(|n| u64::try_from(n).ok());
 
         // The write-doctrine check (no `>`, `tee`, heredoc-to-file, curl -o, …)
         // is an MCP-payload-safety convention, not a security boundary, so it is
@@ -108,7 +110,7 @@ impl McpTool for CtxShellTool {
                         })
                         .unwrap_or_default();
                     let (raw_output, exit_code) = crate::server::execute::execute_command_with_env(
-                        &cmd_clone, &cwd_clone, &extra_env,
+                        &cmd_clone, &cwd_clone, &extra_env, timeout_ms,
                     );
                     let output = redact_shell_output_secrets(&raw_output);
                     // Keep failure reporting consistent on this degraded path:
@@ -161,7 +163,7 @@ impl McpTool for CtxShellTool {
                 .unwrap_or_default();
 
             let (raw_output, exit_code) = crate::server::execute::execute_command_with_env(
-                &cmd_clone, &cwd_clone, &extra_env,
+                &cmd_clone, &cwd_clone, &extra_env, timeout_ms,
             );
 
             // Structured diagnostics (#499) — same hook as the CLI path.

--- a/rust/tests/read_fidelity.rs
+++ b/rust/tests/read_fidelity.rs
@@ -51,10 +51,16 @@ fn cli_lines_read_is_byte_exact() {
 
     let out = read_output(dir.path(), &file, "lines:1-3");
     let stdout = String::from_utf8_lossy(&out.stdout);
-    // The contract under test is fidelity: the source must survive verbatim with
-    // no terse substitutions, regardless of how the range is rendered.
-    assert!(
-        stdout.contains(SAMPLE),
-        "lines: read must not terse-mangle source; got:\n{stdout}"
-    );
+    // The contract under test is fidelity: the SELECTED lines must survive
+    // verbatim with no terse substitutions, regardless of how the range is
+    // rendered. `lines:1-3` is windowed output, not a full-file dump, so the
+    // oracle is the selected slice — not the whole SAMPLE (#684 fix made
+    // `lines:` actually honour the window instead of returning the full file).
+    let selected_lines = &SAMPLE.lines().collect::<Vec<_>>()[..3];
+    for line in selected_lines {
+        assert!(
+            line.is_empty() || stdout.contains(line),
+            "lines: read must not terse-mangle selected source; missing {line:?} in:\n{stdout}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- On Windows, `dev-install`'s final atomic-rename swap can hard-fail with `ACCESS_DENIED` when the IDE-owned MCP stdio server (deliberately not killed, #1036) still has the old binary open.
- Field-tested two retry budgets against a real, live-connected MCP session before landing on the actual fix — see #691 for the full measurement writeup:
  - 2.25s (6 attempts): still failed.
  - 60s: still failed identically — ruling out a short timing race. The lock lasts for the connected session's lifetime, not a few seconds.
- Rather than continuing to chase a longer timeout, this keeps a brief retry (~5s, for a genuinely quick transient like AV/EDR scanning the freshly written exe) and makes the failure actionable: the error now names the likely cause and the fix (reconnect the MCP client) instead of a bare OS error code.

Fixes #691

## Test plan
- [x] Unit tests in `rust/src/cli/dispatch/lifecycle.rs` (`windows_rename_retry_tests`, `#[cfg(windows)]`), using `OpenOptionsExt::share_mode` to simulate a real held-open file without `FILE_SHARE_DELETE`:
  - `recovers_from_transient_lock` / `single_shot_rename_fails_during_the_same_lock` — proves the retry mechanism works and the simulated lock is real.
  - `recovers_from_lock_longer_than_the_original_budget` — a lock held longer than the original 2.25s budget still recovers given a longer configured budget.
  - `gives_up_after_deadline_on_a_permanent_lock` — never hangs forever; cleans up the staged temp file.
  - `permanent_lock_error_explains_the_likely_cause` — the final error message names the MCP-connection cause and the reconnect fix.
- [x] `cargo test --lib` — full suite green (3 pre-existing, unrelated flaky failures confirmed present on unmodified `main` too — see #691 discussion if relevant).
- [x] `cargo clippy --lib --all-features` — no new warnings vs. the 28-warning baseline.
- [x] `cargo fmt --check` — clean.
- [x] Live-verified against a real, connected MCP session on Windows: both the 2.25s and 60s intermediate versions reproduced the exact failure described in #691, confirming the diagnosis before landing on the messaging fix.