### PR TITLE
ci: fix ci-green gate gaps, cache tarpaulin/jemalloc, add concurrency group

### DIFF
--- a/.github/actions/windows-jemalloc/action.yml
+++ b/.github/actions/windows-jemalloc/action.yml
@@ -41,6 +41,18 @@ runs:
   using: composite
   steps:
 
+    # Cache the compiled jemalloc prefix across runs — building it from
+    # source (configure + make) takes real minutes and never changes unless
+    # this action's build recipe does. Cached under the workspace (a stable,
+    # known Windows-native path) rather than MSYS2's /tmp, whose real
+    # location is an implementation detail of the msys2/setup-msys2 action.
+    - name: Cache jemalloc build
+      id: jemalloc-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ github.workspace }}\.jemalloc-prefix
+        key: windows-jemalloc-5.3.0-${{ hashFiles('.github/actions/windows-jemalloc/action.yml') }}
+
     # Step 1 — compile jemalloc 5.3.0 from the GitHub Release tarball
     # ---------------------------------------------------------------
     # Git tag 5.3.0 only has configure.ac / Makefile.in — the generated
@@ -48,12 +60,14 @@ runs:
     # We must pass --with-jemalloc-prefix=_rjem_ (tikv-jemallocator expects
     # _rjem_malloc symbols) and rename the MinGW .lib to the expected name.
     - name: Build jemalloc 5.3.0 from release tarball
+      if: steps.jemalloc-cache.outputs.cache-hit != 'true'
       shell: msys2 {0}
       run: |
         set -eux
+        PREFIX="$(cygpath -u "$GITHUB_WORKSPACE")/.jemalloc-prefix"
         curl -fsSL https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 \
           -o /tmp/jemalloc.tar.bz2
-        mkdir -p /tmp/jemalloc-build /tmp/jemalloc-prefix/lib
+        mkdir -p /tmp/jemalloc-build "$PREFIX/lib"
         tar -xf /tmp/jemalloc.tar.bz2 -C /tmp/jemalloc-build --strip-components=1
         cd /tmp/jemalloc-build
         # config.sub from 2021 doesn't know win32* (MSYS2's build triple)
@@ -62,12 +76,11 @@ runs:
                     --disable-cxx --enable-shared=no \
                     --with-jemalloc-prefix=_rjem_ \
                     --with-private-namespace=_rjem_ \
-                    --prefix=/tmp/jemalloc-prefix
+                    --prefix="$PREFIX"
         make -j$(nproc)
         make install_lib_static install_include
         # MinGW → jemalloc_s.lib; rename for JEMALLOC_OVERRIDE (strips "lib")
-        cp /tmp/jemalloc-prefix/lib/jemalloc_s.lib \
-           /tmp/jemalloc-prefix/lib/libjemalloc.a
+        cp "$PREFIX/lib/jemalloc_s.lib" "$PREFIX/lib/libjemalloc.a"
 
     # Step 2 — create a dummy liballoc.a
     # -----------------------------------
@@ -76,26 +89,28 @@ runs:
     # (no liballoc.a exists).  An empty archive with a single object file
     # satisfies the flag — real symbols come from the .rlib that is already
     # linked statically upstream of the native-library resolution pass.
+    # Cheap either way, so it isn't gated on the cache hit — reruns
+    # harmlessly on a cache hit too.
     - name: Create dummy liballoc.a for -lalloc linker flag
       shell: msys2 {0}
       run: |
         set -eux
+        PREFIX="$(cygpath -u "$GITHUB_WORKSPACE")/.jemalloc-prefix"
         printf 'void __dummy_alloc_ignore(void) {}\n' | \
-          gcc -xc -c - -o /tmp/jemalloc-prefix/lib/dummy.o
-        ar crs /tmp/jemalloc-prefix/lib/liballoc.a \
-              /tmp/jemalloc-prefix/lib/dummy.o
-        rm -f /tmp/jemalloc-prefix/lib/dummy.o
+          gcc -xc -c - -o "$PREFIX/lib/dummy.o"
+        ar crs "$PREFIX/lib/liballoc.a" "$PREFIX/lib/dummy.o"
+        rm -f "$PREFIX/lib/dummy.o"
 
     # Step 3 — export Windows-native paths for subsequent build steps
     # ----------------------------------------------------------------
     # The Rust build script is a native Windows process and cannot resolve
-    # MSYS2 virtual paths (/tmp/...).  cygpath -w produces a proper
-    # absolute Windows path (e.g. D:\a\_temp\msys64\tmp\...) that the
-    # native linker can open.
+    # MSYS2 virtual paths. cygpath -w produces a proper absolute Windows
+    # path that the native linker can open.
     - name: Export Windows-native paths as outputs
       id: set-paths
       shell: msys2 {0}
       run: |
         set -eux
-        echo "jemalloc-override=$(cygpath -w /tmp/jemalloc-prefix/lib/libjemalloc.a)" >> $GITHUB_OUTPUT
-        echo "dummy-dir=$(cygpath -w /tmp/jemalloc-prefix/lib)" >> $GITHUB_OUTPUT
+        PREFIX="$(cygpath -u "$GITHUB_WORKSPACE")/.jemalloc-prefix"
+        echo "jemalloc-override=$(cygpath -w "$PREFIX/lib/libjemalloc.a")" >> $GITHUB_OUTPUT
+        echo "dummy-dir=$(cygpath -w "$PREFIX/lib")" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Cancel a still-running CI for the same ref when a new push supersedes it —
+# avoids burning runner-hours on stale commits during active PR iteration.
+# Never cancel on main: a run there should always finish (e.g. for the
+# scorecard/coverage artifacts it produces), even if another push lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 
@@ -30,6 +38,19 @@ jobs:
     # now include heavy property/fuzz/benchmark suites (#291, #493, #551) —
     # well beyond 90 min on hosted runners. Parallelization is tracked
     # separately; until then the gate gets the time it actually needs.
+    #
+    # Tried switching to cargo-nextest (rust/.config/nextest.toml already
+    # exists and documents the same env-race for 3 known binaries via a
+    # `serial-state` test-group). Reverted: nextest's default parallelism
+    # (test-threads = -4) surfaced several more tests with hidden wall-clock
+    # timing assumptions (e.g. core::cache::tests::hebbian_eviction_bonus_is_wired
+    # depends on two calls landing in the same real-time 500ms window) that a
+    # `max-threads=1` test-group does NOT fix — that only serializes tests
+    # *within* the group against each other, it doesn't protect them from
+    # being scheduling-delayed by the many *other* tests still running in
+    # parallel elsewhere on the same runner. Revisit once those tests are
+    # made robust to scheduling jitter (or the burst window is made
+    # injectable for tests) rather than papering over it with test-groups.
     timeout-minutes: 180
     env:
       # ~60 integration-test binaries each statically link the full lib
@@ -175,6 +196,7 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4 # v4
         with:
@@ -410,8 +432,9 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
           df -h /
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+      - uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2
+        with:
+          tool: cargo-tarpaulin
       - name: Generate coverage
         working-directory: rust
         env:
@@ -622,9 +645,12 @@ jobs:
       - build-minimal
       - fmt
       - cookbook
+      - pi-extension
       - rust-sdk
       - embed-sdk
       - python-sdk
+      - hermes-plugin
+      - sdk-conformance
       - coverage
       - deny
       - adversarial


### PR DESCRIPTION
## Summary

Closes #788.

Follow-up on a CI audit (17 jobs, `ci.yml`), verified against the actual file before implementing — a couple of the audit's claims didn't hold up and were dropped (see Notes):

- **`ci-green` gate gap (real bug)**: `pi-extension`, `hermes-plugin` and `sdk-conformance` were missing from `needs`, so those three jobs could fail without blocking the merge gate. (`test`, `fmt`, `cookbook`, `doc` etc. were already covered, contrary to the initial audit.)
- **`cargo-tarpaulin`** was `cargo install`ed from scratch every coverage run; switched to `taiki-e/install-action` (same pin already used elsewhere in this repo for `cargo-edit`) for a cached binary.
- **Concurrency group** added so a new push cancels a still-running CI for the same PR ref instead of burning runner-hours on superseded commits. Never cancels on `main` (a push there should always finish its scorecard/coverage artifacts).
- **`windows-jemalloc`** now caches the compiled jemalloc prefix (keyed on the action file's own hash) instead of rebuilding it from source via `configure && make` on every Windows test run.
- **`fmt` job**: added `timeout-minutes: 10` (previously unbounded).

**Tried and reverted — cargo-nextest for the `test` matrix**: `rust/.config/nextest.toml` already exists and documents the same env-race the job's `--test-threads=1` comment describes, via a `serial-state` test-group for 3 known binaries. Validated locally before pushing: switching `test` to `cargo nextest run` surfaces *more* tests with hidden wall-clock timing assumptions than that config accounts for (e.g. `core::cache::tests::hebbian_eviction_bonus_is_wired` expects two calls to land within a real-time 500ms burst window). Pinning it into `serial-state` did **not** fix it — that mechanism only serializes tests *within* the group against each other; it doesn't protect a test from being scheduling-delayed by the many *other* tests still running concurrently elsewhere under nextest's default parallelism. Left a detailed comment in `ci.yml` at the `test` job. Revisiting this needs the affected tests made robust to scheduling jitter (or the burst window made injectable) first — out of scope here.

## Test plan

- [x] Validated the `test` job's reverted state still matches `main` (no functional change there beyond the added comment).
- [x] YAML syntax validated for both modified files (`yaml.safe_load`).
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — not runnable here, `clippy` isn't installed on this toolchain.
- [x] `cd rust && cargo fmt --check` — passes, no diff (unrelated to this PR's changes, which are YAML-only).
- [x] N/A — no cookbook/packages changes.

## Notes for reviewers

- Risk areas / edge cases:
  - The audit that prompted this also claimed `bench`/`quality-gate` could share a compiled binary via upload-artifact. Checked and **not implemented**: they build in different Cargo profiles (`bench` via `cargo bench --no-run`, `quality-gate` via `cargo build --quiet`/dev profile) for different binaries, so a direct artifact share wouldn't work as described.
  - `windows-jemalloc`'s cache key is the action file's own hash — bumping the jemalloc version or build recipe automatically invalidates it.
- Backwards compatibility: no change to what ships; CI-only.
- Docs updated: none needed (no user-facing behavior change).

