### PR TITLE
fix(agents): make is_process_alive actually check the OS on Windows

### DIFF
--- a/rust/src/core/agents.rs
+++ b/rust/src/core/agents.rs
@@ -534,19 +534,15 @@ fn generate_short_id() -> String {
     format!("{:08x}", hasher.finish() as u32)
 }
 
+/// #576 already fixed this exact hardcoded-`true` anti-pattern for
+/// `daemon::is_daemon_running` by delegating to `ipc::process::is_alive`
+/// (which has a real Windows `OpenProcess` check); this duplicate copy was
+/// missed, so on non-unix targets `cleanup_stale` could never flip a dead
+/// MCP session's entry to `Finished`, leaving `registry.json` accumulating
+/// stale `Active` entries forever — the root cause of the "N active agents"
+/// dashboard bug on Windows.
 pub fn is_process_alive(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .output()
-            .is_ok_and(|o| o.status.success())
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        true
-    }
+    crate::ipc::process::is_alive(pid)
 }
 
 pub(crate) struct FileLock {
@@ -1009,17 +1005,23 @@ mod tests {
     /// #419: a crashed/exited MCP process leaves an `Active` entry behind.
     /// `cleanup_stale` must flip it to `Finished` (regardless of age) so
     /// `list_active` no longer surfaces it as a live peer — the ghost the
-    /// briefing used to show.
-    #[cfg(unix)]
+    /// briefing used to show. Previously `#[cfg(unix)]`-only, which is why
+    /// the non-unix `is_process_alive` hardcoded-`true` regression (see its
+    /// doc comment) shipped unnoticed: this exact test never ran on Windows.
     #[test]
     fn cleanup_stale_prunes_dead_pid_from_active_list() {
         // Reap a child so its PID is guaranteed dead at assertion time.
         let reaped = {
-            let mut child = std::process::Command::new("true")
-                .spawn()
-                .expect("spawn true");
+            let mut cmd = if cfg!(windows) {
+                let mut c = std::process::Command::new("cmd");
+                c.args(["/C", "exit"]);
+                c
+            } else {
+                std::process::Command::new("true")
+            };
+            let mut child = cmd.spawn().expect("spawn short-lived helper process");
             let pid = child.id();
-            child.wait().expect("reap true");
+            child.wait().expect("reap helper process");
             pid
         };
 


### PR DESCRIPTION
## Summary

`core::agents::is_process_alive()` hardcoded `true` for every PID on non-Unix
targets, so `cleanup_stale()` could never mark a dead MCP session's
`registry.json` entry as `Finished` on Windows — entries for closed sessions
accumulate as `"status": "Active"` forever. This delegates to the already-
correct `ipc::process::is_alive` (real `OpenProcess`-based check on Windows)
instead, and de-gates the only regression test for this path so it actually
runs on Windows.

Fixes #791

## What

- `rust/src/core/agents.rs`: `is_process_alive` now delegates to
  `crate::ipc::process::is_alive`, removing the duplicate (and, on Windows,
  broken) inline implementation.
- Same file: `cleanup_stale_prunes_dead_pid_from_active_list` (the #419
  regression test) drops its `#[cfg(unix)]` gate — it now spawns a
  short-lived helper process (`cmd /C exit` on Windows, `true` elsewhere),
  reaps it, and asserts the dead PID is pruned, on every platform.

## Why

This is the same hardcoded-wrong-on-Windows anti-pattern already fixed once
for a different function: #576 / #577 replaced a similarly-broken Windows
daemon-status stub with a delegation to `ipc::process::is_alive`. This is a
second, independent copy of that pattern that the earlier fix didn't touch.

It's also distinct from #419 (fixed in 3.8.6, which taught `ctx_overview` to
call `cleanup_stale` at all). Every caller of `cleanup_stale` — the dashboard
route, the `ctx_agent` tool, `server_handler.rs`'s own registration path, and
`ctx_overview` post-#419 — already calls it correctly. The bug is that the
liveness primitive itself is a no-op on Windows, so calling it correctly
doesn't help: dead entries never flip to `Finished` and eventually get pruned.

Reproduced live on a Windows dev machine: `registry.json` had 6 of 7 entries
still `"status": "Active"` for PIDs that were not running, hours after they'd
exited and after multiple subsequent sessions had registered (each of which
calls `cleanup_stale(24)` first).

## Test plan

- [x] `cd rust && cargo test --lib core::agents::` — 14/14 pass, including the
      de-gated `cleanup_stale_prunes_dead_pid_from_active_list` (previously
      never ran on Windows; confirmed it now does and passes)
- [x] `cd rust && cargo test --lib ipc::process::` — 5/5 pass (unchanged
      behavior for the delegate)
- [x] `cd rust && cargo fmt --check` — clean
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` —
      **not clean, but pre-existing and unrelated**: this currently fails on
      unmodified `origin/main` too (28 `collapsible_if` errors in
      `src/shell/platform.rs`, a file this PR never touches — reproduced with
      and without `--all-features`), apparently a clippy-version drift
      (1.95.0) rather than anything introduced here. Happy to file that
      separately if useful.

All run locally on Windows 11 (10.0.26200).

## Notes for reviewers

- Risk areas / edge cases: none expected — `ipc::process::is_alive` is
  already exercised elsewhere (`daemon::is_daemon_running`) and has its own
  test coverage (`bogus_pid_is_not_alive`, `current_process_is_alive`). This
  swaps a broken primitive for an already-trusted one with an identical
  signature (`fn(u32) -> bool`); no callers of `is_process_alive` needed to
  change.
- Backwards compatibility: none — this only makes an existing, documented
  behavior (dead sessions get pruned) actually work on the platform where it
  silently didn't.
- Docs updated: n/a (no public surface change).

## Contributor License Agreement

(pending — will sign via the CLA bot comment on this PR)
