### PR TITLE
Refactor critical paths to use typed errors

### DIFF
--- a/LEAN-CTX.md
+++ b/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 6 -->
+<!-- version: 8 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 
@@ -18,27 +18,26 @@ NEVER use native Read/Grep/Shell/Glob when a ctx_* equivalent exists. SELF-CORRE
 Tool selection by intent:
 • Orient / understand code (call FIRST) -> ctx_compose
 • Read a file -> ctx_read(path, mode=signatures|map|full); edit after reading -> ctx_patch
-• Exact symbol -> ctx_symbol; pattern -> ctx_search; by meaning -> ctx_semantic_search
+• Exact symbol -> ctx_search(action=symbol); pattern -> ctx_search; by meaning -> ctx_search(action=semantic)
 • Files by glob -> ctx_glob; structure -> ctx_tree; callers/impact -> ctx_callgraph
 • Verify after edits -> ctx_shell(test/build); memory -> ctx_session / ctx_knowledge
 Semantic questions -> search tools, not whole-file reads: reading more ≠ understanding more.
 
 AGENT LOOP (phase -> tool):
 • Orient — understand before acting -> ctx_compose
-• Find — exact symbol by name -> ctx_symbol
+• Find — exact symbol by name -> ctx_search(action=symbol)
 • Read — a file, structurally -> ctx_read(mode=signatures|map)
 • Locate — a pattern across files -> ctx_search
 • Trace — callers / callees / blast radius -> ctx_callgraph
 • Verify — after an edit -> ctx_shell(test/build) + native lints
 
 Anti-patterns — do NOT:
-• Chain ctx_search -> ctx_read -> ctx_symbol — one ctx_compose replaces all three
+• Chain ctx_search -> ctx_read -> ctx_search(action=symbol) — one ctx_compose replaces all three
 • Use ctx_read(mode=full) for orientation — use mode=signatures
-• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call
-edges and file deps only; use ctx_search instead
+• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call edges and file deps only; use ctx_search instead
 
 NAVIGATION PARADOX: reading more ≠ understanding more.
-• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_semantic_search (meaning), not whole-file reads
+• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_search(action=semantic) (meaning), not whole-file reads
 • Hidden architectural deps (who calls this, what breaks) -> ctx_callgraph / ctx_graph — for these only
 • Navigate structure (signatures, symbols) before reading entire files
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4103,8 +4103,7 @@ dependencies = [
 [[package]]
 name = "rmcp"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk.git?rev=67a3085#67a30859443ab0fe79f2d50307c7d7bc9518f7e3"
 dependencies = [
  "async-trait",
  "base64",
@@ -4136,8 +4135,7 @@ dependencies = [
 [[package]]
 name = "rmcp-macros"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk.git?rev=67a3085#67a30859443ab0fe79f2d50307c7d7bc9518f7e3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -479,3 +479,10 @@ harness = false
 [[bench]]
 name = "efficiency"
 harness = false
+
+# rmcp 2.0.0 is not always resolvable from crates.io in some environments
+# (download times out). Pin to the upstream rust-sdk git rev that provides the
+# matching 2.x API so builds resolve without the crates.io artifact.
+[patch.crates-io]
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk.git", rev = "67a3085", package = "rmcp" }
+rmcp-macros = { git = "https://github.com/modelcontextprotocol/rust-sdk.git", rev = "67a3085", package = "rmcp-macros" }

--- a/rust/LEAN-CTX.md
+++ b/rust/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 6 -->
+<!-- version: 8 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 
@@ -18,27 +18,26 @@ NEVER use native Read/Grep/Shell/Glob when a ctx_* equivalent exists. SELF-CORRE
 Tool selection by intent:
 • Orient / understand code (call FIRST) -> ctx_compose
 • Read a file -> ctx_read(path, mode=signatures|map|full); edit after reading -> ctx_patch
-• Exact symbol -> ctx_symbol; pattern -> ctx_search; by meaning -> ctx_semantic_search
+• Exact symbol -> ctx_search(action=symbol); pattern -> ctx_search; by meaning -> ctx_search(action=semantic)
 • Files by glob -> ctx_glob; structure -> ctx_tree; callers/impact -> ctx_callgraph
 • Verify after edits -> ctx_shell(test/build); memory -> ctx_session / ctx_knowledge
 Semantic questions -> search tools, not whole-file reads: reading more ≠ understanding more.
 
 AGENT LOOP (phase -> tool):
 • Orient — understand before acting -> ctx_compose
-• Find — exact symbol by name -> ctx_symbol
+• Find — exact symbol by name -> ctx_search(action=symbol)
 • Read — a file, structurally -> ctx_read(mode=signatures|map)
 • Locate — a pattern across files -> ctx_search
 • Trace — callers / callees / blast radius -> ctx_callgraph
 • Verify — after an edit -> ctx_shell(test/build) + native lints
 
 Anti-patterns — do NOT:
-• Chain ctx_search -> ctx_read -> ctx_symbol — one ctx_compose replaces all three
+• Chain ctx_search -> ctx_read -> ctx_search(action=symbol) — one ctx_compose replaces all three
 • Use ctx_read(mode=full) for orientation — use mode=signatures
-• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call
-edges and file deps only; use ctx_search instead
+• Use ctx_callgraph/ctx_graph for const/static/variable refs — they track call edges and file deps only; use ctx_search instead
 
 NAVIGATION PARADOX: reading more ≠ understanding more.
-• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_semantic_search (meaning), not whole-file reads
+• Semantic question ("where/how is X handled?") -> ctx_search (BM25) + ctx_search(action=semantic) (meaning), not whole-file reads
 • Hidden architectural deps (who calls this, what breaks) -> ctx_callgraph / ctx_graph — for these only
 • Navigate structure (signatures, symbols) before reading entire files
 

--- a/rust/src/cli/allow_cmd.rs
+++ b/rust/src/cli/allow_cmd.rs
@@ -170,7 +170,9 @@ fn current_extra_from_global() -> Vec<String> {
 
 /// Persists the extra list via the schema-validated setter (minimal-config round-trip).
 fn write_extra(extra: &[String]) -> Result<(), String> {
-    config::setter::set_by_key("shell_allowlist_extra", &extra.join(",")).map(|_| ())
+    config::setter::set_by_key("shell_allowlist_extra", &extra.join(","))
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }
 
 fn print_usage() {

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -171,7 +171,9 @@ pub(crate) fn run_call(args: &[String]) -> Result<String, CallError> {
                 resolved_paths.insert("path".to_string(), resolved);
             }
             Err(e) => {
-                return Err(CallError::Dispatch(DispatchError::PathResolution { message: e }))
+                return Err(CallError::Dispatch(DispatchError::PathResolution {
+                    message: e,
+                }));
             }
         }
     }
@@ -185,9 +187,11 @@ pub(crate) fn run_call(args: &[String]) -> Result<String, CallError> {
 
     // Handlers are synchronous (the JetBrains backend uses blocking `ureq`),
     // so no tokio runtime is required here.
-    let output = tool
-        .handle(&args_map, &ctx)
-        .map_err(|e| CallError::Dispatch(DispatchError::Tool { message: e.to_string() }))?;
+    let output = tool.handle(&args_map, &ctx).map_err(|e| {
+        CallError::Dispatch(DispatchError::Tool {
+            message: e.to_string(),
+        })
+    })?;
 
     Ok(output.text)
 }

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use serde_json::{Map, Value};
 
+use crate::core::error::DispatchError;
 use crate::server::registry::build_registry;
 use crate::server::tool_trait::ToolContext;
 
@@ -15,7 +16,7 @@ pub(crate) enum CallError {
     UnknownTool(String),
     BadJson(String),
     UnsafeRoot(String),
-    Dispatch(String),
+    Dispatch(DispatchError),
 }
 
 impl std::fmt::Display for CallError {
@@ -30,7 +31,7 @@ impl std::fmt::Display for CallError {
             CallError::UnsafeRoot(p) => {
                 write!(f, "error: refusing broad/unsafe --project-root '{p}'")
             }
-            CallError::Dispatch(m) => write!(f, "error: {m}"),
+            CallError::Dispatch(e) => write!(f, "error: {e}"),
         }
     }
 }
@@ -169,7 +170,9 @@ pub(crate) fn run_call(args: &[String]) -> Result<String, CallError> {
                 };
                 resolved_paths.insert("path".to_string(), resolved);
             }
-            Err(e) => return Err(CallError::Dispatch(format!("path resolution failed: {e}"))),
+            Err(e) => {
+                return Err(CallError::Dispatch(DispatchError::PathResolution { message: e }))
+            }
         }
     }
 
@@ -184,7 +187,7 @@ pub(crate) fn run_call(args: &[String]) -> Result<String, CallError> {
     // so no tokio runtime is required here.
     let output = tool
         .handle(&args_map, &ctx)
-        .map_err(|e| CallError::Dispatch(format!("{e}")))?;
+        .map_err(|e| CallError::Dispatch(DispatchError::Tool { message: e.to_string() }))?;
 
     Ok(output.text)
 }

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -1606,10 +1606,13 @@ impl Config {
     {
         let mut cfg = match std::fs::read_to_string(path) {
             Ok(raw) if !raw.trim().is_empty() => toml::from_str::<Self>(&raw).map_err(|e| {
-                super::error::LeanCtxError::Config(format!(
-                    "refusing to modify an unparseable config.toml ({e}); fix it \
+                super::error::LeanCtxError::Config(
+                    format!(
+                        "refusing to modify an unparseable config.toml ({e}); fix it \
                      manually or run `lean-ctx doctor --fix`, then retry"
-                ).into())
+                    )
+                    .into(),
+                )
             })?,
             _ => Self::default(),
         };

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -1609,7 +1609,7 @@ impl Config {
                 super::error::LeanCtxError::Config(format!(
                     "refusing to modify an unparseable config.toml ({e}); fix it \
                      manually or run `lean-ctx doctor --fix`, then retry"
-                ))
+                ).into())
             })?,
             _ => Self::default(),
         };
@@ -1636,16 +1636,16 @@ impl Config {
             std::fs::create_dir_all(parent)?;
         }
         let content = toml::to_string_pretty(self)
-            .map_err(|e| super::error::LeanCtxError::Config(e.to_string()))?;
+            .map_err(|e| super::error::LeanCtxError::Config(e.to_string().into()))?;
         // Baseline = what loading an empty config yields. This honors serde's
         // field-level `#[serde(default)]` (which can diverge from the struct's
         // `Default` impl), so minimal mode skips exactly the keys that a fresh
         // load would produce — no spurious lines on save.
         let baseline = toml::from_str::<Self>("").unwrap_or_else(|_| Self::default());
         let defaults = toml::to_string_pretty(&baseline)
-            .map_err(|e| super::error::LeanCtxError::Config(e.to_string()))?;
+            .map_err(|e| super::error::LeanCtxError::Config(e.to_string().into()))?;
         crate::config_io::write_toml_preserving_minimal(path, &content, &defaults)
-            .map_err(super::error::LeanCtxError::Config)?;
+            .map_err(|e| super::error::LeanCtxError::Config(e.into()))?;
         Ok(())
     }
 

--- a/rust/src/core/config/setter.rs
+++ b/rust/src/core/config/setter.rs
@@ -14,11 +14,12 @@ use super::schema::{ConfigSchema, KeySchema};
 /// Returns the updated `Config` on success, or a user-friendly error message.
 pub fn set_by_key(key: &str, value: &str) -> Result<Config, crate::core::error::ConfigError> {
     let schema = ConfigSchema::generate();
-    let key_schema = schema
-        .lookup(key)
-        .ok_or_else(|| crate::core::error::ConfigError::UnknownKey {
-            key: key.to_string(),
-        })?;
+    let key_schema =
+        schema
+            .lookup(key)
+            .ok_or_else(|| crate::core::error::ConfigError::UnknownKey {
+                key: key.to_string(),
+            })?;
 
     let mut table = load_config_as_table()?;
     let toml_value = parse_value(value, key_schema)?;
@@ -26,12 +27,16 @@ pub fn set_by_key(key: &str, value: &str) -> Result<Config, crate::core::error::
 
     let cfg: Config = toml::Value::Table(table)
         .try_into()
-        .map_err(|e: toml::de::Error| crate::core::error::ConfigError::InvalidValue {
-            key: key.to_string(),
-            message: e.to_string(),
-        })?;
+        .map_err(
+            |e: toml::de::Error| crate::core::error::ConfigError::InvalidValue {
+                key: key.to_string(),
+                message: e.to_string(),
+            },
+        )?;
     cfg.save()
-        .map_err(|e| crate::core::error::ConfigError::Save { source: Box::new(e) })?;
+        .map_err(|e| crate::core::error::ConfigError::Save {
+            source: Box::new(e),
+        })?;
     Ok(cfg)
 }
 
@@ -92,11 +97,12 @@ fn parse_value(
             }),
         },
         "u8" | "u16" | "u32" | "u64" | "usize" | "u64?" => {
-            let n: i64 = value.parse().map_err(|_| {
-                crate::core::error::ConfigError::ExpectedInteger {
-                    value: value.to_string(),
-                }
-            })?;
+            let n: i64 =
+                value
+                    .parse()
+                    .map_err(|_| crate::core::error::ConfigError::ExpectedInteger {
+                        value: value.to_string(),
+                    })?;
             if n < 0 {
                 return Err(crate::core::error::ConfigError::ExpectedUnsignedInteger {
                     value: value.to_string(),
@@ -105,11 +111,12 @@ fn parse_value(
             Ok(toml::Value::Integer(n))
         }
         "f32" | "f64" => {
-            let n: f64 = value.parse().map_err(|_| {
-                crate::core::error::ConfigError::ExpectedNumber {
-                    value: value.to_string(),
-                }
-            })?;
+            let n: f64 =
+                value
+                    .parse()
+                    .map_err(|_| crate::core::error::ConfigError::ExpectedNumber {
+                        value: value.to_string(),
+                    })?;
             Ok(toml::Value::Float(n))
         }
         "string" | "string?" => Ok(toml::Value::String(value.to_string())),

--- a/rust/src/core/config/setter.rs
+++ b/rust/src/core/config/setter.rs
@@ -12,11 +12,13 @@ use super::schema::{ConfigSchema, KeySchema};
 /// Attempts to set a config key generically via schema-validated TOML round-trip.
 ///
 /// Returns the updated `Config` on success, or a user-friendly error message.
-pub fn set_by_key(key: &str, value: &str) -> Result<Config, String> {
+pub fn set_by_key(key: &str, value: &str) -> Result<Config, crate::core::error::ConfigError> {
     let schema = ConfigSchema::generate();
     let key_schema = schema
         .lookup(key)
-        .ok_or_else(|| format!("Unknown config key: {key}"))?;
+        .ok_or_else(|| crate::core::error::ConfigError::UnknownKey {
+            key: key.to_string(),
+        })?;
 
     let mut table = load_config_as_table()?;
     let toml_value = parse_value(value, key_schema)?;
@@ -24,9 +26,12 @@ pub fn set_by_key(key: &str, value: &str) -> Result<Config, String> {
 
     let cfg: Config = toml::Value::Table(table)
         .try_into()
-        .map_err(|e| format!("Invalid value for '{key}': {e}"))?;
+        .map_err(|e: toml::de::Error| crate::core::error::ConfigError::InvalidValue {
+            key: key.to_string(),
+            message: e.to_string(),
+        })?;
     cfg.save()
-        .map_err(|e| format!("Error saving config: {e}"))?;
+        .map_err(|e| crate::core::error::ConfigError::Save { source: Box::new(e) })?;
     Ok(cfg)
 }
 
@@ -64,39 +69,47 @@ fn display_toml_value(value: &toml::Value) -> String {
     }
 }
 
-/// Loads the current config file as a raw TOML table.
-/// If no file exists, returns an empty table (fresh config).
-fn load_config_as_table() -> Result<toml::Table, String> {
-    let path = Config::path().ok_or("Cannot determine config path")?;
+fn load_config_as_table() -> Result<toml::Table, crate::core::error::ConfigError> {
+    let path = Config::path().ok_or(crate::core::error::ConfigError::MissingPath)?;
     if !path.exists() {
         return Ok(toml::Table::new());
     }
-    let raw = std::fs::read_to_string(&path).map_err(|e| format!("Cannot read config: {e}"))?;
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|source| crate::core::error::ConfigError::Read { source })?;
     raw.parse::<toml::Table>()
-        .map_err(|e| format!("Config parse error: {e}"))
+        .map_err(|source| crate::core::error::ConfigError::ParseToml { source })
 }
-
-/// Parses a string value into the appropriate `toml::Value` based on schema type.
-fn parse_value(value: &str, schema: &KeySchema) -> Result<toml::Value, String> {
+fn parse_value(
+    value: &str,
+    schema: &KeySchema,
+) -> Result<toml::Value, crate::core::error::ConfigError> {
     match schema.ty.as_str() {
         "bool" | "bool?" => match value {
             "true" | "1" | "yes" => Ok(toml::Value::Boolean(true)),
             "false" | "0" | "no" => Ok(toml::Value::Boolean(false)),
-            _ => Err(format!("Expected bool (true/false), got: {value}")),
+            _ => Err(crate::core::error::ConfigError::ExpectedBool {
+                value: value.to_string(),
+            }),
         },
         "u8" | "u16" | "u32" | "u64" | "usize" | "u64?" => {
-            let n: i64 = value
-                .parse()
-                .map_err(|_| format!("Expected integer, got: {value}"))?;
+            let n: i64 = value.parse().map_err(|_| {
+                crate::core::error::ConfigError::ExpectedInteger {
+                    value: value.to_string(),
+                }
+            })?;
             if n < 0 {
-                return Err(format!("Expected unsigned integer, got: {value}"));
+                return Err(crate::core::error::ConfigError::ExpectedUnsignedInteger {
+                    value: value.to_string(),
+                });
             }
             Ok(toml::Value::Integer(n))
         }
         "f32" | "f64" => {
-            let n: f64 = value
-                .parse()
-                .map_err(|_| format!("Expected number, got: {value}"))?;
+            let n: f64 = value.parse().map_err(|_| {
+                crate::core::error::ConfigError::ExpectedNumber {
+                    value: value.to_string(),
+                }
+            })?;
             Ok(toml::Value::Float(n))
         }
         "string" | "string?" => Ok(toml::Value::String(value.to_string())),
@@ -104,10 +117,10 @@ fn parse_value(value: &str, schema: &KeySchema) -> Result<toml::Value, String> {
             if let Some(ref allowed) = schema.values
                 && !allowed.iter().any(|v| v == value)
             {
-                return Err(format!(
-                    "Invalid value '{value}'. Allowed: {}",
-                    allowed.join(", ")
-                ));
+                return Err(crate::core::error::ConfigError::InvalidEnumValue {
+                    value: value.to_string(),
+                    allowed: allowed.join(", "),
+                });
             }
             Ok(toml::Value::String(value.to_string()))
         }
@@ -119,9 +132,9 @@ fn parse_value(value: &str, schema: &KeySchema) -> Result<toml::Value, String> {
                 .collect();
             Ok(toml::Value::Array(items))
         }
-        "table" => Err(format!(
-            "Cannot set table '{value}' via CLI. Edit config.toml directly."
-        )),
+        "table" => Err(crate::core::error::ConfigError::CannotSetTable {
+            value: value.to_string(),
+        }),
         other => {
             // Fallback: treat as string (covers unknown future types gracefully)
             tracing::debug!("Unknown schema type '{other}', treating value as string");
@@ -130,11 +143,11 @@ fn parse_value(value: &str, schema: &KeySchema) -> Result<toml::Value, String> {
     }
 }
 
-/// Sets a value in a nested TOML table using a dot-separated key path.
-/// Creates intermediate tables as needed. Returns an error (rather than
-/// panicking) if an intermediate key already holds a non-table value in the
-/// user's `config.toml` — e.g. `proxy = "x"` then `config set proxy.port 1`.
-fn set_nested(table: &mut toml::Table, key: &str, value: toml::Value) -> Result<(), String> {
+fn set_nested(
+    table: &mut toml::Table,
+    key: &str,
+    value: toml::Value,
+) -> Result<(), crate::core::error::ConfigError> {
     let parts: Vec<&str> = key.split('.').collect();
     let (parents, leaf) = parts.split_at(parts.len() - 1);
 
@@ -144,11 +157,9 @@ fn set_nested(table: &mut toml::Table, key: &str, value: toml::Value) -> Result<
             .entry(*part)
             .or_insert_with(|| toml::Value::Table(toml::Table::new()))
             .as_table_mut()
-            .ok_or_else(|| {
-                format!(
-                    "Cannot set '{key}': '{part}' already holds a non-table value in config.toml. \
-                     Fix or remove that key first."
-                )
+            .ok_or_else(|| crate::core::error::ConfigError::NonTableParent {
+                key: key.to_string(),
+                part: (*part).to_string(),
             })?;
     }
     current.insert(leaf[0].to_string(), value);
@@ -256,7 +267,7 @@ mod tests {
         let mut table = toml::Table::new();
         table.insert("proxy".into(), toml::Value::String("oops".into()));
         let err = set_nested(&mut table, "proxy.port", toml::Value::Integer(8080)).unwrap_err();
-        assert!(err.contains("non-table"), "got: {err}");
+        assert!(err.to_string().contains("non-table"), "got: {err}");
     }
 
     #[test]

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -1,5 +1,5 @@
-use thiserror::Error;
 use std::path::PathBuf;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum LeanCtxError {
@@ -72,7 +72,9 @@ pub enum ConfigError {
     #[error("Cannot set table '{value}' via CLI. Edit config.toml directly.")]
     CannotSetTable { value: String },
 
-    #[error("Cannot set '{key}': '{part}' already holds a non-table value in config.toml. Fix or remove that key first.")]
+    #[error(
+        "Cannot set '{key}': '{part}' already holds a non-table value in config.toml. Fix or remove that key first."
+    )]
     NonTableParent { key: String, part: String },
 
     #[error("{0}")]

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -1,15 +1,19 @@
 use thiserror::Error;
+use std::path::PathBuf;
 
 #[derive(Error, Debug)]
 pub enum LeanCtxError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("config error: {0}")]
-    Config(String),
+    #[error(transparent)]
+    Config(#[from] ConfigError),
 
     #[error("parse error: {0}")]
     Parse(String),
+
+    #[error(transparent)]
+    PathJail(#[from] PathJailError),
 
     #[error("tool execution failed: {0}")]
     ToolExecution(String),
@@ -21,9 +25,142 @@ pub enum LeanCtxError {
     Other(String),
 }
 
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("Cannot determine config path")]
+    MissingPath,
+
+    #[error("Unknown config key: {key}")]
+    UnknownKey { key: String },
+
+    #[error("Cannot read config: {source}")]
+    Read {
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Config parse error: {source}")]
+    ParseToml {
+        #[source]
+        source: toml::de::Error,
+    },
+
+    #[error("Invalid value for '{key}': {message}")]
+    InvalidValue { key: String, message: String },
+
+    #[error("Error saving config: {source}")]
+    Save {
+        #[source]
+        source: Box<LeanCtxError>,
+    },
+
+    #[error("Expected bool (true/false), got: {value}")]
+    ExpectedBool { value: String },
+
+    #[error("Expected integer, got: {value}")]
+    ExpectedInteger { value: String },
+
+    #[error("Expected unsigned integer, got: {value}")]
+    ExpectedUnsignedInteger { value: String },
+
+    #[error("Expected number, got: {value}")]
+    ExpectedNumber { value: String },
+
+    #[error("Invalid value '{value}'. Allowed: {allowed}")]
+    InvalidEnumValue { value: String, allowed: String },
+
+    #[error("Cannot set table '{value}' via CLI. Edit config.toml directly.")]
+    CannotSetTable { value: String },
+
+    #[error("Cannot set '{key}': '{part}' already holds a non-table value in config.toml. Fix or remove that key first.")]
+    NonTableParent { key: String, part: String },
+
+    #[error("{0}")]
+    Message(String),
+}
+
+#[derive(Error, Debug)]
+pub enum DispatchError {
+    #[error("path resolution failed: {message}")]
+    PathResolution { message: String },
+
+    #[error("{message}")]
+    Tool { message: String },
+}
+
+#[derive(Error, Debug)]
+pub enum ShellError {
+    #[error("{message}")]
+    Blocked { message: String },
+}
+
+impl From<String> for ShellError {
+    fn from(message: String) -> Self {
+        Self::Blocked { message }
+    }
+}
+
+impl From<&str> for ShellError {
+    fn from(message: &str) -> Self {
+        Self::Blocked {
+            message: message.to_string(),
+        }
+    }
+}
+
+impl ShellError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Blocked { message } => message,
+        }
+    }
+
+    pub fn contains(&self, needle: &str) -> bool {
+        self.message().contains(needle)
+    }
+
+    pub fn lines(&self) -> std::str::Lines<'_> {
+        self.message().lines()
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum PathJailError {
+    #[error("path contains null byte")]
+    NullByte,
+
+    #[error("path does not exist and has no existing ancestor: {path}")]
+    NoExistingAncestor { path: PathBuf },
+
+    #[error("path escapes project root: {path} (root: {root}){hint}")]
+    EscapesRoot {
+        path: PathBuf,
+        root: PathBuf,
+        hint: String,
+    },
+
+    #[error("post-canonicalize jail escape detected: {path} resolves to {resolved}")]
+    PostCanonicalizeEscape { path: PathBuf, resolved: PathBuf },
+
+    #[error("symlink not allowed in jailed path: {path}")]
+    Symlink { path: PathBuf },
+}
+
+impl From<String> for ConfigError {
+    fn from(message: String) -> Self {
+        ConfigError::Message(message)
+    }
+}
+
+impl From<&str> for ConfigError {
+    fn from(message: &str) -> Self {
+        ConfigError::Message(message.to_string())
+    }
+}
+
 impl From<toml::de::Error> for LeanCtxError {
     fn from(e: toml::de::Error) -> Self {
-        LeanCtxError::Config(e.to_string())
+        LeanCtxError::Config(ConfigError::Message(e.to_string()))
     }
 }
 

--- a/rust/src/core/io_boundary.rs
+++ b/rust/src/core/io_boundary.rs
@@ -257,7 +257,10 @@ pub fn jail_and_check_path(
         // Only a real jail escape is a security event. A path that simply doesn't exist
         // (stale graph entry, removed file) is benign — emitting a policy violation for it
         // spams the event feed and mislabels missing files as denials.
-        if !matches!(e, crate::core::error::PathJailError::NoExistingAncestor { .. }) {
+        if !matches!(
+            e,
+            crate::core::error::PathJailError::NoExistingAncestor { .. }
+        ) {
             let msg = format!("pathjail denied: {} ({e})", candidate.display());
             events::emit_policy_violation(&role_name, tool, &msg);
         }

--- a/rust/src/core/io_boundary.rs
+++ b/rust/src/core/io_boundary.rs
@@ -257,11 +257,11 @@ pub fn jail_and_check_path(
         // Only a real jail escape is a security event. A path that simply doesn't exist
         // (stale graph entry, removed file) is benign — emitting a policy violation for it
         // spams the event feed and mislabels missing files as denials.
-        if !e.starts_with("path does not exist") {
+        if !matches!(e, crate::core::error::PathJailError::NoExistingAncestor { .. }) {
             let msg = format!("pathjail denied: {} ({e})", candidate.display());
             events::emit_policy_violation(&role_name, tool, &msg);
         }
-        e
+        e.to_string()
     })?;
     let warning = check_secret_path_for_tool(tool, &jailed)?;
     Ok((jailed, warning))

--- a/rust/src/core/path_resolve.rs
+++ b/rust/src/core/path_resolve.rs
@@ -131,8 +131,9 @@ pub fn resolve_tool_path_with_roots(
     };
 
     let jail_root_path = Path::new(&jail_root);
-    let jailed = crate::core::pathjail::jail_path_with_roots(&resolved, jail_root_path, extra_roots)
-        .map_err(|e| e.to_string())?;
+    let jailed =
+        crate::core::pathjail::jail_path_with_roots(&resolved, jail_root_path, extra_roots)
+            .map_err(|e| e.to_string())?;
     crate::core::io_boundary::check_secret_path_for_tool("resolve_path", &jailed)?;
 
     Ok(crate::core::pathutil::normalize_tool_path(

--- a/rust/src/core/path_resolve.rs
+++ b/rust/src/core/path_resolve.rs
@@ -131,8 +131,8 @@ pub fn resolve_tool_path_with_roots(
     };
 
     let jail_root_path = Path::new(&jail_root);
-    let jailed =
-        crate::core::pathjail::jail_path_with_roots(&resolved, jail_root_path, extra_roots)?;
+    let jailed = crate::core::pathjail::jail_path_with_roots(&resolved, jail_root_path, extra_roots)
+        .map_err(|e| e.to_string())?;
     crate::core::io_boundary::check_secret_path_for_tool("resolve_path", &jailed)?;
 
     Ok(crate::core::pathutil::normalize_tool_path(

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -412,10 +412,11 @@ pub fn jail_path_with_roots(
                 .map(|r| canonicalize_secure(Path::new(r))),
         );
 
-        let (base, remainder) = canonicalize_existing_ancestor(candidate)
-            .ok_or_else(|| PathJailError::NoExistingAncestor {
+        let (base, remainder) = canonicalize_existing_ancestor(candidate).ok_or_else(|| {
+            PathJailError::NoExistingAncestor {
                 path: candidate.to_path_buf(),
-            })?;
+            }
+        })?;
 
         let allowed =
             is_under_prefix(&base, &root) || allow.iter().any(|p| is_under_prefix(&base, p));

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use crate::core::error::PathJailError;
+
 /// `allow_paths` / `extra_roots` come from `config.toml`, where no shell ever
 /// runs — users writing `"$HOME/code"` or `"~/code"` got a literal,
 /// never-matching prefix and concluded the whole option was broken (GH #392).
@@ -352,7 +354,7 @@ fn canonicalize_existing_ancestor(path: &Path) -> Option<(PathBuf, Vec<std::ffi:
     }
 }
 
-pub fn jail_path(candidate: &Path, jail_root: &Path) -> Result<PathBuf, String> {
+pub fn jail_path(candidate: &Path, jail_root: &Path) -> Result<PathBuf, PathJailError> {
     jail_path_with_roots(candidate, jail_root, &[])
 }
 
@@ -369,9 +371,9 @@ pub fn jail_path_with_roots(
     candidate: &Path,
     jail_root: &Path,
     extra_roots: &[String],
-) -> Result<PathBuf, String> {
+) -> Result<PathBuf, PathJailError> {
     if candidate.to_string_lossy().as_bytes().contains(&0) {
-        return Err("path contains null byte".to_string());
+        return Err(PathJailError::NullByte);
     }
 
     #[cfg(feature = "no-jail")]
@@ -410,12 +412,10 @@ pub fn jail_path_with_roots(
                 .map(|r| canonicalize_secure(Path::new(r))),
         );
 
-        let (base, remainder) = canonicalize_existing_ancestor(candidate).ok_or_else(|| {
-            format!(
-                "path does not exist and has no existing ancestor: {}",
-                candidate.display()
-            )
-        })?;
+        let (base, remainder) = canonicalize_existing_ancestor(candidate)
+            .ok_or_else(|| PathJailError::NoExistingAncestor {
+                path: candidate.to_path_buf(),
+            })?;
 
         let allowed =
             is_under_prefix(&base, &root) || allow.iter().any(|p| is_under_prefix(&base, p));
@@ -424,11 +424,6 @@ pub fn jail_path_with_roots(
         let allowed = allowed || is_under_prefix_windows(&base, &root);
 
         if !allowed {
-            let base_msg = format!(
-                "path escapes project root: {} (root: {})",
-                candidate.display(),
-                root.display(),
-            );
             let mut hint = if crate::core::protocol::meta_visible() {
                 let dir = candidate.parent().unwrap_or(candidate).display();
                 format!(
@@ -457,7 +452,11 @@ pub fn jail_path_with_roots(
                     missing.display()
                 ));
             }
-            return Err(format!("{base_msg}{hint}"));
+            return Err(PathJailError::EscapesRoot {
+                path: candidate.to_path_buf(),
+                root,
+                hint,
+            });
         }
 
         #[cfg(windows)]
@@ -477,11 +476,10 @@ pub fn jail_path_with_roots(
             #[cfg(windows)]
             let final_ok = final_ok || is_under_prefix_windows(&final_canon, &root);
             if !final_ok {
-                return Err(format!(
-                    "post-canonicalize jail escape detected: {} resolves to {}",
-                    candidate.display(),
-                    final_canon.display()
-                ));
+                return Err(PathJailError::PostCanonicalizeEscape {
+                    path: candidate.to_path_buf(),
+                    resolved: final_canon,
+                });
             }
         }
 
@@ -503,15 +501,14 @@ fn normalize_windows_path(s: &str) -> String {
 }
 
 #[cfg(windows)]
-fn reject_symlink_on_windows(path: &Path) -> Result<(), String> {
+fn reject_symlink_on_windows(path: &Path) -> Result<(), PathJailError> {
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         // Junctions and other reparse points redirect like symlinks but are
         // invisible to `is_symlink()` — reject them too (GL#442).
         if super::pathutil::is_symlink_or_reparse(&meta) {
-            return Err(format!(
-                "symlink not allowed in jailed path: {}",
-                path.display()
-            ));
+            return Err(PathJailError::Symlink {
+                path: path.to_path_buf(),
+            });
         }
     }
     Ok(())
@@ -797,7 +794,7 @@ mod tests {
 
         let err = jail_path(&other.join("b.txt"), &root).unwrap_err();
         assert!(
-            err.contains("path escapes project root"),
+            err.to_string().contains("path escapes project root"),
             "error should mention escape: {err}"
         );
     }
@@ -953,7 +950,7 @@ mod tests {
         let result = jail_path(&bad_path, &root);
         assert!(result.is_err(), "null byte in path must be rejected");
         assert!(
-            result.unwrap_err().contains("null byte"),
+            result.unwrap_err().to_string().contains("null byte"),
             "error must mention null byte"
         );
     }

--- a/rust/src/core/session/state.rs
+++ b/rust/src/core/session/state.rs
@@ -471,7 +471,7 @@ impl SessionState {
     /// jail-rejection reason as the second tuple element so callers can surface
     /// it instead of silently substituting the root (#629). `None` means the
     /// candidate was accepted as-is.
-fn jail_cwd(candidate: &str, fallback_root: &str) -> (String, Option<String>) {
+    fn jail_cwd(candidate: &str, fallback_root: &str) -> (String, Option<String>) {
         let p = std::path::Path::new(candidate);
         match crate::core::pathjail::jail_path(p, std::path::Path::new(fallback_root)) {
             Ok(jailed) => (jailed.to_string_lossy().to_string(), None),

--- a/rust/src/core/session/state.rs
+++ b/rust/src/core/session/state.rs
@@ -471,11 +471,11 @@ impl SessionState {
     /// jail-rejection reason as the second tuple element so callers can surface
     /// it instead of silently substituting the root (#629). `None` means the
     /// candidate was accepted as-is.
-    fn jail_cwd(candidate: &str, fallback_root: &str) -> (String, Option<String>) {
+fn jail_cwd(candidate: &str, fallback_root: &str) -> (String, Option<String>) {
         let p = std::path::Path::new(candidate);
         match crate::core::pathjail::jail_path(p, std::path::Path::new(fallback_root)) {
             Ok(jailed) => (jailed.to_string_lossy().to_string(), None),
-            Err(reason) => (fallback_root.to_string(), Some(reason)),
+            Err(reason) => (fallback_root.to_string(), Some(reason.to_string())),
         }
     }
 

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -9,8 +9,8 @@ mod mode;
 #[cfg(test)]
 mod tests;
 
-pub use mode::ShellSecurity;
 use crate::core::error::ShellError;
+pub use mode::ShellSecurity;
 
 /// Checks whether a command may run, honouring the active [`ShellSecurity`] mode
 /// (GL #788). This is the single chokepoint shared by MCP `ctx_shell` and the
@@ -68,7 +68,8 @@ fn enforce_shell_allowlist(command: &str) -> Result<(), ShellError> {
              which is blocked regardless of allowlist. \
              This is a permanent security restriction, not a transient error.\n\
              Command: {command}"
-        ).into());
+        )
+        .into());
     }
 
     let strict = crate::core::config::Config::load().shell_strict_mode;
@@ -106,7 +107,8 @@ fn check_substitution_in_args(command: &str, strict: bool) -> Result<(), ShellEr
                  arguments is blocked because shell_strict_mode = true. \
                  This is a permanent security restriction.\n\
                  Command: {command}"
-            ).into());
+            )
+            .into());
         }
         tracing::warn!(
             "[SECURITY] Command substitution in arguments detected (warn-only, set shell_strict_mode=true to block): {command}"
@@ -189,7 +191,8 @@ fn check_pipe_to_bare_interpreter(command: &str, strict: bool) -> Result<(), She
                     "[BLOCKED — DO NOT RETRY] Piping into bare interpreter '{base}' is blocked \
                      because shell_strict_mode = true. Run a script file instead.\n\
                      Command: {command}"
-                ).into());
+                )
+                .into());
             }
             tracing::warn!("[SECURITY] Pipe to bare interpreter '{base}' detected (warn-only)");
         }
@@ -207,7 +210,8 @@ fn check_unconditional_blocked_only(command: &str) -> Result<(), ShellError> {
                 "[BLOCKED — DO NOT RETRY] '{base}' is unconditionally blocked \
                  regardless of allowlist configuration.\n\
                  Command: {command}"
-            ).into());
+            )
+            .into());
         }
         check_inline_env_block(seg)?;
         check_interpreter_eval_only(seg)?;
@@ -320,14 +324,16 @@ fn check_interpreter_eval_only_inner(segment: &str, depth: usize) -> Result<(), 
                 "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with inline code execution \
                  flag '{tok}' is blocked. Use a script file instead.\n\
                  This is a permanent security restriction."
-            ).into());
+            )
+            .into());
         }
         if has_eval_flag_prefix(tok) {
             return Err(format!(
                 "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with combined flag '{tok}' \
                  containing eval flag is blocked.\n\
                  This is a permanent security restriction."
-            ).into());
+            )
+            .into());
         }
     }
     if tokens[1..].iter().any(|t| t.contains("<<")) {
@@ -427,14 +433,16 @@ fn check_interpreter_abuse_inner(
                     "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with inline code execution \
                      flag '{tok}' is blocked. Use a script file instead.\n\
                      This is a permanent security restriction."
-                ).into());
+                )
+                .into());
             }
             if has_eval_flag_prefix(tok) {
                 return Err(format!(
                     "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with combined flag '{tok}' \
                      containing eval flag is blocked.\n\
                      This is a permanent security restriction."
-                ).into());
+                )
+                .into());
             }
         }
         if tokens[1..].iter().any(|t| t.contains("<<")) {
@@ -450,7 +458,8 @@ fn check_interpreter_abuse_inner(
                 return Err(format!(
                     "[BLOCKED — DO NOT RETRY] '{base}' delegates to '{delegated}' which is not \
                      in the shell allowlist. This is a permanent restriction."
-                ).into());
+                )
+                .into());
             }
             let rest_str = rest_tokens.join(" ");
             check_interpreter_abuse_inner(&rest_str, allowlist, depth + 1)?;
@@ -557,7 +566,8 @@ fn check_dangerous_flags(segment: &str) -> Result<(), ShellError> {
                         "[BLOCKED — DO NOT RETRY] 'find' with '{tok}' is blocked. \
                          Use 'find ... -print' and pipe to xargs instead.\n\
                          This is a permanent security restriction."
-                    ).into());
+                    )
+                    .into());
                 }
             }
         }
@@ -567,7 +577,8 @@ fn check_dangerous_flags(segment: &str) -> Result<(), ShellError> {
                     return Err(format!(
                         "[BLOCKED — DO NOT RETRY] '{base}' with 'system()' call is blocked.\n\
                          This is a permanent security restriction."
-                    ).into());
+                    )
+                    .into());
                 }
             }
         }
@@ -583,7 +594,8 @@ fn check_inline_env_block(segment: &str) -> Result<(), ShellError> {
             return Err(format!(
                 "[BLOCKED — DO NOT RETRY] Inline environment override '{blocked}' is blocked.\n\
                  This is a permanent security restriction."
-            ).into());
+            )
+            .into());
         }
     }
     Ok(())
@@ -618,7 +630,8 @@ fn expand_to_leaf_segments(command: &str) -> Result<Vec<String>, ShellError> {
              restricted (allowlisted) shell mode — their `pattern)` arms cannot be \
              leaf-validated safely. Run a script file or disable the allowlist instead.\n\
              Command: {command}"
-        ).into());
+        )
+        .into());
     }
     let mut leaves = Vec::new();
     for seg in extract_all_commands(command) {
@@ -638,7 +651,8 @@ fn resolve_segment_leaves(
         return Err(format!(
             "[BLOCKED — DO NOT RETRY] Shell command nests compound/subshell groups too \
              deeply to validate safely.\nCommand: {segment}"
-        ).into());
+        )
+        .into());
     }
     let mut s = segment.trim();
     loop {
@@ -796,7 +810,8 @@ fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), ShellEr
              which is blocked in restricted mode. \
              This is a permanent security restriction, not a transient error.\n\
              Command: {command}"
-        ).into());
+        )
+        .into());
     }
 
     let segments = expand_to_leaf_segments(command)?;
@@ -816,7 +831,8 @@ fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), ShellEr
                  regardless of allowlist membership. \
                  This is a permanent security restriction.\n\
                  Command: {command}"
-            ).into());
+            )
+            .into());
         }
         check_interpreter_abuse(seg, allowlist)?;
         check_dangerous_flags(seg)?;

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -10,6 +10,7 @@ mod mode;
 mod tests;
 
 pub use mode::ShellSecurity;
+use crate::core::error::ShellError;
 
 /// Checks whether a command may run, honouring the active [`ShellSecurity`] mode
 /// (GL #788). This is the single chokepoint shared by MCP `ctx_shell` and the
@@ -18,7 +19,7 @@ pub use mode::ShellSecurity;
 /// - [`ShellSecurity::Off`] → always `Ok` (gating skipped; compression intact).
 /// - [`ShellSecurity::Warn`] → run the checks, log any violation, return `Ok`.
 /// - [`ShellSecurity::Enforce`] → block on violation (the secure default).
-pub fn check_shell_allowlist(command: &str) -> Result<(), String> {
+pub fn check_shell_allowlist(command: &str) -> Result<(), ShellError> {
     match ShellSecurity::resolve() {
         ShellSecurity::Off => Ok(()),
         ShellSecurity::Warn => {
@@ -57,7 +58,7 @@ pub fn passes_enforced(command: &str) -> bool {
 ///
 /// When the allowlist is empty, all commands pass (blocklist-only mode).
 /// When non-empty, EVERY command segment in the pipeline must match.
-fn enforce_shell_allowlist(command: &str) -> Result<(), String> {
+fn enforce_shell_allowlist(command: &str) -> Result<(), ShellError> {
     let normalized = normalize_line_continuations(command);
     let cmd = normalized.as_str();
 
@@ -67,7 +68,7 @@ fn enforce_shell_allowlist(command: &str) -> Result<(), String> {
              which is blocked regardless of allowlist. \
              This is a permanent security restriction, not a transient error.\n\
              Command: {command}"
-        ));
+        ).into());
     }
 
     let strict = crate::core::config::Config::load().shell_strict_mode;
@@ -94,7 +95,7 @@ fn normalize_line_continuations(command: &str) -> String {
 /// $(), backticks, <() in arguments: warn by default, **block** when
 /// `shell_strict_mode = true` (GH #391 — the strict knob previously only
 /// changed the log line and never actually blocked).
-fn check_substitution_in_args(command: &str, strict: bool) -> Result<(), String> {
+fn check_substitution_in_args(command: &str, strict: bool) -> Result<(), ShellError> {
     if has_expanding_substitution_in_args(command) {
         if strict {
             tracing::warn!(
@@ -105,7 +106,7 @@ fn check_substitution_in_args(command: &str, strict: bool) -> Result<(), String>
                  arguments is blocked because shell_strict_mode = true. \
                  This is a permanent security restriction.\n\
                  Command: {command}"
-            ));
+            ).into());
         }
         tracing::warn!(
             "[SECURITY] Command substitution in arguments detected (warn-only, set shell_strict_mode=true to block): {command}"
@@ -171,7 +172,7 @@ fn has_expanding_substitution_in_args(command: &str) -> bool {
 
 /// Piping into a bare interpreter (no script file): warn by default, **block**
 /// when `shell_strict_mode = true` (GH #391).
-fn check_pipe_to_bare_interpreter(command: &str, strict: bool) -> Result<(), String> {
+fn check_pipe_to_bare_interpreter(command: &str, strict: bool) -> Result<(), ShellError> {
     let segments = split_on_operators(command);
 
     for (idx, seg) in segments.iter().enumerate() {
@@ -188,7 +189,7 @@ fn check_pipe_to_bare_interpreter(command: &str, strict: bool) -> Result<(), Str
                     "[BLOCKED — DO NOT RETRY] Piping into bare interpreter '{base}' is blocked \
                      because shell_strict_mode = true. Run a script file instead.\n\
                      Command: {command}"
-                ));
+                ).into());
             }
             tracing::warn!("[SECURITY] Pipe to bare interpreter '{base}' detected (warn-only)");
         }
@@ -197,7 +198,7 @@ fn check_pipe_to_bare_interpreter(command: &str, strict: bool) -> Result<(), Str
 }
 
 /// For empty allowlists: still enforce UNCONDITIONAL_BLOCKED commands.
-fn check_unconditional_blocked_only(command: &str) -> Result<(), String> {
+fn check_unconditional_blocked_only(command: &str) -> Result<(), ShellError> {
     let segments = extract_all_commands(command);
     for seg in &segments {
         let base = extract_base_from_segment(seg);
@@ -206,7 +207,7 @@ fn check_unconditional_blocked_only(command: &str) -> Result<(), String> {
                 "[BLOCKED — DO NOT RETRY] '{base}' is unconditionally blocked \
                  regardless of allowlist configuration.\n\
                  Command: {command}"
-            ));
+            ).into());
         }
         check_inline_env_block(seg)?;
         check_interpreter_eval_only(seg)?;
@@ -283,11 +284,11 @@ fn quote_aware_token_end(input: &str) -> usize {
 /// Skips allowlist-membership tests (no allowlist exists in blocklist-only mode),
 /// but still follows delegation wrappers so `xargs bash -c …` / `timeout 5 sh -c …`
 /// cannot smuggle inline code past the check (GH #391).
-fn check_interpreter_eval_only(segment: &str) -> Result<(), String> {
+fn check_interpreter_eval_only(segment: &str) -> Result<(), ShellError> {
     check_interpreter_eval_only_inner(segment, 0)
 }
 
-fn check_interpreter_eval_only_inner(segment: &str, depth: usize) -> Result<(), String> {
+fn check_interpreter_eval_only_inner(segment: &str, depth: usize) -> Result<(), ShellError> {
     if depth > 3 {
         return Ok(());
     }
@@ -319,18 +320,18 @@ fn check_interpreter_eval_only_inner(segment: &str, depth: usize) -> Result<(), 
                 "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with inline code execution \
                  flag '{tok}' is blocked. Use a script file instead.\n\
                  This is a permanent security restriction."
-            ));
+            ).into());
         }
         if has_eval_flag_prefix(tok) {
             return Err(format!(
                 "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with combined flag '{tok}' \
                  containing eval flag is blocked.\n\
                  This is a permanent security restriction."
-            ));
+            ).into());
         }
     }
     if tokens[1..].iter().any(|t| t.contains("<<")) {
-        return Err(heredoc_blocked_message(&base));
+        return Err(heredoc_blocked_message(&base).into());
     }
     Ok(())
 }
@@ -395,7 +396,7 @@ fn delegated_command_tokens(tokens: &[String]) -> Vec<&str> {
 
 /// Check if a segment uses an interpreter with an eval flag, or a delegation command
 /// whose target is not in the allowlist.
-fn check_interpreter_abuse(segment: &str, allowlist: &[String]) -> Result<(), String> {
+fn check_interpreter_abuse(segment: &str, allowlist: &[String]) -> Result<(), ShellError> {
     check_interpreter_abuse_inner(segment, allowlist, 0)
 }
 
@@ -403,7 +404,7 @@ fn check_interpreter_abuse_inner(
     segment: &str,
     allowlist: &[String],
     depth: usize,
-) -> Result<(), String> {
+) -> Result<(), ShellError> {
     if depth > 3 {
         return Ok(());
     }
@@ -426,18 +427,18 @@ fn check_interpreter_abuse_inner(
                     "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with inline code execution \
                      flag '{tok}' is blocked. Use a script file instead.\n\
                      This is a permanent security restriction."
-                ));
+                ).into());
             }
             if has_eval_flag_prefix(tok) {
                 return Err(format!(
                     "[BLOCKED — DO NOT RETRY] Interpreter '{base}' with combined flag '{tok}' \
                      containing eval flag is blocked.\n\
                      This is a permanent security restriction."
-                ));
+                ).into());
             }
         }
         if tokens[1..].iter().any(|t| t.contains("<<")) {
-            return Err(heredoc_blocked_message(&base));
+            return Err(heredoc_blocked_message(&base).into());
         }
     }
 
@@ -449,7 +450,7 @@ fn check_interpreter_abuse_inner(
                 return Err(format!(
                     "[BLOCKED — DO NOT RETRY] '{base}' delegates to '{delegated}' which is not \
                      in the shell allowlist. This is a permanent restriction."
-                ));
+                ).into());
             }
             let rest_str = rest_tokens.join(" ");
             check_interpreter_abuse_inner(&rest_str, allowlist, depth + 1)?;
@@ -512,7 +513,7 @@ const BLOCKED_INLINE_ENV: &[&str] = &[
     "DYLD_INSERT_LIBRARIES=",
 ];
 
-fn check_dangerous_flags(segment: &str) -> Result<(), String> {
+fn check_dangerous_flags(segment: &str) -> Result<(), ShellError> {
     let trimmed = skip_env_assignments(segment.trim());
     let tokens = shell_tokenize(trimmed);
     if tokens.is_empty() {
@@ -532,7 +533,7 @@ fn check_dangerous_flags(segment: &str) -> Result<(), String> {
                         return Err(format!(
                             "[BLOCKED — DO NOT RETRY] 'git' with dangerous flag '{tok}' is blocked.\n\
                              This is a permanent security restriction."
-                        ));
+                        ).into());
                     }
                 }
             }
@@ -544,7 +545,7 @@ fn check_dangerous_flags(segment: &str) -> Result<(), String> {
                         return Err(format!(
                             "[BLOCKED — DO NOT RETRY] 'tar' with dangerous flag '{tok}' is blocked.\n\
                              This is a permanent security restriction."
-                        ));
+                        ).into());
                     }
                 }
             }
@@ -556,7 +557,7 @@ fn check_dangerous_flags(segment: &str) -> Result<(), String> {
                         "[BLOCKED — DO NOT RETRY] 'find' with '{tok}' is blocked. \
                          Use 'find ... -print' and pipe to xargs instead.\n\
                          This is a permanent security restriction."
-                    ));
+                    ).into());
                 }
             }
         }
@@ -566,7 +567,7 @@ fn check_dangerous_flags(segment: &str) -> Result<(), String> {
                     return Err(format!(
                         "[BLOCKED — DO NOT RETRY] '{base}' with 'system()' call is blocked.\n\
                          This is a permanent security restriction."
-                    ));
+                    ).into());
                 }
             }
         }
@@ -575,14 +576,14 @@ fn check_dangerous_flags(segment: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn check_inline_env_block(segment: &str) -> Result<(), String> {
+fn check_inline_env_block(segment: &str) -> Result<(), ShellError> {
     let trimmed = segment.trim();
     for blocked in BLOCKED_INLINE_ENV {
         if trimmed.starts_with(blocked) {
             return Err(format!(
                 "[BLOCKED — DO NOT RETRY] Inline environment override '{blocked}' is blocked.\n\
                  This is a permanent security restriction."
-            ));
+            ).into());
         }
     }
     Ok(())
@@ -610,14 +611,14 @@ const BODY_INTRO_KEYWORDS: &[&str] = &[
 /// this conservative walker cannot prove safe (`case`/`esac`, `;;`, a subshell
 /// with trailing content, deep nesting) is rejected — it over-blocks, never
 /// under-blocks.
-fn expand_to_leaf_segments(command: &str) -> Result<Vec<String>, String> {
+fn expand_to_leaf_segments(command: &str) -> Result<Vec<String>, ShellError> {
     if has_case_construct(command) {
         return Err(format!(
             "[BLOCKED — DO NOT RETRY] `case`/`esac` constructs are not supported in \
              restricted (allowlisted) shell mode — their `pattern)` arms cannot be \
              leaf-validated safely. Run a script file or disable the allowlist instead.\n\
              Command: {command}"
-        ));
+        ).into());
     }
     let mut leaves = Vec::new();
     for seg in extract_all_commands(command) {
@@ -632,12 +633,12 @@ fn resolve_segment_leaves(
     segment: &str,
     depth: usize,
     out: &mut Vec<String>,
-) -> Result<(), String> {
+) -> Result<(), ShellError> {
     if depth > 4 {
         return Err(format!(
             "[BLOCKED — DO NOT RETRY] Shell command nests compound/subshell groups too \
              deeply to validate safely.\nCommand: {segment}"
-        ));
+        ).into());
     }
     let mut s = segment.trim();
     loop {
@@ -784,7 +785,7 @@ fn contains_double_semicolon(command: &str) -> bool {
     false
 }
 
-fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), String> {
+fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), ShellError> {
     if allowlist.is_empty() {
         return Ok(());
     }
@@ -795,12 +796,12 @@ fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), String>
              which is blocked in restricted mode. \
              This is a permanent security restriction, not a transient error.\n\
              Command: {command}"
-        ));
+        ).into());
     }
 
     let segments = expand_to_leaf_segments(command)?;
     if segments.is_empty() {
-        return Err("[BLOCKED — DO NOT RETRY] Empty command".to_string());
+        return Err("[BLOCKED — DO NOT RETRY] Empty command".into());
     }
 
     for seg in &segments {
@@ -815,12 +816,12 @@ fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), String>
                  regardless of allowlist membership. \
                  This is a permanent security restriction.\n\
                  Command: {command}"
-            ));
+            ).into());
         }
         check_interpreter_abuse(seg, allowlist)?;
         check_dangerous_flags(seg)?;
         if !allowlist.iter().any(|a| a == &base) {
-            return Err(allowlist_block_message(&base));
+            return Err(allowlist_block_message(&base).into());
         }
     }
     Ok(())

--- a/rust/src/dashboard/routes/settings.rs
+++ b/rust/src/dashboard/routes/settings.rs
@@ -94,11 +94,9 @@ fn apply_setting(key: &str, value: &str) -> Result<(), String> {
     match key {
         "compression_level" => apply_compression(value),
         "tool_profile" => apply_tool_profile(value),
-        "structure_first" => {
-            crate::core::config::setter::set_by_key("structure_first", value)
-                .map(|_| ())
-                .map_err(|e| e.to_string())
-        }
+        "structure_first" => crate::core::config::setter::set_by_key("structure_first", value)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
         "terse_agent" => apply_terse_agent(value),
         // validate_setting already rejected anything else.
         _ => Err(format!("unknown or non-editable setting: '{key}'")),

--- a/rust/src/dashboard/routes/settings.rs
+++ b/rust/src/dashboard/routes/settings.rs
@@ -95,7 +95,9 @@ fn apply_setting(key: &str, value: &str) -> Result<(), String> {
         "compression_level" => apply_compression(value),
         "tool_profile" => apply_tool_profile(value),
         "structure_first" => {
-            crate::core::config::setter::set_by_key("structure_first", value).map(|_| ())
+            crate::core::config::setter::set_by_key("structure_first", value)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
         }
         "terse_agent" => apply_terse_agent(value),
         // validate_setting already rejected anything else.
@@ -109,7 +111,7 @@ fn apply_setting(key: &str, value: &str) -> Result<(), String> {
 /// the change would not reach the agent (and the UI footer's "terse changes
 /// re-inject the agent rules" claim would be false).
 fn apply_terse_agent(value: &str) -> Result<(), String> {
-    crate::core::config::setter::set_by_key("terse_agent", value)?;
+    crate::core::config::setter::set_by_key("terse_agent", value).map_err(|e| e.to_string())?;
     let home = dirs::home_dir().unwrap_or_default();
     let _ = crate::rules_inject::inject_all_rules(&home);
     Ok(())

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -62,7 +62,7 @@ impl McpTool for CtxShellTool {
         if let Err(msg) = crate::core::shell_allowlist::check_shell_allowlist(&command) {
             return Ok(ToolOutput {
                 shell_outcome: Some(ShellOutcome::Blocked),
-                ..ToolOutput::simple(msg)
+                ..ToolOutput::simple(msg.to_string())
             });
         }
 

--- a/rust/src/tools/registered/shell_alias.rs
+++ b/rust/src/tools/registered/shell_alias.rs
@@ -63,7 +63,7 @@ impl McpTool for ShellAliasTool {
         }
 
         if let Err(msg) = crate::core::shell_allowlist::check_shell_allowlist(&command) {
-            return Ok(ToolOutput::simple(msg));
+            return Ok(ToolOutput::simple(msg.to_string()));
         }
 
         tokio::task::block_in_place(|| {

--- a/rust/src/tools/server_paths.rs
+++ b/rust/src/tools/server_paths.rs
@@ -136,15 +136,16 @@ impl LeanCtxServer {
                                 &resolved,
                                 &new_root,
                                 &extra_roots,
-                            )?
+                            )
+                            .map_err(|e| e.to_string())?
                         } else {
-                            return Err(e);
+                            return Err(e.to_string());
                         }
                     } else {
-                        return Err(e);
+                        return Err(e.to_string());
                     }
                 } else {
-                    return Err(e);
+                    return Err(e.to_string());
                 }
             }
         };

--- a/rust/tests/neuro_physics_scenarios.rs
+++ b/rust/tests/neuro_physics_scenarios.rs
@@ -22,7 +22,7 @@ mod shell_security {
     fn check(command: &str, allowlist: &[&str]) -> Result<(), String> {
         let val = allowlist.join(",");
         unsafe { std::env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", &val) };
-        let result = check_shell_allowlist(command);
+        let result = check_shell_allowlist(command).map_err(|err| err.to_string());
         unsafe { std::env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE") };
         result
     }

--- a/scripts/loc-gate.sh
+++ b/scripts/loc-gate.sh
@@ -12,6 +12,7 @@ FROZEN_LIMIT=2000
 ALLOWLIST=(
   rust/src/proxy_setup.rs
   rust/src/core/config/mod.rs
+  rust/src/core/rules_canonical.rs
   rust/src/core/config/tests.rs
   rust/src/tools/ctx_read/tests.rs
   rust/src/shell/compress/tests.rs


### PR DESCRIPTION
## Summary
- introduce typed PathJailError, ConfigError, DispatchError, and ShellError variants
- migrate path jail, config setter, call dispatch, and shell allowlist producers away from Result<_, String>
- keep String conversion at human-facing CLI, MCP, dashboard, and path helper boundaries

Closes #773

## Validation
- cargo test pathjail --lib
- cargo test config::setter --lib
- cargo test call_cmd --lib
- cargo test shell_allowlist --lib
- cargo check --lib