### PR TITLE
fix: silence clippy::map_unwrap_or in rules_overhead (unblocks Clippy CI)

### DIFF
--- a/rust/src/core/rules_overhead.rs
+++ b/rust/src/core/rules_overhead.rs
@@ -141,8 +141,7 @@ pub fn collect_rules_files(home: &Path, project: &Path) -> Vec<RulesFileCost> {
     let mut seen = std::collections::HashSet::new();
     out.retain(|f| {
         let canonical = std::fs::canonicalize(&f.path)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| f.path.clone());
+            .map_or_else(|_| f.path.clone(), |p| p.to_string_lossy().to_string());
         seen.insert(canonical)
     });
 


### PR DESCRIPTION
## Summary

Closes #768.

`cargo clippy --all-features -- -D warnings` (the **Clippy** job) currently fails on `main`:

```
error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
   --> rust/src/core/rules_overhead.rs:143:25
    = note: `-D clippy::map-unwrap-or` implied by `-D warnings`
```

Introduced by `bf4ee7bf` (symlink dedup, #759). This also fails the **Embed SDK (lean-ctx-sdk)** job, which clippy-checks the engine lib as a dependency.

Fix: use `map_or_else` (clippy's own suggestion). Behaviour is unchanged — canonicalize the path to a string, else fall back to the original `f.path`.

```rust
let canonical = std::fs::canonicalize(&f.path)
    .map_or_else(|_| f.path.clone(), |p| p.to_string_lossy().to_string());
```

## Test plan

- [x] `cargo clippy --all-features -- -D warnings` -> passes (no errors)
- [x] `cargo fmt --check`

## Notes for reviewers

- Risk areas / edge cases: none — pure lint fix, identical control flow (Ok -> stringified path, Err -> original path).
- Backwards compatibility: unaffected.
