### PR TITLE
spike(grammar-loader): prove dlopen-a-tree-sitter-grammar on Windows

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1728,6 +1728,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "grammar-dlopen-host"
+version = "0.0.0"
+dependencies = [
+ "libloading 0.8.9",
+ "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "grammar-lua-dylib"
+version = "0.0.0"
+dependencies = [
+ "tree-sitter-lua",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +2573,16 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -3091,7 +3117,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,12 @@
 # crate exactly as before — build the SDK explicitly with `-p lean-ctx-sdk` or
 # the whole workspace with `--workspace`.
 [workspace]
-members = [".", "crates/lean-ctx-sdk"]
+members = [
+  ".",
+  "crates/lean-ctx-sdk",
+  "experiments/grammar-dlopen-spike/dylib",
+  "experiments/grammar-dlopen-spike/host",
+]
 default-members = ["."]
 
 [package]

--- a/rust/experiments/grammar-dlopen-spike/README.md
+++ b/rust/experiments/grammar-dlopen-spike/README.md
@@ -1,0 +1,107 @@
+# Phase 0 spike: dlopen a tree-sitter grammar at runtime
+
+Prototype for #690 (grammar tiering — long-tail tree-sitter grammars as signed
+runtime addons). Answers the single highest-risk question before committing to
+a manifest schema or CI matrix: **can a tree-sitter grammar be loaded from a
+platform-specific dylib fetched at runtime, instead of statically linked?**
+
+## Result: yes, proven on Windows
+
+```
+$ cargo build --release -p grammar-lua-dylib
+$ cargo build --release -p grammar-dlopen-host
+$ ./target/release/grammar-dlopen-host <path-to>/grammar_lua_dylib.dll
+loaded language, abi_version = 15
+parsed root kind: chunk
+SPIKE OK: dlopen-loaded Lua grammar parsed "return 42" cleanly
+```
+
+Windows carries the most uncertainty here (DLL export tables are stricter
+than ELF/Mach-O default symbol visibility), so it's the platform to prove
+first. Not yet re-verified on Linux/macOS — expected to be easier there, but
+worth a quick CI check before Phase 1 lands.
+
+## Design
+
+`dylib/` is a `cdylib` crate depending on `tree-sitter-lua`. It does **not**
+try to re-export the grammar crate's raw `tree_sitter_lua` C symbol — that
+symbol is compiled from vendored C via `tree-sitter-lua`'s own `build.rs`,
+and whether a symbol from a transitively-linked static object gets exported
+in a Windows DLL by default was the actual open question. Instead, it
+defines its own `#[no_mangle]` wrapper:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn lc_grammar_language() -> *const () {
+    unsafe { (tree_sitter_lua::LANGUAGE.into_raw())() }
+}
+```
+
+`LanguageFn::into_raw()`/`::from_raw()` (from the `tree-sitter-language`
+crate — already a transitive dependency of every grammar crate lean-ctx
+uses) round-trip a plain `unsafe extern "C" fn() -> *const ()`, which is
+exactly what `libloading::Symbol` gives back after `dlopen` + symbol lookup.
+Because `lc_grammar_language` is a first-class item defined directly in this
+cdylib crate, rustc's cdylib export-table generation covers it unconditionally
+— no platform-specific linker flags, `.def` file, or `dllexport` attribute
+needed. Swapping the grammar dependency (and this one match arm) is the
+entire diff needed to spike a different long-tail language.
+
+`host/` is a standalone binary that `dlopen`s a built dylib, resolves
+`lc_grammar_language`, reconstructs a `tree_sitter::Language` via
+`LanguageFn::from_raw`, and parses a real source snippet with it — proving
+the full round trip, not just that the symbol resolves.
+
+## What this proves vs. what's still open
+
+Proven:
+- The dlopen/FFI mechanism itself works, on the platform with the most risk.
+- `Language::abi_version()` is readable post-load, which is what a real
+  loader needs to reject a grammar dylib built against an incompatible
+  tree-sitter core version before calling `set_language` on it.
+
+Not yet built (tracked as later phases under #690, not in this spike):
+- Manifest schema for a grammar addon (ext, platform/arch, dylib hash,
+  signature) — extending the pattern in `core/addons/manifest.rs` /
+  `packages/leanctx-verify/src/verify.rs::verify_manifest_signature`.
+- Wiring behind `signatures_ts::queries::get_language()` with a real
+  fetch-and-cache path (this spike takes the dylib path as a CLI arg).
+- CI build matrix producing signed dylibs per grammar × platform × arch.
+- Zero-config UX (first-use fetch, offline fallback to the regex extractor,
+  `doctor` healing) and the binary-size CI gate.
+
+### The fetch-on-demand piece specifically
+
+`core/updater.rs` (lean-ctx's own self-updater) already has almost the whole
+shape needed, directly reusable rather than net-new:
+
+- `https_agent()` / `download_bytes(url)` — bounded-timeout HTTPS GET.
+- `platform_asset_name()` — OS/arch → asset filename, same shape needed for
+  e.g. `grammar-lua-x86_64-pc-windows-msvc.dll`.
+- `verify_download_integrity()` — SHA256SUMS-based checksum verification
+  (a real grammar loader would layer Ed25519 manifest signing on top, per
+  the addon-manifest pattern in `packages/leanctx-verify`, since a bare
+  checksum isn't provenance).
+
+Notably, `replace_binary`'s Windows locked-file handling (spawn a deferred
+`.bat` that retries the rename for up to 60s) does **not** apply to grammar
+dylibs — that complexity exists because the self-updater must replace the
+*currently-running* executable. A grammar dylib is never the running image,
+so a freshly downloaded file can just be `dlopen`'d with no such conflict —
+meaningfully simpler than the binary-update case.
+
+## Running it
+
+This crate pair is an **opt-in** workspace member (`experiments/...`), not in
+`default-members` — `cargo build`/`test`/`clippy` on the main crate are
+unaffected. Build and run explicitly with `-p`:
+
+```
+cargo build --release -p grammar-lua-dylib
+cargo build --release -p grammar-dlopen-host
+./target/release/grammar-dlopen-host <path-to-built>/grammar_lua_dylib.dll
+```
+
+No automated test wraps this yet — it's a manual-run feasibility spike, not
+production code. Automated CI coverage is Phase 1+ scope once the loader is
+wired behind the real entry point.

--- a/rust/experiments/grammar-dlopen-spike/dylib/Cargo.toml
+++ b/rust/experiments/grammar-dlopen-spike/dylib/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "grammar-lua-dylib"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Phase 0 spike for #690 — Lua grammar built as a standalone dlopen-able cdylib"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+tree-sitter-lua = "0.5"

--- a/rust/experiments/grammar-dlopen-spike/dylib/src/lib.rs
+++ b/rust/experiments/grammar-dlopen-spike/dylib/src/lib.rs
@@ -1,0 +1,11 @@
+//! Phase 0 spike for #690: export the Lua grammar's raw `LanguageFn` pointer
+//! under a name we control, sidestepping whether the underlying
+//! `tree_sitter_lua` C symbol (compiled from vendored C via a dependency's
+//! `build.rs`) would survive Windows' DLL export-table generation. This
+//! function is a first-class item in this cdylib crate, so rustc exports it
+//! unconditionally on every platform. See ../README.md for the full writeup.
+
+#[unsafe(no_mangle)]
+pub extern "C" fn lc_grammar_language() -> *const () {
+    unsafe { (tree_sitter_lua::LANGUAGE.into_raw())() }
+}

--- a/rust/experiments/grammar-dlopen-spike/host/Cargo.toml
+++ b/rust/experiments/grammar-dlopen-spike/host/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "grammar-dlopen-host"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Phase 0 spike for #690 — dlopen a grammar dylib, parse real source with it"
+
+[dependencies]
+tree-sitter = "0.26"
+tree-sitter-language = "0.1"
+libloading = "0.8"

--- a/rust/experiments/grammar-dlopen-spike/host/src/main.rs
+++ b/rust/experiments/grammar-dlopen-spike/host/src/main.rs
@@ -1,0 +1,42 @@
+//! Phase 0 spike for #690: dlopen a grammar dylib, resolve `lc_grammar_language`,
+//! reconstruct a `tree_sitter::Language`, and parse real source with it — proving
+//! the full round trip, not just that the symbol resolves. See ../README.md.
+
+use libloading::{Library, Symbol};
+use tree_sitter_language::LanguageFn;
+
+fn main() {
+    let dylib_path = std::env::args()
+        .nth(1)
+        .expect("usage: grammar-dlopen-host <path-to-dylib>");
+
+    unsafe {
+        let lib = Library::new(&dylib_path).expect("failed to load dylib");
+        let sym: Symbol<unsafe extern "C" fn() -> *const ()> = lib
+            .get(b"lc_grammar_language\0")
+            .expect("symbol lc_grammar_language not found in dylib");
+
+        let language_fn = LanguageFn::from_raw(*sym);
+        let language: tree_sitter::Language = language_fn.into();
+
+        println!("loaded language, abi_version = {}", language.abi_version());
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&language)
+            .expect("set_language failed — ABI mismatch or corrupt grammar");
+
+        let source = "return 42";
+        let tree = parser.parse(source, None).expect("parse returned None");
+        let root = tree.root_node();
+        println!("parsed root kind: {}", root.kind());
+        assert!(!root.has_error(), "parse tree has errors");
+
+        // Keep the library alive for the process lifetime — the Language
+        // holds a raw pointer into the loaded module's static data. This
+        // mirrors the production design: grammars stay loaded once fetched.
+        std::mem::forget(lib);
+
+        println!("SPIKE OK: dlopen-loaded Lua grammar parsed \"{source}\" cleanly");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 prototype for #690 — answers the single highest-risk question before committing to a manifest schema or CI matrix: **can a tree-sitter grammar be loaded from a platform-specific dylib fetched at runtime, instead of statically linked?**

Result: yes, proven on Windows (the platform with the most export-table uncertainty — DLL exports are stricter than ELF/Mach-O default symbol visibility).

```
$ cargo build --release -p grammar-lua-dylib
$ cargo build --release -p grammar-dlopen-host
$ ./target/release/grammar-dlopen-host <path-to>/grammar_lua_dylib.dll
loaded language, abi_version = 15
parsed root kind: chunk
SPIKE OK: dlopen-loaded Lua grammar parsed "return 42" cleanly
```

## Design

`dylib/` is a `cdylib` crate depending on `tree-sitter-lua`. It doesn't try to re-export the grammar crate's raw `tree_sitter_lua` C symbol (compiled from vendored C via the grammar crate's own `build.rs` — whether that symbol would survive Windows' DLL export generation was the actual open question). Instead it defines its own `#[no_mangle]` wrapper that calls `LANGUAGE.into_raw()` and forwards the pointer — a first-class item in the cdylib crate, so rustc's export-table generation covers it unconditionally on every platform, no linker flags or `.def` file needed. Swapping the grammar dependency (and this one arm) is the entire diff to spike a different long-tail language.

`host/` `dlopen`s a built dylib, resolves the symbol, reconstructs a `tree_sitter::Language` via `LanguageFn::from_raw`, and parses real source with it — proving the full round trip.

Full writeup, including how `core/updater.rs`'s existing fetch/verify machinery (`https_agent`/`download_bytes`/`platform_asset_name`/`verify_download_integrity`) covers most of the "zero-config fetch" piece already, is in `rust/experiments/grammar-dlopen-spike/README.md`.

## Scope

This is **not** a full implementation of #690 — it's the Phase 0 feasibility spike, kept as an opt-in workspace member (`experiments/grammar-dlopen-spike/*`, not in `default-members`) so it has zero effect on the main crate's build/test/clippy/CI. Not wired behind `signatures_ts::queries::get_language()` yet, no manifest schema, no fetch-and-cache, no CI matrix — those are the next phases, tracked under #690.

Refs #690

## Test plan
- [x] `cargo build --release -p grammar-lua-dylib -p grammar-dlopen-host` — clean.
- [x] `cargo fmt --check` / `cargo clippy -p grammar-lua-dylib -p grammar-dlopen-host` — clean.
- [x] Ran the built host binary against the built dylib — output above, reproduced both from a standalone scratch workspace and from inside this repo's workspace.
- [x] Confirmed the opt-in workspace member doesn't affect `default-members` — `cargo build`/`test`/`clippy` on the main crate untouched.