### PR TITLE
feat(leaderboard): login-less machine linking via pairing codes

### DIFF
--- a/docs/contracts/wrapped-permalink-v1.md
+++ b/docs/contracts/wrapped-permalink-v1.md
@@ -42,6 +42,8 @@ shareable URL (`https://leanctx.com/w/<id>`). No login is required to publish; a
 | GET | `/api/wrapped/:id` | none | Fetch the public card; increments `view_count` |
 | DELETE | `/api/wrapped/:id` | `X-Edit-Token` | Delete the card (wrong/absent token → 403) |
 | POST | `/api/wrapped/:id/claim` | account bearer + `X-Edit-Token` | Bind the anonymous card to the account |
+| POST | `/api/wrapped/:id/link/start` | `X-Edit-Token` | Mint a short-lived pairing code for login-less machine linking → `{ code, expires_in_secs }` |
+| POST | `/api/wrapped/:id/link/complete` | `X-Edit-Token` | Join this card into the code's `link_group` (body: `{ "code": "XXXX-XXXX" }`) |
 | GET | `/api/wrapped/:id/card.svg` | none | Server-rendered share card (SVG) |
 | GET | `/api/wrapped/:id/card.png` | none | Rasterized Open Graph image (PNG, 1200×630, `resvg`) |
 | GET | `/w/:id` | none | Crawler-friendly permalink page (per-card OG/Twitter meta); counts as a view |
@@ -62,6 +64,14 @@ directly, so no asset route needs proxying on the canonical host.
 - **Claim** — an authenticated user (identified by a standard bearer credential — API key or OAuth —
   in the `Authorization` request header) who also presents the matching `X-Edit-Token` binds the card
   to their `user_id`. This is the bridge to future cloud sync; claiming is idempotent and never required.
+- **Link (login-less, v1.2, GH #736)** — two machines merge into one leaderboard entry without any
+  account. Machine A mints a pairing code (`POST /:id/link/start`, authorized by its own
+  `X-Edit-Token`); machine B presents the code plus *its own* `X-Edit-Token`
+  (`POST /:id/link/complete`). Both cards then share a `link_group` and the leaderboard stacks them
+  (tokens summed, token-weighted rate, highest-saving machine as representative). Grouping is
+  transitive across `link_group` and `user_id`. Codes: 8 chars from an unambiguous alphabet
+  (`XXXX-XXXX`), single-use, 10-minute TTL, at most 3 outstanding per card, stored hashed
+  (`sha256`). A leaked expired code is useless; no PII is involved at any point.
 
 ---
 
@@ -214,3 +224,4 @@ person-facing field is the user-chosen `display_name`. Everything else is an agg
 - **Body cap** 8 KB; **`display_name`** length-capped and rejected if it contains markup/control
   characters (defence against stored XSS); the frontend additionally HTML-escapes on render.
 - **Ids** are ≥128-bit from a CSPRNG → not enumerable; `GET` never reveals the `edit_token`.
+

--- a/rust/src/cli/dispatch/analytics/gain.rs
+++ b/rust/src/cli/dispatch/analytics/gain.rs
@@ -69,6 +69,14 @@ pub(in crate::cli::dispatch) fn cmd_gain(rest: &[String]) {
         crate::cli::wrapped_publish::publish(&period, name_arg(rest).as_deref(), leaderboard);
         return;
     }
+    if let Some(req) = link_request(rest) {
+        let code = match &req {
+            LinkReq::Complete(c) => Some(c.as_str()),
+            LinkReq::Start => None,
+        };
+        crate::cli::wrapped_publish::link(code);
+        return;
+    }
 
     if let Some(svg_path) = svg_target(rest) {
         let report = core::wrapped::WrappedReport::generate(&period);
@@ -381,6 +389,28 @@ fn unpublish_request(rest: &[String]) -> Option<UnpublishReq> {
         }
         if a == "--unpublish" {
             return Some(UnpublishReq::Latest);
+        }
+    }
+    None
+}
+
+/// A requested `--link`: start a pairing (mint a code) or complete one with a code.
+enum LinkReq {
+    Start,
+    Complete(String),
+}
+
+/// Parses `--link[=CODE]` / `--link CODE` (GH #736). `None` = not requested.
+fn link_request(rest: &[String]) -> Option<LinkReq> {
+    for (i, a) in rest.iter().enumerate() {
+        if let Some(v) = a.strip_prefix("--link=") {
+            return Some(LinkReq::Complete(v.to_string()));
+        }
+        if a == "--link" {
+            return Some(match rest.get(i + 1) {
+                Some(next) if !next.starts_with('-') => LinkReq::Complete(next.clone()),
+                _ => LinkReq::Start,
+            });
         }
     }
     None

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -144,6 +144,7 @@ COMMANDS:
     gain --svg|--share --open      Also open the written card/page in your browser
     gain --publish [--name=<n>]    Publish an opt-in permalink (leanctx.com/w/<id>)
     gain --publish --leaderboard   Also list the card on the public leaderboard (opt-in)
+    gain --link [CODE]             Combine machines into one leaderboard entry (pairing code, no account)
     gain --unpublish[=<id>]        Remove a published permalink (most recent if no id)
     config set gain.auto_publish true  Auto-(re)publish your recap on each `gain` (opt-in, throttled, off by default)
     savings [summary|verify|export|sign|verify-batch] Verified savings ledger (local, signed)

--- a/rust/src/cli/wrapped_publish.rs
+++ b/rust/src/cli/wrapped_publish.rs
@@ -215,6 +215,71 @@ pub(crate) fn set_auto_submit(on: bool) -> Result<(), String> {
     .map_err(|e| format!("could not save config: {e}"))
 }
 
+// ─── Login-less machine linking (GH #736) ─────────────────────────────────────
+
+/// This machine's linkable card: the all-time card if present (the one the
+/// leaderboard represents), else the most recent one — with a stored edit_token.
+fn linkable_card(store: &PublishedStore) -> Option<&PublishedEntry> {
+    store
+        .cards
+        .iter()
+        .filter(|c| !c.edit_token.is_empty())
+        .max_by_key(|c| (c.period == "all", c.published_at.clone()))
+}
+
+/// `lean-ctx gain --link [CODE]` — merge this machine's leaderboard entry with
+/// another machine's, without any account (GH #736).
+///
+/// Without a code: mints a short-lived pairing code for this machine's card.
+/// With a code (from the other machine): joins both cards into one link group;
+/// the public leaderboard then shows a single combined entry.
+pub(crate) fn link(code: Option<&str>) {
+    let store = PublishedStore::load();
+    let Some(card) = linkable_card(&store) else {
+        eprintln!(
+            "No published card on this machine yet.\n\
+             Publish first:  lean-ctx gain --publish --leaderboard"
+        );
+        std::process::exit(1);
+    };
+
+    match code {
+        None => match cloud_client::link_wrapped_start(&card.id, &card.edit_token) {
+            Ok(minted) => {
+                let mins = (minted.expires_in_secs / 60).max(1);
+                println!("Pairing code:  {}", minted.code);
+                println!();
+                println!("On your other machine, run within {mins} minutes:");
+                println!("  lean-ctx gain --link {}", minted.code);
+                println!();
+                println!(
+                    "Both machines will then appear as one combined leaderboard entry \
+                     (tokens summed). No account needed — the code proves card ownership."
+                );
+            }
+            Err(e) => {
+                eprintln!("Could not create a pairing code: {e}");
+                std::process::exit(1);
+            }
+        },
+        Some(code) => match cloud_client::link_wrapped_complete(&card.id, &card.edit_token, code) {
+            Ok(()) => {
+                println!(
+                    "Linked! This machine and the code's machine now stack as one \
+                     leaderboard entry."
+                );
+                println!(
+                    "Link more machines anytime:  lean-ctx gain --link   (on any linked machine)"
+                );
+            }
+            Err(e) => {
+                eprintln!("Could not complete the link: {e}");
+                std::process::exit(1);
+            }
+        },
+    }
+}
+
 impl PublishedStore {
     fn load() -> Self {
         store_path()
@@ -377,16 +442,16 @@ pub(crate) fn publish(period: &str, name: Option<&str>, leaderboard: bool) {
                 if let Some(base) = card.url.split("/w/").next() {
                     println!("Listed on the community leaderboard: {base}/metrics#leaderboard");
                 }
-                // Account linking (#488): logged-in machines stack under one entry; otherwise
-                // each machine is a separate row. `record_published` did the actual claim — this
-                // only reflects the state to the user.
+                // Machine stacking: logged-in machines stack automatically (#488); everyone
+                // else links machines login-lessly via a pairing code (#736).
                 if cloud_client::is_logged_in() {
                     println!(
                         "Linked to your account — all your machines now stack under one leaderboard entry."
                     );
                 } else {
                     println!(
-                        "Tip: run  lean-ctx login  so your machines stack under one leaderboard entry instead of separate rows."
+                        "Tip: more than one machine? Run  lean-ctx gain --link  to combine them \
+                         into one leaderboard entry (no account needed)."
                     );
                 }
                 // A nameless entry shows as "anonymous" on the board — nudge once toward a handle.

--- a/rust/src/cloud_client.rs
+++ b/rust/src/cloud_client.rs
@@ -459,6 +459,49 @@ pub fn claim_wrapped(id: &str, edit_token: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// A freshly minted pairing code for login-less machine linking (GH #736).
+#[derive(serde::Deserialize)]
+pub struct LinkCode {
+    pub code: String,
+    pub expires_in_secs: i64,
+}
+
+/// Start a login-less machine link: mint a short-lived pairing code for this card.
+/// Auth: the card's `edit_token` only — no account. Server: `POST /api/wrapped/:id/link/start`.
+pub fn link_wrapped_start(id: &str, edit_token: &str) -> Result<LinkCode, String> {
+    let url = format!("{}/api/wrapped/{id}/link/start", api_url());
+
+    let resp = ureq::post(&url)
+        .header("X-Edit-Token", edit_token)
+        .send_empty()
+        .map_err(|e| format!("Link start failed: {e}"))?;
+    let body = resp
+        .into_body()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response: {e}"))?;
+    serde_json::from_str(&body).map_err(|e| format!("Invalid response: {e}"))
+}
+
+/// Complete a login-less machine link on the second machine: join this card into
+/// the pairing code's group. Auth: this card's `edit_token` — no account.
+/// Server: `POST /api/wrapped/:id/link/complete`.
+pub fn link_wrapped_complete(id: &str, edit_token: &str, code: &str) -> Result<(), String> {
+    let url = format!("{}/api/wrapped/{id}/link/complete", api_url());
+    let body = serde_json::json!({ "code": code });
+
+    ureq::post(&url)
+        .header("X-Edit-Token", edit_token)
+        .header("Content-Type", "application/json")
+        .send(&serde_json::to_vec(&body).map_err(|e| format!("JSON error: {e}"))?)
+        .map_err(|e| match e {
+            ureq::Error::StatusCode(404) => {
+                "code invalid or expired — mint a fresh one with  lean-ctx gain --link".to_string()
+            }
+            other => format!("Link failed: {other}"),
+        })?;
+    Ok(())
+}
+
 /// Push the knowledge store as a zero-knowledge vault (GL #467): entries are
 /// sealed client-side (XChaCha20-Poly1305, domain-separated HKDF key) — the
 /// backend stores ciphertext and can never read them. The first vault push

--- a/rust/src/cloud_server/db.rs
+++ b/rust/src/cloud_server/db.rs
@@ -298,6 +298,21 @@ ALTER TABLE wrapped_cards ADD COLUMN IF NOT EXISTS period TEXT;
 CREATE UNIQUE INDEX IF NOT EXISTS wrapped_cards_publisher_period
   ON wrapped_cards (publisher_id, period) WHERE publisher_id IS NOT NULL;
 
+-- Login-less machine linking (GH #736): cards sharing a link_group stack as one
+-- leaderboard entry. Set via the short-lived pairing-code flow
+-- (/api/wrapped/{id}/link/start + /link/complete); authorization is edit_token
+-- possession on both sides -- no account involved.
+ALTER TABLE wrapped_cards ADD COLUMN IF NOT EXISTS link_group TEXT;
+CREATE INDEX IF NOT EXISTS wrapped_cards_link_group
+  ON wrapped_cards (link_group) WHERE link_group IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS wrapped_link_codes (
+  code_hash  TEXT PRIMARY KEY,
+  card_id    TEXT NOT NULL REFERENCES wrapped_cards(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
 DROP TABLE IF EXISTS team_invites CASCADE;
 DROP TABLE IF EXISTS team_members CASCADE;
 DROP TABLE IF EXISTS teams CASCADE;

--- a/rust/src/cloud_server/mod.rs
+++ b/rust/src/cloud_server/mod.rs
@@ -141,6 +141,11 @@ pub async fn run() -> anyhow::Result<()> {
         .route("/api/wrapped/{id}/card.svg", get(wrapped::get_card_svg))
         .route("/api/wrapped/{id}/card.png", get(wrapped::get_card_png))
         .route("/api/wrapped/{id}/claim", post(wrapped::claim_card))
+        .route("/api/wrapped/{id}/link/start", post(wrapped::link_start))
+        .route(
+            "/api/wrapped/{id}/link/complete",
+            post(wrapped::link_complete),
+        )
         .route("/w/{id}", get(wrapped::get_permalink_page))
         .route("/api/leaderboard", get(wrapped::leaderboard))
         .route("/leaderboard", get(wrapped::get_leaderboard_page))

--- a/rust/src/cloud_server/wrapped/mod.rs
+++ b/rust/src/cloud_server/wrapped/mod.rs
@@ -615,9 +615,9 @@ async fn all_ranked_cards(state: &AppState) -> ApiResult<Vec<LeaderRow>> {
     // through so machines claimed to the same account can be stacked below (#488).
     let rows = client
         .query(
-            "SELECT id, payload_json, user_id::text, COALESCE(publisher_id, id) FROM ( \
+            "SELECT id, payload_json, user_id::text, link_group FROM ( \
                SELECT DISTINCT ON (COALESCE(publisher_id, id)) \
-                      id, payload_json, tokens_saved, created_at, user_id, publisher_id \
+                      id, payload_json, tokens_saved, created_at, user_id, link_group \
                FROM wrapped_cards \
                WHERE leaderboard_opt_in = TRUE \
                ORDER BY COALESCE(publisher_id, id), tokens_saved DESC, created_at DESC \
@@ -634,7 +634,7 @@ async fn all_ranked_cards(state: &AppState) -> ApiResult<Vec<LeaderRow>> {
             id: r.get(0),
             payload_json: r.get(1),
             user_id: r.get(2),
-            pub_key: r.get(3),
+            link_group: r.get(3),
         })
         .collect();
 
@@ -648,24 +648,32 @@ async fn all_ranked_cards(state: &AppState) -> ApiResult<Vec<LeaderRow>> {
 }
 
 /// A per-machine leaderboard row as fetched from the DB, before account aggregation.
+/// The SQL guarantees one row per machine (`DISTINCT ON (COALESCE(publisher_id, id))`),
+/// so the aggregation only needs the two merge dimensions, not the machine key itself.
 struct RawLeaderCard {
     id: String,
     payload_json: String,
     /// Account id (`user_id`) as text — present once the card is claimed (`claim_card`).
     user_id: Option<String>,
-    /// `COALESCE(publisher_id, id)` — the per-machine identity used for unclaimed cards.
-    pub_key: String,
+    /// Login-less pairing group (GH #736) — present once linked via `link_complete`.
+    link_group: Option<String>,
 }
 
-/// Collapse a user's machines into one leaderboard entry (#488).
+/// Collapse a user's machines into one leaderboard entry (#488, #736).
 ///
 /// Reported by a user: publishing from two machines produced two leaderboard rows.
 /// The machine identity (`publisher_id`) is derived per device, so each machine is
-/// distinct by construction. Once a user claims their cards to one account
-/// (`POST /api/wrapped/:id/claim` → `user_id`), this stacks them: cards sharing a
-/// `user_id` sum their `tokens_saved` / `cost_avoided_usd`, with the highest-saving
-/// machine as the representative (display name + card URL) and a token-weighted
-/// average compression rate. Unclaimed / legacy cards (no `user_id`) stay
+/// distinct by construction. Two ways to merge machines exist, and they compose:
+///
+/// - **Account claim** (#488): cards sharing a `user_id` stack (login-based).
+/// - **Login-less pairing** (#736): cards sharing a `link_group` stack
+///   (`gain --link`, edit_token-authorized, no account).
+///
+/// Grouping is *transitive across both dimensions* (union-find): if card A and
+/// B share a `link_group` and B and C share a `user_id`, all three form one
+/// entry. Merged entries sum `tokens_saved` / `cost_avoided_usd`, the
+/// highest-saving machine is the representative (display name + card URL), and
+/// the compression rate is token-weighted. Cards with neither dimension stay
 /// individual, keyed by `pub_key`. Pure (no I/O) so the stacking rule is
 /// unit-tested without a database.
 fn aggregate_by_account(raw: Vec<RawLeaderCard>, base: &str) -> Vec<LeaderRow> {
@@ -684,17 +692,54 @@ fn aggregate_by_account(raw: Vec<RawLeaderCard>, base: &str) -> Vec<LeaderRow> {
         pricing_estimated: bool,
     }
 
-    let mut groups: HashMap<String, Acc> = HashMap::new();
-    for c in raw {
+    // Union-find over card indices: cards sharing a user_id OR a link_group
+    // collapse into one cluster (transitively).
+    fn find(parent: &mut Vec<usize>, i: usize) -> usize {
+        if parent[i] != i {
+            let root = find(parent, parent[i]);
+            parent[i] = root;
+        }
+        parent[i]
+    }
+    fn union(parent: &mut Vec<usize>, a: usize, b: usize) {
+        let (ra, rb) = (find(parent, a), find(parent, b));
+        if ra != rb {
+            parent[rb] = ra;
+        }
+    }
+
+    // Every card starts as its own cluster (the SQL already yields one row per
+    // machine, so the row index is a stable identity here); shared user_ids
+    // and shared link_groups merge clusters.
+    let mut parent: Vec<usize> = (0..raw.len()).collect();
+    let mut by_user: HashMap<&str, usize> = HashMap::new();
+    let mut by_group: HashMap<&str, usize> = HashMap::new();
+    for (i, c) in raw.iter().enumerate() {
+        if let Some(u) = c.user_id.as_deref().filter(|u| !u.is_empty()) {
+            match by_user.get(u) {
+                Some(&j) => union(&mut parent, j, i),
+                None => {
+                    by_user.insert(u, i);
+                }
+            }
+        }
+        if let Some(g) = c.link_group.as_deref().filter(|g| !g.is_empty()) {
+            match by_group.get(g) {
+                Some(&j) => union(&mut parent, j, i),
+                None => {
+                    by_group.insert(g, i);
+                }
+            }
+        }
+    }
+    let cluster_of: Vec<usize> = (0..raw.len()).map(|i| find(&mut parent, i)).collect();
+
+    let mut groups: HashMap<usize, Acc> = HashMap::new();
+    for (i, c) in raw.into_iter().enumerate() {
         let Ok(p) = serde_json::from_str::<PublishPayload>(&c.payload_json) else {
             continue;
         };
-        // Claimed cards group by account; everything else stays per-machine.
-        let key = match c.user_id.as_deref() {
-            Some(u) if !u.is_empty() => format!("u:{u}"),
-            _ => format!("p:{}", c.pub_key),
-        };
-        let acc = groups.entry(key).or_insert_with(|| Acc {
+        let acc = groups.entry(cluster_of[i]).or_insert_with(|| Acc {
             rep_tokens: i64::MIN,
             rep_id: String::new(),
             rep_display_name: None,
@@ -1104,6 +1149,167 @@ pub(super) async fn claim_card(
         .await
         .map_err(internal_error)?;
     Ok(Json(serde_json::json!({ "claimed": true })))
+}
+
+// ─── Login-less machine linking (GH #736) ─────────────────────────────────────
+//
+// Two machines prove ownership of their own cards via edit_token possession and
+// get joined into one `link_group`; the leaderboard then stacks all cards of a
+// group into a single entry. No account, no email, no PII — the pairing code is
+// a short-lived (10 min), single-use, hashed-at-rest capability.
+
+/// Pairing-code lifetime. Long enough to walk to the other machine, short
+/// enough that a leaked code is useless soon after.
+const LINK_CODE_TTL_MINUTES: i32 = 10;
+/// Codes a single card may have outstanding — prevents minting unlimited codes.
+const MAX_ACTIVE_LINK_CODES_PER_CARD: i64 = 3;
+
+/// `POST /api/wrapped/:id/link/start` — mint a pairing code for this card.
+/// Requires the card's edit token; returns `{code, expires_in_secs}`.
+pub(super) async fn link_start(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let token =
+        edit_token_header(&headers).ok_or_else(|| err(StatusCode::FORBIDDEN, "forbidden"))?;
+    let client = state.pool.get().await.map_err(internal_error)?;
+
+    let stored = fetch_token_hash(&client, &id).await?;
+    require_token(&token, &stored)?;
+
+    // Opportunistic GC + per-card cap: expired codes vanish, live ones are bounded.
+    client
+        .execute(
+            "DELETE FROM wrapped_link_codes WHERE expires_at < now()",
+            &[],
+        )
+        .await
+        .map_err(internal_error)?;
+    let active: i64 = client
+        .query_one(
+            "SELECT count(*) FROM wrapped_link_codes WHERE card_id = $1",
+            &[&id],
+        )
+        .await
+        .map_err(internal_error)?
+        .get(0);
+    if active >= MAX_ACTIVE_LINK_CODES_PER_CARD {
+        return Err(err(StatusCode::TOO_MANY_REQUESTS, "rate_limited"));
+    }
+
+    let code = generate_link_code();
+    client
+        .execute(
+            "INSERT INTO wrapped_link_codes (code_hash, card_id, expires_at) \
+             VALUES ($1, $2, now() + make_interval(mins => $3))",
+            &[&sha256_hex(&code), &id, &LINK_CODE_TTL_MINUTES],
+        )
+        .await
+        .map_err(internal_error)?;
+
+    Ok(Json(serde_json::json!({
+        "code": code,
+        "expires_in_secs": i64::from(LINK_CODE_TTL_MINUTES) * 60,
+    })))
+}
+
+#[derive(Deserialize)]
+pub(super) struct LinkCompleteBody {
+    pub code: String,
+}
+
+/// `POST /api/wrapped/:id/link/complete` — join this card into the pairing
+/// code's group. Requires *this* card's edit token (both sides prove ownership).
+/// The group id is the initiating card's existing group, else its publisher_id,
+/// else its card id — so repeated links from any machine converge on one group.
+pub(super) async fn link_complete(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<LinkCompleteBody>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let token =
+        edit_token_header(&headers).ok_or_else(|| err(StatusCode::FORBIDDEN, "forbidden"))?;
+    let client = state.pool.get().await.map_err(internal_error)?;
+
+    let stored = fetch_token_hash(&client, &id).await?;
+    require_token(&token, &stored)?;
+
+    let code = body.code.trim().to_uppercase().replace('-', "");
+    if code.is_empty() || code.len() > 32 {
+        return Err(bad_payload());
+    }
+    // Single use: consume the code atomically so it can never join two parties.
+    let row = client
+        .query_opt(
+            "DELETE FROM wrapped_link_codes \
+             WHERE code_hash = $1 AND expires_at >= now() \
+             RETURNING card_id",
+            &[&sha256_hex(&format_link_code(&code))],
+        )
+        .await
+        .map_err(internal_error)?;
+    let Some(row) = row else {
+        return Err(err(StatusCode::NOT_FOUND, "code_invalid_or_expired"));
+    };
+    let initiator_id: String = row.get(0);
+    if initiator_id == id {
+        return Err(bad_payload());
+    }
+
+    // Canonical group: initiator's existing group > its publisher_id > its id.
+    // Merging an already-grouped card drags its whole group along (transitive).
+    let group: String = client
+        .query_one(
+            "SELECT COALESCE(link_group, publisher_id, id) FROM wrapped_cards WHERE id = $1",
+            &[&initiator_id],
+        )
+        .await
+        .map_err(internal_error)?
+        .get(0);
+    let joined = client
+        .execute(
+            "UPDATE wrapped_cards \
+             SET link_group = $1 \
+             WHERE id IN ($2, $3) \
+                OR link_group IN (SELECT link_group FROM wrapped_cards \
+                                  WHERE id IN ($2, $3) AND link_group IS NOT NULL) \
+                OR (publisher_id IS NOT NULL AND publisher_id IN \
+                     (SELECT publisher_id FROM wrapped_cards \
+                      WHERE id IN ($2, $3) AND publisher_id IS NOT NULL))",
+            &[&group, &initiator_id, &id],
+        )
+        .await
+        .map_err(internal_error)?;
+
+    tracing::info!(group, joined, "wrapped cards linked (login-less)");
+    Ok(Json(
+        serde_json::json!({ "linked": true, "group_size": joined }),
+    ))
+}
+
+/// 8-char pairing code from the crypto RNG, formatted `XXXX-XXXX`. Alphabet
+/// drops easily-confused characters (0/O, 1/I/L). 32^8 ≈ 1.1e12 combinations
+/// against a 10-minute, 3-codes-per-card window.
+fn generate_link_code() -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    let bytes: [u8; 8] = rand::random();
+    let chars: String = bytes
+        .iter()
+        .map(|b| ALPHABET[*b as usize % ALPHABET.len()] as char)
+        .collect();
+    format!("{}-{}", &chars[..4], &chars[4..])
+}
+
+/// Normalizes a user-entered code back to the canonical `XXXX-XXXX` form used
+/// for hashing (dashes stripped on input, re-inserted here).
+fn format_link_code(bare: &str) -> String {
+    if bare.len() == 8 {
+        format!("{}-{}", &bare[..4], &bare[4..])
+    } else {
+        bare.to_string()
+    }
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/rust/src/cloud_server/wrapped/tests.rs
+++ b/rust/src/cloud_server/wrapped/tests.rs
@@ -29,14 +29,7 @@ fn accepts_a_well_formed_payload() {
     assert!(valid().validate().is_ok());
 }
 
-fn raw_card(
-    id: &str,
-    user: Option<&str>,
-    pub_key: &str,
-    tokens: i64,
-    name: &str,
-    rate: f64,
-) -> RawLeaderCard {
+fn raw_card(id: &str, user: Option<&str>, tokens: i64, name: &str, rate: f64) -> RawLeaderCard {
     let payload = serde_json::json!({
         "period": "all",
         "tokens_saved": tokens,
@@ -50,7 +43,21 @@ fn raw_card(
         id: id.to_string(),
         payload_json: payload,
         user_id: user.map(str::to_string),
-        pub_key: pub_key.to_string(),
+        link_group: None,
+    }
+}
+
+fn raw_card_linked(
+    id: &str,
+    user: Option<&str>,
+    tokens: i64,
+    name: &str,
+    rate: f64,
+    group: &str,
+) -> RawLeaderCard {
+    RawLeaderCard {
+        link_group: Some(group.to_string()),
+        ..raw_card(id, user, tokens, name, rate)
     }
 }
 
@@ -58,8 +65,8 @@ fn raw_card(
 fn machines_claimed_to_one_account_stack() {
     // Two machines, same account → one stacked entry (the #488 fix).
     let raw = vec![
-        raw_card("cardA", Some("user-1"), "pubA", 1_000, "Stephen", 80.0),
-        raw_card("cardB", Some("user-1"), "pubB", 3_000, "Stephen", 90.0),
+        raw_card("cardA", Some("user-1"), 1_000, "Stephen", 80.0),
+        raw_card("cardB", Some("user-1"), 3_000, "Stephen", 90.0),
     ];
     let out = aggregate_by_account(raw, "https://leanctx.com");
     assert_eq!(
@@ -79,9 +86,9 @@ fn machines_claimed_to_one_account_stack() {
 #[test]
 fn distinct_accounts_and_unclaimed_cards_stay_separate() {
     let raw = vec![
-        raw_card("a", Some("user-1"), "pubA", 1_000, "A", 80.0),
-        raw_card("b", Some("user-2"), "pubB", 2_000, "B", 80.0),
-        raw_card("c", None, "pubC", 1_500, "C", 80.0), // unclaimed, stays individual
+        raw_card("a", Some("user-1"), 1_000, "A", 80.0),
+        raw_card("b", Some("user-2"), 2_000, "B", 80.0),
+        raw_card("c", None, 1_500, "C", 80.0), // unclaimed, stays individual
     ];
     let out = aggregate_by_account(raw, "https://x");
     assert_eq!(out.len(), 3);
@@ -94,8 +101,8 @@ fn distinct_accounts_and_unclaimed_cards_stay_separate() {
 #[test]
 fn aggregation_order_is_deterministic_on_ties() {
     let raw = vec![
-        raw_card("zzz", Some("u1"), "p1", 1_000, "Z", 50.0),
-        raw_card("aaa", Some("u2"), "p2", 1_000, "A", 50.0),
+        raw_card("zzz", Some("u1"), 1_000, "Z", 50.0),
+        raw_card("aaa", Some("u2"), 1_000, "A", 50.0),
     ];
     let out = aggregate_by_account(raw, "https://x");
     assert_eq!(
@@ -107,12 +114,72 @@ fn aggregation_order_is_deterministic_on_ties() {
 
 #[test]
 fn single_machine_is_unchanged_by_aggregation() {
-    let raw = vec![raw_card("solo", None, "pSolo", 1_234, "Solo", 73.0)];
+    let raw = vec![raw_card("solo", None, 1_234, "Solo", 73.0)];
     let out = aggregate_by_account(raw, "https://leanctx.com");
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].tokens_saved, 1_234);
     assert_eq!(out[0].display_name.as_deref(), Some("Solo"));
     assert!((out[0].compression_rate_pct - 73.0).abs() < 1e-9);
+}
+
+#[test]
+fn link_group_stacks_machines_without_account() {
+    // The #736 fix: two machines paired via `gain --link` — no user_id at all.
+    let raw = vec![
+        raw_card_linked("m1", None, 32_900_000, "Stephen.S", 80.0, "g1"),
+        raw_card_linked("m2", None, 2_100_000, "Stephen.S", 70.0, "g1"),
+        raw_card("other", None, 5_000_000, "Other", 60.0),
+    ];
+    let out = aggregate_by_account(raw, "https://x");
+    assert_eq!(out.len(), 2, "linked machines collapse, others stay");
+    assert_eq!(out[0].tokens_saved, 35_000_000);
+    assert!(
+        out[0].url.ends_with("/w/m1"),
+        "highest-saving machine represents the group"
+    );
+    assert_eq!(out[1].id, "other");
+}
+
+#[test]
+fn link_group_and_account_claim_merge_transitively() {
+    // A+B share a link_group; B+C share a user_id → all three are one entry.
+    let raw = vec![
+        raw_card_linked("a", None, 1_000, "N", 50.0, "g"),
+        raw_card_linked("b", Some("u1"), 2_000, "N", 50.0, "g"),
+        raw_card("c", Some("u1"), 4_000, "N", 50.0),
+    ];
+    let out = aggregate_by_account(raw, "https://x");
+    assert_eq!(out.len(), 1, "link_group and user_id chains merge");
+    assert_eq!(out[0].tokens_saved, 7_000);
+    assert!(out[0].url.ends_with("/w/c"));
+}
+
+#[test]
+fn distinct_link_groups_stay_separate() {
+    let raw = vec![
+        raw_card_linked("a", None, 1_000, "A", 50.0, "g1"),
+        raw_card_linked("b", None, 2_000, "B", 50.0, "g2"),
+    ];
+    let out = aggregate_by_account(raw, "https://x");
+    assert_eq!(out.len(), 2, "different groups never merge");
+}
+
+#[test]
+fn link_code_format_is_canonical_and_unambiguous() {
+    for _ in 0..64 {
+        let code = generate_link_code();
+        assert_eq!(code.len(), 9, "XXXX-XXXX");
+        assert_eq!(&code[4..5], "-");
+        assert!(
+            code.chars()
+                .filter(|c| *c != '-')
+                .all(|c| "ABCDEFGHJKMNPQRSTUVWXYZ23456789".contains(c)),
+            "no ambiguous characters (0/O, 1/I/L): {code}"
+        );
+    }
+    // Normalization: user may paste with or without the dash, any case.
+    assert_eq!(format_link_code("KQ3F8ZTN"), "KQ3F-8ZTN");
+    assert_eq!(format_link_code("KQ3F-8ZTN"), "KQ3F-8ZTN");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #736 (self-service part).

## Problem
Multiple machines (or a reinstall that regenerates the Ed25519 key) create separate leaderboard entries. The only merge path was the account claim (#488) — but accounts must stay reserved for paid features, so the baseline flow needs to work **without any login**.

## Solution: pairing codes (no account, no PII)
- Machine A: `lean-ctx gain --link` → mints a single-use code (`XXXX-XXXX`, 10 min TTL)
- Machine B: `lean-ctx gain --link <code>` → both cards join one `link_group`
- Leaderboard stacks a group into **one entry**: tokens summed, token-weighted compression rate, highest-saving machine as representative

## Security model
- Authorization = `edit_token` possession on **both** sides (the token already proves card ownership; returned once at publish)
- Codes: crypto-RNG, unambiguous alphabet (no 0/O/1/I/L), stored as `sha256`, single-use (atomic `DELETE … RETURNING`), max 3 outstanding per card, opportunistic GC
- Transitive union-find across `link_group` **and** `user_id`, so pairing and account-claim compose instead of splitting entries

## Changes
- Server: `POST /api/wrapped/:id/link/start` + `/link/complete`, `wrapped_link_codes` table, `link_group` column (idempotent migrations), aggregation rewritten as union-find
- CLI: `gain --link [CODE]`, publish tip now points to `--link` instead of `login`
- Contract: `wrapped-permalink-v1.md` v1.2 section

## Tests
- `link_group_stacks_machines_without_account` (the exact #736 scenario)
- `link_group_and_account_claim_merge_transitively`
- `distinct_link_groups_stay_separate`
- `link_code_format_is_canonical_and_unambiguous`
- 54/54 wrapped tests, 50/50 gain tests, clippy clean, fmt clean

Made with [Cursor](https://cursor.com)