### PR TITLE
feat(savings-ledger): record lean-ctx version per event (v4)

### DIFF
--- a/rust/src/core/finops_export/mod.rs
+++ b/rust/src/core/finops_export/mod.rs
@@ -153,6 +153,7 @@ mod tests {
             agent_id: "coder".into(),
             prev_hash: String::new(),
             entry_hash: String::new(),
+            version: "3.9.0".into(),
         }
     }
 

--- a/rust/src/core/savings_ledger/event.rs
+++ b/rust/src/core/savings_ledger/event.rs
@@ -22,6 +22,14 @@ fn default_mechanism() -> String {
     MECHANISM_COMPRESSION.to_string()
 }
 
+/// Pre-v4 events carry no `version` field. Empty, not the current crate
+/// version — an empty string honestly says "unknown" instead of implying an
+/// old entry was written by whatever binary happens to be reading it now.
+/// Same convention as `DayStats::version` in `core/stats/model.rs`.
+fn default_version() -> String {
+    String::new()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SavingsEvent {
     pub ts: String,
@@ -59,13 +67,20 @@ pub struct SavingsEvent {
     pub agent_id: String,
     pub prev_hash: String,
     pub entry_hash: String,
+    /// lean-ctx version active when this event was recorded (`CARGO_PKG_VERSION`,
+    /// #NNN). Lets a `stats.json` rebuilt from the ledger (after corruption or
+    /// otherwise) recover the per-day version tag `lean-ctx gain --daily` shows,
+    /// which the ledger previously had no way to answer. Pre-v4 events default
+    /// to empty (unknown), never a guessed version.
+    #[serde(default = "default_version")]
+    pub version: String,
 }
 
 impl SavingsEvent {
-    /// Canonical (v3) representation of the *content* fields (everything except the chain
-    /// hashes), hashed on append and re-hashed on verify. v3 = v2 + the `mechanism`
-    /// attribution field (enterprise#19); the `v3|` prefix pins the scheme so a downgrade
-    /// is itself tamper-evident.
+    /// Canonical (v4) representation of the *content* fields (everything except the chain
+    /// hashes), hashed on append and re-hashed on verify. v4 = v3 + the `version`
+    /// field (#NNN); the `v4|` prefix pins the scheme so a downgrade is itself
+    /// tamper-evident.
     ///
     /// Monetary values are committed as integer **micro-USD** rather than `{:.6}` of a raw
     /// `f64`. A fixed-precision float string is *not* round-trip stable: a value sitting on a
@@ -73,6 +88,29 @@ impl SavingsEvent {
     /// that `{:.6}` rounds the other way, which silently broke the chain for untampered data.
     /// Integers serialise/parse exactly, so the hash is reproducible.
     pub fn canonical_content(&self) -> String {
+        format!(
+            "v4|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            self.ts,
+            self.tool,
+            self.mechanism,
+            self.model_id,
+            self.tokenizer,
+            self.baseline_tokens,
+            self.actual_tokens,
+            self.saved_tokens,
+            self.bounce_adjustment,
+            micro_usd(self.unit_price_per_m_usd),
+            micro_usd(self.saved_usd),
+            self.repo_hash,
+            self.agent_id,
+            self.version,
+        )
+    }
+
+    /// v3 canonical (pre-`version`): v2 + the `mechanism` attribution field
+    /// (enterprise#19). Retained so ledgers written between the v3 fix and v4
+    /// keep verifying unchanged.
+    pub fn canonical_content_v3(&self) -> String {
         format!(
             "v3|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             self.ts,
@@ -132,12 +170,13 @@ impl SavingsEvent {
         )
     }
 
-    /// True if `entry_hash` matches the current (v3) canonical hash, the v2 hash, or the
-    /// legacy v1 hash. Accepting all three lets `verify` validate ledgers written under any
-    /// scheme without forcing a migration (clean old ledgers stay valid; broken-by-bug ones
-    /// are repaired by `rechain`, which re-hashes under v3).
+    /// True if `entry_hash` matches the current (v4) canonical hash, the v3 hash, the v2
+    /// hash, or the legacy v1 hash. Accepting all four lets `verify` validate ledgers
+    /// written under any scheme without forcing a migration (clean old ledgers stay
+    /// valid; broken-by-bug ones are repaired by `rechain`, which re-hashes under v4).
     pub fn hash_matches(&self, prev_hash: &str) -> bool {
         self.entry_hash == compute_hash(prev_hash, &self.canonical_content())
+            || self.entry_hash == compute_hash(prev_hash, &self.canonical_content_v3())
             || self.entry_hash == compute_hash(prev_hash, &self.canonical_content_v2())
             || self.entry_hash == compute_hash(prev_hash, &self.canonical_content_legacy())
     }
@@ -188,6 +227,7 @@ mod tests {
             agent_id: "local".into(),
             prev_hash: String::new(),
             entry_hash: String::new(),
+            version: "3.9.0".into(),
         }
     }
 
@@ -305,6 +345,37 @@ mod tests {
         assert!(
             !forged.hash_matches(&forged.prev_hash),
             "reattributing a routing saving to compression must be tamper-evident"
+        );
+    }
+
+    #[test]
+    fn v3_hash_still_verifies_and_v4_commits_version() {
+        // Pre-version (v3) entries — including their JSON form without the
+        // field — must keep verifying after the v4 upgrade (#NNN).
+        let mut e = ev();
+        e.prev_hash = "genesis".into();
+        e.entry_hash = compute_hash(&e.prev_hash, &e.canonical_content_v3());
+        assert!(e.hash_matches(&e.prev_hash), "v3 hash must verify");
+
+        let json = serde_json::to_string(&e).unwrap();
+        // `version` is the last struct field, so its JSON key is preceded by
+        // a comma, not followed by one.
+        let stripped = json.replace(r#","version":"3.9.0""#, "");
+        let parsed: SavingsEvent = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(parsed.version, "", "serde default for a pre-v4 entry");
+        assert!(parsed.hash_matches(&parsed.prev_hash), "v3 after roundtrip");
+
+        // v4 commits the version: rewriting it breaks the hash.
+        let mut v4 = ev();
+        v4.version = "3.8.18".into();
+        v4.prev_hash = "genesis".into();
+        v4.entry_hash = compute_hash(&v4.prev_hash, &v4.canonical_content());
+        assert!(v4.hash_matches(&v4.prev_hash));
+        let mut forged = v4.clone();
+        forged.version = "3.9.0".into();
+        assert!(
+            !forged.hash_matches(&forged.prev_hash),
+            "rewriting which version recorded a saving must be tamper-evident"
         );
     }
 

--- a/rust/src/core/savings_ledger/mod.rs
+++ b/rust/src/core/savings_ledger/mod.rs
@@ -123,6 +123,7 @@ fn new_event(tool: &str) -> SavingsEvent {
         agent_id: agent_id().to_string(),
         prev_hash: String::new(),
         entry_hash: String::new(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
     }
 }
 

--- a/rust/src/core/savings_ledger/store.rs
+++ b/rust/src/core/savings_ledger/store.rs
@@ -387,6 +387,7 @@ mod tests {
             agent_id: "local".into(),
             prev_hash: String::new(),
             entry_hash: String::new(),
+            version: "3.9.0".into(),
         }
     }
 


### PR DESCRIPTION
## Summary

`SavingsEvent` had no way to say which lean-ctx version recorded a given saving. `stats.json` (the display cache `lean-ctx gain --daily` reads) tracks a per-day version tag separately, but if that cache is ever lost or corrupted, rebuilding it from the append-only savings ledger (the real source of truth) can't recover the version column at all — there's nothing in the ledger to recover it from.

## What

- `version: String` added to `SavingsEvent`, populated with `CARGO_PKG_VERSION` at append time (`savings_ledger/mod.rs::new_event`).
- New v4 canonical-content hash commits it; `canonical_content_v3` (the pre-version format) kept intact so existing ledger entries keep verifying unchanged.
- `hash_matches` now checks v4, v3, v2, and the legacy v1 format, same as before plus one more tier.
- Pre-v4 entries deserialize with `version` defaulting to an empty string via serde, not a guessed current version — same convention already used by `DayStats::version` in `core/stats/model.rs` for the same "unknown, don't fabricate" reason.

This follows the exact pattern this file already used for v2→v3 (the `mechanism` field, enterprise#19): additive field, versioned canonical-content format, old canonical method kept around, backward-compat regression test mirroring the existing one for that transition.

## Why

Hit this directly: `stats.json` got corrupted (unrelated incident, a Windows-encoding bug in a different tool that truncated it mid-write) and had to be rebuilt by replaying `savings/ledger.jsonl`. Everything reconstructed cleanly except the per-day version tag, because the ledger never recorded it. This closes that gap for next time.

## Test Plan

```
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
```
All pass locally.

| Test | What it proves |
|---|---|
| `v3_hash_still_verifies_and_v4_commits_version` | pre-v4 entries (no `version` key in JSON) still verify via `canonical_content_v3`; a v4 entry's hash breaks if `version` is rewritten |
| existing `hash_is_deterministic`, `hash_changes_when_content_changes`, `hash_depends_on_prev` | unchanged, now implicitly exercising the v4 canonical form |
| existing `legacy_v1_hash_still_verifies`, `v2_hash_still_verifies_and_v3_commits_mechanism` | unchanged — proves the new tier didn't disturb older verification paths |

## Backward Compatibility

No schema break. Existing ledger files verify unchanged (v1/v2/v3 canonical forms all still checked by `hash_matches`). New appends use v4. Not a CLI/MCP tool surface change — no registry/schema/docs updates needed.

## Related Issue

No prior issue — small, mechanical, additive change following an established in-file pattern; happy to open one retroactively if you'd rather have that paper trail before merging.
