### PR TITLE
fix: correct config key name in tool-health hint (tools_disabled -> disabled_tools)

### DIFF
--- a/rust/src/core/tool_health.rs
+++ b/rust/src/core/tool_health.rs
@@ -219,7 +219,7 @@ pub fn build_report(
         String::new()
     } else {
         format!(
-            "consider disabling {} low-value tool(s) to reclaim {reclaimable_tokens} tok/session: {} — apply via `tools_disabled` in config or a leaner `tool_profile`",
+            "consider disabling {} low-value tool(s) to reclaim {reclaimable_tokens} tok/session: {} — apply via `disabled_tools` in config or a leaner `tool_profile`",
             disable_candidates.len(),
             disable_candidates.join(", ")
         )


### PR DESCRIPTION
### Problem
The tool-health hint that suggests disabling low-value tools points users at a config key that does not exist. `rust/src/core/tool_health.rs` prints:

> apply via `tools_disabled` in config or a leaner `tool_profile`

But the actual config field is `disabled_tools` (`rust/src/core/config/mod.rs`: `pub disabled_tools: Vec<String>`), which is also what the JSON schema, the `LEAN_CTX_DISABLED_TOOLS` env var, the CHANGELOG, and the docs all use. `tools_disabled` is not a recognized key — it is the only occurrence of that spelling in the entire repo — so a user who copies the hint and sets `tools_disabled = [...]` has it silently ignored.

### Fix
Correct the hint to reference the real key, `disabled_tools`. Single-token change to the message string; no behavior change.

### Verification
`grep -rn tools_disabled` returns only the hint line; the deserializer field, schema, and env parsing all use `disabled_tools`.
