### PR TITLE
fix: recover from mutex poison on ONNX session lock

### DIFF
--- a/rust/src/core/embeddings/mod.rs
+++ b/rust/src/core/embeddings/mod.rs
@@ -366,7 +366,10 @@ impl EmbeddingEngine {
                         input.token_type_ids.iter().map(|&x| x as i64).collect();
                     let type_array = ndarray::Array2::from_shape_vec((1, seq_len), type_vec)?;
                     let type_tensor = ort::value::Tensor::from_array(type_array)?;
-                    let mut _guard = self.session.lock().unwrap();
+                    let mut _guard = self
+                        .session
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     let outputs = _guard.run(ort::inputs![
                         input_ids.as_str() => ids_tensor,
                         attention_mask.as_str() => mask_tensor,
@@ -376,7 +379,10 @@ impl EmbeddingEngine {
                         outputs[self.output_name.as_str()].try_extract_tensor::<f32>()?;
                     data.to_vec()
                 } else {
-                    let mut _guard = self.session.lock().unwrap();
+                    let mut _guard = self
+                        .session
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     let outputs = _guard.run(ort::inputs![
                         input_ids.as_str() => ids_tensor,
                         attention_mask.as_str() => mask_tensor,
@@ -396,7 +402,10 @@ impl EmbeddingEngine {
                 let offsets_array = ndarray::Array1::from_shape_vec(1, vec![0i64])?;
                 let ids_tensor = ort::value::Tensor::from_array(ids_array)?;
                 let offsets_tensor = ort::value::Tensor::from_array(offsets_array)?;
-                let mut _guard = self.session.lock().unwrap();
+                let mut _guard = self
+                    .session
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 let outputs = _guard.run(ort::inputs![
                     input_ids.as_str() => ids_tensor,
                     offsets.as_str() => offsets_tensor,
@@ -460,7 +469,10 @@ impl EmbeddingEngine {
                 let hidden = if let Some(type_id) = token_type_ids {
                     let type_array = ndarray::Array2::from_shape_vec((batch, max_len), type_data)?;
                     let type_tensor = ort::value::Tensor::from_array(type_array)?;
-                    let mut _guard = self.session.lock().unwrap();
+                    let mut _guard = self
+                        .session
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     let outputs = _guard.run(ort::inputs![
                         input_id.as_str() => ids_tensor,
                         mask_id.as_str() => mask_tensor,
@@ -470,7 +482,10 @@ impl EmbeddingEngine {
                         outputs[self.output_name.as_str()].try_extract_tensor::<f32>()?;
                     data.to_vec()
                 } else {
-                    let mut _guard = self.session.lock().unwrap();
+                    let mut _guard = self
+                        .session
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
                     let outputs = _guard.run(ort::inputs![
                         input_id.as_str() => ids_tensor,
                         mask_id.as_str() => mask_tensor,
@@ -510,7 +525,10 @@ impl EmbeddingEngine {
                 let ids_tensor = ort::value::Tensor::from_array(ids_array)?;
                 let offsets_tensor = ort::value::Tensor::from_array(offsets_array)?;
 
-                let mut _guard = self.session.lock().unwrap();
+                let mut _guard = self
+                    .session
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 let outputs = _guard.run(ort::inputs![
                     input_ids.as_str() => ids_tensor,
                     offsets.as_str() => offsets_tensor,

--- a/rust/src/core/neural/line_scorer.rs
+++ b/rust/src/core/neural/line_scorer.rs
@@ -294,7 +294,10 @@ impl NeuralLineScorer {
                 return 0.5;
             }
         };
-        let mut _guard = self.session.lock().unwrap();
+        let mut _guard = self
+            .session
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let outputs = match _guard.run(ort::inputs![self.input_name.as_str() => tensor]) {
             Ok(o) => o,
             Err(e) => {


### PR DESCRIPTION
## Summary

Recover from mutex poison on the ONNX inference `session` lock instead of unwrapping.

Closes #761.

At 7 sites the code used `self.session.lock().unwrap()`. If a thread panics while holding this lock (e.g. an `ort` inference failure), the mutex becomes *poisoned* and every subsequent `.lock().unwrap()` re-panics in cascade — permanently disabling the embeddings / neural line-scoring subsystem for the whole process lifetime.

The fix recovers the guard on poison:

```rust
// before
let mut _guard = self.session.lock().unwrap();
// after
let mut _guard = self.session.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
```

Returned type stays `MutexGuard`, so downstream code is unchanged. No new import (fully-qualified path).

**Affected files**
- `rust/src/core/embeddings/mod.rs` (L369, L379, L399, L463, L473, L513)
- `rust/src/core/neural/line_scorer.rs` (L297)

## Test plan

- [x] `cargo test --features embeddings,neural --lib -- core::embeddings` -> 61 passed, 0 failed
- [x] `cargo test --features embeddings,neural --lib -- core::neural` -> 20 passed, 0 failed
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (not run in this environment)
- [ ] `cargo fmt --check` (not run in this environment)

## Notes for reviewers

- Risk areas / edge cases: purely mechanical, type-invariant change (`MutexGuard` in/out identical); no behavioural change on the happy path. On poison it now returns the inner guard instead of panicking.
- Backwards compatibility: fully compatible.
- Docs updated: n/a.
