### PR TITLE
fix(compress): encoded-blob noise detection + auto-mined repeat-identifier dictionary

### DIFF
--- a/rust/src/core/terse/auto_dict.rs
+++ b/rust/src/core/terse/auto_dict.rs
@@ -19,40 +19,87 @@ const MAX_CANDIDATES: usize = 8;
 /// Bytes for the `"[dict: ]\n"` wrapper, independent of entry count.
 const LEGEND_WRAPPER_OVERHEAD: isize = 9;
 
+/// A repeated-token candidate, tracked with its first-occurrence position so
+/// selection and numbering never depend on `HashMap` iteration order (which
+/// varies per-process) — required for byte-stable output across runs so
+/// providers can prompt-cache on it (#498).
+struct Candidate<'a> {
+    token: &'a str,
+    count: usize,
+    first_idx: usize,
+}
+
 /// Finds long tokens repeated at least `MIN_REPEATS` times, replaces them
 /// with short codes, and prepends a legend. Returns `None` when no
 /// substitution would reduce total size (legend overhead not covered).
 pub fn apply(text: &str) -> Option<String> {
+    // Count occurrences while recording first-occurrence order in a plain
+    // Vec — the HashMap below is only used for O(1) lookups during counting,
+    // never for iteration order.
+    let mut first_seen_order: Vec<&str> = Vec::new();
     let mut counts: HashMap<&str, usize> = HashMap::new();
     for tok in text.split(|c: char| !c.is_alphanumeric() && c != '_') {
         if tok.len() >= MIN_PHRASE_LEN && tok.chars().any(char::is_alphabetic) {
-            *counts.entry(tok).or_insert(0) += 1;
+            let entry = counts.entry(tok).or_insert(0);
+            if *entry == 0 {
+                first_seen_order.push(tok);
+            }
+            *entry += 1;
         }
     }
 
-    let mut candidates: Vec<(&str, usize)> = counts
+    let mut candidates: Vec<Candidate> = first_seen_order
         .into_iter()
-        .filter(|(_, n)| *n >= MIN_REPEATS)
+        .enumerate()
+        .filter_map(|(first_idx, token)| {
+            let count = counts[token];
+            (count >= MIN_REPEATS).then_some(Candidate {
+                token,
+                count,
+                first_idx,
+            })
+        })
         .collect();
     if candidates.is_empty() {
         return None;
     }
-    candidates.sort_by_key(|(tok, n)| std::cmp::Reverse(tok.len() * n));
+
+    // Selection: biggest savings first, so the limited MAX_CANDIDATES slots
+    // go to the highest-value tokens. Ties are broken by first occurrence
+    // then lexicographically — never left to arbitrary hash order.
+    candidates.sort_by(|a, b| {
+        let score_a = a.token.len() * a.count;
+        let score_b = b.token.len() * b.count;
+        score_b
+            .cmp(&score_a)
+            .then_with(|| a.first_idx.cmp(&b.first_idx))
+            .then_with(|| a.token.cmp(b.token))
+    });
     candidates.truncate(MAX_CANDIDATES);
+
+    // Numbering: @D0/@D1/... assigned by first occurrence (tie-broken
+    // lexicographically), independent of the savings-based selection order
+    // above, so the same input always yields the same short-code assignment.
+    candidates.sort_by(|a, b| {
+        a.first_idx
+            .cmp(&b.first_idx)
+            .then_with(|| a.token.cmp(b.token))
+    });
 
     let mut output = text.to_string();
     let mut legend: Vec<(String, &str)> = Vec::new();
     let mut total_savings: isize = 0;
 
-    for (idx, (tok, n)) in candidates.iter().enumerate() {
+    for (idx, c) in candidates.iter().enumerate() {
         let short = format!("@D{idx}");
-        let entry_cost = (short.len() + 1 + tok.len() + 2) as isize;
-        let savings = (*n as isize) * (tok.len() as isize - short.len() as isize) - entry_cost;
+        let entry_cost = (short.len() + 1 + c.token.len() + 2) as isize;
+        let savings =
+            (c.count as isize) * (c.token.len() as isize - short.len() as isize) - entry_cost;
         if savings <= 0 {
             continue;
         }
-        output = replace_whole_word(&output, tok, &short);
-        legend.push((short, *tok));
+        output = replace_whole_word(&output, c.token, &short);
+        legend.push((short, c.token));
         total_savings += savings;
     }
 
@@ -94,7 +141,10 @@ mod tests {
             result.contains("ConfigurationManagerFactory"),
             "full identifier must survive once, in the legend: {result}"
         );
-        assert!(result.starts_with("[dict: "), "legend header missing: {result}");
+        assert!(
+            result.starts_with("[dict: "),
+            "legend header missing: {result}"
+        );
         assert!(
             result.matches("ConfigurationManagerFactory").count() == 1,
             "only the legend should keep the long form, body must use the short code: {result}"
@@ -111,5 +161,37 @@ mod tests {
             result.len(),
             text.len()
         );
+    }
+
+    /// #498: two candidates with an identical savings score (same length,
+    /// same repeat count) must still get a byte-stable @D0/@D1 assignment —
+    /// the first one to appear in the text, not whichever a HashMap's
+    /// randomized iteration order happens to visit first.
+    #[test]
+    fn tied_candidates_are_numbered_by_first_occurrence_not_hash_order() {
+        let text = "AlphaBetaGammaDeltaEpsilon here\nAlphaBetaGammaDeltaEpsilon there\nAlphaBetaGammaDeltaEpsilon again\nZetaEtaThetaIotaKappaOmega here\nZetaEtaThetaIotaKappaOmega there\nZetaEtaThetaIotaKappaOmega again";
+        let result = apply(text).expect("both 26-char tokens repeat 3x — should fire");
+        assert!(
+            result.starts_with(
+                "[dict: @D0=AlphaBetaGammaDeltaEpsilon, @D1=ZetaEtaThetaIotaKappaOmega]"
+            ),
+            "first-seen token must be @D0 even when tied on savings score: {result}"
+        );
+    }
+
+    /// #498: same input compressed repeatedly must yield byte-identical
+    /// output — the determinism/prompt-cache guarantee the maintainer asked
+    /// for, same pattern as the existing guards in `ctx_read`/`shell::redact`.
+    #[test]
+    fn mining_output_is_deterministic_across_repeated_calls() {
+        let text = "AlphaBetaGammaDeltaEpsilon here\nAlphaBetaGammaDeltaEpsilon there\nAlphaBetaGammaDeltaEpsilon again\nZetaEtaThetaIotaKappaOmega here\nZetaEtaThetaIotaKappaOmega there\nZetaEtaThetaIotaKappaOmega again";
+        let first = apply(text);
+        for _ in 0..20 {
+            assert_eq!(
+                apply(text),
+                first,
+                "mining must be byte-stable across repeated calls on identical input"
+            );
+        }
     }
 }

--- a/rust/src/core/terse/auto_dict.rs
+++ b/rust/src/core/terse/auto_dict.rs
@@ -1,0 +1,115 @@
+//! Auto-mined phrase dictionary: abbreviates long identifiers/phrases that
+//! repeat within a single compression call.
+//!
+//! Unlike the static `GENERAL`/`GIT`/`CARGO`/`NPM` dictionaries (known English
+//! abbreviations an LLM already understands without a lookup), a repeated
+//! project-specific identifier has no universally-known short form. So every
+//! substitution is accompanied by a self-describing legend line mapping
+//! short -> long. This keeps the full identifier present in the output (the
+//! legend), which is what `quality::check`'s identifier-preservation gate
+//! looks for, and lets the model resolve the short form unambiguously instead
+//! of guessing.
+
+use super::dictionaries::replace_whole_word;
+use std::collections::HashMap;
+
+const MIN_PHRASE_LEN: usize = 10;
+const MIN_REPEATS: usize = 3;
+const MAX_CANDIDATES: usize = 8;
+/// Bytes for the `"[dict: ]\n"` wrapper, independent of entry count.
+const LEGEND_WRAPPER_OVERHEAD: isize = 9;
+
+/// Finds long tokens repeated at least `MIN_REPEATS` times, replaces them
+/// with short codes, and prepends a legend. Returns `None` when no
+/// substitution would reduce total size (legend overhead not covered).
+pub fn apply(text: &str) -> Option<String> {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for tok in text.split(|c: char| !c.is_alphanumeric() && c != '_') {
+        if tok.len() >= MIN_PHRASE_LEN && tok.chars().any(char::is_alphabetic) {
+            *counts.entry(tok).or_insert(0) += 1;
+        }
+    }
+
+    let mut candidates: Vec<(&str, usize)> = counts
+        .into_iter()
+        .filter(|(_, n)| *n >= MIN_REPEATS)
+        .collect();
+    if candidates.is_empty() {
+        return None;
+    }
+    candidates.sort_by_key(|(tok, n)| std::cmp::Reverse(tok.len() * n));
+    candidates.truncate(MAX_CANDIDATES);
+
+    let mut output = text.to_string();
+    let mut legend: Vec<(String, &str)> = Vec::new();
+    let mut total_savings: isize = 0;
+
+    for (idx, (tok, n)) in candidates.iter().enumerate() {
+        let short = format!("@D{idx}");
+        let entry_cost = (short.len() + 1 + tok.len() + 2) as isize;
+        let savings = (*n as isize) * (tok.len() as isize - short.len() as isize) - entry_cost;
+        if savings <= 0 {
+            continue;
+        }
+        output = replace_whole_word(&output, tok, &short);
+        legend.push((short, *tok));
+        total_savings += savings;
+    }
+
+    if legend.is_empty() || total_savings <= LEGEND_WRAPPER_OVERHEAD {
+        return None;
+    }
+
+    let legend_line = format!(
+        "[dict: {}]\n",
+        legend
+            .iter()
+            .map(|(short, tok)| format!("{short}={tok}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    Some(format!("{legend_line}{output}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_candidates_returns_none() {
+        assert!(apply("short words only, nothing repeats here").is_none());
+    }
+
+    #[test]
+    fn below_repeat_threshold_returns_none() {
+        let text = "ConfigurationManagerFactory appears twice ConfigurationManagerFactory here";
+        assert!(apply(text).is_none());
+    }
+
+    #[test]
+    fn repeated_long_identifier_gets_abbreviated_with_legend() {
+        let text = "ConfigurationManagerFactory init\nConfigurationManagerFactory ready\nConfigurationManagerFactory done\nConfigurationManagerFactory closed";
+        let result = apply(text).expect("should fire: 4 repeats of a 27-char token");
+        assert!(
+            result.contains("ConfigurationManagerFactory"),
+            "full identifier must survive once, in the legend: {result}"
+        );
+        assert!(result.starts_with("[dict: "), "legend header missing: {result}");
+        assert!(
+            result.matches("ConfigurationManagerFactory").count() == 1,
+            "only the legend should keep the long form, body must use the short code: {result}"
+        );
+    }
+
+    #[test]
+    fn short_output_is_never_larger_than_input() {
+        let text = "ConfigurationManagerFactory init\nConfigurationManagerFactory ready\nConfigurationManagerFactory done\nConfigurationManagerFactory closed";
+        let result = apply(text).unwrap();
+        assert!(
+            result.len() < text.len(),
+            "mined dictionary must actually shrink output: {} vs {}",
+            result.len(),
+            text.len()
+        );
+    }
+}

--- a/rust/src/core/terse/dictionaries.rs
+++ b/rust/src/core/terse/dictionaries.rs
@@ -437,7 +437,7 @@ fn is_word_boundary(b: u8) -> bool {
     !b.is_ascii_alphanumeric() && b != b'-' && b != b'_' && b != b'\'' && b != b'"'
 }
 
-fn replace_whole_word(text: &str, pattern: &str, replacement: &str) -> String {
+pub(crate) fn replace_whole_word(text: &str, pattern: &str, replacement: &str) -> String {
     if pattern.is_empty() {
         return text.to_string();
     }

--- a/rust/src/core/terse/engine.rs
+++ b/rust/src/core/terse/engine.rs
@@ -148,6 +148,10 @@ fn compress_at_level(text: &str, tokens_before: u32, level: &CompressionLevel) -
         CompressionLevel::Lite | CompressionLevel::Off => DictLevel::General,
     };
     let compressed = dictionaries::apply_dictionaries(&filtered, dict_level);
+    let compressed = match dict_level {
+        DictLevel::Full => super::auto_dict::apply(&compressed).unwrap_or(compressed),
+        DictLevel::General => compressed,
+    };
     let tokens_after = counter::count(&compressed);
 
     EngineResult {

--- a/rust/src/core/terse/mod.rs
+++ b/rust/src/core/terse/mod.rs
@@ -19,6 +19,7 @@
 //! - **Layer 4** (`mcp_compress.rs`): MCP description compression — shrinks tool
 //!   descriptions, lazy-load stubs, on-demand expansion.
 
+pub mod auto_dict;
 pub mod counter;
 pub mod dictionaries;
 pub mod engine;

--- a/rust/src/core/terse/quality.rs
+++ b/rust/src/core/terse/quality.rs
@@ -112,10 +112,18 @@ fn looks_like_path(s: &str) -> bool {
 
 const MAX_IDENTIFIERS: usize = 200;
 
+/// A token counts as a must-preserve identifier if it looks like an ordinary
+/// code identifier (has a letter) OR looks like an encoded blob (hex/base64,
+/// e.g. a `git rev-parse HEAD` hash) — the latter has no alphabetic
+/// character for the ordinary check to key on, but dropping it is exactly
+/// the failure mode the noise-detector in `scoring.rs` must not cause: a
+/// payload-shaped blob must still trip this gate if compression removes it.
 fn extract_identifiers(text: &str, min_len: usize) -> HashSet<String> {
     let mut idents = HashSet::new();
     for word in text.split(|c: char| !c.is_alphanumeric() && c != '_') {
-        if word.len() >= min_len && word.chars().any(char::is_alphabetic) {
+        let looks_like_identifier = word.len() >= min_len
+            && (word.chars().any(char::is_alphabetic) || super::scoring::is_blob_token(word));
+        if looks_like_identifier {
             idents.insert(word.to_string());
             if idents.len() >= MAX_IDENTIFIERS {
                 break;
@@ -178,5 +186,21 @@ mod tests {
         let compressed = "error occurred";
         let report = check(original, compressed, 100, 50, &QualityConfig::default());
         assert!(!report.paths_preserved);
+    }
+
+    /// A pure-digit, hex-shaped blob (e.g. an all-numeric slice of a
+    /// `git rev-parse HEAD` hash) has no alphabetic character, so the
+    /// ordinary identifier check alone would miss it — `is_blob_token` closes
+    /// that gap so dropping it still fails the gate.
+    #[test]
+    fn quality_fails_when_payload_blob_is_dropped() {
+        let blob = "1".repeat(9) + &"2".repeat(9) + &"3".repeat(9);
+        let original = format!("commit hash: {blob}");
+        let compressed = "commit hash:";
+        let report = check(&original, compressed, 100, 10, &QualityConfig::default());
+        assert!(
+            !report.identifiers_preserved,
+            "dropping a pure-digit hash-shaped blob must fail the identifier gate"
+        );
     }
 }

--- a/rust/src/core/terse/scoring.rs
+++ b/rust/src/core/terse/scoring.rs
@@ -145,29 +145,38 @@ fn compute_combined(entropy: f32, has_marker: bool, rep_ratio: f32, is_noise: bo
     (entropy + marker_bonus - rep_penalty).max(0.0)
 }
 
-/// True when `line` is a single encoded blob (base64 or hex) rather than
-/// prose/code — high Shannon entropy but zero semantic content, so it must
-/// not be scored as information-dense.
+/// True when `line` contains an encoded blob (base64 or hex) — either as the
+/// whole line or as one whitespace-delimited token in a `label: <blob>`
+/// shaped line (`trace id: <hex>`, `commit <sha>`, `session token: <b64>`,
+/// all common in real logs) — rather than prose/code. High Shannon entropy
+/// but zero semantic content, so it must not be scored as information-dense.
 fn is_encoded_blob(line: &str) -> bool {
+    line.split_whitespace().any(is_blob_token)
+}
+
+/// True when a single whitespace-delimited token looks like a random,
+/// non-prose blob (base64 or hex) rather than an English word or code
+/// identifier.
+fn is_blob_token(token: &str) -> bool {
     const MIN_BLOB_LEN: usize = 24;
 
-    if line.len() < MIN_BLOB_LEN || line.contains(char::is_whitespace) {
+    if token.len() < MIN_BLOB_LEN {
         return false;
     }
 
-    let is_hex = line.chars().all(|c| c.is_ascii_hexdigit());
+    let is_hex = token.chars().all(|c| c.is_ascii_hexdigit());
 
     // Base64 padding/symbols are an unambiguous signal on their own. Without
     // them, require the digit+upper+lower mix typical of random tokens so a
     // long plain identifier (all-lowercase or camelCase, no digits) doesn't
     // get misclassified as noise.
-    let has_b64_symbol = line.contains('+') || line.contains('/') || line.contains('=');
-    let charset_ok = line
+    let has_b64_symbol = token.contains('+') || token.contains('/') || token.contains('=');
+    let charset_ok = token
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=');
-    let has_digit = line.chars().any(|c| c.is_ascii_digit());
-    let has_upper = line.chars().any(|c| c.is_ascii_uppercase());
-    let has_lower = line.chars().any(|c| c.is_ascii_lowercase());
+    let has_digit = token.chars().any(|c| c.is_ascii_digit());
+    let has_upper = token.chars().any(|c| c.is_ascii_uppercase());
+    let has_lower = token.chars().any(|c| c.is_ascii_lowercase());
     let is_base64 = charset_ok && (has_b64_symbol || (has_digit && has_upper && has_lower));
 
     is_hex || is_base64
@@ -220,6 +229,27 @@ mod tests {
         ));
         assert!(!is_encoded_blob("src/core/config.rs"));
         assert!(!is_encoded_blob("this is a simple line with words"));
+    }
+
+    #[test]
+    fn prefixed_blob_is_still_detected_as_noise() {
+        // Real logs almost always label the blob rather than emit it bare
+        // (`trace id: <hex>`, `commit <sha>`, `session token: <b64>`). Built
+        // at runtime (not a literal) so a fake test token isn't itself
+        // mistaken for a real secret by tooling.
+        let hex64: String = "9f86d0".repeat(11);
+        let b64_padded: String = format!("{}==", "aZ9".repeat(8));
+
+        assert!(is_encoded_blob(&format!("trace id: {hex64}")));
+        assert!(is_encoded_blob(&format!("build session token: {b64_padded}")));
+        assert!(is_encoded_blob(&format!("commit {hex64}")));
+    }
+
+    #[test]
+    fn prefixed_real_content_is_not_noise() {
+        assert!(!is_encoded_blob(
+            "error in module ConfigurationManagerFactory during init"
+        ));
     }
 
     #[test]

--- a/rust/src/core/terse/scoring.rs
+++ b/rust/src/core/terse/scoring.rs
@@ -30,7 +30,8 @@ pub fn score_lines(text: &str) -> Vec<LineScore> {
         let trimmed = line.trim();
 
         let entropy = char_entropy(trimmed);
-        let has_marker = has_structural_marker(trimmed);
+        let is_noise = is_encoded_blob(trimmed);
+        let has_marker = !is_noise && has_structural_marker(trimmed);
         let rep_ratio = if trigram_saturated {
             0.0
         } else {
@@ -44,7 +45,7 @@ pub fn score_lines(text: &str) -> Vec<LineScore> {
             }
         }
 
-        let combined = compute_combined(entropy, has_marker, rep_ratio);
+        let combined = compute_combined(entropy, has_marker, rep_ratio, is_noise);
 
         scores.push(LineScore {
             line_idx: idx,
@@ -135,10 +136,41 @@ fn register_trigrams(line: &str, seen: &mut HashSet<String>) {
     }
 }
 
-fn compute_combined(entropy: f32, has_marker: bool, rep_ratio: f32) -> f32 {
+fn compute_combined(entropy: f32, has_marker: bool, rep_ratio: f32, is_noise: bool) -> f32 {
+    if is_noise {
+        return 0.0;
+    }
     let marker_bonus = if has_marker { 0.3 } else { 0.0 };
     let rep_penalty = rep_ratio * 0.5;
     (entropy + marker_bonus - rep_penalty).max(0.0)
+}
+
+/// True when `line` is a single encoded blob (base64 or hex) rather than
+/// prose/code — high Shannon entropy but zero semantic content, so it must
+/// not be scored as information-dense.
+fn is_encoded_blob(line: &str) -> bool {
+    const MIN_BLOB_LEN: usize = 24;
+
+    if line.len() < MIN_BLOB_LEN || line.contains(char::is_whitespace) {
+        return false;
+    }
+
+    let is_hex = line.chars().all(|c| c.is_ascii_hexdigit());
+
+    // Base64 padding/symbols are an unambiguous signal on their own. Without
+    // them, require the digit+upper+lower mix typical of random tokens so a
+    // long plain identifier (all-lowercase or camelCase, no digits) doesn't
+    // get misclassified as noise.
+    let has_b64_symbol = line.contains('+') || line.contains('/') || line.contains('=');
+    let charset_ok = line
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=');
+    let has_digit = line.chars().any(|c| c.is_ascii_digit());
+    let has_upper = line.chars().any(|c| c.is_ascii_uppercase());
+    let has_lower = line.chars().any(|c| c.is_ascii_lowercase());
+    let is_base64 = charset_ok && (has_b64_symbol || (has_digit && has_upper && has_lower));
+
+    is_hex || is_base64
 }
 
 #[cfg(test)]
@@ -176,6 +208,36 @@ mod tests {
     #[test]
     fn structural_marker_missing() {
         assert!(!has_structural_marker("this is a simple line"));
+    }
+
+    #[test]
+    fn encoded_blob_detected_as_noise() {
+        assert!(is_encoded_blob(
+            "MTIzNDU2Nzg5MGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6MDk4NzY1NDMyMQ=="
+        ));
+        assert!(is_encoded_blob(
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        ));
+        assert!(!is_encoded_blob("src/core/config.rs"));
+        assert!(!is_encoded_blob("this is a simple line with words"));
+    }
+
+    #[test]
+    fn long_camel_case_identifier_is_not_noise() {
+        assert!(!is_encoded_blob("configureApplicationRuntimeEnvironmentSettings"));
+        assert!(!is_encoded_blob("configure_premium_feature_flags_for_tenant"));
+    }
+
+    #[test]
+    fn encoded_blob_scores_lower_than_real_error_line() {
+        let text = "error: connection refused at host during handshake attempt\nMTIzNDU2Nzg5MGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6MDk4NzY1NDMyMQ==";
+        let scores = score_lines(text);
+        assert!(
+            scores[0].combined > scores[1].combined,
+            "real error line should score above encoded blob noise: {} vs {}",
+            scores[0].combined,
+            scores[1].combined
+        );
     }
 
     #[test]

--- a/rust/src/core/terse/scoring.rs
+++ b/rust/src/core/terse/scoring.rs
@@ -156,8 +156,12 @@ fn is_encoded_blob(line: &str) -> bool {
 
 /// True when a single whitespace-delimited token looks like a random,
 /// non-prose blob (base64 or hex) rather than an English word or code
-/// identifier.
-fn is_blob_token(token: &str) -> bool {
+/// identifier. `pub(super)` so `quality::check` can also treat a long blob
+/// as a must-preserve identifier — a payload-shaped blob (e.g. the resolved
+/// hash from `git rev-parse HEAD`) must still trip the quality gate if
+/// dropped, even though it has no alphabetic characters for the ordinary
+/// identifier check to key on.
+pub(super) fn is_blob_token(token: &str) -> bool {
     const MIN_BLOB_LEN: usize = 24;
 
     if token.len() < MIN_BLOB_LEN {
@@ -241,7 +245,9 @@ mod tests {
         let b64_padded: String = format!("{}==", "aZ9".repeat(8));
 
         assert!(is_encoded_blob(&format!("trace id: {hex64}")));
-        assert!(is_encoded_blob(&format!("build session token: {b64_padded}")));
+        assert!(is_encoded_blob(&format!(
+            "build session token: {b64_padded}"
+        )));
         assert!(is_encoded_blob(&format!("commit {hex64}")));
     }
 
@@ -254,8 +260,12 @@ mod tests {
 
     #[test]
     fn long_camel_case_identifier_is_not_noise() {
-        assert!(!is_encoded_blob("configureApplicationRuntimeEnvironmentSettings"));
-        assert!(!is_encoded_blob("configure_premium_feature_flags_for_tenant"));
+        assert!(!is_encoded_blob(
+            "configureApplicationRuntimeEnvironmentSettings"
+        ));
+        assert!(!is_encoded_blob(
+            "configure_premium_feature_flags_for_tenant"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two compression improvements for the terse engine, plus three fixes the maintainer asked for in #704 before this went up as a PR.

1. `scoring.rs` now scores a base64/hex blob line as noise (score 0) instead of "high entropy, therefore important." Catches bare blob lines and the more common `label: <blob>` shape (`trace id:`, `commit`, `session token:`).
2. New `auto_dict.rs` mines identifiers >=10 chars that repeat >=3x in one output, replaces them with a short code, and prepends a legend (`[dict: @D0=LongIdentifier]`) so the full identifier stays recoverable.
3. Candidate ordering for (2) no longer depends on HashMap iteration order. Ties are broken by first occurrence, so the same input always produces the same @D0/@D1 assignment - needed for prompt caching per #498.
4. `quality.rs`'s identifier-preservation check now also recognizes a pure-digit hex/base64 run as an identifier, so dropping a payload blob (e.g. `git rev-parse HEAD` output) fails the gate and reverts to passthrough instead of silently eating real data.

## Why

Opened #704 first since this touches the compression heuristics directly. Maintainer confirmed the legend format, the per-token blob scan, and Standard/Max-only scope, and asked for the three fixes above before a PR.

## Testing

```
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
```
All green. Did not run `cargo test --release`.

Manually compared before/after on the installed binary with a small synthetic log (base64 line + `trace id: <hex>` line + some repeated words): 566 -> 392 chars. The noise-drop was also what pushed the sample over the existing 3%-min-savings gate, so the pre-existing GENERAL dictionary abbreviations kicked in too - previously the whole thing reverted to passthrough.

| Test | What it checks |
|---|---|
| `encoded_blob_scores_lower_than_real_error_line` | bare blob scores below a real error line with similar entropy |
| `prefixed_blob_is_still_detected_as_noise` | `trace id:` / `commit` / `session token:` prefixed blobs still caught |
| `prefixed_real_content_is_not_noise` | a message with a long identifier isn't misflagged |
| `long_camel_case_identifier_is_not_noise` | long plain identifiers (no digit/case mix) aren't false positives |
| `repeated_long_identifier_gets_abbreviated_with_legend` | legend keeps the full identifier findable |
| `tied_candidates_are_numbered_by_first_occurrence_not_hash_order` | equal-savings candidates still get stable numbering |
| `mining_output_is_deterministic_across_repeated_calls` | same input, 20 runs, byte-identical output |
| `quality_fails_when_payload_blob_is_dropped` | dropping a pure-digit hash blob fails the identifier gate |

## Compatibility

No API/CLI/MCP schema changes. Only affects `Standard`/`Max` compression levels (`DictLevel::Full`); `Lite` is untouched, matching what we agreed in #704.

Fixes #704.