### PR TITLE
feat(embeddings): managed ONNX Runtime provisioning

### DIFF
--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -152,6 +152,7 @@ COMMANDS:
     pack --pr                      PR Context Pack (changed files, impact, tests, artifacts)
     snapshot create|list|show|verify|restore|publish|import  Context Time Machine: git-anchored, signed snapshots; replay, resume + share
     index <status|build|build-full|watch>  Codebase index utilities
+    embeddings <status|provision>  Managed ONNX Runtime for semantic embeddings (official CPU build, sha256-pinned)
     cep                            CEP report (compression metrics, cache, modes, trends)
     verify-cache [path] [--json]   Prove the session cache: re-read collapses to a ~13-token stub
     health [path] [--json] [--gate]  Code-health report: cognitive complexity, naming, navigability score + token tax

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -159,6 +159,10 @@ pub fn run() {
                 crate::cli::addon_cmd::cmd_addon(&rest);
                 return;
             }
+            "embeddings" => {
+                crate::cli::embeddings_cmd::cmd_embeddings(&rest);
+                return;
+            }
             "rules" => {
                 crate::cli::rules_cmd::cmd_rules(&rest);
                 return;

--- a/rust/src/cli/embeddings_cmd.rs
+++ b/rust/src/cli/embeddings_cmd.rs
@@ -1,0 +1,59 @@
+//! `lean-ctx embeddings` — semantic-embedding runtime management (GH #732).
+//!
+//! The embedding engine loads ONNX Runtime dynamically. `provision` performs
+//! the **explicit, consent-gated** download of the official CPU runtime into
+//! the managed artifact layout; `status` shows what the resolver would use.
+//! Nothing here runs implicitly — the policy decided on #732 is "no silent
+//! download at first tool call, ever".
+
+use crate::core::addons::ort_provision;
+
+pub(crate) fn cmd_embeddings(rest: &[String]) {
+    match rest.first().map(String::as_str) {
+        Some("provision") => {
+            let force = rest.iter().any(|a| a == "--force");
+            println!(
+                "Fetching the official ONNX Runtime {} (CPU) from microsoft/onnxruntime…",
+                ort_provision::ORT_VERSION
+            );
+            match ort_provision::provision(force) {
+                Ok(path) => {
+                    println!("Installed: {}", path.display());
+                    println!(
+                        "Embeddings now work out of the box — semantic search picks this \
+                         runtime up automatically (ORT_DYLIB_PATH still overrides it)."
+                    );
+                }
+                Err(e) => {
+                    eprintln!("Provisioning failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Some("status") | None => {
+            println!("{}", ort_provision::status_line());
+            #[cfg(feature = "embeddings")]
+            println!(
+                "This build requires ONNX Runtime >= 1.{}.x (ort api level).",
+                ort::MINOR_VERSION
+            );
+            #[cfg(not(feature = "embeddings"))]
+            println!(
+                "This build was compiled without the `embeddings` feature — the managed \
+                 runtime is only used by embedding-enabled builds."
+            );
+            if let Ok(p) = std::env::var("ORT_DYLIB_PATH") {
+                println!("ORT_DYLIB_PATH override active: {p}");
+            }
+        }
+        Some(other) => {
+            eprintln!(
+                "Unknown subcommand `{other}`.\n\n\
+                 Usage:\n  \
+                 lean-ctx embeddings status              Show the managed ONNX Runtime state\n  \
+                 lean-ctx embeddings provision [--force] Download the official CPU runtime (sha256-pinned)"
+            );
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -13,6 +13,7 @@ mod context_cmd;
 mod debug_log_cmd;
 mod discover_cmd;
 pub mod dispatch;
+pub(crate) mod embeddings_cmd;
 pub mod eval_cmd;
 pub mod explore_cmd;
 pub mod export_rules;

--- a/rust/src/core/addons/mod.rs
+++ b/rust/src/core/addons/mod.rs
@@ -71,6 +71,7 @@ pub mod install;
 pub mod integrity;
 pub mod manifest;
 pub mod meter;
+pub mod ort_provision;
 pub mod policy;
 pub mod publish;
 pub mod registry;

--- a/rust/src/core/addons/ort_provision.rs
+++ b/rust/src/core/addons/ort_provision.rs
@@ -1,0 +1,375 @@
+//! Managed ONNX Runtime provisioning (GH #732) — the consent-gated download
+//! that makes embeddings work out of the box, without owning a GPU driver
+//! matrix.
+//!
+//! Policy (decided on the issue, aligned with epic #724):
+//!
+//! - Release binaries stay CPU-only `load-dynamic`; nothing is bundled.
+//! - Provisioning is **explicit** (`lean-ctx embeddings provision`) — never a
+//!   silent download on first tool call. `addons.policy = locked` blocks it.
+//! - Only the official CPU runtime is managed. GPU/NPU execution providers
+//!   remain opt-in feature builds with user-supplied runtimes.
+//!
+//! The managed copy lives in the same layout as every other managed binary
+//! artifact (`<data_dir>/addons/bin/onnxruntime/<version>/`), is SHA-256
+//! pinned against the official `microsoft/onnxruntime` release assets, and is
+//! resolved by `ort_environment::resolve_ort_dylib` right after
+//! `ORT_DYLIB_PATH` — the operator override always wins.
+//!
+//! The pinned version tracks the `ort` crate's API level (`api-24` ⇒ ONNX
+//! Runtime ≥ 1.24); a version-lockstep test below fails the build if the
+//! crate is bumped without updating this table.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use super::artifact_install::current_target_triple;
+use super::binhash::sha256_file;
+use super::policy::AddonPolicy;
+
+/// Managed ONNX Runtime version. Must satisfy `1.{ort::MINOR_VERSION}.x` of
+/// the `ort` crate compiled into this binary (guarded by a test when the
+/// `embeddings` feature is on).
+pub const ORT_VERSION: &str = "1.24.4";
+
+/// One platform's official CPU runtime archive.
+#[derive(Debug)]
+struct OrtArchive {
+    /// Official release asset URL (microsoft/onnxruntime).
+    url: &'static str,
+    /// SHA-256 of the archive bytes, from the GitHub release asset digest.
+    sha256: &'static str,
+    /// Path of the dylib inside the archive.
+    member: &'static str,
+}
+
+/// Official CPU archives for `ORT_VERSION`, keyed by Rust target triple.
+/// macOS x86_64 is absent upstream (Microsoft ships arm64-only since 1.24) —
+/// `archive_for` returns a descriptive error pointing at Homebrew.
+fn archive_for(triple: &str) -> Result<&'static OrtArchive, String> {
+    const LINUX_X64: OrtArchive = OrtArchive {
+        url: "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-1.24.4.tgz",
+        sha256: "3a211fbea252c1e66290658f1b735b772056149f28321e71c308942cdb54b747",
+        member: "onnxruntime-linux-x64-1.24.4/lib/libonnxruntime.so.1.24.4",
+    };
+    const LINUX_ARM64: OrtArchive = OrtArchive {
+        url: "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-aarch64-1.24.4.tgz",
+        sha256: "866109a9248d057671a039b9d725be4bd86888e3754140e6701ec621be9d4d7e",
+        member: "onnxruntime-linux-aarch64-1.24.4/lib/libonnxruntime.so.1.24.4",
+    };
+    const MACOS_ARM64: OrtArchive = OrtArchive {
+        url: "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-osx-arm64-1.24.4.tgz",
+        sha256: "93787795f47e1eee369182e43ed51b9e5da0878ab0346aecf4258979b8bba989",
+        member: "onnxruntime-osx-arm64-1.24.4/lib/libonnxruntime.1.24.4.dylib",
+    };
+    const WIN_X64: OrtArchive = OrtArchive {
+        url: "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-win-x64-1.24.4.zip",
+        sha256: "d2319fddfb6ea4db99ccc4b60c85c517bcd855721f5daa6a06d40d7cb2ee2357",
+        member: "onnxruntime-win-x64-1.24.4/lib/onnxruntime.dll",
+    };
+    const WIN_ARM64: OrtArchive = OrtArchive {
+        url: "https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-win-arm64-1.24.4.zip",
+        sha256: "47dc80aa39da792271af10be5993919536a4dab0965ec1e6043ef37f1df7a693",
+        member: "onnxruntime-win-arm64-1.24.4/lib/onnxruntime.dll",
+    };
+
+    match triple {
+        "x86_64-unknown-linux-gnu" => Ok(&LINUX_X64),
+        "aarch64-unknown-linux-gnu" => Ok(&LINUX_ARM64),
+        "aarch64-apple-darwin" => Ok(&MACOS_ARM64),
+        "x86_64-pc-windows-msvc" => Ok(&WIN_X64),
+        "aarch64-pc-windows-msvc" => Ok(&WIN_ARM64),
+        "x86_64-apple-darwin" => Err(
+            "Microsoft ships no official Intel-macOS ONNX Runtime build since 1.24 — \
+             install it via  brew install onnxruntime  (or set ORT_DYLIB_PATH)"
+                .to_string(),
+        ),
+        other => Err(format!(
+            "no managed ONNX Runtime archive for platform `{other}` — \
+             install onnxruntime via your package manager or set ORT_DYLIB_PATH"
+        )),
+    }
+}
+
+/// Installed filename — the plain platform dylib name, so the resolver and
+/// `ORT_DYLIB_PATH` users see the conventional name.
+fn dylib_filename() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "onnxruntime.dll"
+    } else if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    }
+}
+
+/// The managed install dir: `<data_dir>/addons/bin/onnxruntime/<version>/`.
+pub fn managed_dir() -> Result<PathBuf, String> {
+    Ok(crate::core::data_dir::lean_ctx_data_dir()?
+        .join("addons")
+        .join("bin")
+        .join("onnxruntime")
+        .join(ORT_VERSION))
+}
+
+/// The managed dylib if (and only if) it is already installed. Pure path
+/// check — no policy read, no network. This is the resolver hook.
+pub fn managed_dylib_path() -> Option<PathBuf> {
+    let path = managed_dir().ok()?.join(dylib_filename());
+    path.is_file().then_some(path)
+}
+
+/// Download, verify and install the managed CPU ONNX Runtime for this
+/// platform. Explicit consent flow: only the `embeddings provision` CLI (and
+/// doctor's suggestion text) reach this. Idempotent — an existing install
+/// returns immediately unless `force`.
+pub fn provision(force: bool) -> Result<PathBuf, String> {
+    let dest = managed_dir()?.join(dylib_filename());
+    if !force && dest.is_file() {
+        return Ok(dest);
+    }
+
+    let addons = crate::core::config::Config::load().addons;
+    if addons.policy() == AddonPolicy::Locked {
+        return Err("addons.policy = locked: managed artifact fetch disabled".into());
+    }
+
+    let archive = archive_for(current_target_triple())?;
+
+    let agent = crate::core::http_client::ureq_agent_with_timeouts(
+        Some(std::time::Duration::from_secs(10)),
+        // CPU archives are 5–25 MB; allow slow links without hanging forever.
+        Some(std::time::Duration::from_mins(2)),
+        Some(std::time::Duration::from_mins(3)),
+    );
+    let response = agent
+        .get(archive.url)
+        .header(
+            "User-Agent",
+            &format!("lean-ctx/{}", env!("CARGO_PKG_VERSION")),
+        )
+        .call()
+        .map_err(|e| format!("ONNX Runtime fetch failed: {e}"))?;
+    let mut bytes = Vec::new();
+    response
+        .into_body()
+        .into_reader()
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("ONNX Runtime download read failed: {e}"))?;
+
+    // Verify the archive against the pinned official digest before touching
+    // any archive parser — corrupt/tampered bytes never reach decompression.
+    let actual = sha256_bytes(&bytes);
+    if !actual.eq_ignore_ascii_case(archive.sha256) {
+        return Err(format!(
+            "ONNX Runtime archive hash mismatch: expected {}, got {actual} — refusing to install",
+            archive.sha256
+        ));
+    }
+
+    let dylib = extract_member(&bytes, archive.url, archive.member)?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let tmp = dest.with_extension("tmp");
+    std::fs::write(&tmp, &dylib).map_err(|e| e.to_string())?;
+
+    // Same hardening as every managed in-process dylib (artifact_install):
+    // read-only on disk, ad-hoc signed on macOS, atomic rename into place.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o444));
+    }
+    #[cfg(target_os = "macos")]
+    crate::core::codesign::adhoc_sign(&tmp);
+
+    std::fs::rename(&tmp, &dest).map_err(|e| e.to_string())?;
+
+    // Egress transparency: the one network round-trip must be visible.
+    tracing::info!(
+        "managed ONNX Runtime {ORT_VERSION} installed from {} (sha256 verified)",
+        archive.url
+    );
+
+    // Sanity: the just-installed file must hash cleanly (I/O errors surface
+    // here rather than at first dlopen).
+    sha256_file(&dest)?;
+    Ok(dest)
+}
+
+/// Extract a single member from a `.tgz` or `.zip` archive (decided by the
+/// URL suffix, matching the official asset naming).
+// The URLs are our own pinned lowercase constants, not user paths — a
+// case-insensitive Path::extension dance would only obscure that.
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
+fn extract_member(bytes: &[u8], url: &str, member: &str) -> Result<Vec<u8>, String> {
+    if url.ends_with(".tgz") || url.ends_with(".tar.gz") {
+        extract_tgz_member(bytes, member)
+    } else if url.ends_with(".zip") {
+        extract_zip_member(bytes, member)
+    } else {
+        Err(format!("unsupported archive format: {url}"))
+    }
+}
+
+fn extract_tgz_member(bytes: &[u8], member: &str) -> Result<Vec<u8>, String> {
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let mut tar = tar::Archive::new(gz);
+    let entries = tar
+        .entries()
+        .map_err(|e| format!("archive read failed: {e}"))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| format!("archive entry failed: {e}"))?;
+        let path = entry
+            .path()
+            .map_err(|e| format!("archive path failed: {e}"))?;
+        if path == Path::new(member) {
+            let mut out = Vec::new();
+            entry
+                .read_to_end(&mut out)
+                .map_err(|e| format!("archive extract failed: {e}"))?;
+            return Ok(out);
+        }
+    }
+    Err(format!("`{member}` not found in archive"))
+}
+
+fn extract_zip_member(bytes: &[u8], member: &str) -> Result<Vec<u8>, String> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut zip = zip::ZipArchive::new(cursor).map_err(|e| format!("zip open failed: {e}"))?;
+    let mut file = zip
+        .by_name(member)
+        .map_err(|_| format!("`{member}` not found in archive"))?;
+    let mut out = Vec::new();
+    file.read_to_end(&mut out)
+        .map_err(|e| format!("zip extract failed: {e}"))?;
+    Ok(out)
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    crate::core::agent_identity::hex_encode(&hasher.finalize())
+}
+
+/// One-line status for doctor / `embeddings status`.
+pub fn status_line() -> String {
+    match managed_dylib_path() {
+        Some(p) => format!("managed ONNX Runtime {ORT_VERSION}: {}", p.display()),
+        None => format!(
+            "managed ONNX Runtime: not installed (run  lean-ctx embeddings provision  \
+             to fetch the official CPU runtime {ORT_VERSION})"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The managed version must satisfy the `ort` crate's API requirement —
+    /// bumping `ort` without updating the pinned archives breaks provisioning
+    /// invisibly, so make it a compile-visible test failure instead.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn managed_version_matches_ort_api_level() {
+        let minor: u32 = ORT_VERSION.split('.').nth(1).unwrap().parse().unwrap();
+        assert!(
+            minor >= ort::MINOR_VERSION,
+            "managed ONNX Runtime {ORT_VERSION} is older than the ort crate's API level 1.{} — \
+             update the pinned archives in ort_provision.rs",
+            ort::MINOR_VERSION
+        );
+    }
+
+    #[test]
+    fn every_supported_platform_has_a_pinned_archive() {
+        for triple in [
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
+            "aarch64-apple-darwin",
+            "x86_64-pc-windows-msvc",
+            "aarch64-pc-windows-msvc",
+        ] {
+            let a = archive_for(triple).unwrap();
+            assert!(a.url.contains(ORT_VERSION), "{triple}: url/version drift");
+            let is_dll = std::path::Path::new(a.member)
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("dll"));
+            assert!(a.member.contains(ORT_VERSION) || is_dll);
+            assert_eq!(a.sha256.len(), 64, "{triple}: sha256 must be pinned");
+        }
+    }
+
+    #[test]
+    fn intel_macos_gets_a_descriptive_error() {
+        let err = archive_for("x86_64-apple-darwin").unwrap_err();
+        assert!(err.contains("brew install onnxruntime"), "got: {err}");
+    }
+
+    #[test]
+    fn unknown_platform_gets_a_descriptive_error() {
+        let err = archive_for("riscv64gc-unknown-linux-gnu").unwrap_err();
+        assert!(err.contains("ORT_DYLIB_PATH"), "got: {err}");
+    }
+
+    #[test]
+    fn tgz_member_extraction_roundtrips() {
+        // Build a tiny tgz in memory containing the member path.
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_bytes);
+            let data = b"dylib-bytes";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "pkg/lib/libonnxruntime.so.1.24.4", &data[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            use std::io::Write;
+            let mut enc = flate2::write::GzEncoder::new(&mut gz, flate2::Compression::fast());
+            enc.write_all(&tar_bytes).unwrap();
+            enc.finish().unwrap();
+        }
+
+        let out = extract_tgz_member(&gz, "pkg/lib/libonnxruntime.so.1.24.4").unwrap();
+        assert_eq!(out, b"dylib-bytes");
+        assert!(
+            extract_tgz_member(&gz, "pkg/lib/missing.so")
+                .unwrap_err()
+                .contains("not found")
+        );
+    }
+
+    #[test]
+    fn zip_member_extraction_roundtrips() {
+        let mut buf = Vec::new();
+        {
+            use std::io::Write;
+            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            writer
+                .start_file::<_, ()>(
+                    "pkg/lib/onnxruntime.dll",
+                    zip::write::FileOptions::default(),
+                )
+                .unwrap();
+            writer.write_all(b"dll-bytes").unwrap();
+            writer.finish().unwrap();
+        }
+        let out = extract_zip_member(&buf, "pkg/lib/onnxruntime.dll").unwrap();
+        assert_eq!(out, b"dll-bytes");
+        assert!(
+            extract_zip_member(&buf, "pkg/other.dll")
+                .unwrap_err()
+                .contains("not found")
+        );
+    }
+}

--- a/rust/src/core/ort_environment.rs
+++ b/rust/src/core/ort_environment.rs
@@ -7,10 +7,12 @@
 //! # Search order
 //!
 //! 1. `ORT_DYLIB_PATH` env var (resolved relative to the executable directory)
-//! 2. Nix profile paths — `/run/current-system/sw/lib/`, `~/.nix-profile/lib/` (Linux)
-//! 3. Well-known system directories per platform, including the active
+//! 2. The lean-ctx managed runtime (`lean-ctx embeddings provision`, GH #732)
+//!    — version-matched to this build's `ort` API level by construction
+//! 3. Nix profile paths — `/run/current-system/sw/lib/`, `~/.nix-profile/lib/` (Linux)
+//! 4. Well-known system directories per platform, including the active
 //!    `HOMEBREW_PREFIX` and the standard Homebrew/Linuxbrew lib dirs
-//! 4. `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH`
+//! 5. `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH`
 //!
 //! If no copy is found, [`ensure_ort_env`] returns an eager error — session
 //! creation hangs rather than failing, so we fail fast.
@@ -157,31 +159,40 @@ fn resolve_ort_dylib() -> anyhow::Result<PathBuf> {
         anyhow::bail!("ORT_DYLIB_PATH={p} set but file does not exist");
     }
 
-    // 2. Nix profile paths (Linux) — system & user profiles always point to
+    // 2. Managed runtime (GH #732) — installed by `lean-ctx embeddings
+    //    provision`, SHA-256 pinned to the official release and version-
+    //    matched to this build's ort API level. After ORT_DYLIB_PATH so an
+    //    operator override always wins.
+    if let Some(found) = crate::core::addons::ort_provision::managed_dylib_path() {
+        return Ok(found);
+    }
+
+    // 3. Nix profile paths (Linux) — system & user profiles always point to
     //    the currently activated version.
     #[cfg(target_os = "linux")]
     if let Some(found) = nix_profile_search(name) {
         return Ok(found);
     }
 
-    // 3. Well-known system paths (per platform)
+    // 4. Well-known system paths (per platform)
     if let Some(found) = well_known_paths(name) {
         return Ok(found);
     }
 
-    // 4. LD_LIBRARY_PATH / DYLD_LIBRARY_PATH
+    // 5. LD_LIBRARY_PATH / DYLD_LIBRARY_PATH
     if let Some(found) = lib_path_search(name) {
         return Ok(found);
     }
 
     anyhow::bail!(
         "libonnxruntime not found.\n\
-         Set ORT_DYLIB_PATH=<path> to point to the shared library.\n\
+         Managed:  lean-ctx embeddings provision  (official CPU runtime, sha256-pinned)\n\
+         Or set ORT_DYLIB_PATH=<path> to point to the shared library.\n\
          Install:  pip install onnxruntime  (Python bundles the .so)\n\
          NixOS:    nix-shell -p onnxruntime\n\
          Homebrew: brew install onnxruntime\n\
-         Searched: ORT_DYLIB_PATH, Nix store, well-known system dirs, \
-         LD_LIBRARY_PATH/DYLD_LIBRARY_PATH"
+         Searched: ORT_DYLIB_PATH, managed runtime dir, Nix store, \
+         well-known system dirs, LD_LIBRARY_PATH/DYLD_LIBRARY_PATH"
     )
 }
 

--- a/rust/src/doctor/checks/security.rs
+++ b/rust/src/doctor/checks/security.rs
@@ -317,3 +317,30 @@ pub(crate) fn managed_addon_binaries_outcome() -> Option<Outcome> {
         ),
     })
 }
+
+/// Managed ONNX Runtime state (GH #732). Only rendered on embedding-enabled
+/// builds; `None` when the runtime is simply not provisioned (embeddings are
+/// opt-in — a missing optional runtime is not a finding, the provision hint
+/// lives in the embeddings CLI and the resolver error).
+pub(crate) fn managed_ort_outcome() -> Option<Outcome> {
+    if !cfg!(feature = "embeddings") {
+        return None;
+    }
+    let path = crate::core::addons::ort_provision::managed_dylib_path()?;
+    let ok = crate::core::addons::binhash::sha256_file(&path).is_ok();
+    Some(Outcome {
+        ok,
+        line: if ok {
+            format!(
+                "{BOLD}Managed ONNX Runtime{RST}  {GREEN}{}{RST}  {DIM}({}){RST}",
+                crate::core::addons::ort_provision::ORT_VERSION,
+                path.display()
+            )
+        } else {
+            format!(
+                "{BOLD}Managed ONNX Runtime{RST}  {RED}unreadable{RST}  {DIM}({} — fix: lean-ctx embeddings provision --force){RST}",
+                path.display()
+            )
+        },
+    })
+}

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -317,6 +317,12 @@ pub fn run() -> u32 {
         board.check(&managed_bins);
     }
 
+    // 5b3d) Managed ONNX Runtime (GH #732): present + readable on
+    // embedding-enabled builds. Silent when not provisioned (opt-in).
+    if let Some(managed_ort) = managed_ort_outcome() {
+        board.check(&managed_ort);
+    }
+
     // 5b4) Cognition v2 activation (science subsystems wired + active)
     let cognition = cognition_activity_outcome();
     board.check(&cognition);


### PR DESCRIPTION
Fixes #732.

## Policy (as documented on the issue, aligned with epic #724)
1. Official release binaries stay **CPU-only `load-dynamic`**, nothing bundled
2. Provisioning is **explicit and consent-gated**: `lean-ctx embeddings provision` — never a silent download at first tool call; `addons.policy = locked` blocks it
3. Only the **official CPU runtime** is managed; CUDA/ROCm/DirectML/CoreML/WebGPU remain opt-in feature builds with user-supplied runtimes
4. GPU-requested-but-unavailable already degrades to CPU via the existing EP fallback

## What ships
- `ort_provision`: SHA-256-pinned official `microsoft/onnxruntime` **1.24.4** archives per target triple (digests taken from the GitHub release asset digests), bounded-timeout download, **verify-before-extract**, single-member tgz/zip extraction, managed layout `<data>/addons/bin/onnxruntime/<v>/`, read-only perms + macOS ad-hoc signing, atomic rename
- Resolver order: `ORT_DYLIB_PATH` → **managed runtime** → Nix → well-known dirs → `LD_LIBRARY_PATH` (operator override always wins); the not-found error now names the provision command first
- CLI: `lean-ctx embeddings <status|provision [--force]>`
- Doctor: managed-ORT status line on embedding-enabled builds (silent when not provisioned — embeddings are opt-in)
- **Version-lockstep test**: `ORT_VERSION` must satisfy `ort::MINOR_VERSION` (`api-24` ⇒ ≥ 1.24), so an `ort` crate bump cannot silently outrun the pinned archives
- Intel macOS: no official upstream build since 1.24 → descriptive `brew install onnxruntime` pointer

## Verification
- End-to-end on `aarch64-apple-darwin`: `provision` (7s, 34 MB) → `semantic-search --mode dense` loads the managed dylib (`ort: Loaded ONNX Runtime dylib … version '1.24.4'`)
- 6 new unit tests (platform table, archive extraction roundtrips, error texts), clippy `--all-targets -D warnings` clean, fmt clean

Made with [Cursor](https://cursor.com)