### PR TITLE
feat(index): include/exclude corpus filters for all index builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Index-time include/exclude filters (GH #735).** The retrieval corpus is
+  now declared explicitly instead of abusing `.gitignore` for retrieval
+  policy: new `[index]` config (`exclude`, `include`, `respect_gitignore`)
+  plus per-run CLI overlays on every `lean-ctx index` build command —
+  repeatable `--exclude <glob>` / `--include <glob>` (both `--flag value` and
+  `--flag=value` forms) and `--no-gitignore` / `--respect-gitignore`. One
+  shared filter layer (`core::index_filter`) drives the BM25 walk, the graph
+  scan, the graph staleness check, and the watch snapshot; the semantic index
+  chunks the BM25 corpus and inherits the same universe — excluded files
+  produce no chunks, graph nodes, or embeddings. Globs match the
+  root-relative path (forward slashes on every platform); exclude wins over
+  include; a non-empty include list admits matching files only. CLI
+  `--exclude` appends to config, `--include` replaces the config set for the
+  run, and a run with overlay flags skips the daemon delegation so the
+  one-off corpus can't be overwritten by a config-built index. `index status`
+  (human + `--json`) reports the active filter summary; repo-local config
+  extends global excludes and can only tighten gitignore handling. Empty
+  filters preserve today's behavior byte-for-byte.
 - **Personas now drive the whole pipeline (persona-spec-v1 runtime wiring,
   GL #1178).** The five declared persona fields were spec +
   capability-reporting only; every one of them is now consumed at runtime:

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -236,6 +236,14 @@ Per-IDE allowed paths. Keys are agent names (cursor, codex, opencode, antigravit
 
 _No sub-keys (presence of the section toggles the feature)._
 
+## `[index]`
+
+Index-time file filters: declare the retrieval corpus explicitly (BM25 + graph + semantic + watch share one filter layer, #735)
+
+- `exclude` (string[], default `[]`) — Globs dropped from the index corpus (root-relative, forward slashes), e.g. ["**/*.csv", "fixtures/**"]. Wins over include. CLI --exclude appends per run. Excluded files produce no chunks, graph nodes, or embeddings.
+- `include` (string[], default `[]`) — When non-empty, ONLY matching files enter the index corpus, e.g. ["**/*.rs", "**/*.ts"]. Empty = no restriction. CLI --include replaces this set per run.
+- `respect_gitignore` (bool, default `true`) — Honor .gitignore / global gitignore / .git/info/exclude during index walks. false indexes ignored files too (the vendor-directory guard still applies). CLI override: --no-gitignore / --respect-gitignore.
+
 ## `[llm]`
 
 Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable.

--- a/rust/LOCK_ORDERING.md
+++ b/rust/LOCK_ORDERING.md
@@ -71,6 +71,7 @@ All `std::sync::Mutex` unless noted otherwise.
 | L58 | `SNAPSHOT` | `proxy/policy_gate.rs:76` | `RwLock<Option<CachedSnapshot>>` | TTL-cached org-policy gate rules (enterprise#25) so the forward path re-verifies the signed policy at most once per minute; independent leaf lock, never nested |
 | L59 | `LEDGER` | `proxy/policy_gate.rs:247` | `OnceLock<Mutex<BudgetLedger>>` | In-process person/day + project/month spend counters backing hard budget caps (enterprise#25); fed from the metering choke-point, seeded from Postgres when available; independent leaf lock, never nested |
 | L60 | `RATE` | `proxy/policy_gate.rs:281` | `OnceLock<Mutex<RateLedger>>` | Per-person accepted-request counts for the current UTC minute backing the org-policy rate limit (enterprise#66); reset on every minute roll, at most one entry per active person; independent leaf lock, never nested |
+| L61 | `CLI_OVERLAY` | `core/index_filter.rs:31` | `RwLock<Option<CliOverlay>>` | Per-run index corpus filter overlay (#735): written once by the `index` CLI dispatch before builders start, read by every index walk via `IndexFileFilter::resolve`; independent leaf lock, never nested |
 
 ### Test / Environment Locks (serialise env-var mutations)
 
@@ -180,9 +181,9 @@ Override via `LEAN_CTX_WORKER_THREADS` (positive integer) for environments with 
 concurrent subagents. Example: `LEAN_CTX_WORKER_THREADS=8`. The blocking thread pool
 is always `worker_threads * 4`, clamped to `[8, 32]`.
 
-### Independent Static Locks (L3–L57)
+### Independent Static Locks (L3–L61)
 
-All other static locks (L3–L57) — **except the L22 → L4 pair documented above** — are
+All other static locks (L3–L61) — **except the L22 → L4 pair documented above** — are
 **independent singletons**: they protect isolated subsystem state and are never nested inside
 each other. Each should be acquired in isolation:
 
@@ -241,4 +242,5 @@ across any other lock acquisition.
 3. Assign a lock number (append to Section 1) and document the acquisition order here.
 4. If nesting is required, document the outer → inner relationship in Section 3.
 5. Run `cargo check --all-features` to verify `Send`/`Sync` bounds.
+
 

--- a/rust/src/cli/index_cmd.rs
+++ b/rust/src/cli/index_cmd.rs
@@ -6,10 +6,12 @@ pub(crate) fn cmd_index(args: &[String]) {
     let project_root = super::common::detect_project_root(args);
     let root = Path::new(&project_root);
 
-    let sub = args
-        .iter()
-        .find(|a| !a.starts_with("--"))
-        .map(String::as_str);
+    // #735: install the per-run filter overlay (repeatable --include/--exclude
+    // globs, --no-gitignore/--respect-gitignore) before any builder runs, so
+    // BM25 + graph + semantic + watch share the declared corpus for this run.
+    install_filter_overlay(args);
+
+    let sub = find_subcommand(args);
     match sub {
         Some("status") => {
             let json_flag = args.iter().any(|a| a == "--json");
@@ -190,16 +192,91 @@ pub(crate) fn cmd_index(args: &[String]) {
         _ => {
             eprintln!(
                 "Usage: lean-ctx index <status|build|build-full|build-graph|build-semantic|watch> [--root <path>]\n\
+                 Filter flags (#735, apply to this run; persist via [index] config):\n\
+                   --exclude <glob>       drop matching files from the corpus (repeatable)\n\
+                   --include <glob>       corpus = matching files only (repeatable)\n\
+                   --no-gitignore         index .gitignore'd files too\n\
+                   --respect-gitignore    honor .gitignore (default)\n\
                  Examples:\n\
                    lean-ctx index status\n\
                    lean-ctx index build              (graph + BM25 indexes)\n\
                    lean-ctx index build-full         (force rebuild all indexes)\n\
+                   lean-ctx index build-full --exclude \"**/*.csv\" --exclude \"**/*.jsonl\"\n\
+                   lean-ctx index build-semantic --include \"**/*.{{java,kt,ts}}\"\n\
                    lean-ctx index build-graph        (SQLite property graph for impact analysis)\n\
                    lean-ctx index build-semantic     (dense embedding index, builds BM25 first if needed)\n\
                    lean-ctx index watch"
             );
         }
     }
+}
+
+/// First non-flag token, skipping the values of value-taking flags — so
+/// `index build --exclude "**/*.csv"` resolves the subcommand `build`, not the
+/// glob (#735).
+fn find_subcommand(args: &[String]) -> Option<&str> {
+    const VALUE_FLAGS: [&str; 4] = ["--exclude", "--include", "--root", "--project-root"];
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        if VALUE_FLAGS.contains(&a.as_str()) {
+            let _ = it.next();
+            continue;
+        }
+        if a.starts_with("--") {
+            continue;
+        }
+        return Some(a.as_str());
+    }
+    None
+}
+
+/// Parse the #735 filter flags and install the per-run overlay. No-op when no
+/// filter flag is present, so config-only runs take the config path.
+fn install_filter_overlay(args: &[String]) {
+    let (include, exclude, respect_gitignore) = parse_filter_flags(args);
+    if !include.is_empty() || !exclude.is_empty() || respect_gitignore.is_some() {
+        crate::core::index_filter::set_cli_overlay(include, exclude, respect_gitignore);
+    }
+}
+
+/// Pure #735 flag parser: `--exclude` / `--include` are repeatable and accept
+/// both `--flag value` and `--flag=value` forms; the last of `--no-gitignore`
+/// / `--respect-gitignore` wins.
+fn parse_filter_flags(args: &[String]) -> (Vec<String>, Vec<String>, Option<bool>) {
+    let mut include: Vec<String> = Vec::new();
+    let mut exclude: Vec<String> = Vec::new();
+    let mut respect_gitignore: Option<bool> = None;
+
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--exclude" => {
+                if let Some(v) = it.next() {
+                    exclude.push(v.clone());
+                } else {
+                    eprintln!("--exclude requires a glob argument");
+                }
+            }
+            "--include" => {
+                if let Some(v) = it.next() {
+                    include.push(v.clone());
+                } else {
+                    eprintln!("--include requires a glob argument");
+                }
+            }
+            "--no-gitignore" => respect_gitignore = Some(false),
+            "--respect-gitignore" => respect_gitignore = Some(true),
+            other => {
+                if let Some(v) = other.strip_prefix("--exclude=") {
+                    exclude.push(v.to_string());
+                } else if let Some(v) = other.strip_prefix("--include=") {
+                    include.push(v.to_string());
+                }
+            }
+        }
+    }
+
+    (include, exclude, respect_gitignore)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -248,11 +325,14 @@ fn run_watcher(project_root: &Path) {
 }
 
 fn snapshot_code_files(project_root: &Path) -> HashMap<String, FileState> {
+    // #735: the watcher observes the same declared corpus as the builders it
+    // triggers — a change to an excluded file must not cause rebuild churn.
+    let filter = crate::core::index_filter::IndexFileFilter::effective();
     let walker = ignore::WalkBuilder::new(project_root)
         .hidden(true)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
+        .git_ignore(filter.respect_gitignore)
+        .git_global(filter.respect_gitignore)
+        .git_exclude(filter.respect_gitignore)
         .require_git(false)
         .filter_entry(crate::core::walk_filter::keep_entry)
         .build();
@@ -291,6 +371,9 @@ fn snapshot_code_files(project_root: &Path) -> HashMap<String, FileState> {
         if rel.is_empty() {
             continue;
         }
+        if filter.is_excluded(&rel.replace('\\', "/")) {
+            continue;
+        }
 
         out.insert(
             rel,
@@ -323,6 +406,12 @@ fn print_human_status(project_root: &str) {
         "  Semantic Index: {}",
         format_disk_line(&disk.semantic_index, "vectors")
     );
+    // #735: surface the active corpus filter so a filtered index is always
+    // recognizable. Absent for the default (unfiltered) config, keeping the
+    // default output byte-identical.
+    if let Some(summary) = crate::core::index_filter::IndexFileFilter::effective().summary() {
+        println!("  Index Filters:  {summary}");
+    }
 }
 
 fn format_disk_line(ds: &crate::core::index_orchestrator::DiskStatus, count_label: &str) -> String {
@@ -351,5 +440,79 @@ fn format_bytes(bytes: u64) -> String {
         format!("{:.1} KB", bytes as f64 / 1024.0)
     } else {
         format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn subcommand_found_before_flags() {
+        assert_eq!(
+            find_subcommand(&args(&["build", "--root", "/x"])),
+            Some("build")
+        );
+        assert_eq!(find_subcommand(&args(&["status"])), Some("status"));
+    }
+
+    #[test]
+    fn subcommand_skips_filter_flag_values() {
+        // The glob value must never be mistaken for the subcommand (#735).
+        assert_eq!(
+            find_subcommand(&args(&["--exclude", "**/*.csv", "build-full"])),
+            Some("build-full")
+        );
+        assert_eq!(
+            find_subcommand(&args(&["build-semantic", "--include", "**/*.java"])),
+            Some("build-semantic")
+        );
+        assert_eq!(
+            find_subcommand(&args(&["--root", "/x", "--no-gitignore", "watch"])),
+            Some("watch")
+        );
+    }
+
+    #[test]
+    fn subcommand_none_for_flag_only_args() {
+        assert_eq!(find_subcommand(&args(&["--exclude", "**/*.csv"])), None);
+        assert_eq!(find_subcommand(&[]), None);
+    }
+
+    #[test]
+    fn filter_flags_repeatable_and_both_forms() {
+        let (include, exclude, gitignore) = parse_filter_flags(&args(&[
+            "build-full",
+            "--exclude",
+            "**/*.csv",
+            "--exclude=**/*.jsonl",
+            "--include",
+            "**/*.rs",
+            "--include=**/*.ts",
+        ]));
+        assert_eq!(exclude, vec!["**/*.csv", "**/*.jsonl"]);
+        assert_eq!(include, vec!["**/*.rs", "**/*.ts"]);
+        assert_eq!(gitignore, None);
+    }
+
+    #[test]
+    fn gitignore_flags_last_one_wins() {
+        let (_, _, gitignore) =
+            parse_filter_flags(&args(&["build", "--no-gitignore", "--respect-gitignore"]));
+        assert_eq!(gitignore, Some(true));
+        let (_, _, gitignore) = parse_filter_flags(&args(&["build", "--no-gitignore"]));
+        assert_eq!(gitignore, Some(false));
+    }
+
+    #[test]
+    fn no_filter_flags_yields_empty_overlay_inputs() {
+        let (include, exclude, gitignore) = parse_filter_flags(&args(&["build", "--root", "/x"]));
+        assert!(include.is_empty());
+        assert!(exclude.is_empty());
+        assert_eq!(gitignore, None);
     }
 }

--- a/rust/src/core/bm25_index/mod.rs
+++ b/rust/src/core/bm25_index/mod.rs
@@ -876,17 +876,22 @@ fn index_dir(root: &Path) -> PathBuf {
 }
 
 fn list_code_files(root: &Path) -> Vec<String> {
+    let cfg = crate::core::config::Config::load();
+    // #735: the declared corpus filter ([index] config + CLI overlay) decides
+    // membership before anything is chunked; the semantic index chunks this
+    // corpus, so it inherits the same universe.
+    let filter = crate::core::index_filter::IndexFileFilter::resolve(&cfg);
+
     let walker = ignore::WalkBuilder::new(root)
         .hidden(true)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
+        .git_ignore(filter.respect_gitignore)
+        .git_global(filter.respect_gitignore)
+        .git_exclude(filter.respect_gitignore)
         .require_git(false)
         .max_depth(Some(20))
         .filter_entry(crate::core::walk_filter::keep_entry)
         .build();
 
-    let cfg = crate::core::config::Config::load();
     let mut ignore_patterns: Vec<glob::Pattern> = DEFAULT_BM25_IGNORES
         .iter()
         .filter_map(|p| glob::Pattern::new(p).ok())
@@ -898,6 +903,7 @@ fn list_code_files(root: &Path) -> Vec<String> {
     );
 
     let mut files: Vec<String> = Vec::new();
+    let mut filtered_out = 0usize;
     for entry in walker.flatten() {
         let path = entry.path();
         if !path.is_file() {
@@ -917,6 +923,13 @@ fn list_code_files(root: &Path) -> Vec<String> {
         if ignore_patterns.iter().any(|p| p.matches(&rel)) {
             continue;
         }
+        // Match on forward slashes so globs behave identically on Windows;
+        // the index key keeps the platform separator (existing indexes stay
+        // valid).
+        if filter.is_excluded(&rel.replace('\\', "/")) {
+            filtered_out += 1;
+            continue;
+        }
         if files.len() >= MAX_BM25_FILES {
             tracing::warn!(
                 "[bm25] file cap reached ({MAX_BM25_FILES}), skipping remaining files in {}",
@@ -925,6 +938,13 @@ fn list_code_files(root: &Path) -> Vec<String> {
             break;
         }
         files.push(rel);
+    }
+
+    if filtered_out > 0 {
+        tracing::info!(
+            "[bm25] index filter excluded {filtered_out} files ({})",
+            filter.summary().unwrap_or_default()
+        );
     }
 
     files.sort();

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -399,6 +399,10 @@ pub struct Config {
     /// Code-graph settings, including traversal (co-access) edges (#289).
     #[serde(default)]
     pub graph: GraphConfig,
+    /// Index-time file filters (#735): include/exclude globs + gitignore
+    /// handling, applied by every index builder via `core::index_filter`.
+    #[serde(default)]
+    pub index: IndexConfig,
     /// Skillify miner settings (#290): codify recurring patterns into rules.
     #[serde(default)]
     pub skillify: SkillifyConfig,
@@ -738,6 +742,7 @@ impl Default for Config {
             auto_capture: true,
             search: crate::core::hybrid_search::HybridConfig::default(),
             graph: GraphConfig::default(),
+            index: IndexConfig::default(),
             skillify: SkillifyConfig::default(),
             summaries: SummariesConfig::default(),
             llm: crate::core::llm_enhance::LlmConfig::default(),
@@ -1619,6 +1624,19 @@ impl Config {
         if !local.extra_ignore_patterns.is_empty() {
             self.extra_ignore_patterns
                 .extend(local.extra_ignore_patterns);
+        }
+        // Index filters (#735): repo-local excludes extend the global list; a
+        // repo-local include set (the stricter, corpus-defining axis) replaces
+        // the global one; gitignore handling can only be switched off locally
+        // (same only-tighten pattern as the bool flags above).
+        if !local.index.exclude.is_empty() {
+            self.index.exclude.extend(local.index.exclude);
+        }
+        if !local.index.include.is_empty() {
+            self.index.include = local.index.include;
+        }
+        if !local.index.respect_gitignore {
+            self.index.respect_gitignore = false;
         }
         if local.rules_scope.is_some() {
             self.rules_scope = local.rules_scope;

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -913,6 +913,41 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         },
     );
 
+    let mut index = BTreeMap::new();
+    index.insert(
+        "respect_gitignore".into(),
+        key(
+            "bool",
+            serde_json::json!(cfg.index.respect_gitignore),
+            "Honor .gitignore / global gitignore / .git/info/exclude during index walks. false indexes ignored files too (the vendor-directory guard still applies). CLI override: --no-gitignore / --respect-gitignore.",
+        ),
+    );
+    index.insert(
+        "exclude".into(),
+        key(
+            "string[]",
+            serde_json::json!(cfg.index.exclude),
+            "Globs dropped from the index corpus (root-relative, forward slashes), e.g. [\"**/*.csv\", \"fixtures/**\"]. Wins over include. CLI --exclude appends per run. Excluded files produce no chunks, graph nodes, or embeddings.",
+        ),
+    );
+    index.insert(
+        "include".into(),
+        key(
+            "string[]",
+            serde_json::json!(cfg.index.include),
+            "When non-empty, ONLY matching files enter the index corpus, e.g. [\"**/*.rs\", \"**/*.ts\"]. Empty = no restriction. CLI --include replaces this set per run.",
+        ),
+    );
+    sections.insert(
+        "index".into(),
+        SectionSchema {
+            description:
+                "Index-time file filters: declare the retrieval corpus explicitly (BM25 + graph + semantic + watch share one filter layer, #735)"
+                    .into(),
+            keys: index,
+        },
+    );
+
     let mut skillify = BTreeMap::new();
     skillify.insert(
         "enabled".into(),

--- a/rust/src/core/config/sections.rs
+++ b/rust/src/core/config/sections.rs
@@ -577,6 +577,40 @@ impl Default for CodeHealthConfig {
     }
 }
 
+/// Index-time file filters (#735): declare the retrieval corpus explicitly
+/// instead of abusing `.gitignore` for retrieval policy.
+///
+/// Applies to every index builder through one shared filter layer
+/// (`core::index_filter`): BM25, graph, and the watch/incremental path; the
+/// semantic index chunks the BM25 corpus and inherits the same universe.
+/// Excluded files never produce chunks, graph nodes, or embeddings. Globs are
+/// matched against the root-relative path (forward slashes); exclude wins
+/// over include. The empty default preserves today's behavior byte-for-byte.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct IndexConfig {
+    /// Honor `.gitignore` / global gitignore / `.git/info/exclude` during
+    /// index walks. `false` indexes ignored files too (rarely wanted; the
+    /// vendor-directory guard still applies).
+    pub respect_gitignore: bool,
+    /// Files to drop from the index corpus, e.g. `["**/*.csv", "fixtures/**"]`.
+    /// Evaluated after `include`; a file matching both is excluded.
+    pub exclude: Vec<String>,
+    /// When non-empty, ONLY matching files enter the index corpus, e.g.
+    /// `["**/*.rs", "**/*.ts"]`. Empty = no restriction.
+    pub include: Vec<String>,
+}
+
+impl Default for IndexConfig {
+    fn default() -> Self {
+        Self {
+            respect_gitignore: true,
+            exclude: Vec::new(),
+            include: Vec::new(),
+        }
+    }
+}
+
 /// Settings for the code graph — in particular the *traversal* (co-access) edges
 /// learned from real agent sessions (#289).
 ///

--- a/rust/src/core/graph_index/mod.rs
+++ b/rust/src/core/graph_index/mod.rs
@@ -608,11 +608,14 @@ fn source_content_changed_since_index(index: &ProjectIndex, root_abs: &str) -> b
         // No persisted index yet — the existence/TTL checks above already decided.
         return false;
     };
+    // #735: excluded files must not flag the index stale (a change to CSV seed
+    // data would otherwise force needless graph rescans forever).
+    let index_filter = crate::core::index_filter::IndexFileFilter::effective();
     let walker = ignore::WalkBuilder::new(root_abs)
         .hidden(true)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
+        .git_ignore(index_filter.respect_gitignore)
+        .git_global(index_filter.respect_gitignore)
+        .git_exclude(index_filter.respect_gitignore)
         .require_git(false)
         .max_depth(Some(20))
         .filter_entry(crate::core::walk_filter::keep_entry)
@@ -644,6 +647,9 @@ fn source_content_changed_since_index(index: &ProjectIndex, root_abs: &str) -> b
         }
         // Candidate: confirm against the stored content hash.
         let rel = make_relative(&path.to_string_lossy(), root_abs);
+        if index_filter.is_excluded(&rel.replace('\\', "/")) {
+            continue;
+        }
         let Some(file_entry) = index.files.get(&rel) else {
             // A newly added indexable file is genuinely new content.
             return true;
@@ -744,17 +750,20 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
         HashMap::new()
     };
 
+    let cfg = crate::core::config::Config::load();
+    // #735: shared corpus filter — same membership decision as the BM25 walk.
+    let index_filter = crate::core::index_filter::IndexFileFilter::resolve(&cfg);
+
     let walker = ignore::WalkBuilder::new(&project_root)
         .hidden(true)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
+        .git_ignore(index_filter.respect_gitignore)
+        .git_global(index_filter.respect_gitignore)
+        .git_exclude(index_filter.respect_gitignore)
         .require_git(false)
         .max_depth(Some(20))
         .filter_entry(crate::core::walk_filter::keep_entry)
         .build();
 
-    let cfg = crate::core::config::Config::load();
     let extra_ignores: Vec<glob::Pattern> = cfg
         .extra_ignore_patterns
         .iter()
@@ -863,6 +872,9 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
 
         let rel = make_relative(&file_path, &project_root);
         if extra_ignores.iter().any(|p| p.matches(&rel)) {
+            continue;
+        }
+        if index_filter.is_excluded(&rel.replace('\\', "/")) {
             continue;
         }
 

--- a/rust/src/core/index_filter.rs
+++ b/rust/src/core/index_filter.rs
@@ -1,0 +1,248 @@
+//! Index-time file filters (#735): one shared corpus-membership decision for
+//! every index builder.
+//!
+//! Source-control intent (`.gitignore`) and retrieval policy (what belongs in
+//! the index corpus) are different axes: a file can be versioned and important
+//! while still being bad context for code search (CSV seed data, fixtures,
+//! lockfiles, vendored blobs). This module carries the declared retrieval
+//! policy — `[index] include/exclude/respect_gitignore` from config, plus an
+//! optional per-run CLI overlay (`lean-ctx index build --exclude …`) — so the
+//! BM25, graph, and watch builders can never disagree about corpus membership.
+//! The semantic (embedding) index chunks the BM25 corpus, so it inherits the
+//! same universe by construction.
+//!
+//! Excluded files never enter the pipeline: no chunks, no graph nodes, no
+//! embeddings. Globs are evaluated against the root-relative path with forward
+//! slashes (same semantics as `extra_ignore_patterns`, which remains honored
+//! as the legacy exclude list). Precedence: exclude wins over include; a
+//! non-empty include list turns the corpus into "matching files only".
+
+use std::sync::RwLock;
+
+/// Per-run overlay set by the `lean-ctx index` CLI before builders run.
+/// Process-local by design: one-off experiment flags must not leak into the
+/// persisted config, and the short-lived CLI process is the only consumer.
+struct CliOverlay {
+    include: Vec<String>,
+    exclude: Vec<String>,
+    respect_gitignore: Option<bool>,
+}
+
+static CLI_OVERLAY: RwLock<Option<CliOverlay>> = RwLock::new(None);
+
+/// Install the per-run CLI filter overlay (repeatable `--include`/`--exclude`
+/// globs, `--no-gitignore`/`--respect-gitignore`). Called once by the `index`
+/// CLI dispatch before any build starts.
+pub fn set_cli_overlay(
+    include: Vec<String>,
+    exclude: Vec<String>,
+    respect_gitignore: Option<bool>,
+) {
+    let mut guard = CLI_OVERLAY
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = Some(CliOverlay {
+        include,
+        exclude,
+        respect_gitignore,
+    });
+}
+
+/// True when a CLI overlay is installed. The orchestrator uses this to skip
+/// delegating the build to the daemon: the daemon would build with *its*
+/// config and could overwrite the one-off filtered result.
+pub fn cli_overlay_active() -> bool {
+    CLI_OVERLAY
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .is_some()
+}
+
+/// The resolved corpus-membership filter for one indexing run.
+#[derive(Debug)]
+pub struct IndexFileFilter {
+    include: Vec<glob::Pattern>,
+    exclude: Vec<glob::Pattern>,
+    /// Whether walkers should honor `.gitignore`/global/exclude files.
+    pub respect_gitignore: bool,
+}
+
+impl IndexFileFilter {
+    /// Resolve the effective filter: `[index]` config, extended by the CLI
+    /// overlay. CLI `--exclude` appends to the config excludes; CLI
+    /// `--include` replaces the config include set for this run (a one-off
+    /// experiment declares its corpus outright); an explicit gitignore flag
+    /// overrides the config boolean.
+    pub fn effective() -> Self {
+        let cfg = crate::core::config::Config::load();
+        Self::resolve(&cfg)
+    }
+
+    /// [`Self::effective`] with an already-loaded config (builders that hold
+    /// one avoid a second load).
+    pub fn resolve(cfg: &crate::core::config::Config) -> Self {
+        let mut include: Vec<String> = cfg.index.include.clone();
+        let mut exclude: Vec<String> = cfg.index.exclude.clone();
+        let mut respect_gitignore = cfg.index.respect_gitignore;
+
+        let guard = CLI_OVERLAY
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(overlay) = guard.as_ref() {
+            if !overlay.include.is_empty() {
+                include.clone_from(&overlay.include);
+            }
+            exclude.extend(overlay.exclude.iter().cloned());
+            if let Some(flag) = overlay.respect_gitignore {
+                respect_gitignore = flag;
+            }
+        }
+
+        Self::from_lists(&include, &exclude, respect_gitignore)
+    }
+
+    /// Build a filter from raw glob lists. Invalid globs are dropped with a
+    /// warning rather than aborting the build — matching the long-standing
+    /// `extra_ignore_patterns` behavior.
+    pub fn from_lists(include: &[String], exclude: &[String], respect_gitignore: bool) -> Self {
+        let compile = |patterns: &[String], role: &str| -> Vec<glob::Pattern> {
+            patterns
+                .iter()
+                .filter_map(|p| match glob::Pattern::new(p) {
+                    Ok(pat) => Some(pat),
+                    Err(e) => {
+                        tracing::warn!("[index_filter] ignoring invalid {role} glob {p:?}: {e}");
+                        None
+                    }
+                })
+                .collect()
+        };
+        Self {
+            include: compile(include, "include"),
+            exclude: compile(exclude, "exclude"),
+            respect_gitignore,
+        }
+    }
+
+    /// Corpus-membership decision for one file, by root-relative path with
+    /// forward slashes. Exclude wins over include; a non-empty include list
+    /// admits matching files only; the empty filter admits everything
+    /// (byte-for-byte today's behavior).
+    pub fn is_excluded(&self, rel_path: &str) -> bool {
+        if self.exclude.iter().any(|p| p.matches(rel_path)) {
+            return true;
+        }
+        if !self.include.is_empty() && !self.include.iter().any(|p| p.matches(rel_path)) {
+            return true;
+        }
+        false
+    }
+
+    /// True when this filter changes corpus membership relative to the
+    /// unfiltered default (gitignore deviation counts: it changes the walk).
+    pub fn is_active(&self) -> bool {
+        !self.include.is_empty() || !self.exclude.is_empty() || !self.respect_gitignore
+    }
+
+    /// One-line human/JSON summary of the active filter for `index status`.
+    /// `None` when the filter is the do-nothing default, so default output
+    /// stays byte-identical.
+    pub fn summary(&self) -> Option<String> {
+        if !self.is_active() {
+            return None;
+        }
+        let fmt = |patterns: &[glob::Pattern]| -> String {
+            patterns
+                .iter()
+                .map(glob::Pattern::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let mut parts: Vec<String> = Vec::new();
+        if !self.include.is_empty() {
+            parts.push(format!("include=[{}]", fmt(&self.include)));
+        }
+        if !self.exclude.is_empty() {
+            parts.push(format!("exclude=[{}]", fmt(&self.exclude)));
+        }
+        if !self.respect_gitignore {
+            parts.push("gitignore=off".to_string());
+        }
+        Some(parts.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filter(include: &[&str], exclude: &[&str]) -> IndexFileFilter {
+        let inc: Vec<String> = include.iter().map(ToString::to_string).collect();
+        let exc: Vec<String> = exclude.iter().map(ToString::to_string).collect();
+        IndexFileFilter::from_lists(&inc, &exc, true)
+    }
+
+    #[test]
+    fn empty_filter_admits_everything() {
+        let f = filter(&[], &[]);
+        assert!(!f.is_excluded("src/main.rs"));
+        assert!(!f.is_excluded("data/seed.csv"));
+        assert!(!f.is_active());
+        assert!(f.summary().is_none());
+    }
+
+    #[test]
+    fn exclude_glob_drops_matching_files() {
+        // The #735 motivating case: versioned Liquibase CSV seed data.
+        let f = filter(&[], &["src/main/resources/liquibase/data/*.csv"]);
+        assert!(f.is_excluded("src/main/resources/liquibase/data/users.csv"));
+        assert!(!f.is_excluded("src/main/java/App.java"));
+    }
+
+    #[test]
+    fn recursive_exclude_matches_at_any_depth() {
+        let f = filter(&[], &["**/*.csv"]);
+        assert!(f.is_excluded("data/seed.csv"));
+        assert!(f.is_excluded("a/b/c/d.csv"));
+        assert!(f.is_excluded("top.csv"));
+        assert!(!f.is_excluded("src/lib.rs"));
+    }
+
+    #[test]
+    fn include_list_admits_matching_files_only() {
+        let f = filter(&["**/*.rs", "**/*.java"], &[]);
+        assert!(!f.is_excluded("src/lib.rs"));
+        assert!(!f.is_excluded("src/main/java/App.java"));
+        assert!(f.is_excluded("README.md"));
+        assert!(f.is_excluded("data/seed.csv"));
+    }
+
+    #[test]
+    fn exclude_wins_over_include() {
+        let f = filter(&["**/*.rs"], &["src/generated/**"]);
+        assert!(!f.is_excluded("src/lib.rs"));
+        assert!(f.is_excluded("src/generated/bindings.rs"));
+    }
+
+    #[test]
+    fn invalid_glob_is_dropped_not_fatal() {
+        let f = filter(&[], &["[unclosed", "**/*.csv"]);
+        assert!(f.is_excluded("data/seed.csv"));
+        assert!(!f.is_excluded("src/lib.rs"));
+    }
+
+    #[test]
+    fn gitignore_deviation_marks_filter_active() {
+        let f = IndexFileFilter::from_lists(&[], &[], false);
+        assert!(f.is_active());
+        assert_eq!(f.summary().as_deref(), Some("gitignore=off"));
+    }
+
+    #[test]
+    fn summary_lists_both_axes() {
+        let f = filter(&["**/*.rs"], &["**/*.csv", "**/*.jsonl"]);
+        let s = f.summary().expect("active filter has a summary");
+        assert!(s.contains("include=[**/*.rs]"));
+        assert!(s.contains("exclude=[**/*.csv, **/*.jsonl]"));
+    }
+}

--- a/rust/src/core/index_orchestrator.rs
+++ b/rust/src/core/index_orchestrator.rs
@@ -273,7 +273,13 @@ pub fn ensure_all_background(project_root: &str) {
     // one is running and we aren't it. Deduped naturally — we only reach here
     // when this process is actually about to start a build. Purely additive: the
     // local build below still runs and load-shares via the per-repo locks.
-    nudge_daemon_index(project_root);
+    //
+    // #735 exception: with a per-run CLI filter overlay active, the daemon
+    // (which builds with *its* config, not the overlay) could overwrite the
+    // filtered result — the one-off run keeps the build local instead.
+    if !crate::core::index_filter::cli_overlay_active() {
+        nudge_daemon_index(project_root);
+    }
 
     let state = entry_for(project_root);
     let root = project_root.to_string();
@@ -691,6 +697,10 @@ struct StatusResponse<'a> {
     /// in; "ready" means embeddings are persisted and search will use them.
     semantic_index: ComponentStatus<'a>,
     disk: DiskStatusAll,
+    /// Active corpus filter summary (#735). Omitted for the unfiltered
+    /// default, keeping default output byte-identical.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index_filters: Option<String>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -822,6 +832,7 @@ pub fn status_json(project_root: &str) -> String {
         bm25_index: component_status(&s.bm25),
         semantic_index: component_status(&s.semantic),
         disk,
+        index_filters: crate::core::index_filter::IndexFileFilter::effective().summary(),
     };
     serde_json::to_string(&res).unwrap_or_else(|_| "{}".to_string())
 }

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -404,6 +404,7 @@ pub mod ide_permissions;
 pub mod import_resolver;
 pub mod index_admission;
 pub mod index_bundle;
+pub mod index_filter;
 pub mod index_namespace;
 pub mod index_orchestrator;
 pub mod index_paths;


### PR DESCRIPTION
Closes #735

## Summary
- New `[index]` config section — `exclude` / `include` glob lists + `respect_gitignore` — declares the retrieval corpus explicitly instead of abusing `.gitignore` for retrieval policy.
- Per-run CLI overlay on every `lean-ctx index` build command: repeatable `--exclude <glob>` / `--include <glob>` (both `--flag value` and `--flag=value` forms), `--no-gitignore` / `--respect-gitignore`.
- One shared filter layer (`core::index_filter`) drives the BM25 walk, the graph scan, the graph staleness check, and the watch snapshot. The semantic index chunks the BM25 corpus, so it inherits the same universe — excluded files produce **no chunks, no graph nodes, no embeddings**, and no longer flag the graph index stale or cause watch rebuild churn.

## Semantics
- Exclude wins over include; a non-empty include list = allowlist ("corpus is exactly these files").
- Globs match root-relative paths with forward slashes on every platform (index keys keep platform separators, so existing indexes stay valid).
- CLI `--exclude` appends to config; CLI `--include` replaces the config set for the run.
- A run with overlay flags skips the daemon build delegation (#460) so a config-built index can't overwrite the one-off corpus.
- Repo-local config extends global excludes, replaces include, and can only tighten gitignore handling.
- Empty filters preserve today's behavior byte-for-byte (also in `index status` output, #498).

## Surfaces
- `index status` (human + `--json`) reports the active filter summary (`Index Filters: exclude=[**/*.csv] …`).
- `docs/reference/generated/config-keys.md` regenerated (gen_docs).
- BM25 build logs how many files the filter excluded.

## Test plan
- [x] 14 new unit tests: filter matching (precedence, recursion, invalid globs, gitignore deviation, summary) + CLI parsing (subcommand detection with flag values, repeatable flags, both flag forms, last-wins gitignore).
- [x] Full `cargo test --lib`: 7370 passed / 0 failed.
- [x] `cargo clippy --lib -- -D warnings` clean, `cargo fmt --check` clean, `gen_docs --check` no drift.
- [x] `scripts/preflight.sh fast` green.

Made with [Cursor](https://cursor.com)