### PR TITLE
fix(addons): #727 follow-up fixes — pack_dir expansion, declared deps, min_lean_ctx preflight

### DIFF
--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -28,7 +28,7 @@ Two tables: `[addon]` (metadata) and `[mcp]` (how lean-ctx runs the server).
 | `license` | string | `""` | SPDX id (e.g. `Apache-2.0`). |
 | `categories` | string[] | `[]` | Coarse buckets for browsing (e.g. `plans`, `workflow`, `search`). |
 | `keywords` | string[] | `[]` | Free-form search terms. |
-| `min_lean_ctx` | string | `""` | Minimum lean-ctx version targeted (informational). |
+| `min_lean_ctx` | string | `""` | Minimum lean-ctx version required. **Enforced**: `addon add` / `addon update` abort when the running binary is older, naming both versions. Empty = no requirement. |
 | `verified` | bool | `false` | **Registry-controlled** trust tier. `true` only for entries a maintainer has audited and vouched for. Setting it in a hand-written manifest is meaningless — trust is conferred by the registry an entry ships in, not by the entry claiming it. |
 
 ### `[mcp]`

--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -40,7 +40,7 @@ Mirrors a `[[gateway.servers]]` entry — installation is a direct translation.
 | `transport` | `stdio` \| `http` | `stdio` | both | Wire protocol. |
 | `command` | string | `""` | stdio | Executable to spawn. |
 | `args` | string[] | `[]` | stdio | Arguments passed to `command`. |
-| `env` | table | `{}` | stdio | Extra environment variables for the child process. |
+| `env` | table | `{}` | stdio | Extra environment variables for the child process. A value may contain `{pack_dir:@ns/name}`, which lean-ctx expands at install time to the on-disk directory of a declared `kind=skills` dependency. Any other `{…}` pattern, and any `{` without a closing `}`, is rejected at manifest parse. |
 | `sha256` | string | `""` | stdio | Optional SHA-256 pin of the `command` binary (the value `shasum -a 256` prints). When set, the gateway hashes the resolved binary before spawn and refuses a mismatch (fail-closed). Empty = unpinned. |
 | `url` | string | `""` | http | Streamable-HTTP endpoint (must be `http(s)://`). |
 | `headers` | table | `{}` | http | Extra request headers (e.g. auth). |
@@ -106,6 +106,32 @@ all platforms.
 
 The capabilities the user consents to at install are recorded in
 `installed.json` as `granted_capabilities`.
+
+### `[[dependencies]]` (optional, additive in v1)
+
+Context packages this addon needs at runtime, resolved depth-1 against the
+hosted registry and installed **before** the addon is wired.
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `name` | string | — (required) | Scoped package reference `@ns/name`. |
+| `version_req` | string | — (required) | SemVer range (e.g. `^0.2`). Empty or `*` means any version. |
+| `optional` | bool | `false` | `true` → never resolved by `addon add`. A `{pack_dir:…}` placeholder may not name an optional dependency. |
+
+```toml
+[[dependencies]]
+name        = "@dasTholo/lean-md-skills"
+version_req = "^0.2"
+optional    = false
+
+[mcp.env]
+LEAN_MD_SKILLS_DIR = "{pack_dir:@dasTholo/lean-md-skills}"
+```
+
+A dependency must be published to the hosted registry: the resolver looks
+versions up through the registry index only. A pack that exists solely as a
+GitHub release asset (the `[artifacts]` channel) is invisible to it, and
+`addon add` fails with "no installable version matches".
 
 ### `[pricing]` (optional — sellable addons, Track B)
 

--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -28,7 +28,7 @@ Two tables: `[addon]` (metadata) and `[mcp]` (how lean-ctx runs the server).
 | `license` | string | `""` | SPDX id (e.g. `Apache-2.0`). |
 | `categories` | string[] | `[]` | Coarse buckets for browsing (e.g. `plans`, `workflow`, `search`). |
 | `keywords` | string[] | `[]` | Free-form search terms. |
-| `min_lean_ctx` | string | `""` | Minimum lean-ctx version required. **Enforced**: `addon add` / `addon update` abort when the running binary is older, naming both versions. Empty = no requirement. |
+| `min_lean_ctx` | string | `""` | Minimum lean-ctx version required. **Enforced** from the release that introduced `[[dependencies]]` (3.9.x) onward: `addon add` / `addon update` abort when the running binary is older, naming both versions. Caveat: a binary predating that release contains neither the gate nor the `[[dependencies]]` / `{pack_dir:}` feature, so it silently ignores both this field and the declaration — check the running binary's version if the guarantee matters. Empty = no requirement. |
 | `verified` | bool | `false` | **Registry-controlled** trust tier. `true` only for entries a maintainer has audited and vouched for. Setting it in a hand-written manifest is meaningless — trust is conferred by the registry an entry ships in, not by the entry claiming it. |
 
 ### `[mcp]`

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -220,6 +220,15 @@ args = ["serve"]
 # transport = "http"
 # url = "https://my-addon.example.com/mcp"
 # headers = { Authorization = "Bearer ..." }
+
+# Context packages this addon needs at runtime (depth-1, installed first):
+[[dependencies]]
+name        = "@dasTholo/lean-md-skills"
+version_req = "^0.2"
+optional    = false
+
+[mcp.env]
+LEAN_MD_SKILLS_DIR = "{pack_dir:@dasTholo/lean-md-skills}"
 ```
 
 See the [contract](../contracts/addon-manifest-v1.md) for every field.

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -358,7 +358,11 @@ fn cmd_add(target: &str, args: &[String]) {
     // dependency list lives in the addon manifest itself, so a local
     // `lean-ctx-addon.toml` install resolves them the same as a hosted pack
     // (Finding A).
-    let preview_deps = resolve_declared_deps(&manifest.dependencies, &manifest.addon.name, args);
+    // Self-dependency root: the addon's own scoped `@ns/slug` when the source
+    // names a namespace (hosted pack), else `None` (a local manifest cannot
+    // name itself) — never the bare `addon.name` slug (GH #727, Finding A).
+    let root_ref = addon_self_ref(&source);
+    let preview_deps = resolve_declared_deps(&manifest.dependencies, root_ref.as_deref(), args);
     if !preview_deps.is_empty() {
         println!("\nDeclared dependencies (installed alongside, depth-1):");
         for d in &preview_deps {
@@ -385,7 +389,7 @@ fn cmd_add(target: &str, args: &[String]) {
     let installed_deps = if preview_deps.is_empty() {
         Vec::new()
     } else {
-        install_declared_deps(&manifest.dependencies, &manifest.addon.name, args)
+        install_declared_deps(&manifest.dependencies, root_ref.as_deref(), args)
     };
 
     match provision_and_wire(manifest, &source, force, no_verify, &cfg, &installed_deps) {
@@ -756,6 +760,11 @@ fn cmd_update(name: &str, args: &[String]) {
     let force = args.iter().any(|a| a == "--force" || a == "-f");
     let no_verify = args.iter().any(|a| a == "--no-verify");
 
+    // Self-dependency root: the addon's own scoped `@ns/slug` derived from the
+    // (hosted) update source, else `None` — never the bare `addon.name` slug
+    // (GH #727, Finding A). A `local` source already exited above.
+    let root_ref = addon_self_ref(&update_source);
+
     // Up-to-date check: same version and (for managed binaries) same artifact
     // pin ⇒ nothing to do. `--force` reinstalls anyway.
     let same_version = manifest.addon.version == entry.version;
@@ -778,7 +787,7 @@ fn cmd_update(name: &str, args: &[String]) {
         );
         // A skills/context dependency may have bumped even when the addon
         // itself did not (GH #727) — refresh those without re-wiring.
-        refresh_pack_dependencies(&manifest.dependencies, &manifest.addon.name, args);
+        refresh_pack_dependencies(&manifest.dependencies, root_ref.as_deref(), args);
         return;
     }
 
@@ -797,7 +806,7 @@ fn cmd_update(name: &str, args: &[String]) {
         return;
     }
 
-    let preview_deps = resolve_declared_deps(&manifest.dependencies, &manifest.addon.name, args);
+    let preview_deps = resolve_declared_deps(&manifest.dependencies, root_ref.as_deref(), args);
     // The wiring must expand `{pack_dir:}` against the versions the install step
     // actually landed (lockfile honoured), not the preview's highest-match
     // resolution (GH #727, Finding B).
@@ -805,7 +814,7 @@ fn cmd_update(name: &str, args: &[String]) {
         Vec::new()
     } else {
         println!("Installing declared dependencies (depth-1) …");
-        install_declared_deps(&manifest.dependencies, &manifest.addon.name, args)
+        install_declared_deps(&manifest.dependencies, root_ref.as_deref(), args)
     };
 
     let new_version = manifest.addon.version.clone();
@@ -837,12 +846,29 @@ fn cmd_update(name: &str, args: &[String]) {
     }
 }
 
+/// The addon's own **scoped** package reference (`@ns/slug`), derived from the
+/// recorded install `source`. This is the self-dependency root handed to the
+/// depth-1 resolver (GH #727, Finding A): a declared dependency whose name
+/// equals it is the addon depending on its own pack and is refused.
+///
+/// Only a hosted `ctxpkg:@ns/slug@ver` source carries a namespace. A local
+/// manifest (`"local"`) or a bundled-registry slug (`"registry"`) has none, so
+/// a self-reference is unnameable and the guard is deliberately vacuous
+/// (`None`) — never the bare `[addon] name` slug, which could never equal a
+/// scoped `@ns/name` dependency and would only give the guard the false
+/// appearance of being active.
+fn addon_self_ref(source: &str) -> Option<String> {
+    let spec = source.strip_prefix("ctxpkg:")?;
+    let remote_ref = crate::core::context_package::remote::parse_remote_ref(spec)?;
+    Some(format!("@{}/{}", remote_ref.namespace, remote_ref.name))
+}
+
 /// Re-resolve and install the declared dependencies of an addon (GH #727) —
 /// used on `addon update`, where a dependency can move forward independently of
 /// the addon binary.
 fn refresh_pack_dependencies(
     deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: &str,
+    root_name: Option<&str>,
     args: &[String],
 ) {
     if deps.iter().all(|d| d.optional) {
@@ -878,7 +904,7 @@ fn refresh_pack_dependencies(
 /// is always correct; only the pre-consent print can differ.
 fn resolve_declared_deps(
     deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: &str,
+    root_name: Option<&str>,
     args: &[String],
 ) -> Vec<crate::core::context_package::deps::ResolvedDep> {
     if deps.iter().all(|d| d.optional) {
@@ -909,7 +935,7 @@ fn resolve_declared_deps(
 /// `{pack_dir:}` against exactly this returned slice (GH #727, Finding B).
 fn install_declared_deps(
     deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: &str,
+    root_name: Option<&str>,
     args: &[String],
 ) -> Vec<crate::core::context_package::deps::ResolvedDep> {
     let base = crate::core::context_package::remote::registry_base(
@@ -1562,4 +1588,36 @@ fn print_help() {
          \n    \
              Full guide: docs/guides/addons.md"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pure part of the addon install path that GH #727 Finding A got
+    /// wrong: deriving the self-dependency root from the recorded install
+    /// source. A hosted `ctxpkg:@ns/slug@ver` source yields the scoped
+    /// `@ns/slug` the resolver's guard compares against; a `local` manifest or
+    /// a bundled `registry` slug has no namespace, so the guard is deliberately
+    /// vacuous (`None`) — the pre-fix code instead passed the bare `addon.name`
+    /// slug, which could never match a scoped dependency and silently disabled
+    /// the guard on this path.
+    #[test]
+    fn addon_self_ref_is_scoped_for_hosted_sources_and_none_otherwise() {
+        // Hosted pack: scoped `@ns/slug`, version pin stripped.
+        assert_eq!(
+            addon_self_ref("ctxpkg:@dasTholo/lean-md@0.2.0").as_deref(),
+            Some("@dasTholo/lean-md")
+        );
+        assert_eq!(
+            addon_self_ref("ctxpkg:@dasTholo/lean-md").as_deref(),
+            Some("@dasTholo/lean-md")
+        );
+
+        // No namespace ⇒ self-reference unnameable ⇒ guard vacuous.
+        assert_eq!(addon_self_ref("local"), None);
+        assert_eq!(addon_self_ref("registry"), None);
+        // A bare slug is never returned, so the bug (bare root) is unreachable.
+        assert_eq!(addon_self_ref("ctxpkg:demo"), None);
+    }
 }

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -286,7 +286,6 @@ fn cmd_add(target: &str, args: &[String]) {
         || target.starts_with('.')
         || target.starts_with('/')
         || Path::new(target).exists();
-    let mut pack_manifest: Option<crate::core::context_package::PackageManifest> = None;
     let (manifest, source) = if is_local_path {
         match AddonManifest::from_path(Path::new(target)) {
             Ok(m) => (m, "local".to_string()),
@@ -298,10 +297,7 @@ fn cmd_add(target: &str, args: &[String]) {
     } else if let Some(remote_ref) = crate::core::context_package::remote::parse_remote_ref(target)
     {
         match fetch_addon_pack(&remote_ref, flag_value(args, "--registry").as_deref()) {
-            Ok((m, s, pm)) => {
-                pack_manifest = Some(pm);
-                (m, s)
-            }
+            Ok((m, s)) => (m, s),
             Err(e) => {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
@@ -358,11 +354,14 @@ fn cmd_add(target: &str, args: &[String]) {
     print_install_preview(&manifest);
 
     // Depth-1 dependency resolution (GH #727): declared deps are part of the
-    // consent surface — resolve before asking, install before wiring.
-    let resolved_deps = resolve_declared_deps(pack_manifest.as_ref(), args);
-    if !resolved_deps.is_empty() {
+    // consent surface — preview before asking, install before wiring. The
+    // dependency list lives in the addon manifest itself, so a local
+    // `lean-ctx-addon.toml` install resolves them the same as a hosted pack
+    // (Finding A).
+    let preview_deps = resolve_declared_deps(&manifest.dependencies, &manifest.addon.name, args);
+    if !preview_deps.is_empty() {
         println!("\nDeclared dependencies (installed alongside, depth-1):");
-        for d in &resolved_deps {
+        for d in &preview_deps {
             println!("  + {}@{}", d.name, d.version);
         }
     }
@@ -379,11 +378,17 @@ fn cmd_add(target: &str, args: &[String]) {
         return;
     }
 
-    if !resolved_deps.is_empty() {
-        install_declared_deps(pack_manifest.as_ref(), args);
-    }
+    // The slice wired into `[mcp.env]` must be the versions the install step
+    // actually landed (lockfile honoured), never the preview's highest-match
+    // resolution — otherwise `{pack_dir:}` could point at a directory that does
+    // not exist (Finding B).
+    let installed_deps = if preview_deps.is_empty() {
+        Vec::new()
+    } else {
+        install_declared_deps(&manifest.dependencies, &manifest.addon.name, args)
+    };
 
-    match provision_and_wire(manifest, &source, force, no_verify, &cfg, &resolved_deps) {
+    match provision_and_wire(manifest, &source, force, no_verify, &cfg, &installed_deps) {
         Ok((outcome, verified)) => {
             println!(
                 "\n✓ Installed `{}` → gateway server `{}`.",
@@ -529,14 +534,7 @@ fn provision_and_wire(
 fn fetch_addon_pack(
     remote_ref: &crate::core::context_package::remote::RemoteRef,
     registry_flag: Option<&str>,
-) -> Result<
-    (
-        AddonManifest,
-        String,
-        crate::core::context_package::PackageManifest,
-    ),
-    String,
-> {
+) -> Result<(AddonManifest, String), String> {
     use crate::core::context_package::{remote, verify};
 
     let base = remote::registry_base(registry_flag);
@@ -598,9 +596,11 @@ fn fetch_addon_pack(
     let manifest = AddonManifest::from_toml(&payload.manifest_toml)?;
 
     let source = format!("ctxpkg:@{ns}/{name}@{}", info.version);
-    // The pack manifest rides along for depth-1 dependency resolution
-    // (GH #727): declared skills/context deps install with the addon.
-    Ok((manifest, source, pack_manifest))
+    // Depth-1 dependencies (GH #727) travel inside the addon manifest itself
+    // (`manifest.dependencies`, parsed from the pack's embedded TOML above), so
+    // they resolve the same on every source path — the hosted `pack_manifest`
+    // no longer needs to ride along.
+    Ok((manifest, source))
 }
 
 /// `addon publish [manifest] --namespace <ns>` — build the signed
@@ -726,7 +726,6 @@ fn cmd_update(name: &str, args: &[String]) {
     // Re-resolve from where it came: a hosted ctxpkg pack updates against the
     // registry it was installed from (latest non-yanked version), everything
     // else against the bundled registry snapshot.
-    let mut pack_manifest: Option<crate::core::context_package::PackageManifest> = None;
     let (manifest, update_source) = if let Some(spec) = entry.source.strip_prefix("ctxpkg:") {
         let unpinned = spec.split('@').take(2).collect::<Vec<_>>().join("@");
         let Some(remote_ref) = crate::core::context_package::remote::parse_remote_ref(&unpinned)
@@ -738,10 +737,7 @@ fn cmd_update(name: &str, args: &[String]) {
             std::process::exit(1);
         };
         match fetch_addon_pack(&remote_ref, flag_value(args, "--registry").as_deref()) {
-            Ok((m, s, pm)) => {
-                pack_manifest = Some(pm);
-                (m, s)
-            }
+            Ok((m, s)) => (m, s),
             Err(e) => {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
@@ -782,7 +778,7 @@ fn cmd_update(name: &str, args: &[String]) {
         );
         // A skills/context dependency may have bumped even when the addon
         // itself did not (GH #727) — refresh those without re-wiring.
-        refresh_pack_dependencies(pack_manifest.as_ref(), args);
+        refresh_pack_dependencies(&manifest.dependencies, &manifest.addon.name, args);
         return;
     }
 
@@ -801,11 +797,16 @@ fn cmd_update(name: &str, args: &[String]) {
         return;
     }
 
-    let resolved_deps = resolve_declared_deps(pack_manifest.as_ref(), args);
-    if !resolved_deps.is_empty() {
+    let preview_deps = resolve_declared_deps(&manifest.dependencies, &manifest.addon.name, args);
+    // The wiring must expand `{pack_dir:}` against the versions the install step
+    // actually landed (lockfile honoured), not the preview's highest-match
+    // resolution (GH #727, Finding B).
+    let installed_deps = if preview_deps.is_empty() {
+        Vec::new()
+    } else {
         println!("Installing declared dependencies (depth-1) …");
-        install_declared_deps(pack_manifest.as_ref(), args);
-    }
+        install_declared_deps(&manifest.dependencies, &manifest.addon.name, args)
+    };
 
     let new_version = manifest.addon.version.clone();
     match provision_and_wire(
@@ -814,7 +815,7 @@ fn cmd_update(name: &str, args: &[String]) {
         force,
         no_verify,
         &cfg,
-        &resolved_deps,
+        &installed_deps,
     ) {
         Ok((outcome, verified)) => {
             // The new version is wired and healthy — now prune superseded
@@ -836,15 +837,15 @@ fn cmd_update(name: &str, args: &[String]) {
     }
 }
 
-/// Re-resolve and install the declared dependencies of an addon's pack
-/// manifest (GH #727) — used on `addon update`, where a dependency can move
-/// forward independently of the addon binary.
+/// Re-resolve and install the declared dependencies of an addon (GH #727) —
+/// used on `addon update`, where a dependency can move forward independently of
+/// the addon binary.
 fn refresh_pack_dependencies(
-    pack_manifest: Option<&crate::core::context_package::PackageManifest>,
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: &str,
     args: &[String],
 ) {
-    let Some(pm) = pack_manifest else { return };
-    if pm.dependencies.iter().all(|d| d.optional) {
+    if deps.iter().all(|d| d.optional) {
         return;
     }
     let base = crate::core::context_package::remote::registry_base(
@@ -854,7 +855,8 @@ fn refresh_pack_dependencies(
     let project_root = super::common::detect_project_root(args);
     println!("Refreshing declared dependencies (depth-1) …");
     if let Err(e) = super::pack_remote::install_declared_dependencies(
-        pm,
+        deps,
+        root_name,
         &base,
         token.as_deref(),
         &project_root,
@@ -864,22 +866,34 @@ fn refresh_pack_dependencies(
     }
 }
 
-/// Resolve the declared depth-1 dependencies of an addon's pack manifest so
-/// the caller can show them in the consent preview and hand them to
-/// `provision_and_wire` (GH #727). Exits on a resolution failure — nothing
-/// has been touched at this point.
+/// Resolve the declared depth-1 dependencies of an addon so the caller can
+/// show them in the consent preview (GH #727). Exits on a resolution failure —
+/// nothing has been touched at this point.
+///
+/// This is a **preview only**: it picks the highest in-range version and does
+/// not consult `ctxpkg.lock`. The authoritative versions that get wired into
+/// `[mcp.env]` come from [`install_declared_deps`] (which honours the lockfile),
+/// so in the rare case where the lockfile pins an older in-range version this
+/// preview may list a newer version than the install actually lands. The wiring
+/// is always correct; only the pre-consent print can differ.
 fn resolve_declared_deps(
-    pack_manifest: Option<&crate::core::context_package::PackageManifest>,
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: &str,
     args: &[String],
 ) -> Vec<crate::core::context_package::deps::ResolvedDep> {
-    let Some(pm) = pack_manifest.filter(|pm| pm.dependencies.iter().any(|d| !d.optional)) else {
+    if deps.iter().all(|d| d.optional) {
         return Vec::new();
-    };
+    }
     let base = crate::core::context_package::remote::registry_base(
         flag_value(args, "--registry").as_deref(),
     );
     let token = crate::core::context_package::remote::publish_token(None);
-    match crate::core::context_package::deps::resolve_dependencies(pm, &base, token.as_deref()) {
+    match crate::core::context_package::deps::resolve_dependencies(
+        deps,
+        root_name,
+        &base,
+        token.as_deref(),
+    ) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("Error: {e}");
@@ -888,28 +902,34 @@ fn resolve_declared_deps(
     }
 }
 
-/// Install the resolved dependencies **before** anything is wired. A path
+/// Install the declared dependencies **before** anything is wired and return
+/// the [`ResolvedDep`]s that actually landed (locked versions honoured). A path
 /// burned into `[mcp.env]` must exist before it is burned in, so a failed
-/// dependency install wires nothing at all.
+/// dependency install wires nothing at all — and the wiring expands
+/// `{pack_dir:}` against exactly this returned slice (GH #727, Finding B).
 fn install_declared_deps(
-    pack_manifest: Option<&crate::core::context_package::PackageManifest>,
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: &str,
     args: &[String],
-) {
-    let Some(pm) = pack_manifest else { return };
+) -> Vec<crate::core::context_package::deps::ResolvedDep> {
     let base = crate::core::context_package::remote::registry_base(
         flag_value(args, "--registry").as_deref(),
     );
     let token = crate::core::context_package::remote::publish_token(None);
     let project_root = super::common::detect_project_root(args);
-    if let Err(e) = super::pack_remote::install_declared_dependencies(
-        pm,
+    match super::pack_remote::install_declared_dependencies(
+        deps,
+        root_name,
         &base,
         token.as_deref(),
         &project_root,
         false,
     ) {
-        eprintln!("Error: dependency install failed: {e}\n  Nothing was wired.");
-        std::process::exit(1);
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: dependency install failed: {e}\n  Nothing was wired.");
+            std::process::exit(1);
+        }
     }
 }
 

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -7,6 +7,9 @@
 
 use std::path::Path;
 
+use super::addon_deps::{
+    addon_self_ref, install_declared_deps, refresh_pack_dependencies, resolve_declared_deps,
+};
 use crate::core::addons::manifest::AddonManifest;
 use crate::core::addons::revocation::RevocationList;
 use crate::core::addons::store::{ArtifactReceipt, InstalledStore};
@@ -846,119 +849,6 @@ fn cmd_update(name: &str, args: &[String]) {
     }
 }
 
-/// The addon's own **scoped** package reference (`@ns/slug`), derived from the
-/// recorded install `source`. This is the self-dependency root handed to the
-/// depth-1 resolver (GH #727, Finding A): a declared dependency whose name
-/// equals it is the addon depending on its own pack and is refused.
-///
-/// Only a hosted `ctxpkg:@ns/slug@ver` source carries a namespace. A local
-/// manifest (`"local"`) or a bundled-registry slug (`"registry"`) has none, so
-/// a self-reference is unnameable and the guard is deliberately vacuous
-/// (`None`) — never the bare `[addon] name` slug, which could never equal a
-/// scoped `@ns/name` dependency and would only give the guard the false
-/// appearance of being active.
-fn addon_self_ref(source: &str) -> Option<String> {
-    let spec = source.strip_prefix("ctxpkg:")?;
-    let remote_ref = crate::core::context_package::remote::parse_remote_ref(spec)?;
-    Some(format!("@{}/{}", remote_ref.namespace, remote_ref.name))
-}
-
-/// Re-resolve and install the declared dependencies of an addon (GH #727) —
-/// used on `addon update`, where a dependency can move forward independently of
-/// the addon binary.
-fn refresh_pack_dependencies(
-    deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: Option<&str>,
-    args: &[String],
-) {
-    if deps.iter().all(|d| d.optional) {
-        return;
-    }
-    let base = crate::core::context_package::remote::registry_base(
-        flag_value(args, "--registry").as_deref(),
-    );
-    let token = crate::core::context_package::remote::publish_token(None);
-    let project_root = super::common::detect_project_root(args);
-    println!("Refreshing declared dependencies (depth-1) …");
-    if let Err(e) = super::pack_remote::install_declared_dependencies(
-        deps,
-        root_name,
-        &base,
-        token.as_deref(),
-        &project_root,
-        true,
-    ) {
-        eprintln!("Warning: dependency refresh failed: {e}\n  The addon update itself succeeded.");
-    }
-}
-
-/// Resolve the declared depth-1 dependencies of an addon so the caller can
-/// show them in the consent preview (GH #727). Exits on a resolution failure —
-/// nothing has been touched at this point.
-///
-/// This is a **preview only**: it picks the highest in-range version and does
-/// not consult `ctxpkg.lock`. The authoritative versions that get wired into
-/// `[mcp.env]` come from [`install_declared_deps`] (which honours the lockfile),
-/// so in the rare case where the lockfile pins an older in-range version this
-/// preview may list a newer version than the install actually lands. The wiring
-/// is always correct; only the pre-consent print can differ.
-fn resolve_declared_deps(
-    deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: Option<&str>,
-    args: &[String],
-) -> Vec<crate::core::context_package::deps::ResolvedDep> {
-    if deps.iter().all(|d| d.optional) {
-        return Vec::new();
-    }
-    let base = crate::core::context_package::remote::registry_base(
-        flag_value(args, "--registry").as_deref(),
-    );
-    let token = crate::core::context_package::remote::publish_token(None);
-    match crate::core::context_package::deps::resolve_dependencies(
-        deps,
-        root_name,
-        &base,
-        token.as_deref(),
-    ) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
-/// Install the declared dependencies **before** anything is wired and return
-/// the [`ResolvedDep`]s that actually landed (locked versions honoured). A path
-/// burned into `[mcp.env]` must exist before it is burned in, so a failed
-/// dependency install wires nothing at all — and the wiring expands
-/// `{pack_dir:}` against exactly this returned slice (GH #727, Finding B).
-fn install_declared_deps(
-    deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: Option<&str>,
-    args: &[String],
-) -> Vec<crate::core::context_package::deps::ResolvedDep> {
-    let base = crate::core::context_package::remote::registry_base(
-        flag_value(args, "--registry").as_deref(),
-    );
-    let token = crate::core::context_package::remote::publish_token(None);
-    let project_root = super::common::detect_project_root(args);
-    match super::pack_remote::install_declared_dependencies(
-        deps,
-        root_name,
-        &base,
-        token.as_deref(),
-        &project_root,
-        false,
-    ) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Error: dependency install failed: {e}\n  Nothing was wired.");
-            std::process::exit(1);
-        }
-    }
-}
-
 fn cmd_remove(name: &str, args: &[String]) {
     let Some(entry) = InstalledStore::load().get(name).cloned() else {
         eprintln!("Addon `{name}` is not installed.");
@@ -1342,7 +1232,7 @@ fn cmd_audit(target: &str) {
 }
 
 /// Read the value following `flag` in `args` (e.g. `--reason "text"`).
-fn flag_value(args: &[String], flag: &str) -> Option<String> {
+pub(super) fn flag_value(args: &[String], flag: &str) -> Option<String> {
     args.iter()
         .position(|a| a == flag)
         .and_then(|i| args.get(i + 1))
@@ -1588,36 +1478,4 @@ fn print_help() {
          \n    \
              Full guide: docs/guides/addons.md"
     );
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The pure part of the addon install path that GH #727 Finding A got
-    /// wrong: deriving the self-dependency root from the recorded install
-    /// source. A hosted `ctxpkg:@ns/slug@ver` source yields the scoped
-    /// `@ns/slug` the resolver's guard compares against; a `local` manifest or
-    /// a bundled `registry` slug has no namespace, so the guard is deliberately
-    /// vacuous (`None`) — the pre-fix code instead passed the bare `addon.name`
-    /// slug, which could never match a scoped dependency and silently disabled
-    /// the guard on this path.
-    #[test]
-    fn addon_self_ref_is_scoped_for_hosted_sources_and_none_otherwise() {
-        // Hosted pack: scoped `@ns/slug`, version pin stripped.
-        assert_eq!(
-            addon_self_ref("ctxpkg:@dasTholo/lean-md@0.2.0").as_deref(),
-            Some("@dasTholo/lean-md")
-        );
-        assert_eq!(
-            addon_self_ref("ctxpkg:@dasTholo/lean-md").as_deref(),
-            Some("@dasTholo/lean-md")
-        );
-
-        // No namespace ⇒ self-reference unnameable ⇒ guard vacuous.
-        assert_eq!(addon_self_ref("local"), None);
-        assert_eq!(addon_self_ref("registry"), None);
-        // A bare slug is never returned, so the bug (bare root) is unreachable.
-        assert_eq!(addon_self_ref("ctxpkg:demo"), None);
-    }
 }

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -358,27 +358,8 @@ fn cmd_add(target: &str, args: &[String]) {
     print_install_preview(&manifest);
 
     // Depth-1 dependency resolution (GH #727): declared deps are part of the
-    // consent surface — resolve before asking, install after wiring succeeds.
-    let registry_base = crate::core::context_package::remote::registry_base(
-        flag_value(args, "--registry").as_deref(),
-    );
-    let reg_token = crate::core::context_package::remote::publish_token(None);
-    let resolved_deps = match pack_manifest.as_ref() {
-        Some(pm) if pm.dependencies.iter().any(|d| !d.optional) => {
-            match crate::core::context_package::deps::resolve_dependencies(
-                pm,
-                &registry_base,
-                reg_token.as_deref(),
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    std::process::exit(1);
-                }
-            }
-        }
-        _ => Vec::new(),
-    };
+    // consent surface — resolve before asking, install before wiring.
+    let resolved_deps = resolve_declared_deps(pack_manifest.as_ref(), args);
     if !resolved_deps.is_empty() {
         println!("\nDeclared dependencies (installed alongside, depth-1):");
         for d in &resolved_deps {
@@ -398,7 +379,11 @@ fn cmd_add(target: &str, args: &[String]) {
         return;
     }
 
-    match provision_and_wire(manifest, &source, force, no_verify, &cfg) {
+    if !resolved_deps.is_empty() {
+        install_declared_deps(pack_manifest.as_ref(), args);
+    }
+
+    match provision_and_wire(manifest, &source, force, no_verify, &cfg, &resolved_deps) {
         Ok((outcome, verified)) => {
             println!(
                 "\n✓ Installed `{}` → gateway server `{}`.",
@@ -409,23 +394,6 @@ fn cmd_add(target: &str, args: &[String]) {
             }
             if let Some(n) = verified {
                 println!("  Verified: {n} tool(s) reachable.");
-            }
-            if let Some(pm) = pack_manifest.as_ref().filter(|_| !resolved_deps.is_empty()) {
-                let project_root = super::common::detect_project_root(args);
-                if let Err(e) = super::pack_remote::install_declared_dependencies(
-                    pm,
-                    &registry_base,
-                    reg_token.as_deref(),
-                    &project_root,
-                    false,
-                ) {
-                    eprintln!("Error: dependency install failed: {e}");
-                    eprintln!(
-                        "  The addon itself is wired; re-run `lean-ctx addon add {}` to retry.",
-                        outcome.name
-                    );
-                    std::process::exit(1);
-                }
             }
             println!(
                 "  Its tools are reachable via `ctx_tools` (find/call). \
@@ -440,16 +408,34 @@ fn cmd_add(target: &str, args: &[String]) {
 }
 
 /// The impure provisioning pipeline `add` and `update` share, run after user
-/// consent: managed artifact (GH #725) → bootstrap (#1105) → health probe
-/// (#1076) → wire. On any error nothing is wired. Returns the install outcome
-/// plus the probed tool count (`None` with `--no-verify`).
+/// consent: pack-env expansion (#727) → managed artifact (GH #725) → bootstrap
+/// (#1105) → health probe (#1076) → wire. On any error nothing is wired.
+/// Returns the install outcome plus the probed tool count (`None` with
+/// `--no-verify`).
 fn provision_and_wire(
     mut manifest: AddonManifest,
     source: &str,
     force: bool,
     no_verify: bool,
     cfg: &crate::core::config::Config,
+    resolved_deps: &[crate::core::context_package::deps::ResolvedDep],
 ) -> Result<(install::InstallOutcome, Option<usize>), String> {
+    // Pack-dir delivery (GH #727): expand `{pack_dir:@ns/name}` in [mcp.env]
+    // against the resolved dependency versions. The caller installed those
+    // dependencies already, so every path burned into the wiring exists. The
+    // parameter *is* the ordering guarantee — this cannot be called before the
+    // deps are resolved.
+    if !manifest.mcp.env.is_empty() {
+        let store_root = crate::core::context_package::LocalRegistry::open()?
+            .root()
+            .to_path_buf();
+        manifest.mcp.env = crate::core::addons::pack_env::expand_pack_env(
+            &manifest.mcp.env,
+            resolved_deps,
+            &store_root,
+        )?;
+    }
+
     // Managed artifact (GH #725, Phase 1): a prebuilt binary for this platform
     // takes precedence over [install]/PATH. It lands in the managed bin dir
     // (never PATH), hash-verified; the gateway command is rewritten to the
@@ -815,8 +801,21 @@ fn cmd_update(name: &str, args: &[String]) {
         return;
     }
 
+    let resolved_deps = resolve_declared_deps(pack_manifest.as_ref(), args);
+    if !resolved_deps.is_empty() {
+        println!("Installing declared dependencies (depth-1) …");
+        install_declared_deps(pack_manifest.as_ref(), args);
+    }
+
     let new_version = manifest.addon.version.clone();
-    match provision_and_wire(manifest, &update_source, force, no_verify, &cfg) {
+    match provision_and_wire(
+        manifest,
+        &update_source,
+        force,
+        no_verify,
+        &cfg,
+        &resolved_deps,
+    ) {
         Ok((outcome, verified)) => {
             // The new version is wired and healthy — now prune superseded
             // managed binaries (side-by-side rollback safety until here).
@@ -828,7 +827,6 @@ fn cmd_update(name: &str, args: &[String]) {
             if let Some(n) = verified {
                 println!("  Verified: {n} tool(s) reachable.");
             }
-            refresh_pack_dependencies(pack_manifest.as_ref(), args);
             println!("  Restart your MCP client to pick up the new version.");
         }
         Err(e) => {
@@ -863,6 +861,55 @@ fn refresh_pack_dependencies(
         true,
     ) {
         eprintln!("Warning: dependency refresh failed: {e}\n  The addon update itself succeeded.");
+    }
+}
+
+/// Resolve the declared depth-1 dependencies of an addon's pack manifest so
+/// the caller can show them in the consent preview and hand them to
+/// `provision_and_wire` (GH #727). Exits on a resolution failure — nothing
+/// has been touched at this point.
+fn resolve_declared_deps(
+    pack_manifest: Option<&crate::core::context_package::PackageManifest>,
+    args: &[String],
+) -> Vec<crate::core::context_package::deps::ResolvedDep> {
+    let Some(pm) = pack_manifest.filter(|pm| pm.dependencies.iter().any(|d| !d.optional)) else {
+        return Vec::new();
+    };
+    let base = crate::core::context_package::remote::registry_base(
+        flag_value(args, "--registry").as_deref(),
+    );
+    let token = crate::core::context_package::remote::publish_token(None);
+    match crate::core::context_package::deps::resolve_dependencies(pm, &base, token.as_deref()) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Install the resolved dependencies **before** anything is wired. A path
+/// burned into `[mcp.env]` must exist before it is burned in, so a failed
+/// dependency install wires nothing at all.
+fn install_declared_deps(
+    pack_manifest: Option<&crate::core::context_package::PackageManifest>,
+    args: &[String],
+) {
+    let Some(pm) = pack_manifest else { return };
+    let base = crate::core::context_package::remote::registry_base(
+        flag_value(args, "--registry").as_deref(),
+    );
+    let token = crate::core::context_package::remote::publish_token(None);
+    let project_root = super::common::detect_project_root(args);
+    if let Err(e) = super::pack_remote::install_declared_dependencies(
+        pm,
+        &base,
+        token.as_deref(),
+        &project_root,
+        false,
+    ) {
+        eprintln!("Error: dependency install failed: {e}\n  Nothing was wired.");
+        std::process::exit(1);
     }
 }
 

--- a/rust/src/cli/addon_deps.rs
+++ b/rust/src/cli/addon_deps.rs
@@ -1,0 +1,150 @@
+//! Dependency resolution and installation for the addon `add`/`update` paths
+//! (GH #727): a declared depth-1 dependency is part of the install consent
+//! surface, so it must be previewed before the user is asked and installed
+//! before anything is wired. Split out of `addon_cmd` to keep that file under
+//! the LOC gate (`scripts/loc-gate.sh`, limit 1500 lines).
+
+/// The addon's own **scoped** package reference (`@ns/slug`), derived from the
+/// recorded install `source`. This is the self-dependency root handed to the
+/// depth-1 resolver (GH #727, Finding A): a declared dependency whose name
+/// equals it is the addon depending on its own pack and is refused.
+///
+/// Only a hosted `ctxpkg:@ns/slug@ver` source carries a namespace. A local
+/// manifest (`"local"`) or a bundled-registry slug (`"registry"`) has none, so
+/// a self-reference is unnameable and the guard is deliberately vacuous
+/// (`None`) — never the bare `[addon] name` slug, which could never equal a
+/// scoped `@ns/name` dependency and would only give the guard the false
+/// appearance of being active.
+pub(super) fn addon_self_ref(source: &str) -> Option<String> {
+    let spec = source.strip_prefix("ctxpkg:")?;
+    let remote_ref = crate::core::context_package::remote::parse_remote_ref(spec)?;
+    Some(format!("@{}/{}", remote_ref.namespace, remote_ref.name))
+}
+
+/// Re-resolve and install the declared dependencies of an addon (GH #727) —
+/// used on `addon update`, where a dependency can move forward independently of
+/// the addon binary.
+pub(super) fn refresh_pack_dependencies(
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: Option<&str>,
+    args: &[String],
+) {
+    if deps.iter().all(|d| d.optional) {
+        return;
+    }
+    let base = crate::core::context_package::remote::registry_base(
+        super::addon_cmd::flag_value(args, "--registry").as_deref(),
+    );
+    let token = crate::core::context_package::remote::publish_token(None);
+    let project_root = super::common::detect_project_root(args);
+    println!("Refreshing declared dependencies (depth-1) …");
+    if let Err(e) = super::pack_remote::install_declared_dependencies(
+        deps,
+        root_name,
+        &base,
+        token.as_deref(),
+        &project_root,
+        true,
+    ) {
+        eprintln!("Warning: dependency refresh failed: {e}\n  The addon update itself succeeded.");
+    }
+}
+
+/// Resolve the declared depth-1 dependencies of an addon so the caller can
+/// show them in the consent preview (GH #727). Exits on a resolution failure —
+/// nothing has been touched at this point.
+///
+/// This is a **preview only**: it picks the highest in-range version and does
+/// not consult `ctxpkg.lock`. The authoritative versions that get wired into
+/// `[mcp.env]` come from [`install_declared_deps`] (which honours the lockfile),
+/// so in the rare case where the lockfile pins an older in-range version this
+/// preview may list a newer version than the install actually lands. The wiring
+/// is always correct; only the pre-consent print can differ.
+pub(super) fn resolve_declared_deps(
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: Option<&str>,
+    args: &[String],
+) -> Vec<crate::core::context_package::deps::ResolvedDep> {
+    if deps.iter().all(|d| d.optional) {
+        return Vec::new();
+    }
+    let base = crate::core::context_package::remote::registry_base(
+        super::addon_cmd::flag_value(args, "--registry").as_deref(),
+    );
+    let token = crate::core::context_package::remote::publish_token(None);
+    match crate::core::context_package::deps::resolve_dependencies(
+        deps,
+        root_name,
+        &base,
+        token.as_deref(),
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Install the declared dependencies **before** anything is wired and return
+/// the [`ResolvedDep`]s that actually landed (locked versions honoured). A path
+/// burned into `[mcp.env]` must exist before it is burned in, so a failed
+/// dependency install wires nothing at all — and the wiring expands
+/// `{pack_dir:}` against exactly this returned slice (GH #727, Finding B).
+pub(super) fn install_declared_deps(
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: Option<&str>,
+    args: &[String],
+) -> Vec<crate::core::context_package::deps::ResolvedDep> {
+    let base = crate::core::context_package::remote::registry_base(
+        super::addon_cmd::flag_value(args, "--registry").as_deref(),
+    );
+    let token = crate::core::context_package::remote::publish_token(None);
+    let project_root = super::common::detect_project_root(args);
+    match super::pack_remote::install_declared_dependencies(
+        deps,
+        root_name,
+        &base,
+        token.as_deref(),
+        &project_root,
+        false,
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: dependency install failed: {e}\n  Nothing was wired.");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pure part of the addon install path that GH #727 Finding A got
+    /// wrong: deriving the self-dependency root from the recorded install
+    /// source. A hosted `ctxpkg:@ns/slug@ver` source yields the scoped
+    /// `@ns/slug` the resolver's guard compares against; a `local` manifest or
+    /// a bundled `registry` slug has no namespace, so the guard is deliberately
+    /// vacuous (`None`) — the pre-fix code instead passed the bare `addon.name`
+    /// slug, which could never match a scoped dependency and silently disabled
+    /// the guard on this path.
+    #[test]
+    fn addon_self_ref_is_scoped_for_hosted_sources_and_none_otherwise() {
+        // Hosted pack: scoped `@ns/slug`, version pin stripped.
+        assert_eq!(
+            addon_self_ref("ctxpkg:@dasTholo/lean-md@0.2.0").as_deref(),
+            Some("@dasTholo/lean-md")
+        );
+        assert_eq!(
+            addon_self_ref("ctxpkg:@dasTholo/lean-md").as_deref(),
+            Some("@dasTholo/lean-md")
+        );
+
+        // No namespace ⇒ self-reference unnameable ⇒ guard vacuous.
+        assert_eq!(addon_self_ref("local"), None);
+        assert_eq!(addon_self_ref("registry"), None);
+        // A bare slug is never returned, so the bug (bare root) is unreachable.
+        assert_eq!(addon_self_ref("ctxpkg:demo"), None);
+    }
+}

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod addon_cmd;
+mod addon_deps;
 mod agent_cmd;
 mod allow_cmd;
 pub mod audit_report;

--- a/rust/src/cli/pack_remote.rs
+++ b/rust/src/cli/pack_remote.rs
@@ -152,7 +152,7 @@ pub(crate) fn cmd_pack_install_remote(
     // install from the same registry and land in the same lockfile.
     if let Err(e) = install_declared_dependencies(
         &manifest.dependencies,
-        &manifest.name,
+        Some(&manifest.name),
         &base,
         token.as_deref(),
         project_root,
@@ -184,7 +184,7 @@ pub(crate) fn cmd_pack_install_remote(
 /// way (Finding A).
 pub(crate) fn install_declared_dependencies(
     deps: &[crate::core::context_package::manifest::PackageDependency],
-    root_name: &str,
+    root_name: Option<&str>,
     base: &str,
     token: Option<&str>,
     project_root: &str,

--- a/rust/src/cli/pack_remote.rs
+++ b/rust/src/cli/pack_remote.rs
@@ -150,9 +150,14 @@ pub(crate) fn cmd_pack_install_remote(
 
     // Depth-1 dependency resolution (GH #727): declared, non-optional deps
     // install from the same registry and land in the same lockfile.
-    if let Err(e) =
-        install_declared_dependencies(&manifest, &base, token.as_deref(), project_root, refresh)
-    {
+    if let Err(e) = install_declared_dependencies(
+        &manifest.dependencies,
+        &manifest.name,
+        &base,
+        token.as_deref(),
+        project_root,
+        refresh,
+    ) {
         eprintln!("ERROR: dependency install failed: {e}");
         eprintln!(
             "  `{}` itself is installed; fix the dependency and re-run.",
@@ -164,35 +169,47 @@ pub(crate) fn cmd_pack_install_remote(
     apply_or_report(&manifest.name, &manifest.version, project_root);
 }
 
-/// Install every non-optional declared dependency of `manifest` (depth 1,
-/// GH #727). Already-locked deps present in the store are skipped offline;
-/// everything else resolves SemVer against the registry, downloads through
-/// the standard verified import path, and is pinned in the lockfile.
+/// Install every non-optional declared dependency in `deps` (declared by the
+/// root package `root_name`, depth 1, GH #727). Already-locked deps present in
+/// the store are skipped offline; everything else resolves SemVer against the
+/// registry, downloads through the standard verified import path, and is
+/// pinned in the lockfile.
+///
+/// Returns the [`ResolvedDep`]s that actually landed — already-satisfied deps
+/// at their **locked** version, freshly resolved ones at the picked version —
+/// so the caller can expand `[mcp.env]` `{pack_dir:}` against the exact
+/// versions on disk rather than a second, possibly-divergent resolution
+/// (GH #727, Finding B). Takes the dependency slice + root name directly so a
+/// local `lean-ctx-addon.toml` (no hosted `PackageManifest`) installs the same
+/// way (Finding A).
 pub(crate) fn install_declared_dependencies(
-    manifest: &crate::core::context_package::PackageManifest,
+    deps: &[crate::core::context_package::manifest::PackageDependency],
+    root_name: &str,
     base: &str,
     token: Option<&str>,
     project_root: &str,
     refresh: bool,
-) -> Result<(), String> {
+) -> Result<Vec<crate::core::context_package::deps::ResolvedDep>, String> {
     use crate::core::context_package::{LocalRegistry, deps, lockfile, remote};
 
-    if manifest.dependencies.iter().all(|d| d.optional) {
-        return Ok(());
+    if deps.iter().all(|d| d.optional) {
+        return Ok(Vec::new());
     }
     let registry = LocalRegistry::open()?;
     let root = std::path::Path::new(project_root);
+    let mut resolved_deps = Vec::new();
 
-    for dep in manifest.dependencies.iter().filter(|d| !d.optional) {
-        if !refresh && let Some(ver) = deps::already_satisfied(root, &registry, dep) {
+    for dep in deps.iter().filter(|d| !d.optional) {
+        if !refresh && let Some(resolved) = deps::already_satisfied(root, &registry, dep) {
             println!(
-                "Dependency {}@{ver} already satisfied (locked, offline).",
-                dep.name
+                "Dependency {}@{} already satisfied (locked, offline).",
+                dep.name, resolved.version
             );
+            resolved_deps.push(resolved);
             continue;
         }
 
-        let resolved = deps::resolve_one(&manifest.name, dep, base, token)?;
+        let resolved = deps::resolve_one(root_name, dep, base, token)?;
         let (ns, slug) = (&resolved.namespace, &resolved.slug);
         println!(
             "Installing dependency @{ns}/{slug}@{} (declared: `{} {}`)",
@@ -229,8 +246,9 @@ pub(crate) fn install_declared_dependencies(
             "  ✓ {}@{} installed + pinned",
             dep_manifest.name, dep_manifest.version
         );
+        resolved_deps.push(resolved);
     }
-    Ok(())
+    Ok(resolved_deps)
 }
 
 /// `pack update <ns>/<name>` — refresh a hosted pack (and its declared

--- a/rust/src/core/addons/install.rs
+++ b/rust/src/core/addons/install.rs
@@ -32,6 +32,25 @@ pub fn preflight(
     force: bool,
 ) -> Result<GatewayServer, String> {
     manifest.validate()?;
+
+    // Version gate (GH #727): an older lean-ctx does not understand this addon's
+    // `[[dependencies]]` / `{pack_dir:…}` wiring — it would install the addon and
+    // silently ignore both. Abort. This deliberately diverges from
+    // `context_package::loader`, which only warns on a min-version mismatch: a
+    // warning here would leave exactly the silent-ignore path this gate exists to
+    // close.
+    let min_version = manifest.addon.min_lean_ctx.trim();
+    if !min_version.is_empty() {
+        let current = env!("CARGO_PKG_VERSION");
+        if crate::core::context_package::loader::version_lt(current, min_version) {
+            return Err(format!(
+                "addon `{}` requires lean-ctx >= {min_version}, but this binary is {current} — \
+                 upgrade lean-ctx and retry.",
+                manifest.addon.name
+            ));
+        }
+    }
+
     let server = manifest.to_gateway_server();
     server.resolve().map_err(|e| {
         format!(
@@ -308,6 +327,33 @@ mod tests {
         let _iso = isolated_data_dir();
         let listed = AddonManifest::from_toml("[addon]\nname = \"listed\"\n").expect("parse");
         assert!(install(&listed, "registry", false, None).is_err());
+    }
+
+    /// The running binary's own version always clears its own gate.
+    #[test]
+    fn preflight_accepts_an_equal_min_lean_ctx() {
+        let _iso = isolated_data_dir();
+        let toml = format!(
+            "[addon]\nname = \"demo\"\nversion = \"1.0.0\"\nmin_lean_ctx = \"{}\"\n\
+             [mcp]\ncommand = \"demo-bin\"\n",
+            env!("CARGO_PKG_VERSION")
+        );
+        let m = AddonManifest::from_toml(&toml).expect("parses");
+        preflight(&m, &AddonsConfig::default(), false).expect("equal version passes");
+    }
+
+    /// A requirement above the running binary aborts, naming both versions.
+    #[test]
+    fn preflight_aborts_when_the_binary_is_too_old() {
+        let _iso = isolated_data_dir();
+        let m = AddonManifest::from_toml(
+            "[addon]\nname = \"demo\"\nversion = \"1.0.0\"\nmin_lean_ctx = \"999.0.0\"\n\
+             [mcp]\ncommand = \"demo-bin\"\n",
+        )
+        .expect("parses");
+        let err = preflight(&m, &AddonsConfig::default(), false).expect_err("too old");
+        assert!(err.contains("requires lean-ctx >= 999.0.0"), "{err}");
+        assert!(err.contains(env!("CARGO_PKG_VERSION")), "{err}");
     }
 
     #[test]

--- a/rust/src/core/addons/manifest.rs
+++ b/rust/src/core/addons/manifest.rs
@@ -108,6 +108,13 @@ pub struct AddonManifest {
     /// bootstrap → `[mcp] command` on `PATH`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub artifacts: BTreeMap<String, super::artifact_install::ArtifactAsset>,
+    /// `[[dependencies]]` — context packages this addon needs at runtime
+    /// (depth-1, GH #727). Forwarded verbatim into the published pack's
+    /// `PackageManifest.dependencies`, where the existing resolver consumes it.
+    /// A `{pack_dir:@ns/name}` placeholder in `[mcp.env]` may only name a
+    /// non-optional dependency declared here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<crate::core::context_package::manifest::PackageDependency>,
 }
 
 impl AddonManifest {
@@ -181,6 +188,39 @@ impl AddonManifest {
                     "addon `{name}` artifact for `{triple}` is missing `sha256` — a managed \
                      binary must be pinned"
                 ));
+            }
+        }
+        for dep in &self.dependencies {
+            if crate::core::context_package::remote::parse_remote_ref(&dep.name).is_none() {
+                return Err(format!(
+                    "addon `{name}` dependency `{}` must be a scoped `@ns/name` reference",
+                    dep.name
+                ));
+            }
+            crate::core::context_package::deps::parse_version_req(&dep.version_req)
+                .map_err(|e| format!("addon `{name}` dependency `{}`: {e}", dep.name))?;
+        }
+
+        // A `{pack_dir:…}` placeholder may only name a declared, non-optional
+        // dependency: `addon add` never resolves optional deps, so the placeholder
+        // could never expand. Both are manifest-parse errors, never install-time ones.
+        for (key, value) in &self.mcp.env {
+            let refs = super::pack_env::referenced_packs(value)
+                .map_err(|e| format!("addon `{name}` [mcp.env] `{key}`: {e}"))?;
+            for pack in refs {
+                let Some(dep) = self.dependencies.iter().find(|d| d.name == pack) else {
+                    return Err(format!(
+                        "addon `{name}` [mcp.env] `{key}`: `{{pack_dir:{pack}}}` names a pack that is \
+                         not declared in [[dependencies]]"
+                    ));
+                };
+                if dep.optional {
+                    return Err(format!(
+                        "addon `{name}` [mcp.env] `{key}`: `{{pack_dir:{pack}}}` refers to an optional \
+                         dependency — optional dependencies are never resolved, so the placeholder \
+                         could never expand"
+                    ));
+                }
             }
         }
         Ok(())
@@ -486,5 +526,87 @@ sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         assert!(m.artifacts.is_empty());
         let toml = toml::to_string(&m).expect("serialize");
         assert!(!toml.contains("[artifacts"), "got: {toml}");
+    }
+
+    // ── [[dependencies]] — depth-1 pack dependencies (GH #727) ──
+
+    const DEP_MANIFEST: &str = r#"
+[addon]
+name = "demo"
+version = "0.2.0"
+
+[mcp]
+command = "demo-bin"
+
+[mcp.env]
+LEAN_MD_SKILLS_DIR = "{pack_dir:@dasTholo/lean-md-skills}"
+
+[[dependencies]]
+name = "@dasTholo/lean-md-skills"
+version_req = "^0.2"
+"#;
+
+    #[test]
+    fn dependencies_parse_and_validate() {
+        let m = AddonManifest::from_toml(DEP_MANIFEST).expect("parses");
+        assert_eq!(m.dependencies.len(), 1);
+        assert_eq!(m.dependencies[0].name, "@dasTholo/lean-md-skills");
+        assert_eq!(m.dependencies[0].version_req, "^0.2");
+        assert!(!m.dependencies[0].optional);
+        m.validate().expect("valid");
+    }
+
+    #[test]
+    fn unscoped_dependency_name_is_rejected() {
+        let toml = DEP_MANIFEST.replace("@dasTholo/lean-md-skills", "lean-md-skills");
+        let err = AddonManifest::from_toml(&toml)
+            .expect("parses")
+            .validate()
+            .expect_err("unscoped");
+        assert!(err.contains("scoped `@ns/name`"), "{err}");
+    }
+
+    #[test]
+    fn bad_semver_range_is_rejected() {
+        let toml =
+            DEP_MANIFEST.replace(r#"version_req = "^0.2""#, r#"version_req = "not-a-range""#);
+        let err = AddonManifest::from_toml(&toml)
+            .expect("parses")
+            .validate()
+            .expect_err("bad range");
+        assert!(err.contains("invalid version range"), "{err}");
+    }
+
+    #[test]
+    fn optional_dependency_behind_a_placeholder_is_rejected() {
+        let toml = format!("{DEP_MANIFEST}optional = true\n");
+        let err = AddonManifest::from_toml(&toml)
+            .expect("parses")
+            .validate()
+            .expect_err("optional + placeholder");
+        assert!(err.contains("optional dependency"), "{err}");
+    }
+
+    #[test]
+    fn placeholder_naming_an_undeclared_pack_is_rejected() {
+        let toml = DEP_MANIFEST.replace(
+            "{pack_dir:@dasTholo/lean-md-skills}",
+            "{pack_dir:@dasTholo/other}",
+        );
+        let err = AddonManifest::from_toml(&toml)
+            .expect("parses")
+            .validate()
+            .expect_err("undeclared pack");
+        assert!(err.contains("not declared in [[dependencies]]"), "{err}");
+    }
+
+    #[test]
+    fn unknown_placeholder_scheme_is_rejected() {
+        let toml = DEP_MANIFEST.replace("pack_dir:", "bin_dir:");
+        let err = AddonManifest::from_toml(&toml)
+            .expect("parses")
+            .validate()
+            .expect_err("unknown scheme");
+        assert!(err.contains("unknown placeholder"), "{err}");
     }
 }

--- a/rust/src/core/addons/manifest.rs
+++ b/rust/src/core/addons/manifest.rs
@@ -610,19 +610,22 @@ version_req = "^0.2"
         assert!(err.contains("unknown placeholder"), "{err}");
     }
 
-    /// Regression (GH #727, Finding A): the dependency list that drives
-    /// `{pack_dir:}` expansion is `AddonManifest::dependencies` — present on
-    /// **every** install source, including a local `lean-ctx-addon.toml` where
-    /// no hosted `PackageManifest` exists. `addon add` now builds the resolved
-    /// slice from `manifest.dependencies` on every path, so such a slice expands
-    /// the env instead of aborting with "not a declared dependency".
+    /// Characterization of [`crate::core::addons::pack_env::expand_pack_env`]
+    /// (GH #727): a `{pack_dir:@ns/name}` placeholder resolves against the
+    /// resolved-dependency slice built from `AddonManifest::dependencies`,
+    /// yielding the versioned on-disk store path. This asserts the *expansion*
+    /// only — it hand-builds the `ResolvedDep` slice and does not exercise
+    /// `cmd_add`'s resolve/install wiring.
     ///
-    /// Uncovered here (needs the network / a live registry, plan-forbidden as an
-    /// integration test): that `cmd_add`'s local path actually reaches
-    /// `resolve`/`install` for these deps. That wiring is guaranteed by the
-    /// type-checked call passing `&manifest.dependencies`.
+    /// The self-dependency guard on the addon path (Finding A) is covered
+    /// elsewhere, not here: the root-reference derivation by
+    /// `cli::addon_cmd::addon_self_ref` (unit-tested in that module) and the
+    /// scoped-vs-bare refusal by
+    /// `context_package::deps::addon_scoped_self_dependency_is_refused`. The
+    /// end-to-end install path stays network-bound and is plan-forbidden as a
+    /// live-registry integration test.
     #[test]
-    fn local_manifest_dependencies_drive_pack_dir_expansion() {
+    fn expand_pack_env_maps_declared_dependency_to_pack_dir() {
         use crate::core::context_package::deps::ResolvedDep;
         use crate::core::context_package::remote::parse_remote_ref;
 

--- a/rust/src/core/addons/manifest.rs
+++ b/rust/src/core/addons/manifest.rs
@@ -609,4 +609,51 @@ version_req = "^0.2"
             .expect_err("unknown scheme");
         assert!(err.contains("unknown placeholder"), "{err}");
     }
+
+    /// Regression (GH #727, Finding A): the dependency list that drives
+    /// `{pack_dir:}` expansion is `AddonManifest::dependencies` — present on
+    /// **every** install source, including a local `lean-ctx-addon.toml` where
+    /// no hosted `PackageManifest` exists. `addon add` now builds the resolved
+    /// slice from `manifest.dependencies` on every path, so such a slice expands
+    /// the env instead of aborting with "not a declared dependency".
+    ///
+    /// Uncovered here (needs the network / a live registry, plan-forbidden as an
+    /// integration test): that `cmd_add`'s local path actually reaches
+    /// `resolve`/`install` for these deps. That wiring is guaranteed by the
+    /// type-checked call passing `&manifest.dependencies`.
+    #[test]
+    fn local_manifest_dependencies_drive_pack_dir_expansion() {
+        use crate::core::context_package::deps::ResolvedDep;
+        use crate::core::context_package::remote::parse_remote_ref;
+
+        let m = AddonManifest::from_toml(DEP_MANIFEST).expect("parses");
+        m.validate().expect("valid");
+
+        // Simulate the slice the install step produces from `manifest.dependencies`.
+        let resolved: Vec<ResolvedDep> = m
+            .dependencies
+            .iter()
+            .map(|d| {
+                let r = parse_remote_ref(&d.name).expect("scoped");
+                ResolvedDep {
+                    name: d.name.clone(),
+                    namespace: r.namespace,
+                    slug: r.name,
+                    version: "0.2.0".into(),
+                    artifact_sha256: "a".repeat(64),
+                }
+            })
+            .collect();
+
+        let out = crate::core::addons::pack_env::expand_pack_env(
+            &m.mcp.env,
+            &resolved,
+            std::path::Path::new("/store"),
+        )
+        .expect("expands against manifest.dependencies");
+        assert_eq!(
+            out["LEAN_MD_SKILLS_DIR"],
+            "/store/skills/@dasTholo__lean-md-skills/0.2.0"
+        );
+    }
 }

--- a/rust/src/core/addons/manifest.rs
+++ b/rust/src/core/addons/manifest.rs
@@ -654,9 +654,15 @@ version_req = "^0.2"
             std::path::Path::new("/store"),
         )
         .expect("expands against manifest.dependencies");
-        assert_eq!(
-            out["LEAN_MD_SKILLS_DIR"],
-            "/store/skills/@dasTholo__lean-md-skills/0.2.0"
-        );
+        // Segment names are explicit here (only the separator comes from the
+        // platform): `Path::join` is production's own separator, so this
+        // asserts the real invariant instead of duplicating the code under test.
+        let expected = std::path::Path::new("/store")
+            .join("skills")
+            .join("@dasTholo__lean-md-skills")
+            .join("0.2.0")
+            .display()
+            .to_string();
+        assert_eq!(out["LEAN_MD_SKILLS_DIR"], expected);
     }
 }

--- a/rust/src/core/addons/mod.rs
+++ b/rust/src/core/addons/mod.rs
@@ -14,6 +14,8 @@
 //! - [`bootstrap`] — `[install]` block executor: provisions an addon's upstream
 //!   package via a pinned package manager (uv/pip/cargo/npm/brew/dotnet) on `add`,
 //!   uninstalls it on `remove` (#1105, Phase 2). Never goes through a shell.
+//! - [`pack_env`] — expands `{pack_dir:@ns/name}` in an addon's `[mcp.env]`
+//!   to the on-disk location of a declared `kind=skills` dependency (#727).
 //! - [`scaffold`] — `addon init` starter manifest generator (DX, P4).
 //!
 //! Security (#863, P1):
@@ -72,6 +74,7 @@ pub mod integrity;
 pub mod manifest;
 pub mod meter;
 pub mod ort_provision;
+pub mod pack_env;
 pub mod policy;
 pub mod publish;
 pub mod registry;

--- a/rust/src/core/addons/pack_env.rs
+++ b/rust/src/core/addons/pack_env.rs
@@ -1,0 +1,199 @@
+//! `{pack_dir:@ns/name}` expansion for an addon's `[mcp.env]` (GH #727).
+//!
+//! An addon that ships its content in a `kind=skills` pack must learn where
+//! that pack was materialized. The author names the variable and states which
+//! pack it refers to; lean-ctx expands the placeholder at wiring time against
+//! the resolved dependency version:
+//!
+//! ```toml
+//! [mcp.env]
+//! LEAN_MD_SKILLS_DIR = "{pack_dir:@dasTholo/lean-md-skills}"
+//! ```
+//!
+//! Pure by construction: the store root is a parameter, never read from the
+//! environment here, so the expansion is a deterministic function of
+//! (declared env, resolved deps, store root).
+//!
+//! No env-scrub change is required. [`super::env_scrub::apply_env`] applies the
+//! declared env *after* `env_clear()`, so an expanded value reaches the child
+//! without an allowlist entry — lean-ctx computed this value, it is not a host
+//! variable smuggled through.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::core::context_package::deps::ResolvedDep;
+use crate::core::context_package::skills::skills_dir;
+
+const SCHEME: &str = "pack_dir:";
+
+/// Every pack name referenced by a `{pack_dir:…}` placeholder in `value`.
+///
+/// A `{` always opens a placeholder — there is no literal-brace escape. An
+/// unterminated brace, or a `{…}` whose body is not `pack_dir:<name>`, is a
+/// hard error: a typo must never survive as an env value with braces in it.
+pub fn referenced_packs(value: &str) -> Result<Vec<String>, String> {
+    let mut names = Vec::new();
+    let mut rest = value;
+    while let Some(open) = rest.find('{') {
+        let after = &rest[open + 1..];
+        let close = after
+            .find('}')
+            .ok_or_else(|| format!("unterminated `{{` in `{value}`"))?;
+        let body = &after[..close];
+        let name = body.strip_prefix(SCHEME).ok_or_else(|| {
+            format!(
+                "unknown placeholder `{{{body}}}` in `{value}` — only \
+                 `{{pack_dir:@ns/name}}` is supported"
+            )
+        })?;
+        if name.trim().is_empty() {
+            return Err(format!("empty pack name in `{value}`"));
+        }
+        names.push(name.to_string());
+        rest = &after[close + 1..];
+    }
+    Ok(names)
+}
+
+/// Expand every `{pack_dir:@ns/name}` in `declared_env` against `resolved`.
+///
+/// A placeholder naming a pack that is not a resolved dependency is a hard
+/// error; a value without a placeholder passes through unchanged.
+pub fn expand_pack_env(
+    declared_env: &BTreeMap<String, String>,
+    resolved: &[ResolvedDep],
+    store_root: &Path,
+) -> Result<BTreeMap<String, String>, String> {
+    let mut out = BTreeMap::new();
+    for (key, value) in declared_env {
+        let names = referenced_packs(value).map_err(|e| format!("[mcp.env] `{key}`: {e}"))?;
+        if names.is_empty() {
+            out.insert(key.clone(), value.clone());
+            continue;
+        }
+        let mut expanded = value.clone();
+        for name in names {
+            let dep = resolved.iter().find(|d| d.name == name).ok_or_else(|| {
+                format!(
+                    "[mcp.env] `{key}`: `{{pack_dir:{name}}}` names a pack that is not a \
+                     declared dependency"
+                )
+            })?;
+            let dir = skills_dir(store_root, &dep.name, &dep.version);
+            expanded = expanded.replace(&format!("{{{SCHEME}{name}}}"), &dir.display().to_string());
+        }
+        out.insert(key.clone(), expanded);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dep(name: &str, version: &str) -> ResolvedDep {
+        let bare = name.trim_start_matches('@');
+        let (ns, slug) = bare.split_once('/').expect("scoped name");
+        ResolvedDep {
+            name: name.to_string(),
+            namespace: ns.to_string(),
+            slug: slug.to_string(),
+            version: version.to_string(),
+            artifact_sha256: "a".repeat(64),
+        }
+    }
+
+    fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn one_placeholder_expands_to_the_skills_dir() {
+        let root = Path::new("/store");
+        let deps = [dep("@dasTholo/lean-md-skills", "0.2.0")];
+        let out = expand_pack_env(
+            &env(&[("LEAN_MD_SKILLS_DIR", "{pack_dir:@dasTholo/lean-md-skills}")]),
+            &deps,
+            root,
+        )
+        .expect("expands");
+        assert_eq!(
+            out["LEAN_MD_SKILLS_DIR"],
+            "/store/skills/@dasTholo__lean-md-skills/0.2.0"
+        );
+    }
+
+    #[test]
+    fn two_dependencies_two_variables_both_expand() {
+        let root = Path::new("/store");
+        let deps = [dep("@ns/one", "1.0.0"), dep("@ns/two", "2.3.4")];
+        let out = expand_pack_env(
+            &env(&[
+                ("ONE_DIR", "{pack_dir:@ns/one}"),
+                ("TWO_DIR", "{pack_dir:@ns/two}"),
+            ]),
+            &deps,
+            root,
+        )
+        .expect("expands");
+        assert_eq!(out["ONE_DIR"], "/store/skills/@ns__one/1.0.0");
+        assert_eq!(out["TWO_DIR"], "/store/skills/@ns__two/2.3.4");
+    }
+
+    #[test]
+    fn placeholder_naming_an_unknown_pack_is_an_error() {
+        let deps = [dep("@ns/one", "1.0.0")];
+        let err = expand_pack_env(
+            &env(&[("D", "{pack_dir:@ns/other}")]),
+            &deps,
+            Path::new("/store"),
+        )
+        .expect_err("unknown pack");
+        assert!(err.contains("not a declared dependency"), "{err}");
+    }
+
+    #[test]
+    fn unknown_placeholder_scheme_is_an_error() {
+        let err = expand_pack_env(
+            &env(&[("D", "{bin_dir:@ns/one}")]),
+            &[],
+            Path::new("/store"),
+        )
+        .expect_err("unknown scheme");
+        assert!(err.contains("unknown placeholder"), "{err}");
+    }
+
+    #[test]
+    fn value_without_a_placeholder_passes_through_unchanged() {
+        let out = expand_pack_env(
+            &env(&[("PLAIN", "/etc/passwd"), ("EMPTY", "")]),
+            &[],
+            Path::new("/store"),
+        )
+        .expect("passes through");
+        assert_eq!(out["PLAIN"], "/etc/passwd");
+        assert_eq!(out["EMPTY"], "");
+    }
+
+    /// Incidental braces are an ERROR, not a pass-through: a `{` opens a
+    /// placeholder unconditionally, so a typo fails loudly at manifest parse
+    /// instead of reaching the child as a literal `{…}` env value.
+    #[test]
+    fn incidental_braces_are_an_error() {
+        let unterminated =
+            expand_pack_env(&env(&[("D", "a{b")]), &[], Path::new("/store")).expect_err("open");
+        assert!(unterminated.contains("unterminated"), "{unterminated}");
+
+        let bare =
+            expand_pack_env(&env(&[("D", "{HOME}")]), &[], Path::new("/store")).expect_err("bare");
+        assert!(bare.contains("unknown placeholder"), "{bare}");
+
+        let empty = expand_pack_env(&env(&[("D", "{pack_dir:}")]), &[], Path::new("/store"))
+            .expect_err("empty");
+        assert!(empty.contains("empty pack name"), "{empty}");
+    }
+}

--- a/rust/src/core/addons/pack_env.rs
+++ b/rust/src/core/addons/pack_env.rs
@@ -121,10 +121,16 @@ mod tests {
             root,
         )
         .expect("expands");
-        assert_eq!(
-            out["LEAN_MD_SKILLS_DIR"],
-            "/store/skills/@dasTholo__lean-md-skills/0.2.0"
-        );
+        // Segment names are explicit here (only the separator comes from the
+        // platform): `Path::join` is production's own separator, so this
+        // asserts the real invariant instead of duplicating the code under test.
+        let expected = Path::new("/store")
+            .join("skills")
+            .join("@dasTholo__lean-md-skills")
+            .join("0.2.0")
+            .display()
+            .to_string();
+        assert_eq!(out["LEAN_MD_SKILLS_DIR"], expected);
     }
 
     #[test]
@@ -140,8 +146,20 @@ mod tests {
             root,
         )
         .expect("expands");
-        assert_eq!(out["ONE_DIR"], "/store/skills/@ns__one/1.0.0");
-        assert_eq!(out["TWO_DIR"], "/store/skills/@ns__two/2.3.4");
+        let expected_one = Path::new("/store")
+            .join("skills")
+            .join("@ns__one")
+            .join("1.0.0")
+            .display()
+            .to_string();
+        let expected_two = Path::new("/store")
+            .join("skills")
+            .join("@ns__two")
+            .join("2.3.4")
+            .display()
+            .to_string();
+        assert_eq!(out["ONE_DIR"], expected_one);
+        assert_eq!(out["TWO_DIR"], expected_two);
     }
 
     #[test]

--- a/rust/src/core/addons/publish.rs
+++ b/rust/src/core/addons/publish.rs
@@ -132,7 +132,7 @@ pub fn build_addon_pack(manifest_path: &Path, namespace: &str) -> Result<AddonPa
         created_at: Utc::now(),
         updated_at: None,
         layers: Vec::new(),
-        dependencies: Vec::new(),
+        dependencies: addon.dependencies.clone(),
         tags: addon
             .addon
             .categories
@@ -315,5 +315,38 @@ sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
         let err = build_addon_pack(&path, "acme").expect_err("must fail");
         assert!(err.contains("description"), "got: {err}");
+    }
+
+    #[test]
+    fn build_addon_pack_forwards_declared_dependencies() {
+        let dir = std::env::temp_dir().join(format!("lc-addon-deps-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tmp dir");
+        let path = dir.join("lean-ctx-addon.toml");
+        std::fs::write(
+            &path,
+            r#"
+[addon]
+name = "demo"
+version = "0.2.0"
+description = "a demo addon"
+
+[mcp]
+command = "demo-bin"
+
+[[dependencies]]
+name = "@dasTholo/lean-md-skills"
+version_req = "^0.2"
+"#,
+        )
+        .expect("write manifest");
+
+        let plan = build_addon_pack(&path, "dastholo").expect("builds");
+        std::fs::remove_dir_all(&dir).ok();
+
+        let bundle: serde_json::Value =
+            serde_json::from_str(&plan.bundle_json).expect("bundle json");
+        let deps = &bundle["manifest"]["dependencies"];
+        assert_eq!(deps[0]["name"], "@dasTholo/lean-md-skills");
+        assert_eq!(deps[0]["version_req"], "^0.2");
     }
 }

--- a/rust/src/core/context_package/deps.rs
+++ b/rust/src/core/context_package/deps.rs
@@ -34,10 +34,13 @@ pub struct ResolvedDep {
 }
 
 /// Resolve the direct, non-optional dependencies in `deps` (declared by the
-/// root package named `root_name`) against the registry at `base`. Fails on:
-/// unscoped names, self-dependency, invalid ranges, and ranges with no
-/// installable match — a partially-resolved install is worse than a refused
-/// one.
+/// root package whose scoped reference is `root_name`) against the registry at
+/// `base`. Fails on: unscoped names, self-dependency, invalid ranges, and
+/// ranges with no installable match — a partially-resolved install is worse
+/// than a refused one.
+///
+/// `root_name` is the root's **scoped** reference (`Some("@ns/name")`) or
+/// `None` when the install source cannot name one (see [`resolve_one`]).
 ///
 /// Takes the dependency slice + root name directly (rather than a
 /// `PackageManifest`) so every install source can resolve the same way — a
@@ -46,7 +49,7 @@ pub struct ResolvedDep {
 /// `PackageManifest` to key off (GH #727, Finding A).
 pub fn resolve_dependencies(
     deps: &[PackageDependency],
-    root_name: &str,
+    root_name: Option<&str>,
     base: &str,
     token: Option<&str>,
 ) -> Result<Vec<ResolvedDep>, String> {
@@ -61,8 +64,16 @@ pub fn resolve_dependencies(
 }
 
 /// Resolve a single declared dependency against the registry index.
+///
+/// `root_name` is the root package's **scoped** reference (`@ns/name`) or
+/// `None` when the install source cannot name one. Pass a scoped reference,
+/// never a bare `[addon] name` slug: the self-dependency guard compares against
+/// the scoped dependency name, so a bare slug can never match and would
+/// silently disable the guard (GH #727, Finding A). A local
+/// `lean-ctx-addon.toml` has only a bare slug — a self-reference is unnameable
+/// there, so its caller passes `None` and the guard is vacuous by construction.
 pub fn resolve_one(
-    root_name: &str,
+    root_name: Option<&str>,
     dep: &PackageDependency,
     base: &str,
     token: Option<&str>,
@@ -73,7 +84,9 @@ pub fn resolve_one(
             dep.name
         ));
     };
-    if dep.name.trim_start_matches('@') == root_name.trim_start_matches('@') {
+    if let Some(root) = root_name
+        && dep.name.trim_start_matches('@') == root.trim_start_matches('@')
+    {
         return Err(format!(
             "package depends on itself (`{}`) — refused",
             dep.name
@@ -252,7 +265,7 @@ mod tests {
         // fires before any network I/O, so an invalid base URL never matters.
         let err = resolve_dependencies(
             &manifest.dependencies,
-            &manifest.name,
+            Some(&manifest.name),
             "http://127.0.0.1:1",
             None,
         )
@@ -264,12 +277,56 @@ mod tests {
         assert_eq!(
             resolve_dependencies(
                 &manifest.dependencies,
-                &manifest.name,
+                Some(&manifest.name),
                 "http://127.0.0.1:1",
                 None
             )
             .unwrap(),
             Vec::new()
+        );
+    }
+
+    /// The **addon** install path (GH #727, Finding A) resolves self-dependency
+    /// against the addon's *scoped* self-reference (`@ns/slug`), which
+    /// [`crate::cli::addon_cmd::addon_self_ref`] derives from the install
+    /// source — never the bare `[addon] name` slug that the pre-fix code
+    /// passed. The existing `self_dependency_is_refused` goes through
+    /// `PackageManifest.name` (already scoped) and so never covered this path.
+    ///
+    /// This is the regression guard: with the scoped root the guard fires
+    /// before any network I/O; with the pre-fix bare slug it never fires (the
+    /// bare slug cannot equal a scoped `@ns/name` dependency), so resolution
+    /// falls through to the network instead of refusing.
+    #[test]
+    fn addon_scoped_self_dependency_is_refused() {
+        let dep = PackageDependency {
+            name: "@dasTholo/demo".into(),
+            version_req: "^0.2".into(),
+            optional: false,
+        };
+
+        // Fixed addon path: scoped self-ref → refused before any network I/O
+        // (the bad base URL is never reached).
+        let err =
+            resolve_one(Some("@dasTholo/demo"), &dep, "http://127.0.0.1:1", None).unwrap_err();
+        assert!(err.contains("depends on itself"), "got: {err}");
+
+        // Regression witness: the pre-fix bare slug (`[addon] name` = "demo")
+        // does NOT trip the guard — proving why a bare name must never be
+        // passed as the root. Resolution proceeds to the (refused) network, so
+        // the error is anything BUT "depends on itself".
+        let err_bare = resolve_one(Some("demo"), &dep, "http://127.0.0.1:1", None).unwrap_err();
+        assert!(
+            !err_bare.contains("depends on itself"),
+            "bare slug must not trip the self-guard; got: {err_bare}"
+        );
+
+        // A source with no namespace (`None`) is vacuous by construction — same
+        // fall-through, never a false self-match.
+        let err_none = resolve_one(None, &dep, "http://127.0.0.1:1", None).unwrap_err();
+        assert!(
+            !err_none.contains("depends on itself"),
+            "None root must not trip the self-guard; got: {err_none}"
         );
     }
 
@@ -285,7 +342,7 @@ mod tests {
         };
         let err = resolve_dependencies(
             &manifest.dependencies,
-            &manifest.name,
+            Some(&manifest.name),
             "http://127.0.0.1:1",
             None,
         )

--- a/rust/src/core/context_package/deps.rs
+++ b/rust/src/core/context_package/deps.rs
@@ -15,7 +15,7 @@
 //! **highest non-yanked version matching the range** — and repeated installs
 //! short-circuit offline via the lockfile + local store (`already_satisfied`).
 
-use super::manifest::{PackageDependency, PackageManifest};
+use super::manifest::PackageDependency;
 use super::remote::{self, VersionInfo};
 
 /// One resolved direct dependency, ready to download.
@@ -33,21 +33,29 @@ pub struct ResolvedDep {
     pub artifact_sha256: String,
 }
 
-/// Resolve the direct, non-optional dependencies of `manifest` against the
-/// registry at `base`. Fails on: unscoped names, self-dependency, invalid
-/// ranges, and ranges with no installable match — a partially-resolved
-/// install is worse than a refused one.
+/// Resolve the direct, non-optional dependencies in `deps` (declared by the
+/// root package named `root_name`) against the registry at `base`. Fails on:
+/// unscoped names, self-dependency, invalid ranges, and ranges with no
+/// installable match — a partially-resolved install is worse than a refused
+/// one.
+///
+/// Takes the dependency slice + root name directly (rather than a
+/// `PackageManifest`) so every install source can resolve the same way — a
+/// local `lean-ctx-addon.toml` carries its `[[dependencies]]` in
+/// [`crate::core::addons::manifest::AddonManifest`], with no hosted
+/// `PackageManifest` to key off (GH #727, Finding A).
 pub fn resolve_dependencies(
-    manifest: &PackageManifest,
+    deps: &[PackageDependency],
+    root_name: &str,
     base: &str,
     token: Option<&str>,
 ) -> Result<Vec<ResolvedDep>, String> {
     let mut resolved = Vec::new();
-    for dep in &manifest.dependencies {
+    for dep in deps {
         if dep.optional {
             continue;
         }
-        resolved.push(resolve_one(&manifest.name, dep, base, token)?);
+        resolved.push(resolve_one(root_name, dep, base, token)?);
     }
     Ok(resolved)
 }
@@ -131,14 +139,20 @@ pub fn locked_version(name: &str, project_root: &std::path::Path) -> Option<Stri
         .map(|p| p.version.clone())
 }
 
-/// True when `name@version-satisfying-req` is already pinned in the lockfile
-/// **and** present in the local store — the offline-reproducible fast path:
-/// a second `pack install` touches no network for satisfied dependencies.
+/// The resolved dependency when `name@version-satisfying-req` is already
+/// pinned in the lockfile **and** present in the local store — the
+/// offline-reproducible fast path: a second `pack install` touches no network
+/// for satisfied dependencies.
+///
+/// Returns the full [`ResolvedDep`] (at the **locked** version, not a fresh
+/// highest-match) so the install step can hand the exact same version to
+/// `[mcp.env]` `{pack_dir:}` expansion — the wiring must point at the version
+/// that actually landed on disk (GH #727, Finding B).
 pub fn already_satisfied(
     project_root: &std::path::Path,
     registry: &super::registry::LocalRegistry,
     dep: &PackageDependency,
-) -> Option<String> {
+) -> Option<ResolvedDep> {
     let lock = super::lockfile::load(project_root).ok()?;
     let locked = lock.packages.iter().find(|p| p.name == dep.name)?;
     let req = parse_version_req(&dep.version_req).ok()?;
@@ -147,7 +161,14 @@ pub fn already_satisfied(
         return None;
     }
     let installed = registry.get(&dep.name, Some(&locked.version)).ok()??;
-    Some(installed.version)
+    let remote_ref = remote::parse_remote_ref(&dep.name)?;
+    Some(ResolvedDep {
+        name: dep.name.clone(),
+        namespace: remote_ref.namespace,
+        slug: remote_ref.name,
+        version: installed.version,
+        artifact_sha256: locked.artifact_sha256.clone(),
+    })
 }
 
 #[cfg(test)]
@@ -229,13 +250,25 @@ mod tests {
         };
         // resolve_one is exercised via resolve_dependencies; the self-check
         // fires before any network I/O, so an invalid base URL never matters.
-        let err = resolve_dependencies(&manifest, "http://127.0.0.1:1", None).unwrap_err();
+        let err = resolve_dependencies(
+            &manifest.dependencies,
+            &manifest.name,
+            "http://127.0.0.1:1",
+            None,
+        )
+        .unwrap_err();
         assert!(err.contains("depends on itself"), "got: {err}");
 
         // Optional dependencies are skipped entirely.
         manifest.dependencies[0].optional = true;
         assert_eq!(
-            resolve_dependencies(&manifest, "http://127.0.0.1:1", None).unwrap(),
+            resolve_dependencies(
+                &manifest.dependencies,
+                &manifest.name,
+                "http://127.0.0.1:1",
+                None
+            )
+            .unwrap(),
             Vec::new()
         );
     }
@@ -250,8 +283,58 @@ mod tests {
             }],
             ..minimal("@acme/root")
         };
-        let err = resolve_dependencies(&manifest, "http://127.0.0.1:1", None).unwrap_err();
+        let err = resolve_dependencies(
+            &manifest.dependencies,
+            &manifest.name,
+            "http://127.0.0.1:1",
+            None,
+        )
+        .unwrap_err();
         assert!(err.contains("not a scoped"), "got: {err}");
+    }
+
+    #[test]
+    fn already_satisfied_returns_the_locked_version_as_a_resolved_dep() {
+        use crate::core::context_package::lockfile::{self, LockedPackage};
+
+        let store = tempfile::tempdir().unwrap();
+        let proj = tempfile::tempdir().unwrap();
+        let registry = super::super::registry::LocalRegistry::open_at(store.path()).unwrap();
+
+        // The pack is installed on disk at the older, in-range 0.2.0…
+        let mut manifest = minimal("@ns/skills");
+        manifest.version = "0.2.0".into();
+        registry
+            .install(&manifest, &super::super::content::PackageContent::default())
+            .unwrap();
+
+        // …and the lockfile pins exactly that version.
+        lockfile::upsert(
+            proj.path(),
+            LockedPackage {
+                name: "@ns/skills".into(),
+                version: "0.2.0".into(),
+                artifact_sha256: "a".repeat(64),
+                registry: "https://example.test".into(),
+            },
+        )
+        .unwrap();
+
+        let dep = PackageDependency {
+            name: "@ns/skills".into(),
+            version_req: "^0.2".into(),
+            optional: false,
+        };
+        let resolved =
+            already_satisfied(proj.path(), &registry, &dep).expect("locked + present on disk");
+
+        // Regression (GH #727, Finding B): the version the env path burns in must
+        // be the LOCKED/on-disk one — never a fresh highest-match resolve that
+        // could point `{pack_dir:}` at a directory that does not exist.
+        assert_eq!(resolved.version, "0.2.0");
+        assert_eq!(resolved.name, "@ns/skills");
+        assert_eq!(resolved.namespace, "ns");
+        assert_eq!(resolved.slug, "skills");
     }
 
     fn minimal(name: &str) -> crate::core::context_package::manifest::PackageManifest {

--- a/rust/src/core/context_package/loader.rs
+++ b/rust/src/core/context_package/loader.rs
@@ -444,7 +444,7 @@ fn import_gotchas(
     }
 }
 
-fn version_lt(current: &str, required: &str) -> bool {
+pub(crate) fn version_lt(current: &str, required: &str) -> bool {
     let parse = |v: &str| -> Vec<u32> {
         v.split('.')
             .map(|s| s.parse::<u32>().unwrap_or(0))

--- a/rust/src/core/context_package/manifest.rs
+++ b/rust/src/core/context_package/manifest.rs
@@ -117,7 +117,7 @@ impl PackageLayer {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PackageDependency {
     pub name: String,
     pub version_req: String,


### PR DESCRIPTION
## Summary

Six follow-up fixes on top of #743 (`kind=skills` content packs + depth-1 dependency
resolution), which is already merged. Each one closes a gap that surfaced while wiring a
real pack through the install path:

- `{pack_dir:}` expander for `[mcp.env]` — pure, testable, no I/O
- `[[dependencies]]` authoring surface in `lean-ctx-addon.toml`, forwarded into the published pack
- `min_lean_ctx` is enforced in preflight instead of being parsed and ignored
- declared dependencies are installed **before** wiring, so `{pack_dir:}` always expands to a path that exists on disk
- declared dependencies resolve on **every** source path (local manifest and hosted pack), and the wired version is the installed one, not a second resolve
- the self-dependency guard on the addon resolve path is restored (it compared a bare slug against a scoped `@ns/name`, so it never fired)

Touches only `core/addons/*`, `core/context_package/*`, `cli/addon_cmd.rs`,
`cli/pack_remote.rs` and two docs — **file-disjoint from #721**, so the two can land in
either order.

Refs #727.

## Test plan

- [x] `cd rust && cargo test` — run as `cargo nextest run` (this repo's test runner): 8759 passed
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cd rust && cargo fmt --check` — clean
- [ ] If cookbook/packages changed: relevant `npm test` / build steps — n/a, no cookbook or package changes

## Notes for reviewers

- Risk areas / edge cases:
  - The pre-consent **preview** resolves the highest in-range version and therefore may cosmetically
    differ from the lockfile-pinned version that actually gets installed. The **wiring** always uses
    the install step's output, never a second resolve.
  - That preview costs a second network resolve (TOCTOU / offline caveat). Documented on
    `resolve_declared_deps`.
  - `root_name` in `resolve_one` / `resolve_dependencies` / `install_declared_dependencies` must be the
    **scoped** reference (`Some("@ns/name")`) or `None` — a bare slug silently disables the
    self-dependency guard. That is the regression the last commit fixes; two tests pin it.
- Backwards compatibility:
  - `[[dependencies]]` and the `min_lean_ctx` gate are additive. The gate is only enforced from the
    release that ships them onward; older binaries parse neither and are unaffected.
  - `deps::already_satisfied` now returns `Option<ResolvedDep>` instead of `Option<String>`, and
    `deps::resolve_dependencies` takes `(&[PackageDependency], root_name)` instead of
    `&PackageManifest`. Both are internal.
- Docs updated (links/files):
  - `docs/contracts/addon-manifest-v1.md` — `[[dependencies]]` + `min_lean_ctx` semantics
  - `docs/guides/addons.md` — authoring a pack with dependencies

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
