### PR TITLE
feat: add GPU embedding runtime support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: python3 scripts/check-package-versions.py
 
   build:
-    name: Build ${{ matrix.target }}
+    name: Build ${{ matrix.artifact || matrix.target }}
     needs: sdk-gate
     runs-on: ${{ matrix.os }}
     strategy:
@@ -42,6 +42,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
+          - target: x86_64-unknown-linux-gnu
+            artifact: x86_64-unknown-linux-gnu-cuda
+            os: ubuntu-22.04
+            cargo_features: ort-cuda
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
             cross: true
@@ -147,37 +151,43 @@ jobs:
         working-directory: rust
         shell: bash
         run: |
+          features="${{ matrix.cargo_features }}"
+          feature_args=()
+          if [[ -n "$features" ]]; then
+            feature_args+=(--features "$features")
+          fi
           if [[ "${{ matrix.zig }}" == "true" ]]; then
-            cargo zigbuild --release --locked --target ${{ matrix.target }}
+            cargo zigbuild --release --locked --target ${{ matrix.target }} "${feature_args[@]}"
           elif [[ "${{ matrix.jemalloc }}" == "true" ]]; then
             JEMALLOC_OVERRIDE="${{ steps.jemalloc.outputs.jemalloc-override }}" \
               CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-L ${{ steps.jemalloc.outputs.dummy-dir }}" \
-              cargo build --release --locked --target ${{ matrix.target }}
+              cargo build --release --locked --target ${{ matrix.target }} "${feature_args[@]}"
           else
-            cargo build --release --locked --target ${{ matrix.target }}
+            cargo build --release --locked --target ${{ matrix.target }} "${feature_args[@]}"
           fi
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
+          artifact="${{ matrix.artifact || matrix.target }}"
           cd rust/target/${{ matrix.target }}/release
-          tar czf ../../../../lean-ctx-${{ matrix.target }}.tar.gz lean-ctx
+          tar czf ../../../../lean-ctx-${artifact}.tar.gz lean-ctx
           cd ../../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Compress-Archive -Path "rust/target/${{ matrix.target }}/release/lean-ctx.exe" -DestinationPath "lean-ctx-${{ matrix.target }}.zip"
+          Compress-Archive -Path "rust/target/${{ matrix.target }}/release/lean-ctx.exe" -DestinationPath "lean-ctx-${{ matrix.artifact || matrix.target }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: lean-ctx-${{ matrix.target }}
+          name: lean-ctx-${{ matrix.artifact || matrix.target }}
           path: |
-            lean-ctx-${{ matrix.target }}.tar.gz
-            lean-ctx-${{ matrix.target }}.zip
+            lean-ctx-${{ matrix.artifact || matrix.target }}.tar.gz
+            lean-ctx-${{ matrix.artifact || matrix.target }}.zip
 
   release:
     name: Create Release

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   ./install.sh                # download pre-built binary (no Rust needed)
 #   ./install.sh --download     # download pre-built binary (no Rust needed)
+#   ./install.sh --cuda         # download Linux x86_64 CUDA-enabled binary
 #   ./install.sh --build-only   # build only, don't install
 #   ./install.sh --uninstall    # fully remove lean-ctx (processes, configs, autostart, data, binary)
 #
@@ -18,6 +19,7 @@ set -eu
 
 REPO="yvgude/lean-ctx"
 INSTALL_DIR="${LEAN_CTX_INSTALL_DIR:-$HOME/.local/bin}"
+INSTALL_FLAVOR="${LEAN_CTX_INSTALL_FLAVOR:-cpu}"
 # Resolve the script's directory when invoked as a file. When piped via
 # `curl ... | sh`, $0 is "sh" (or similar) — the [ -f "$0" ] guard then
 # falls back to pwd, which is what the bottom-of-file dispatcher expects:
@@ -140,6 +142,21 @@ stop_running_instance() {
 
 install_download() {
   target="$(detect_target)"
+  case "$INSTALL_FLAVOR" in
+    cuda|gpu)
+      if [ "$target" != "x86_64-unknown-linux-gnu" ]; then
+        echo "Error: CUDA pre-built binary is currently published for x86_64 GNU/Linux only."
+        echo "Detected: $target"
+        exit 1
+      fi
+      target="${target}-cuda"
+      ;;
+    cpu|"") ;;
+    *)
+      echo "Error: unknown install flavor '$INSTALL_FLAVOR' (expected cpu or cuda)"
+      exit 1
+      ;;
+  esac
   echo "Mode: download pre-built binary"
   echo "Platform: $target"
   echo ""
@@ -294,13 +311,15 @@ uninstall() {
 
 case "${1:-}" in
   --download)    install_download ;;
+  --cuda|--gpu)  INSTALL_FLAVOR="cuda"; install_download ;;
   --build-only)  install_from_source --build-only ;;
   --uninstall)   shift; uninstall "$@" ;;
   --help|-h)
-    echo "Usage: $0 [--download|--build-only|--uninstall|--help]"
+    echo "Usage: $0 [--download|--cuda|--build-only|--uninstall|--help]"
     echo ""
     echo "  (no args)     Download pre-built binary (builds from source if run inside the lean-ctx repo)"
     echo "  --download    Download pre-built binary (no Rust needed)"
+    echo "  --cuda        Download Linux x86_64 CUDA-enabled binary"
     echo "  --build-only  Build only, don't install"
     echo "  --uninstall   Fully remove lean-ctx (processes, configs, autostart, data, binary)"
     echo ""
@@ -309,6 +328,7 @@ case "${1:-}" in
     echo ""
     echo "Environment:"
     echo "  LEAN_CTX_INSTALL_DIR  Custom install directory (default: ~/.local/bin)"
+    echo "  LEAN_CTX_INSTALL_FLAVOR  Binary flavor: cpu or cuda (default: cpu)"
     ;;
   *)
     if [ -d "$RUST_DIR" ]; then

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -71,6 +71,7 @@ EVERYDAY COMMANDS:
 MANAGE:
     lean-ctx status                Am I connected? (quick check)
     lean-ctx update                Update to the latest version
+    lean-ctx enable-gpu            Install the CUDA-enabled Linux binary
     lean-ctx uninstall             Remove lean-ctx cleanly
 
 SAFETY (env vars):
@@ -218,6 +219,7 @@ COMMANDS:
     slow-log [list|clear]          Show/clear slow command log (~/.lean-ctx/slow-commands.log)
     debug-log [list|tail N|clear|path]  Opt-in tool-call + hook-routing log (set debug_log / LEAN_CTX_DEBUG_LOG)
     update [<version>] [--check]   Update lean-ctx, or pin a version, from GitHub Releases
+    enable-gpu [--check]           Install CUDA-enabled binary (x86_64 GNU/Linux)
     stop                           Stop ALL lean-ctx processes (daemon, proxy, orphans)
     restart                        Restart daemon (applies config.toml changes)
     dev-install                    Build release + atomic install + restart (for development)

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -163,6 +163,10 @@ pub fn run() {
                 crate::cli::embeddings_cmd::cmd_embeddings(&rest);
                 return;
             }
+            "enable-gpu" | "gpu" => {
+                core::updater::enable_gpu(&rest);
+                return;
+            }
             "rules" => {
                 crate::cli::rules_cmd::cmd_rules(&rest);
                 return;

--- a/rust/src/cli/embeddings_cmd.rs
+++ b/rust/src/cli/embeddings_cmd.rs
@@ -45,13 +45,26 @@ pub(crate) fn cmd_embeddings(rest: &[String]) {
             if let Ok(p) = std::env::var("ORT_DYLIB_PATH") {
                 println!("ORT_DYLIB_PATH override active: {p}");
             }
+            #[cfg(feature = "embeddings")]
+            println!(
+                "{}",
+                crate::core::ort_execution_providers::execution_provider_status()
+            );
+            #[cfg(feature = "embeddings")]
+            println!(
+                "{}",
+                crate::core::ort_execution_providers::execution_provider_help()
+            );
         }
         Some(other) => {
             eprintln!(
                 "Unknown subcommand `{other}`.\n\n\
                  Usage:\n  \
                  lean-ctx embeddings status              Show the managed ONNX Runtime state\n  \
-                 lean-ctx embeddings provision [--force] Download the official CPU runtime (sha256-pinned)"
+                                 lean-ctx embeddings provision [--force] Download the official CPU runtime (sha256-pinned)
+
+                                 GPU opt-in:
+                                     LEAN_CTX_ORT_EXECUTION_PROVIDER=gpu|auto"
             );
             std::process::exit(1);
         }

--- a/rust/src/cli/index_cmd.rs
+++ b/rust/src/cli/index_cmd.rs
@@ -55,6 +55,10 @@ pub(crate) fn cmd_index(args: &[String]) {
             }
         }
         Some("build-full") => {
+            // Cooperative Ctrl-C: the synchronous dense-embedding phase below
+            // spends its time in CUDA FFI; a plain SIGINT kill mid-kernel leaks
+            // VRAM and leaves a zombie. This lets embedding stop between batches.
+            crate::core::interrupt::install_ctrlc_handler();
             let bm25_path = crate::core::bm25_index::BM25Index::index_file_path(root);
             let _ = std::fs::remove_file(&bm25_path);
             // #696 C4: purge the property graph (graph.db + wal/shm + meta) and
@@ -148,6 +152,9 @@ pub(crate) fn cmd_index(args: &[String]) {
             }
         }
         Some("build-semantic") => {
+            // Cooperative Ctrl-C for the synchronous CUDA embedding phase (see
+            // build-full): stop between batches instead of killing mid-kernel.
+            crate::core::interrupt::install_ctrlc_handler();
             // Build the dense embedding index on top of BM25.  If BM25 is not yet
             // built, build graph + BM25 first, then build semantic.
             let disk = crate::core::index_orchestrator::disk_status(&project_root);

--- a/rust/src/core/embeddings/mod.rs
+++ b/rust/src/core/embeddings/mod.rs
@@ -103,8 +103,15 @@ impl EmbeddingEngine {
         let eps = if deterministic {
             vec![ort::ep::CPU::default().build()]
         } else {
-            crate::core::ort_execution_providers::gpu_execution_providers()
+            crate::core::ort_execution_providers::execution_providers()
         };
+        // Surface a loud, actionable warning when the user expected the GPU but
+        // the CUDA runtime is unusable, so it doesn't silently crawl on CPU.
+        if !deterministic
+            && let Some(msg) = crate::core::ort_execution_providers::gpu_fallback_warning()
+        {
+            tracing::warn!("{msg}");
+        }
         let num_cpus = if deterministic {
             1
         } else {
@@ -277,17 +284,49 @@ impl EmbeddingEngine {
             .map(|t| tokenize(&self.tokenizer, t, self.max_seq_len))
             .collect();
 
-        // Process in mini-batches to cap peak memory
+        // Process in mini-batches to cap peak memory.
         // Override via LEAN_CTX_EMBEDDING_BATCH_SIZE env var (e.g. "128").
+        // Default is larger on GPU (256 vs. 64): each mini-batch is one
+        // sequential session.run() call (no fan-out across batches), so small
+        // batches under-utilize the GPU and pay kernel-launch / host↔device
+        // copy overhead per call that a bigger matmul would amortize better.
         let batch_size: usize = std::env::var("LEAN_CTX_EMBEDDING_BATCH_SIZE")
             .ok()
             .and_then(|v| v.parse().ok())
             .filter(|&v| v >= 1)
-            .unwrap_or(64);
-        let mut results = Vec::with_capacity(texts.len());
-        for chunk in tokenized.chunks(batch_size) {
+            .unwrap_or_else(default_batch_size);
+
+        let total = tokenized.len();
+        let total_batches = total.div_ceil(batch_size);
+        let mut results = Vec::with_capacity(total);
+        let start = std::time::Instant::now();
+        for (batch_idx, chunk) in tokenized.chunks(batch_size).enumerate() {
+            // Cooperative cancellation checkpoint (between FFI calls, never
+            // inside `session.run()`): bail on user Ctrl-C or a memory-guard
+            // abort. Stopping here leaves the CUDA context intact so the driver
+            // can reclaim VRAM on the ensuing clean exit, instead of the process
+            // being killed mid-kernel and lingering as a zombie holding VRAM.
+            if crate::core::interrupt::is_cancelled()
+                || crate::core::memory_guard::abort_requested()
+            {
+                anyhow::bail!(
+                    "embedding cancelled after {done}/{total_batches} batches ({embedded}/{total} chunks)",
+                    done = batch_idx,
+                    embedded = results.len(),
+                );
+            }
+            let batch_start = std::time::Instant::now();
             let batch_out = self.run_inference_batch(chunk)?;
             results.extend(batch_out);
+            tracing::info!(
+                batch = batch_idx + 1,
+                total_batches,
+                embedded = results.len(),
+                total,
+                batch_ms = batch_start.elapsed().as_millis(),
+                elapsed_ms = start.elapsed().as_millis(),
+                "embedding progress"
+            );
         }
         Ok(results)
     }
@@ -543,6 +582,20 @@ impl EmbeddingEngine {
     fn run_inference_batch(&self, _inputs: &[TokenizedInput]) -> anyhow::Result<Vec<Vec<f32>>> {
         anyhow::bail!("Embeddings feature not enabled")
     }
+}
+
+#[cfg(any(feature = "embeddings", feature = "neural"))]
+fn default_batch_size() -> usize {
+    if crate::core::ort_execution_providers::gpu_active() {
+        256
+    } else {
+        64
+    }
+}
+
+#[cfg(not(any(feature = "embeddings", feature = "neural")))]
+fn default_batch_size() -> usize {
+    64
 }
 
 /// Load the appropriate tokenizer for the model config.

--- a/rust/src/core/interrupt.rs
+++ b/rust/src/core/interrupt.rs
@@ -1,0 +1,69 @@
+//! User-initiated cooperative cancellation (Ctrl-C / SIGINT).
+//!
+//! Long-running CLI builds (notably dense embedding via CUDA) spend most of
+//! their time inside ONNX Runtime FFI (`session.run()`). If the default SIGINT
+//! disposition kills the process mid-kernel, the CUDA context is never torn
+//! down cleanly: the process lingers as a zombie and its VRAM stays allocated
+//! until the driver reclaims it (observed under WSL2 GPU passthrough).
+//!
+//! This module installs a *cooperative* SIGINT handler: the first Ctrl-C only
+//! flips a global flag. Cancellable loops poll [`is_cancelled`] **between** FFI
+//! calls and return early, so control is back in Rust code — not inside a CUDA
+//! kernel — when the process exits. That lets the driver reclaim VRAM on a
+//! clean exit. A second Ctrl-C forces an immediate `_exit` for the impatient.
+//!
+//! The handler body only performs async-signal-safe operations (atomic stores
+//! and, on the second signal, `libc::_exit`).
+
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+static CANCELLED: AtomicBool = AtomicBool::new(false);
+static HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
+static SIGNAL_COUNT: AtomicU8 = AtomicU8::new(0);
+
+/// `true` once the user has requested cancellation via Ctrl-C.
+pub fn is_cancelled() -> bool {
+    CANCELLED.load(Ordering::Relaxed)
+}
+
+/// Clear the cancellation state before starting a fresh cancellable operation.
+pub fn reset() {
+    CANCELLED.store(false, Ordering::SeqCst);
+    SIGNAL_COUNT.store(0, Ordering::SeqCst);
+}
+
+#[cfg(unix)]
+extern "C" fn handle_sigint(_sig: libc::c_int) {
+    CANCELLED.store(true, Ordering::SeqCst);
+    let count = SIGNAL_COUNT
+        .fetch_add(1, Ordering::SeqCst)
+        .saturating_add(1);
+    if count >= 2 {
+        // Second Ctrl-C: the user wants out now. `_exit` is async-signal-safe
+        // and terminates the process without running (unsafe-in-a-handler)
+        // destructors; the OS/driver reclaims the CUDA context on death.
+        // SAFETY: `_exit` is async-signal-safe and does not run Rust destructors.
+        unsafe { libc::_exit(130) };
+    }
+}
+
+/// Install the cooperative SIGINT handler (idempotent).
+///
+/// Call this at the start of a long-running, cancellable CLI operation. The
+/// daemon/MCP server never calls it, so [`is_cancelled`] stays `false` there
+/// and background embedding is unaffected.
+pub fn install_ctrlc_handler() {
+    if HANDLER_INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    #[cfg(unix)]
+    // SAFETY: `handle_sigint` only performs async-signal-safe work (atomic
+    // stores, and `libc::_exit` on the second signal). Registering it replaces
+    // the default terminate-immediately disposition with a cooperative one.
+    unsafe {
+        libc::signal(
+            libc::SIGINT,
+            handle_sigint as *const () as libc::sighandler_t,
+        );
+    }
+}

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -61,6 +61,7 @@ pub mod compression {
 // Domain: Memory
 // ---------------------------------------------------------------------------
 pub mod episodic_memory;
+pub mod interrupt;
 pub mod memory_archive;
 pub mod memory_boundary;
 pub mod memory_capacity;

--- a/rust/src/core/neural/line_scorer.rs
+++ b/rust/src/core/neural/line_scorer.rs
@@ -224,7 +224,7 @@ pub struct LineContext {
 impl NeuralLineScorer {
     #[cfg(feature = "neural")]
     pub fn load(model_path: &Path) -> anyhow::Result<Self> {
-        let eps = crate::core::ort_execution_providers::gpu_execution_providers();
+        let eps = crate::core::ort_execution_providers::execution_providers();
         let num_cpus = std::thread::available_parallelism().map_or(4, |n| n.get().max(1));
         crate::core::ort_environment::ensure_ort_env(&eps)?;
         let session = ort::session::Session::builder()

--- a/rust/src/core/ort_environment.rs
+++ b/rust/src/core/ort_environment.rs
@@ -54,7 +54,7 @@ pub fn ensure_ort_env(eps: &[ExecutionProviderDispatch]) -> anyhow::Result<()> {
 /// The library path is resolved by [`resolve_ort_dylib`]; errors are
 /// propagated eagerly to avoid hanging on first session creation.
 fn init_ort(eps: &[ExecutionProviderDispatch]) -> anyhow::Result<()> {
-    let path = resolve_ort_dylib()?;
+    let path = resolved_ort_dylib_path()?;
 
     tracing::debug!("Loading libonnxruntime from {}", path.display());
     validate_ort_dylib_version(&path)?;
@@ -69,6 +69,10 @@ fn init_ort(eps: &[ExecutionProviderDispatch]) -> anyhow::Result<()> {
 
     tracing::info!("ONNX Runtime initialised ({})", path.display());
     Ok(())
+}
+
+pub(crate) fn resolved_ort_dylib_path() -> anyhow::Result<PathBuf> {
+    resolve_ort_dylib()
 }
 
 type OrtGetApiBase = unsafe extern "C" fn() -> *const OrtApiBase;

--- a/rust/src/core/ort_execution_providers.rs
+++ b/rust/src/core/ort_execution_providers.rs
@@ -1,14 +1,207 @@
-//! GPU execution provider selection: per-vendor feature flags, session-level config.
+//! ONNX Runtime execution provider selection: CPU default, opt-in GPU providers.
 //!
 //! Each GPU EP is gated behind its own Cargo feature (`ort-cuda`, `ort-rocm`, etc.).
-//! When no GPU features are enabled, an empty vec is returned — ORT uses CPU only.
-//! When a GPU feature IS enabled but the GPU is unavailable, ORT silently falls back
-//! to the next EP in the list; we emit [`tracing::warn!`] so users know.
+//! `LEAN_CTX_ORT_EXECUTION_PROVIDER=cpu|gpu|auto` controls runtime selection.
+//! By default, `auto` enables GPU only when the selected ORT dylib looks like a
+//! GPU runtime; otherwise CPU is used. ORT falls back to CPU when a registered
+//! GPU EP is unusable.
+
+use std::path::Path;
+
+const PROVIDER_ENV: &str = "LEAN_CTX_ORT_EXECUTION_PROVIDER";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderPolicy {
+    Cpu,
+    Gpu,
+    Auto,
+}
+
+/// Build the execution provider list for the current runtime policy.
+pub fn execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
+    match provider_policy() {
+        ProviderPolicy::Cpu => cpu_execution_providers(),
+        ProviderPolicy::Gpu => gpu_execution_providers(),
+        ProviderPolicy::Auto => {
+            if selected_runtime_looks_gpu() {
+                gpu_execution_providers()
+            } else {
+                tracing::debug!(
+                    env = PROVIDER_ENV,
+                    "ONNX Runtime GPU auto-detect did not find a GPU runtime; using CPU"
+                );
+                cpu_execution_providers()
+            }
+        }
+    }
+}
+
+pub fn execution_provider_status() -> String {
+    let policy = provider_policy_name();
+    let compiled = compiled_gpu_provider_names();
+    let compiled = if compiled.is_empty() {
+        "none".to_string()
+    } else {
+        compiled.join(",")
+    };
+    format!(
+        "ORT execution provider policy: {policy} (env {PROVIDER_ENV}; compiled GPU EPs: {compiled})"
+    )
+}
+
+/// Whether the current policy resolves to a GPU execution provider — regardless
+/// of whether that provider's runtime dependencies can actually be loaded.
+fn policy_wants_gpu() -> bool {
+    if compiled_gpu_provider_names().is_empty() {
+        return false;
+    }
+    match provider_policy() {
+        ProviderPolicy::Cpu => false,
+        ProviderPolicy::Gpu => true,
+        ProviderPolicy::Auto => selected_runtime_looks_gpu(),
+    }
+}
+
+/// Whether a real GPU execution provider will *actually* run inference — i.e.
+/// the policy wants a GPU **and** the provider's runtime libraries load. Used to
+/// scale batch size: small mini-batches under-utilize a GPU and pay
+/// kernel-launch/host↔device-copy overhead per call that isn't amortized
+/// (notably under WSL2 GPU passthrough), but oversizing batches for a GPU that
+/// silently fell back to CPU makes the CPU path dramatically slower — so this
+/// must reflect the EP that ORT will really register, not just the policy.
+pub fn gpu_active() -> bool {
+    if !policy_wants_gpu() {
+        return false;
+    }
+    // The shipped Linux/Windows GPU build compiles only the CUDA EP. If its
+    // runtime deps (libcudart/libcublas/libcudnn/…) can't be dlopen'd, ORT
+    // silently registers CPU instead; don't size batches for a phantom GPU.
+    #[cfg(feature = "ort-cuda")]
+    {
+        cuda_runtime_available()
+    }
+    #[cfg(not(feature = "ort-cuda"))]
+    {
+        true
+    }
+}
+
+/// When the policy expects a GPU but the CUDA runtime can't be loaded (so ORT
+/// falls back to CPU), returns a user-facing explanation with the exact install
+/// commands for the missing libraries. Returns `None` when the GPU actually
+/// works or when CPU was requested.
+pub fn gpu_fallback_warning() -> Option<String> {
+    #[cfg(feature = "ort-cuda")]
+    {
+        if !policy_wants_gpu() || cuda_runtime_available() {
+            return None;
+        }
+        let detail = probe_cuda_runtime().err().unwrap_or_default();
+        Some(cuda_missing_message(&detail))
+    }
+    #[cfg(not(feature = "ort-cuda"))]
+    {
+        None
+    }
+}
+
+/// Filename of the ORT CUDA provider shared library for the current platform.
+#[cfg(feature = "ort-cuda")]
+fn cuda_provider_lib_name() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "onnxruntime_providers_cuda.dll"
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "libonnxruntime_providers_cuda.dylib"
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        "libonnxruntime_providers_cuda.so"
+    }
+}
+
+/// Path to the ORT CUDA provider library, resolved next to the selected ORT dylib.
+#[cfg(feature = "ort-cuda")]
+fn cuda_provider_lib_path() -> Option<std::path::PathBuf> {
+    let dylib = crate::core::ort_environment::resolved_ort_dylib_path().ok()?;
+    Some(dylib.parent()?.join(cuda_provider_lib_name()))
+}
+
+/// Probe whether the CUDA provider library and its transitive CUDA runtime
+/// dependencies can be loaded — the same resolution ORT performs when it
+/// registers the EP. `Err` carries the loader message (e.g. the first missing
+/// `.so`), which surfaces in the fallback warning.
+#[cfg(feature = "ort-cuda")]
+fn probe_cuda_runtime() -> Result<(), String> {
+    let path = cuda_provider_lib_path()
+        .ok_or_else(|| "could not resolve the ORT CUDA provider library path".to_string())?;
+    if !path.exists() {
+        return Err(format!("{} not found", path.display()));
+    }
+    // SAFETY: loading the ORT CUDA provider shared library, exactly as ONNX
+    // Runtime itself does when registering the CUDA EP. We drop it immediately;
+    // this only checks that its runtime dependencies resolve.
+    unsafe { libloading::Library::new(&path) }
+        .map(|_lib| ())
+        .or_else(|e| {
+            let err = e.to_string();
+            // ORT provider plugins are normally loaded by libonnxruntime itself.
+            // A direct dlopen may fail on ORT host symbols after CUDA/cuDNN deps
+            // have resolved; that is still enough for this dependency probe.
+            if err.contains("Provider_GetHost") {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })
+}
+
+/// Cached result of [`probe_cuda_runtime`]; the dlopen runs at most once.
+#[cfg(feature = "ort-cuda")]
+fn cuda_runtime_available() -> bool {
+    static CACHE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| probe_cuda_runtime().is_ok())
+}
+
+/// User-facing message shown when the CUDA runtime is missing, including the
+/// exact commands to install the required libraries.
+#[cfg(feature = "ort-cuda")]
+fn cuda_missing_message(probe_err: &str) -> String {
+    format!(
+        "GPU requested (via {env}) but the CUDA runtime libraries required by ONNX Runtime \
+         could not be loaded — embedding is running on CPU. Loader error: {probe_err}\n\
+         ONNX Runtime 1.{ort_minor}.x needs CUDA 12 + cuDNN 9. Missing libraries typically \
+         include: libcudart.so.12, libcublas.so.12, libcublasLt.so.12, libcudnn.so.9, \
+         libcurand.so.10, libcufft.so.11.\n\
+         Install them on Ubuntu / WSL2:\n  \
+         wget -O /tmp/cuda-keyring_1.1-1_all.deb https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-keyring_1.1-1_all.deb\n  \
+         sudo dpkg -i /tmp/cuda-keyring_1.1-1_all.deb && rm -f /tmp/cuda-keyring_1.1-1_all.deb && sudo apt-get update\n  \
+         sudo apt-get install -y cuda-cudart-12-8 libcublas-12-8 libcurand-12-8 libcufft-12-8\n  \
+         python3 -m venv $HOME/.local/share/lean-ctx/cuda-libs\n  \
+         $HOME/.local/share/lean-ctx/cuda-libs/bin/python -m pip install nvidia-cudnn-cu12==9.8.0.87\n  \
+         # then ensure the loader can find them (if not already on the path):\n  \
+         export LD_LIBRARY_PATH=$($HOME/.local/share/lean-ctx/cuda-libs/bin/python -c 'import pathlib, nvidia.cudnn; print(pathlib.Path(nvidia.cudnn.__file__).parent / '\''lib'\'')'):/usr/local/cuda-12.8/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH\n\
+         To silence this and stay on CPU, set {env}=cpu.",
+        env = PROVIDER_ENV,
+        ort_minor = ort::MINOR_VERSION,
+    )
+}
+
+pub fn execution_provider_help() -> &'static str {
+    "By default lean-ctx auto-detects GPU runtimes from ORT_DYLIB_PATH and otherwise uses CPU. Set LEAN_CTX_ORT_EXECUTION_PROVIDER=cpu|gpu|auto to override."
+}
+
+fn cpu_execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
+    vec![ort::ep::CPU::default().build()]
+}
 
 /// Build the list of GPU execution providers in registration-priority order.
 pub fn gpu_execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
     #[allow(unused_mut)]
     let mut eps: Vec<ort::ep::ExecutionProviderDispatch> = Vec::new();
+    let compiled_gpu_count = compiled_gpu_provider_names().len();
 
     #[cfg(feature = "ort-cuda")]
     {
@@ -39,10 +232,98 @@ pub fn gpu_execution_providers() -> Vec<ort::ep::ExecutionProviderDispatch> {
         eps.push(ort::ep::CoreML::default().build());
     }
 
-    if eps.is_empty() {
+    if compiled_gpu_count == 0 {
+        tracing::warn!(
+            "GPU execution provider requested, but this lean-ctx binary was built without ort-cuda/ort-rocm/etc.; using CPU only"
+        );
+    } else if eps.is_empty() {
         tracing::debug!("No GPU execution providers configured — using CPU only");
     }
 
     eps.push(ort::ep::CPU::default().build());
     eps
+}
+
+fn provider_policy() -> ProviderPolicy {
+    match std::env::var(PROVIDER_ENV) {
+        Ok(value) => provider_policy_from_value(&value),
+        Err(_) => ProviderPolicy::Auto,
+    }
+}
+
+fn provider_policy_name() -> &'static str {
+    match provider_policy() {
+        ProviderPolicy::Cpu => "cpu",
+        ProviderPolicy::Gpu => "gpu",
+        ProviderPolicy::Auto => "auto",
+    }
+}
+
+fn provider_policy_from_value(value: &str) -> ProviderPolicy {
+    match value.trim().to_lowercase().as_str() {
+        "gpu" | "cuda" | "rocm" | "webgpu" | "directml" | "coreml" => ProviderPolicy::Gpu,
+        "auto" => ProviderPolicy::Auto,
+        _ => ProviderPolicy::Cpu,
+    }
+}
+
+fn selected_runtime_looks_gpu() -> bool {
+    crate::core::ort_environment::resolved_ort_dylib_path()
+        .ok()
+        .as_deref()
+        .is_some_and(runtime_path_looks_gpu)
+}
+
+fn runtime_path_looks_gpu(path: &Path) -> bool {
+    let path_text = path.to_string_lossy().to_lowercase();
+    if path_text.contains("gpu") || path_text.contains("cuda") || path_text.contains("rocm") {
+        return true;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    [
+        "libonnxruntime_providers_cuda.so",
+        "libonnxruntime_providers_rocm.so",
+        "onnxruntime_providers_cuda.dll",
+        "onnxruntime_providers_rocm.dll",
+        "libonnxruntime_providers_cuda.dylib",
+        "libonnxruntime_providers_rocm.dylib",
+    ]
+    .iter()
+    .any(|name| parent.join(name).exists())
+}
+
+fn compiled_gpu_provider_names() -> Vec<&'static str> {
+    vec![
+        #[cfg(feature = "ort-cuda")]
+        "cuda",
+        #[cfg(feature = "ort-rocm")]
+        "rocm",
+        #[cfg(feature = "ort-webgpu")]
+        "webgpu",
+        #[cfg(all(target_os = "windows", feature = "ort-directml"))]
+        "directml",
+        #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "ort-coreml"))]
+        "coreml",
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_policy_defaults_to_cpu_for_unknown_values() {
+        assert_eq!(provider_policy_from_value(""), ProviderPolicy::Cpu);
+        assert_eq!(provider_policy_from_value("bogus"), ProviderPolicy::Cpu);
+        assert_eq!(provider_policy_from_value("cpu"), ProviderPolicy::Cpu);
+    }
+
+    #[test]
+    fn provider_policy_accepts_gpu_and_auto_aliases() {
+        assert_eq!(provider_policy_from_value("gpu"), ProviderPolicy::Gpu);
+        assert_eq!(provider_policy_from_value("CUDA"), ProviderPolicy::Gpu);
+        assert_eq!(provider_policy_from_value("auto"), ProviderPolicy::Auto);
+    }
 }

--- a/rust/src/core/updater.rs
+++ b/rust/src/core/updater.rs
@@ -4,6 +4,20 @@ const GITHUB_API_RELEASES: &str = "https://api.github.com/repos/yvgude/lean-ctx/
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn run(args: &[String]) {
+    run_with_mode(args, UpdateMode::Normal);
+}
+
+pub fn enable_gpu(args: &[String]) {
+    run_with_mode(args, UpdateMode::EnableGpu);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdateMode {
+    Normal,
+    EnableGpu,
+}
+
+fn run_with_mode(args: &[String], mode: UpdateMode) {
     let mut check_only = args.iter().any(|a| a == "--check");
     let insecure = args.iter().any(|a| a == "--insecure");
     let quiet = args.iter().any(|a| a == "--quiet");
@@ -130,7 +144,11 @@ pub fn run(args: &[String]) {
 
     if !quiet {
         println!();
-        println!("  \x1b[1m◆ lean-ctx updater\x1b[0m  \x1b[2mv{CURRENT_VERSION}\x1b[0m");
+        let title = match mode {
+            UpdateMode::Normal => "lean-ctx updater",
+            UpdateMode::EnableGpu => "lean-ctx GPU enablement",
+        };
+        println!("  \x1b[1m◆ {title}\x1b[0m  \x1b[2mv{CURRENT_VERSION}\x1b[0m");
         println!("  \x1b[2mChecking github.com/yvgude/lean-ctx …\x1b[0m");
     }
 
@@ -156,7 +174,7 @@ pub fn run(args: &[String]) {
         std::process::exit(1);
     };
 
-    if target_tag == CURRENT_VERSION {
+    if target_tag == CURRENT_VERSION && mode == UpdateMode::Normal {
         if quiet {
             return;
         }
@@ -195,16 +213,28 @@ pub fn run(args: &[String]) {
         }
     }
 
+    let asset_name = match mode {
+        UpdateMode::Normal => platform_asset_name(),
+        UpdateMode::EnableGpu => match gpu_platform_asset_name() {
+            Ok(name) => name,
+            Err(e) => {
+                tracing::error!("{e}");
+                std::process::exit(1);
+            }
+        },
+    };
+
     if check_only {
-        if pinned {
-            println!("Run 'lean-ctx update {target_tag}' to install.");
-        } else {
-            println!("Run 'lean-ctx update' to install.");
+        match mode {
+            UpdateMode::Normal if pinned => {
+                println!("Run 'lean-ctx update {target_tag}' to install.");
+            }
+            UpdateMode::Normal => println!("Run 'lean-ctx update' to install."),
+            UpdateMode::EnableGpu => println!("Run 'lean-ctx enable-gpu' to install {asset_name}."),
         }
         return;
     }
 
-    let asset_name = platform_asset_name();
     if !quiet {
         println!("  \x1b[2mDownloading {asset_name} …\x1b[0m");
     }
@@ -258,10 +288,17 @@ pub fn run(args: &[String]) {
         println!();
         if pinned {
             println!("  \x1b[1;32m✓ Now running lean-ctx v{target_tag}\x1b[0m");
+        } else if mode == UpdateMode::EnableGpu {
+            println!("  \x1b[1;32m✓ Enabled lean-ctx GPU binary v{target_tag}\x1b[0m");
         } else {
             println!("  \x1b[1;32m✓ Updated to lean-ctx v{target_tag}\x1b[0m");
         }
         println!("  \x1b[2mBinary: {}\x1b[0m", current_exe.display());
+        if mode == UpdateMode::EnableGpu {
+            println!(
+                "  \x1b[2mSet ORT_DYLIB_PATH to your ONNX Runtime GPU lib; lean-ctx auto-detects it.\x1b[0m"
+            );
+        }
     }
 
     if !quiet {
@@ -1075,7 +1112,14 @@ fn platform_asset_name() -> String {
     let target = match (os, arch) {
         ("macos", "aarch64") => "aarch64-apple-darwin".to_string(),
         ("macos", "x86_64") => "x86_64-apple-darwin".to_string(),
-        ("linux", "x86_64") => format!("x86_64-unknown-linux-{}", detect_linux_libc()),
+        ("linux", "x86_64") => {
+            let libc = detect_linux_libc();
+            if current_build_prefers_gpu_asset() && libc == "gnu" {
+                "x86_64-unknown-linux-gnu-cuda".to_string()
+            } else {
+                format!("x86_64-unknown-linux-{libc}")
+            }
+        }
         ("linux", "aarch64") => format!("aarch64-unknown-linux-{}", detect_linux_libc()),
         ("windows", "x86_64") => "x86_64-pc-windows-msvc".to_string(),
         _ => {
@@ -1092,6 +1136,26 @@ fn platform_asset_name() -> String {
     } else {
         format!("lean-ctx-{target}.tar.gz")
     }
+}
+
+fn gpu_platform_asset_name() -> Result<String, String> {
+    if std::env::consts::OS != "linux" || std::env::consts::ARCH != "x86_64" {
+        return Err(
+            "CUDA binary is currently published for x86_64 GNU/Linux only. Use `lean-ctx update` for the CPU binary or build with --features ort-cuda."
+                .to_string(),
+        );
+    }
+    if detect_linux_libc() != "gnu" {
+        return Err(
+            "CUDA binary requires GNU libc Linux. This system detected musl; use the CPU binary or build with --features ort-cuda."
+                .to_string(),
+        );
+    }
+    Ok("lean-ctx-x86_64-unknown-linux-gnu-cuda.tar.gz".to_string())
+}
+
+fn current_build_prefers_gpu_asset() -> bool {
+    cfg!(feature = "ort-cuda")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds first-class opt-in GPU runtime support for semantic embedding indexes.

This PR adds a CUDA-enabled Linux x86_64 release artifact, installer/update paths for that artifact, execution-provider policy handling, GPU fallback diagnostics, GPU-aware embedding batch sizing, and cooperative cancellation during long embedding index builds.

Main changes:
- Add CUDA release artifact: `lean-ctx-x86_64-unknown-linux-gnu-cuda.tar.gz`.
- Add `install.sh --cuda` / `--gpu`.
- Add `lean-ctx enable-gpu`.
- Add `LEAN_CTX_ORT_EXECUTION_PROVIDER=cpu|gpu|auto`.
- Extend `lean-ctx embeddings status` with provider policy/status details.
- Route embeddings and neural line scorer through the provider policy.
- Detect missing CUDA/cuDNN runtime dependencies before treating GPU as active.
- Warn when GPU was requested but ONNX Runtime cannot load the CUDA provider runtime.
- Use default embedding batch size 256 on active GPU and 64 on CPU/fallback.
- Log embedding progress per batch.
- Add cooperative Ctrl-C handling for `index build-full` and `index build-semantic`.

Fixes #763

## Test plan

- [x] `cd rust && cargo check --release --features ort-cuda`
- [x] `cd rust && cargo build --features ort-cuda`
- [x] `cd rust && cargo build --release --features ort-cuda`
- [x] Release GPU smoke test with `LEAN_CTX_ORT_EXECUTION_PROVIDER=gpu`
- [x] Full semantic index build of this repository with miniLM + CUDA provider
- [ ] `cd rust && cargo test`
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

Validation details:
- CUDA provider registered successfully via ONNX Runtime.
- No GPU fallback warning when CUDA/cuDNN runtime libraries are available.
- Full repo semantic indexing completed successfully:
  - 2261 files
  - 28086 chunks
  - 109s wall time
  - `LEAN_CTX_EMBEDDING_MODEL=minilm`
  - `LEAN_CTX_ORT_EXECUTION_PROVIDER=gpu`
  - `LEAN_CTX_EMBEDDING_BATCH_SIZE=128`

A clean detached worktree validation without the local rmcp patch was attempted, but crates.io download of `rmcp v2.0.0` timed out before compilation.

## Notes for reviewers

- Risk areas / edge cases:
  - CUDA provider detection uses a direct `dlopen` probe to catch missing transitive CUDA/cuDNN libraries. A direct load may fail on ORT host symbols such as `Provider_GetHost` after dependencies are resolved; this is treated as a successful dependency probe because ORT itself loads provider plugins through `libonnxruntime`.
  - `lean-ctx enable-gpu` intentionally proceeds even when the current version is already installed, because the user may be switching from the CPU artifact to the GPU artifact for the same release tag.
  - CUDA binary publishing is currently limited to x86_64 GNU/Linux.

- Backwards compatibility:
  - CPU remains the default behavior.
  - Existing `lean-ctx update` behavior remains unchanged for CPU artifacts.
  - GPU execution is opt-in through the CUDA artifact and/or `LEAN_CTX_ORT_EXECUTION_PROVIDER`.
  - If GPU runtime dependencies are missing, ORT can still fall back to CPU, but lean-ctx now warns and avoids GPU-sized batches.

- Docs updated (links/files):
  - `install.sh` help now documents `--cuda`.
  - CLI help now documents `lean-ctx enable-gpu`.
  - `lean-ctx embeddings status` now reports execution-provider policy/help.

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
