### PR TITLE
fix(embeddings): resolve libonnxruntime in NixOS per-user profile paths

### DIFF
--- a/rust/src/core/ort_environment.rs
+++ b/rust/src/core/ort_environment.rs
@@ -215,9 +215,16 @@ fn nix_profile_search(name: &str) -> Option<PathBuf> {
     let user_profile = home
         .as_ref()
         .map(|h| h.join(".nix-profile").join("lib").join(name));
+    let nixos_user_profile = std::env::var("USER").ok().map(|u| {
+        PathBuf::from("/etc/profiles/per-user")
+            .join(u)
+            .join("lib")
+            .join(name)
+    });
     let candidates = [
         Some(Path::new("/run/current-system/sw/lib").join(name)),
         user_profile,
+        nixos_user_profile,
     ];
     candidates.into_iter().flatten().find(|c| c.is_file())
 }


### PR DESCRIPTION
### Title
`fix(embeddings): resolve libonnxruntime in NixOS per-user profile paths`

---

### Description
On modern NixOS hosts (specifically when utilizing Home Manager with `useUserPackages = true` or defining declarative user packages via `users.users.<name>.packages`), user packages and libraries are symlinked into `/etc/profiles/per-user/$USER/lib/` rather than the legacy `~/.nix-profile/lib/` or the system-wide `/run/current-system/sw/lib/`.

This PR appends the `/etc/profiles/per-user/$USER/lib/` path dynamically to the Nix profile lookup candidate array in `nix_profile_search` to ensure the dynamically loaded `libonnxruntime.so` is successfully resolved on modern NixOS configurations without requiring manual overrides like `ORT_DYLIB_PATH`.

This is a non-destructive change. It does not replace the existing search paths; it simply adds the per-user profile path as a fallback. Non-NixOS and legacy Nix users are unaffected, as paths that do not exist are safely skipped during the `is_file()` validation check.

---

### Test Plan
We verified the fix by:
1. Installing `onnxruntime` globally inside a NixOS 26.05 home manager configuration.
2. Rebuilding the system to populate `/etc/profiles/per-user/jsantos/lib/libonnxruntime.so`.
3. Running the unit tests under a clean Nix environment:
   ```bash
   nix-shell -p pkg-config openssl --run "export NIX_HARDENING_ENABLE=0; cargo test --manifest-path rust/Cargo.toml --lib core::ort_environment"
   ```
   **Result:** All 6 tests in `ort_environment` passed successfully.
4. Building `lean-ctx` in release mode (`make install`) and running:
   ```bash
   lean-ctx index build-full
   ```
   **Result:** The semantic indexing process successfully resolved the NixOS system's shared library and completed with no warnings:
   ```text
   building semantic (dense embedding) index ...
     semantic index ready
   ```
