### PR TITLE
fix(model): parse [1m] window suffix + claude-opus-4-8 registry entries

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -324,6 +324,12 @@ Procedural memory budgets (learned patterns)
 - `min_repetitions` (usize, default `3`) — Minimum repetitions before a pattern is stored
 - `min_sequence_len` (usize, default `2`) — Minimum sequence length for procedure detection
 
+## `[model_context_windows]`
+
+Per-model context-window overrides in tokens. Keys are model names (case-insensitive), values override every registry layer — use for models the bundled/local registry does not know yet. Bracketed window markers in the model name itself (e.g. `claude-opus-4-8[1m]`) are parsed automatically and need no entry here. Example: `[model_context_windows]\n"my-custom-model" = 500000`
+
+_No sub-keys (presence of the section toggles the feature)._
+
 ## `[providers]`
 
 External context providers (GitHub, GitLab, Jira, MCP bridges, etc.). Set tokens via env vars (GITHUB_TOKEN, GITLAB_TOKEN). MCP bridges connect external MCP servers as context sources.

--- a/rust/data/model_registry.json
+++ b/rust/data/model_registry.json
@@ -29,6 +29,8 @@
     "claude-4.5-sonnet": { "context_window": 200000, "max_output": 16000 },
     "claude-4.6-opus": { "context_window": 200000, "max_output": 32000 },
     "claude-4.6-sonnet": { "context_window": 200000, "max_output": 16000 },
+    "claude-opus-4-8": { "context_window": 200000, "max_output": 32000 },
+    "claude-4.8-opus": { "context_window": 200000, "max_output": 32000 },
     "claude-3.5-sonnet": { "context_window": 200000, "max_output": 8192 },
     "claude-3.5-haiku": { "context_window": 200000, "max_output": 8192 },
     "gemini-2.5-pro": { "context_window": 1048576, "max_output": 65536 },
@@ -59,3 +61,4 @@
     "codex": 192000
   }
 }
+

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -747,6 +747,14 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             },
         );
 
+    sections.insert(
+            "model_context_windows".into(),
+            SectionSchema {
+                description: "Per-model context-window overrides in tokens. Keys are model names (case-insensitive), values override every registry layer — use for models the bundled/local registry does not know yet. Bracketed window markers in the model name itself (e.g. `claude-opus-4-8[1m]`) are parsed automatically and need no entry here. Example: `[model_context_windows]\\n\"my-custom-model\" = 500000`".into(),
+                keys: BTreeMap::new(),
+            },
+        );
+
     let mut lsp_keys = BTreeMap::new();
     lsp_keys.insert(
         "rust".into(),

--- a/rust/src/core/model_registry.rs
+++ b/rust/src/core/model_registry.rs
@@ -69,6 +69,34 @@ fn user_config_override(model: &str) -> Option<usize> {
         .copied()
 }
 
+/// Parse a trailing long-context marker like `[1m]` / `[1M]` / `[200k]` into
+/// its token window (GH #739). Clients append these suffixes for context-beta
+/// variants (e.g. `claude-opus-4-8[1m]`); the marker is an explicit statement
+/// of the window, so it wins over any registry entry for the base model.
+fn window_from_suffix(model: &str) -> Option<usize> {
+    let (_, marker) = split_window_suffix(model)?;
+    let digits: String = marker.chars().take_while(char::is_ascii_digit).collect();
+    let n: usize = digits.parse().ok()?;
+    let unit = &marker[digits.len()..];
+    match unit {
+        "m" => Some(n.checked_mul(1_000_000)?),
+        "k" => Some(n.checked_mul(1_000)?),
+        _ => None,
+    }
+}
+
+/// Split `name[marker]` into `(name, lowercased marker)` when the model ends
+/// in a bracketed suffix. Returns `None` for models without one.
+fn split_window_suffix(model: &str) -> Option<(&str, String)> {
+    let stripped = model.strip_suffix(']')?;
+    let open = stripped.rfind('[')?;
+    let marker = stripped[open + 1..].to_lowercase();
+    if marker.is_empty() {
+        return None;
+    }
+    Some((&model[..open], marker))
+}
+
 fn registry_lookup(model: &str, registry: &Registry) -> Option<usize> {
     let m = model.to_lowercase();
 
@@ -105,22 +133,34 @@ fn registry_lookup(model: &str, registry: &Registry) -> Option<usize> {
 }
 
 /// Look up context window for a model name.
-/// Layers: User Config → Local Registry → Bundled Registry → 200k default.
+/// Layers: User Config → `[1m]`-style suffix → Local Registry → Bundled
+/// Registry → 200k default.
 pub fn context_window_for_model(model: &str) -> usize {
-    // Layer 1: User config override
+    // Layer 1: User config override ([model_context_windows] in config.toml)
     if let Some(w) = user_config_override(model) {
         return w;
     }
 
-    // Layer 2: Local registry (auto-updated via lean-ctx update)
+    // Layer 2: explicit window marker in the model name itself (GH #739).
+    // `claude-opus-4-8[1m]` means the client runs the 1M-context variant —
+    // registries would only ever know the base model's window.
+    if let Some(w) = window_from_suffix(model) {
+        return w;
+    }
+
+    // Registry lookups see the base name so `foo[1m]` variants of unknown
+    // markers still match their base entry instead of falling through.
+    let base = split_window_suffix(model).map_or(model, |(base, _)| base);
+
+    // Layer 3: Local registry (auto-updated via lean-ctx update)
     if let Some(local) = local_registry()
-        && let Some(w) = registry_lookup(model, local)
+        && let Some(w) = registry_lookup(base, local)
     {
         return w;
     }
 
-    // Layer 3: Bundled registry (compiled into binary)
-    if let Some(w) = registry_lookup(model, bundled()) {
+    // Layer 4: Bundled registry (compiled into binary)
+    if let Some(w) = registry_lookup(base, bundled()) {
         return w;
     }
 
@@ -175,5 +215,37 @@ mod tests {
             context_window_for_model("totally-unknown-model-xyz"),
             200_000
         );
+    }
+
+    #[test]
+    fn long_context_suffix_wins_over_registry() {
+        // GH #739: the [1m] marker is the client's explicit window statement.
+        assert_eq!(context_window_for_model("claude-opus-4-8[1m]"), 1_000_000);
+        assert_eq!(context_window_for_model("claude-opus-4-8[1M]"), 1_000_000);
+        assert_eq!(context_window_for_model("some-future-model[200k]"), 200_000);
+        assert_eq!(context_window_for_model("gpt-5.5[2m]"), 2_000_000);
+    }
+
+    #[test]
+    fn base_model_of_suffix_variant_resolves_normally() {
+        // Without the marker the registry (exact/prefix/family) decides.
+        assert_eq!(context_window_for_model("claude-opus-4-8"), 200_000);
+    }
+
+    #[test]
+    fn unknown_marker_falls_back_to_base_lookup() {
+        // A non-window bracket suffix must not break base-model resolution.
+        assert_eq!(context_window_for_model("gpt-5.5[thinking]"), 1_048_576);
+    }
+
+    #[test]
+    fn suffix_parsing_is_strict() {
+        assert_eq!(window_from_suffix("model[1m]"), Some(1_000_000));
+        assert_eq!(window_from_suffix("model[128k]"), Some(128_000));
+        assert_eq!(window_from_suffix("model[]"), None);
+        assert_eq!(window_from_suffix("model[m]"), None);
+        assert_eq!(window_from_suffix("model[1x]"), None);
+        assert_eq!(window_from_suffix("model"), None);
+        assert_eq!(window_from_suffix("model[1m"), None);
     }
 }


### PR DESCRIPTION
Fixes #739.

## Problem
The bundled model registry caps every Claude entry at 200k and has no entry for `claude-opus-4-8`, so the 1M-context beta (`claude-opus-4-8[1m]`) fell through to the generic `"claude": 200000` family default. Pressure math, eviction candidates and planner budgets were ~5x too conservative, and there was no discoverable override.

## Fix (three layers, exactly as requested in the report)
1. **Generic `[Nm]`/`[Nk]` suffix parsing** — a bracketed window marker in the model name is an explicit client statement of the window and now wins over every registry layer. `claude-opus-4-8[1m]` → 1,000,000. Future 1M variants need no registry bump.
2. **Registry entries** — `claude-opus-4-8` / `claude-4.8-opus` added with a 200k base window. Unknown bracket suffixes (e.g. `[thinking]`) now resolve via the base model instead of the family fallback.
3. **Discoverable override** — the existing `[model_context_windows]` config table is now registered in the config schema, so `lean-ctx config schema` and the generated `config-keys.md` document it (the reporter checked both and could not find it).

## Tests
- `long_context_suffix_wins_over_registry` (`[1m]`, `[1M]`, `[200k]`, `[2m]`)
- `base_model_of_suffix_variant_resolves_normally`
- `unknown_marker_falls_back_to_base_lookup`
- `suffix_parsing_is_strict` (empty/garbage markers rejected)
- 31/31 model_registry lib tests pass, clippy clean, gen_docs regenerated

Made with [Cursor](https://cursor.com)