### PR TITLE
fix: bash rewrite hook and extract_json_field mangle multi-line commands

### DIFF
--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -1327,5 +1327,34 @@ fn extract_json_field(input: &str, field: &str) -> Option<String> {
         return None;
     }
     let raw = &rest[..end];
-    Some(raw.replace("\\\"", "\"").replace("\\\\", "\\"))
+    Some(unescape_json_string(raw))
+}
+
+/// Single-pass JSON string unescaping (#787).
+///
+/// Handles \\, \", \n, \t, \r, \/ — the standard JSON escape sequences
+/// that agents actually emit in hook payloads. \uXXXX is passed through
+/// unchanged (extremely rare in shell commands, not worth the complexity).
+fn unescape_json_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('"') => out.push('"'),
+                Some('/') => out.push('/'),
+                Some('\\') | None => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -733,6 +733,45 @@ fn extract_field_handles_complex_curl() {
 }
 
 #[test]
+fn extract_field_decodes_json_newlines() {
+    let input = r#"{"tool_name":"Bash","command":"git add .\ngit commit -m \"done\""}"#;
+    assert_eq!(
+        extract_json_field(input, "command"),
+        Some("git add .\ngit commit -m \"done\"".to_string())
+    );
+}
+
+#[test]
+fn extract_field_decodes_json_tab_and_cr() {
+    let input = r#"{"command":"echo\t\"hello\"\r\n"}"#;
+    assert_eq!(
+        extract_json_field(input, "command"),
+        Some("echo\t\"hello\"\r\n".to_string())
+    );
+}
+
+#[test]
+fn extract_field_preserves_escaped_backslash_before_n() {
+    let input = r#"{"command":"echo \\n"}"#;
+    assert_eq!(
+        extract_json_field(input, "command"),
+        Some("echo \\n".to_string())
+    );
+}
+
+#[test]
+fn unescape_json_string_roundtrips() {
+    assert_eq!(super::unescape_json_string(r"a\nb"), "a\nb");
+    assert_eq!(super::unescape_json_string(r"a\tb"), "a\tb");
+    assert_eq!(super::unescape_json_string(r"a\\b"), "a\\b");
+    assert_eq!(super::unescape_json_string(r#"a\"b"#), "a\"b");
+    assert_eq!(super::unescape_json_string(r"a\/b"), "a/b");
+    assert_eq!(super::unescape_json_string(r"a\r\nb"), "a\r\nb");
+    assert_eq!(super::unescape_json_string(r"\\n"), "\\n");
+    assert_eq!(super::unescape_json_string("plain"), "plain");
+}
+
+#[test]
 fn to_bash_compatible_path_windows_drive() {
     let p = crate::hooks::to_bash_compatible_path(r"E:\packages\lean-ctx.exe");
     assert_eq!(p, "/e/packages/lean-ctx.exe");

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -418,6 +418,10 @@ if [ -z "$CMD" ] || echo "$CMD" | grep -qE "^(lean-ctx |\"?$LEAN_CTX_BIN\"? )"; 
   exit 0
 fi
 
+# Skip multi-line commands: the grep/sed extraction above does not decode
+# JSON \n into real newlines, so lean-ctx -c would receive fused lines (#787).
+if printf '%s' "$CMD" | grep -qF '\n'; then exit 0; fi
+
 case "$CMD" in
   {case_pattern})
     # Shell-escape then JSON-escape (two passes)
@@ -443,6 +447,7 @@ LEAN_CTX_BIN={quoted_binary}
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | grep -oE '"command":"([^"\\]|\\.)*"' | head -1 | sed 's/^"command":"//;s/"$//' | sed 's/\\"/"/g;s/\\\\/\\/g' 2>/dev/null || echo "")
 if [ -z "$CMD" ] || echo "$CMD" | grep -qE "^(lean-ctx |\"?$LEAN_CTX_BIN\"? )"; then exit 0; fi
+if printf '%s' "$CMD" | grep -qF '\n'; then exit 0; fi
 case "$CMD" in
   {case_pattern})
     SHELL_ESC=$(printf '%s' "$CMD" | sed 's/\\/\\\\/g;s/"/\\"/g')

--- a/rust/src/hooks/tests.rs
+++ b/rust/src/hooks/tests.rs
@@ -675,6 +675,20 @@ fn rewrite_scripts_contain_all_registry_commands() {
 }
 
 #[test]
+fn rewrite_script_skips_multiline_commands() {
+    let script = generate_rewrite_script("lean-ctx");
+    assert!(
+        script.contains(r"grep -qF '\n'"),
+        "rewrite script must guard against unresolved JSON \\n (#787)"
+    );
+    let compact = generate_compact_rewrite_script("lean-ctx");
+    assert!(
+        compact.contains(r"grep -qF '\n'"),
+        "compact rewrite script must guard against unresolved JSON \\n (#787)"
+    );
+}
+
+#[test]
 fn codex_is_hybrid() {
     assert_eq!(recommend_hook_mode("codex"), HookMode::Hybrid);
 }


### PR DESCRIPTION
Closes #787

## Summary

- **Root cause:** The `grep`/`sed` JSON extraction in generated bash scripts (`generate_rewrite_script`, `generate_compact_rewrite_script`) only unescaped `\"` and `\\` — JSON `\n` stayed as a literal 2-char sequence. `lean-ctx -c` then received fused lines instead of a multi-line command. Same bug in `extract_json_field` (Codex hook path).
- **Fix 1 — `extract_json_field`:** Replace the chained `.replace("\\\"", "\"").replace("\\\\", "\\")` with a proper single-pass `unescape_json_string()` that handles all standard JSON escapes: `\n`, `\t`, `\r`, `\"`, `\\`, `\/`. `\uXXXX` is passed through unchanged (extremely rare in shell commands).
- **Fix 2 — bash scripts:** Add a multi-line guard (`grep -qF '\n'`) before the `case` statement in both `generate_rewrite_script` and `generate_compact_rewrite_script`. Commands containing unresolved `\n` pass through to the native handler instead of being mangled.

Community feedback from @hiSandog ("Using a real JSON parser instead of grep/sed extraction seems important beyond the demonstrated newline case") is addressed by Fix 1 for the Rust path. The bash scripts' grep/sed extraction is guarded but not replaced — full migration to the Rust `lean-ctx hook rewrite` path is tracked as a separate follow-up.

## Test plan

- [x] `cargo test --lib -- extract_field` — 9 passed (6 existing + 3 new regression tests)
- [x] `cargo test --lib -- unescape_json` — 1 passed (8 assertions covering all escape sequences)
- [x] `cargo test --lib -- rewrite_script_skips` — 1 passed (both script variants contain the guard)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Preflight gate — passed

## New tests

| Test | What it verifies |
|------|-----------------|
| `extract_field_decodes_json_newlines` | Multi-line `git add .\ngit commit` decoded correctly |
| `extract_field_decodes_json_tab_and_cr` | `\t`, `\r`, `\n` all decoded |
| `extract_field_preserves_escaped_backslash_before_n` | `\\n` (literal backslash + n) stays `\n`, not newline |
| `unescape_json_string_roundtrips` | All 6 JSON escapes + edge cases |
| `rewrite_script_skips_multiline_commands` | Both bash script variants contain the `\n` guard |

Made with [Cursor](https://cursor.com)