### PR TITLE
fix(hermes-lean-ctx): surface real tool-call errors instead of generic 'daemon unavailable'

### DIFF
--- a/integrations/hermes-lean-ctx/tests/test_tools.py
+++ b/integrations/hermes-lean-ctx/tests/test_tools.py
@@ -44,13 +44,13 @@ def test_handle_unknown_tool_returns_error():
 
 def test_handle_known_tool_daemon_down_returns_error():
     out = tools.handle_tool_call(_offline_gateway(), "ctx_search", {"pattern": "x"})
-    assert "unavailable" in json.loads(out)["error"]
+    assert json.loads(out)["error"].startswith("lean-ctx call failed:")
 
 
 def test_handle_tool_coerces_string_args():
     # invalid name still short-circuits before any call; string args must parse
     out = tools.handle_tool_call(_offline_gateway(), "ctx_search", "{\"pattern\": \"x\"}")
-    assert "unavailable" in json.loads(out)["error"]  # reached daemon path, then no-op
+    assert json.loads(out)["error"].startswith("lean-ctx call failed:")
 
 
 def test_recall_hint_lists_tools():

--- a/integrations/hermes-lean-ctx/tools.py
+++ b/integrations/hermes-lean-ctx/tools.py
@@ -54,7 +54,8 @@ def handle_tool_call(
     arguments: Optional[Dict[str, Any]] = _coerce_args(args)
     text = gateway.call_text(name, arguments)
     if text is None:
+        detail = gateway.last_error or "daemon unavailable"
         return json.dumps(
-            {"error": f"lean-ctx daemon unavailable; '{name}' could not be executed."}
+            {"error": f"lean-ctx call failed: {detail}; '{name}' could not be executed."}
         )
     return text

--- a/integrations/hermes-lean-ctx/transport.py
+++ b/integrations/hermes-lean-ctx/transport.py
@@ -28,6 +28,7 @@ class ToolGateway:
         self._client_error: Optional[str] = None
         self._healthy: Optional[bool] = None
         self._health_checked_at: float = 0.0
+        self.last_error: Optional[str] = None
 
     # --- client construction ------------------------------------------------
 
@@ -95,11 +96,13 @@ class ToolGateway:
         """Call a tool, returning its text result or ``None`` on any failure."""
         client = self._get_client()
         if client is None:
+            self.last_error = self._client_error
             return None
         try:
             return client.call_tool_text(name, arguments or {})
         except Exception as exc:
             logger.warning("lean-ctx engine: tool '%s' failed: %s", name, exc)
+            self.last_error = str(exc)
             self._healthy = False
             self._health_checked_at = time.monotonic()
             return None


### PR DESCRIPTION
## Problem

`ToolGateway.call_text()` swallows the underlying exception and returns `None`, so `handle_tool_call` reports every failure as:

```
lean-ctx daemon unavailable; 'ctx_read' could not be executed.
```

That's misleading when the daemon is healthy and the call failed for another reason (e.g. the server rejecting a path with `path escapes project root`) — the real error only appears in the serve log.

## Fix

Keep the last failure on the gateway (`last_error`) and include it in the returned error string: `lean-ctx call failed: <real error>; '<tool>' could not be executed.` Failures still degrade to an error string, never raise into the host loop.

## Tests

`tests/test_tools.py` updated for the new format; 7 passed.