### PR TITLE
fix: prevent XDG data-dir split-brain hiding dashboard history after upgrade

### DIFF
--- a/LEAN-CTX.md
+++ b/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 6 -->
+<!-- version: 8 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 
@@ -18,27 +18,26 @@ NEVER use native Read/Grep/Shell/Glob when a ctx_* equivalent exists. SELF-CORRE
 Tool selection by intent:
 • Orient / understand code (call FIRST) -> ctx_compose
 • Read a file -> ctx_read(path, mode=signatures|map|full); edit after reading -> ctx_patch
-• Exact symbol -> ctx_symbol; pattern -> ctx_search; by meaning -> ctx_semantic_search
+• Exact symbol -> ctx_search(action=symbol); pattern -> ctx_search; by meaning -> ctx_search(action=semantic)
 • Files by glob -> ctx_glob; structure -> ctx_tree; callers/impact -> ctx_callgraph
 • Verify after edits -> ctx_shell(test/build); memory -> ctx_session / ctx_knowledge
 Semantic questions -> search tools, not whole-file reads: reading more ≠ understanding more.
 
 AGENT LOOP (phase -> tool):
 • Orient — understand before acting -> ctx_compose
-• Find — exact symbol by name -> ctx_symbol
+• Find — exact symbol by name -> ctx_search(action=symbol)
 • Read — a file, structurally -> ctx_read(mode=signatures|map)
 • Locate — a pattern across files -> ctx_search
 • Trace — callers / callees / blast radius -> ctx_callgraph
 • Verify — after an edit -> ctx_shell(test/build) + native lints
 
 Anti-patterns — do NOT:
-• Chain ctx_search -> ctx_read -> ctx_symbol — one ctx_compose replaces all three
+• Chain ctx_search -> ctx_read -> ctx_search(action=symbol) — one ctx_compose replaces all three
 • Use ctx_read(mode=full) for orientation — use mode=signatures
-• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call
-edges and file deps only; use ctx_search instead
+• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call edges and file deps only; use ctx_search instead
 
 NAVIGATION PARADOX: reading more ≠ understanding more.
-• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_semantic_search (meaning), not whole-file reads
+• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_search(action=semantic) (meaning), not whole-file reads
 • Hidden architectural deps (who calls this, what breaks) -> ctx_callgraph / ctx_graph — for these only
 • Navigate structure (signatures, symbols) before reading entire files
 

--- a/rust/LEAN-CTX.md
+++ b/rust/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 6 -->
+<!-- version: 8 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 
@@ -18,27 +18,26 @@ NEVER use native Read/Grep/Shell/Glob when a ctx_* equivalent exists. SELF-CORRE
 Tool selection by intent:
 • Orient / understand code (call FIRST) -> ctx_compose
 • Read a file -> ctx_read(path, mode=signatures|map|full); edit after reading -> ctx_patch
-• Exact symbol -> ctx_symbol; pattern -> ctx_search; by meaning -> ctx_semantic_search
+• Exact symbol -> ctx_search(action=symbol); pattern -> ctx_search; by meaning -> ctx_search(action=semantic)
 • Files by glob -> ctx_glob; structure -> ctx_tree; callers/impact -> ctx_callgraph
 • Verify after edits -> ctx_shell(test/build); memory -> ctx_session / ctx_knowledge
 Semantic questions -> search tools, not whole-file reads: reading more ≠ understanding more.
 
 AGENT LOOP (phase -> tool):
 • Orient — understand before acting -> ctx_compose
-• Find — exact symbol by name -> ctx_symbol
+• Find — exact symbol by name -> ctx_search(action=symbol)
 • Read — a file, structurally -> ctx_read(mode=signatures|map)
 • Locate — a pattern across files -> ctx_search
 • Trace — callers / callees / blast radius -> ctx_callgraph
 • Verify — after an edit -> ctx_shell(test/build) + native lints
 
 Anti-patterns — do NOT:
-• Chain ctx_search -> ctx_read -> ctx_symbol — one ctx_compose replaces all three
+• Chain ctx_search -> ctx_read -> ctx_search(action=symbol) — one ctx_compose replaces all three
 • Use ctx_read(mode=full) for orientation — use mode=signatures
-• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call
-edges and file deps only; use ctx_search instead
+• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call edges and file deps only; use ctx_search instead
 
 NAVIGATION PARADOX: reading more ≠ understanding more.
-• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_semantic_search (meaning), not whole-file reads
+• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_search(action=semantic) (meaning), not whole-file reads
 • Hidden architectural deps (who calls this, what breaks) -> ctx_callgraph / ctx_graph — for these only
 • Navigate structure (signatures, symbols) before reading entire files
 

--- a/rust/src/core/data_dir.rs
+++ b/rust/src/core/data_dir.rs
@@ -349,6 +349,11 @@ mod tests {
 
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", "");
         crate::test_env::set_var("XDG_CONFIG_HOME", xdg_base.to_str().unwrap());
+        // Isolate XDG_DATA_HOME to an empty base so the mixed config dir (not a
+        // pre-existing XDG data tree) is what wins here.
+        let xdg_data_base = std::env::temp_dir().join("test_xdg_override_wins_data");
+        let _ = std::fs::remove_dir_all(&xdg_data_base);
+        crate::test_env::set_var("XDG_DATA_HOME", xdg_data_base.to_str().unwrap());
 
         // Calls the home resolver directly: lean_ctx_data_dir() is sandboxed
         // under cfg(test) (GL #512) and would short-circuit before XDG logic.
@@ -356,6 +361,7 @@ mod tests {
 
         crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
         crate::test_env::remove_var("XDG_CONFIG_HOME");
+        crate::test_env::remove_var("XDG_DATA_HOME");
 
         let home = dirs::home_dir().unwrap();
         let legacy = home.join(".lean-ctx");
@@ -367,6 +373,7 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&xdg_base);
+        let _ = std::fs::remove_dir_all(&xdg_data_base);
     }
 
     #[cfg(unix)]

--- a/rust/src/core/paths.rs
+++ b/rust/src/core/paths.rs
@@ -90,7 +90,8 @@ pub(crate) fn single_dir_override() -> Option<PathBuf> {
     }
     let home = dirs::home_dir()?;
     let xdg_config_base = xdg_base("XDG_CONFIG_HOME", ".config").ok()?;
-    single_dir_override_fs(&home, &xdg_config_base)
+    let xdg_data_base = xdg_base("XDG_DATA_HOME", ".local/share").ok();
+    single_dir_override_fs(&home, &xdg_config_base, xdg_data_base.as_deref())
 }
 
 /// True when `p` is exactly the standard XDG data dir (`$XDG_DATA_HOME/lean-ctx`,
@@ -114,7 +115,11 @@ pub(crate) fn data_pin_diverges_config(pin: &Path) -> bool {
 }
 
 /// Filesystem half of [`single_dir_override`], parameterized for hermetic tests.
-fn single_dir_override_fs(home: &Path, xdg_config_base: &Path) -> Option<PathBuf> {
+fn single_dir_override_fs(
+    home: &Path,
+    xdg_config_base: &Path,
+    xdg_data_base: Option<&Path>,
+) -> Option<PathBuf> {
     // A committed XDG install is the single source of truth: never re-collapse
     // it onto a stray legacy/mixed data marker (GL #623). The pin lives next to
     // the mixed probe below, so the two reads always agree on `xdg_config_base`.
@@ -127,6 +132,17 @@ fn single_dir_override_fs(home: &Path, xdg_config_base: &Path) -> Option<PathBuf
     }
     let mixed = xdg_config_base.join("lean-ctx");
     if mixed.exists() && has_data_files(&mixed) {
+        // GL #623 follow-up: an already-split XDG install (real data under
+        // `$XDG_DATA_HOME/lean-ctx`) must NOT re-collapse config/state/cache/data
+        // onto the *config* dir just because a stray data marker leaked there
+        // (e.g. during an upgrade, before the layout pin is written). That would
+        // scatter stats/events/journal/sessions into `$XDG_CONFIG_HOME` and split
+        // history across two trees.
+        if let Some(data_base) = xdg_data_base
+            && has_data_files(&data_base.join("lean-ctx"))
+        {
+            return None;
+        }
         return Some(mixed);
     }
     None
@@ -347,7 +363,7 @@ mod tests {
         std::fs::write(legacy.join("stats.json"), "{}").unwrap();
 
         assert_eq!(
-            single_dir_override_fs(home.path(), xdg.path()),
+            single_dir_override_fs(home.path(), xdg.path(), None),
             Some(legacy)
         );
     }
@@ -362,7 +378,10 @@ mod tests {
         // lives alone in the config dir and must not trigger single-dir mode.
         std::fs::write(mixed.join("stats.json"), "{}").unwrap();
 
-        assert_eq!(single_dir_override_fs(home.path(), xdg.path()), Some(mixed));
+        assert_eq!(
+            single_dir_override_fs(home.path(), xdg.path(), None),
+            Some(mixed)
+        );
     }
 
     #[test]
@@ -376,7 +395,7 @@ mod tests {
         std::fs::write(mixed.join("config.toml"), "").unwrap();
         std::fs::write(mixed.join("shell-hook.zsh"), "").unwrap();
 
-        assert_eq!(single_dir_override_fs(home.path(), xdg.path()), None);
+        assert_eq!(single_dir_override_fs(home.path(), xdg.path(), None), None);
     }
 
     #[test]
@@ -391,7 +410,7 @@ mod tests {
         std::fs::write(mixed.join("stats.json"), "{}").unwrap();
 
         assert_eq!(
-            single_dir_override_fs(home.path(), xdg.path()),
+            single_dir_override_fs(home.path(), xdg.path(), None),
             Some(legacy)
         );
     }
@@ -409,7 +428,7 @@ mod tests {
         std::fs::create_dir_all(&legacy).unwrap();
         std::fs::write(legacy.join("stats.json"), "{}").unwrap();
 
-        assert_eq!(single_dir_override_fs(home.path(), xdg.path()), None);
+        assert_eq!(single_dir_override_fs(home.path(), xdg.path(), None), None);
     }
 
     #[test]
@@ -423,7 +442,42 @@ mod tests {
         let mixed = xdg.path().join("lean-ctx");
         std::fs::write(mixed.join("stats.json"), "{}").unwrap();
 
-        assert_eq!(single_dir_override_fs(home.path(), xdg.path()), None);
+        assert_eq!(single_dir_override_fs(home.path(), xdg.path(), None), None);
+    }
+
+    #[test]
+    fn split_install_ignores_stray_mixed_marker_when_xdg_data_present() {
+        // Regression: an XDG-split install with real data under
+        // `$XDG_DATA_HOME/lean-ctx` must not re-collapse onto the config dir just
+        // because a stray marker leaked into `$XDG_CONFIG_HOME/lean-ctx` before
+        // the layout pin was written (the upgrade window). Without the guard this
+        // scattered stats/events/journal/sessions into the config dir and split
+        // history across two trees.
+        let home = tempfile::tempdir().unwrap();
+        let xdg_config = tempfile::tempdir().unwrap();
+        let xdg_data = tempfile::tempdir().unwrap();
+
+        let mixed = xdg_config.path().join("lean-ctx");
+        std::fs::create_dir_all(&mixed).unwrap();
+        std::fs::write(mixed.join("stats.json"), "{}").unwrap();
+
+        let data = xdg_data.path().join("lean-ctx");
+        std::fs::create_dir_all(&data).unwrap();
+        std::fs::write(data.join("stats.json"), "{}").unwrap();
+
+        assert_eq!(
+            single_dir_override_fs(home.path(), xdg_config.path(), Some(xdg_data.path())),
+            None,
+            "a populated XDG data dir must keep the config dir from collapsing"
+        );
+
+        // With no real data dir the stray marker still collapses (legacy
+        // single-dir semantics preserved).
+        let empty_data = tempfile::tempdir().unwrap();
+        assert_eq!(
+            single_dir_override_fs(home.path(), xdg_config.path(), Some(empty_data.path())),
+            Some(mixed)
+        );
     }
 
     #[test]
@@ -433,7 +487,7 @@ mod tests {
         std::fs::create_dir_all(home.path().join(".lean-ctx")).unwrap();
         std::fs::create_dir_all(xdg.path().join("lean-ctx")).unwrap();
 
-        assert_eq!(single_dir_override_fs(home.path(), xdg.path()), None);
+        assert_eq!(single_dir_override_fs(home.path(), xdg.path(), None), None);
     }
 
     #[test]
@@ -444,7 +498,7 @@ mod tests {
         std::fs::create_dir_all(&mixed).unwrap();
         std::fs::write(mixed.join("random.txt"), "x").unwrap();
 
-        assert_eq!(single_dir_override_fs(home.path(), xdg.path()), None);
+        assert_eq!(single_dir_override_fs(home.path(), xdg.path(), None), None);
     }
 
     #[test]

--- a/rust/src/core/rules_overhead.rs
+++ b/rust/src/core/rules_overhead.rs
@@ -141,8 +141,7 @@ pub fn collect_rules_files(home: &Path, project: &Path) -> Vec<RulesFileCost> {
     let mut seen = std::collections::HashSet::new();
     out.retain(|f| {
         let canonical = std::fs::canonicalize(&f.path)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| f.path.clone());
+            .map_or_else(|_| f.path.clone(), |p| p.to_string_lossy().to_string());
         seen.insert(canonical)
     });
 


### PR DESCRIPTION
## Summary

Closes #766.

Fix a data-dir resolution split-brain that makes the dashboard history "disappear" after an upgrade (observed on 3.9.3), on WSL/Linux XDG installs.

**Root cause:** `single_dir_override_fs` (`rust/src/core/paths.rs`) re-collapses an already-split XDG install onto the **config dir** as soon as a stray data marker (`stats.json` / `sessions` / `vectors` / `graphs` / `knowledge`) leaks into `$XDG_CONFIG_HOME/lean-ctx` during the pre-pin window of an upgrade. `stats`/`events`/`journal` (via `state_dir()`) and `sessions` (via `data_dir()`) then get written to the config dir, so the dashboard reads a near-empty tree while the real history stays orphaned under `$XDG_DATA_HOME/lean-ctx`. No data is deleted — it is a resolution split, confirmed by `lean-ctx doctor` (`data dir split — stats.json found in 2 locations`, layout `xdg-pinned`).

Ruled out: not `doctor --fix` — `data_consolidate::consolidate()` (the only tree-moving routine) never ran; the `layout.toml` pin is written by the startup self-heal `ensure_pinned()`.

**Fix (`rust/src/core/paths.rs`):**
- `single_dir_override_fs` takes a new `xdg_data_base: Option<&Path>`. In the "mixed" (config-dir) branch it returns `None` (no collapse) when a real `$XDG_DATA_HOME/lean-ctx` tree already holds data. `single_dir_override()` passes `xdg_base("XDG_DATA_HOME", ".local/share")`.
- Also unblocks the chicken-and-egg in `ensure_pinned()` (which skipped when `single_dir_override().is_some()`).
- Updates the 8 test call-sites and adds regression test `split_install_ignores_stray_mixed_marker_when_xdg_data_present`.

**`rust/src/core/data_dir.rs`:** make `xdg_override_with_data_wins` hermetic by isolating `XDG_DATA_HOME` in an empty temp dir (it previously read the machine's real `~/.local/share`, causing a false failure).

## Test plan

- [x] `cargo test --lib -- core::paths core::data_dir core::layout_pin` -> 35 passed, 0 failed (incl. new regression test)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features -- -D warnings` (note: `main` is currently red on an unrelated pre-existing lint at `rust/src/core/rules_overhead.rs:143`)

## Notes for reviewers

- Risk areas / edge cases: behaviour changes only when a populated `$XDG_DATA_HOME/lean-ctx` coexists with a stray marker in the config dir; the legacy single-dir collapse is preserved when no real data dir exists (covered by the new test's second assertion).
- Backwards compatibility: an empty-slice / `None` data base is byte-for-byte the previous behaviour; existing single-dir installs are unaffected.
- Scope: prevents recurrence. An install already split still needs a one-time `lean-ctx doctor --fix` (newer-wins, non-clobber) to merge the two trees — recommend backing up both dirs first.
