### PR TITLE
Fix formatting and remove unnecessary newlines

### DIFF
--- a/packages/lean-ctx-bin/postinstall.js
+++ b/packages/lean-ctx-bin/postinstall.js
@@ -229,6 +229,3 @@ main().catch((err) => {
   console.error("Install from source instead: cargo install lean-ctx");
   process.exit(1);
 });
-
-
---- lean-ctx: ctx_compose bundles search+read+symbols in one call ---


### PR DESCRIPTION
caused this error : 
/home/vscode/.nvm/versions/node/v24.18.0/lib/node_modules/lean-ctx-bin/postinstall.js:234 npm error --- lean-ctx: ctx_compose bundles search+read+symbols in one call ---
npm error   ^^^^^^
npm error
npm error SyntaxError: Invalid left-hand side expression in prefix operation
npm error     at wrapSafe (node:internal/modules/cjs/loader:1804:18)
npm error     at Module._compile (node:internal/modules/cjs/loader:1845:20)
npm error     at Object..js (node:internal/modules/cjs/loader:2002:10)
npm error     at Module.load (node:internal/modules/cjs/loader:1594:32)
npm error     at Module._load (node:internal/modules/cjs/loader:1396:12)
npm error     at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
npm error     at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
npm error     at node:internal/main/run_main_module:33:47

## Summary

What does this PR change and why?

## Test plan

- [ ] `cd rust && cargo test`
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases:
- Backwards compatibility:
- Docs updated (links/files):

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
