### PR TITLE
fix(ctx_read): honor start_line/limit on mode=anchored

### DIFF
--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -166,6 +166,100 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
     Ok(crate::core::io_boundary::strip_utf8_bom(s))
 }
 
+/// A streamed line-window read (#811): only the requested span's raw lines,
+/// plus the file's true total line count for the header — the rest of the
+/// file is never buffered.
+struct LineWindow {
+    /// Raw lines within `[start, end]`, joined with `\n`.
+    body: String,
+    /// True total line count of the file.
+    total_lines: usize,
+    /// Clamped, 1-based inclusive bounds actually served.
+    start: usize,
+    end: usize,
+}
+
+/// Parses an `anchored:` window payload for the disk-streaming short-circuit
+/// below. Only the dash form (`"N-M"`) is fast-pathed — `anchored_lines_mode`
+/// (the registered handler) always emits it, using the `999999` EOF sentinel
+/// rather than a bare `"N"`. A hand-typed bare payload (meaning "N to EOF")
+/// returns `None` and falls through to the normal full-read path instead of
+/// guessing a total line count up front.
+fn parse_disk_anchor_range(payload: &str) -> Option<(usize, usize)> {
+    let (s, e) = payload.split_once('-')?;
+    let start = s.trim().parse::<usize>().ok()?.max(1);
+    let end = e.trim().parse::<usize>().ok()?;
+    Some((start, end))
+}
+
+/// Streams `path` line-by-line and extracts only `[start, end]` (1-based,
+/// inclusive) without ever holding the whole file in memory — the
+/// anchored-window counterpart to [`read_file_lossy`] (#811). Every line is
+/// still counted (one cheap UTF-8 pass, no per-line allocation outside the
+/// requested window) so the caller can report the true total. Returns `None`
+/// on anything that isn't a clean streamed text read (I/O error, a binary
+/// file, invalid UTF-8 anywhere in the file) so the caller can fall back to
+/// the existing, more permissive `read_file_lossy` path — behaviour never
+/// regresses, it just doesn't always get the fast path.
+fn read_line_window(path: &str, start: usize, end: usize) -> Option<LineWindow> {
+    if crate::core::binary_detect::is_binary_file(path) {
+        return None;
+    }
+    use std::io::BufRead;
+    let file = open_with_retry(path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let mut total = 0usize;
+    let mut collected = Vec::new();
+    for line in reader.lines() {
+        let line = line.ok()?;
+        total += 1;
+        if total >= start && total <= end {
+            collected.push(line);
+        }
+    }
+    Some(LineWindow {
+        body: collected.join("\n"),
+        total_lines: total,
+        start: start.min(total.max(1)),
+        end: end.min(total),
+    })
+}
+
+/// #811: attempt the disk-streaming short-circuit for a fresh `anchored:N-M`
+/// read. `None` when the request isn't eligible (not a windowed anchored
+/// read, or a preread is already in hand — nothing to short-circuit) or the
+/// fast path can't run cleanly (binary file, invalid UTF-8, I/O error); the
+/// caller falls through to the normal full-read path in that case.
+fn try_disk_anchored_window(
+    path: &str,
+    mode: &str,
+    fresh: bool,
+    preread_is_none: bool,
+    file_ref: &str,
+    short: &str,
+) -> Option<ReadOutput> {
+    if !fresh || !preread_is_none {
+        return None;
+    }
+    let range = mode.strip_prefix("anchored:")?;
+    let (start, end) = parse_disk_anchor_range(range)?;
+    let window = read_line_window(path, start, end)?;
+    let (out, _) = format_anchored_output_window(
+        file_ref,
+        short,
+        &window.body,
+        window.total_lines,
+        Some((window.start, window.end)),
+    );
+    let out = crate::core::redaction::redact_text_if_enabled(&out);
+    let sent = count_tokens(&out);
+    Some(ReadOutput {
+        content: out,
+        resolved_mode: mode.to_string(),
+        output_tokens: sent,
+    })
+}
+
 /// Opens a file, retrying once after a brief pause on NotFound.
 /// Works around overlay/FUSE stat-cache races in container runtimes (Docker, Codex).
 /// Uses O_NOFOLLOW on Unix for TOCTOU symlink protection.
@@ -782,6 +876,13 @@ fn handle_with_options_inner(
             };
         }
         cache.invalidate(path);
+    }
+
+    // #811: a fresh, explicitly windowed `anchored:N-M` read never needs the
+    // cache (fresh always bypasses it) or the whole file in memory — try the
+    // disk-streaming short-circuit first.
+    if let Some(out) = try_disk_anchored_window(path, mode, fresh, preread.is_none(), &file_ref, &short) {
+        return out;
     }
 
     if mode == "diff" {

--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -70,8 +70,9 @@ pub(crate) enum ReadMode {
     /// original line structure while saving framing overhead.
     FullCompact,
     /// Verbatim + per-line `N:hh|` hash anchors, edit-ready for `ctx_patch`
-    /// (epic #1008) — `"anchored"`. Lossless (a strict superset of `full`).
-    Anchored,
+    /// (epic #1008) — `"anchored"`, or windowed as `"anchored:N-M"` (#811) so a
+    /// bounded anchored read never has to materialize/anchor the whole file.
+    Anchored(Option<LineRange>),
     /// Exact bytes, no framing — `"raw"`.
     Raw,
     /// API surface — `"signatures"`.
@@ -138,7 +139,7 @@ impl FromStr for ReadMode {
         Ok(match s {
             "full" => ReadMode::Full,
             "full-compact" => ReadMode::FullCompact,
-            "anchored" => ReadMode::Anchored,
+            "anchored" => ReadMode::Anchored(None),
             "raw" => ReadMode::Raw,
             "signatures" => ReadMode::Signatures,
             "map" => ReadMode::Map,
@@ -151,6 +152,8 @@ impl FromStr for ReadMode {
             other => {
                 if let Some(payload) = other.strip_prefix("lines:") {
                     ReadMode::Lines(parse_line_range(payload)?)
+                } else if let Some(payload) = other.strip_prefix("anchored:") {
+                    ReadMode::Anchored(Some(parse_line_range(payload)?))
                 } else if let Some(payload) = other.strip_prefix("density:") {
                     let target = payload
                         .trim()
@@ -170,7 +173,6 @@ impl fmt::Display for ReadMode {
         let keyword = match self {
             ReadMode::Full => "full",
             ReadMode::FullCompact => "full-compact",
-            ReadMode::Anchored => "anchored",
             ReadMode::Raw => "raw",
             ReadMode::Signatures => "signatures",
             ReadMode::Map => "map",
@@ -180,6 +182,8 @@ impl fmt::Display for ReadMode {
             ReadMode::Reference => "reference",
             ReadMode::Auto => "auto",
             ReadMode::Diff => "diff",
+            ReadMode::Anchored(None) => "anchored",
+            ReadMode::Anchored(Some(range)) => return write!(f, "anchored:{range}"),
             ReadMode::Lines(range) => return write!(f, "lines:{range}"),
             // Matches the handler's historical `format!("density:{:.2}", …)`.
             ReadMode::Density(target) => return write!(f, "density:{target:.2}"),
@@ -210,7 +214,7 @@ impl ReadMode {
                 // Anchored carries per-line anchors the agent edits against;
                 // collapsing to bare bytes on a small file would strip them and
                 // defeat the mode, so it opts out of the #361 raw cap.
-                | ReadMode::Anchored
+                | ReadMode::Anchored(_)
         )
     }
 
@@ -241,7 +245,7 @@ impl ReadMode {
         // `full-compact` only strips trailing whitespace — functionally verbatim.
         !matches!(
             self,
-            ReadMode::Full | ReadMode::FullCompact | ReadMode::Diff | ReadMode::Anchored
+            ReadMode::Full | ReadMode::FullCompact | ReadMode::Diff | ReadMode::Anchored(_)
         )
     }
 }
@@ -381,6 +385,29 @@ mod tests {
     #[test]
     fn line_range_clamps_start_to_one() {
         assert_eq!(LineRange::new(0, 10).start, 1);
+    }
+
+    #[test]
+    fn anchored_window_parses_and_displays() {
+        assert_eq!(
+            "anchored:5-10".parse::<ReadMode>().unwrap(),
+            ReadMode::Anchored(Some(LineRange::new(5, 10)))
+        );
+        assert_eq!(
+            "anchored:5-10".parse::<ReadMode>().unwrap().to_string(),
+            "anchored:5-10"
+        );
+        assert_eq!(
+            "anchored".parse::<ReadMode>().unwrap(),
+            ReadMode::Anchored(None)
+        );
+    }
+
+    #[test]
+    fn anchored_window_opts_out_of_raw_cap_and_compressed_count() {
+        let windowed: ReadMode = "anchored:5-10".parse().unwrap();
+        assert!(!windowed.allows_raw_cap());
+        assert!(!windowed.counts_as_compressed());
     }
 
     #[test]

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -125,13 +125,48 @@ pub(crate) fn format_anchored_output(
     content: &str,
     line_count: usize,
 ) -> (String, usize) {
+    format_anchored_output_window(file_ref, short, content, line_count, None)
+}
+
+/// Windowed variant of [`format_anchored_output`] (#811): when `window` is
+/// `Some((start, end))`, `content` is sliced to that 1-based inclusive span
+/// *before* anchoring, so a bounded anchored read never has to hash/render
+/// lines outside the requested window — only the slice is annotated, numbered
+/// from its true position in the file so anchors still line up with
+/// `ctx_patch`. `None` reproduces the whole-file behaviour above.
+pub(crate) fn format_anchored_output_window(
+    file_ref: &str,
+    short: &str,
+    content: &str,
+    line_count: usize,
+    window: Option<(usize, usize)>,
+) -> (String, usize) {
     let _mode_guard = crate::core::savings_footer::ModeGuard::new("anchored");
-    let header = if crate::core::protocol::meta_visible() && !file_ref.is_empty() {
-        format!("{file_ref}={short} {line_count}L [anchored: N:hh|line → edit via ctx_patch]")
-    } else {
-        format!("{short} {line_count}L [anchored: N:hh|line → edit via ctx_patch]")
+    let (body, start_line, range_suffix) = match window {
+        Some((start, end)) => {
+            let lines: Vec<&str> = content.lines().collect();
+            let total = lines.len();
+            let start = start.max(1).min(total.max(1));
+            let end = end.min(total);
+            let body = if total > 0 && end >= start {
+                lines[start - 1..end].join("\n")
+            } else {
+                String::new()
+            };
+            (body, start, format!(" lines:{start}-{end}"))
+        }
+        None => (content.to_string(), 1, String::new()),
     };
-    let annotated = crate::core::anchor::annotate(content, 1);
+    let header = if crate::core::protocol::meta_visible() && !file_ref.is_empty() {
+        format!(
+            "{file_ref}={short} {line_count}L{range_suffix} [anchored: N:hh|line → edit via ctx_patch]"
+        )
+    } else {
+        format!(
+            "{short} {line_count}L{range_suffix} [anchored: N:hh|line → edit via ctx_patch]"
+        )
+    };
+    let annotated = crate::core::anchor::annotate(&body, start_line);
     let output = format!("{header}\n{annotated}");
     let sent = count_tokens(&output);
     (output, sent)
@@ -267,6 +302,11 @@ pub(crate) fn process_mode_tuned(
         ),
         "full-compact" => format_full_compact_output(content),
         "anchored" => format_anchored_output(file_ref, short, content, line_count),
+        mode if mode.starts_with("anchored:") => {
+            let range_str = &mode[9..];
+            let (start, end) = parse_anchored_range(range_str, line_count);
+            format_anchored_output_window(file_ref, short, content, line_count, Some((start, end)))
+        }
         "signatures" => render_signatures(content, ctx),
         "map" => render_map(content, ctx),
         "aggressive" => render_aggressive(content, ctx),
@@ -477,6 +517,21 @@ pub(crate) fn extract_line_range(content: &str, range_str: &str) -> String {
         "No lines matched the range.".to_string()
     } else {
         selected.join("\n")
+    }
+}
+
+/// Parses a single `"start-end"` (or bare `"start"`, meaning "to EOF") window
+/// payload for `anchored:N-M` (#811). Single-span only — unlike `lines:`,
+/// an anchored window feeds `ctx_patch`, which edits one contiguous region at
+/// a time, so comma multi-select isn't needed here.
+fn parse_anchored_range(range_str: &str, total: usize) -> (usize, usize) {
+    if let Some((s, e)) = range_str.split_once('-') {
+        let start = s.trim().parse::<usize>().unwrap_or(1).max(1);
+        let end = e.trim().parse::<usize>().unwrap_or(total).min(total);
+        (start, end)
+    } else {
+        let start = range_str.trim().parse::<usize>().unwrap_or(1).max(1);
+        (start, total)
     }
 }
 

--- a/rust/src/tools/ctx_read/render.rs
+++ b/rust/src/tools/ctx_read/render.rs
@@ -137,25 +137,14 @@ pub(crate) fn format_anchored_output(
 pub(crate) fn format_anchored_output_window(
     file_ref: &str,
     short: &str,
-    content: &str,
+    body: &str,
     line_count: usize,
     window: Option<(usize, usize)>,
 ) -> (String, usize) {
     let _mode_guard = crate::core::savings_footer::ModeGuard::new("anchored");
-    let (body, start_line, range_suffix) = match window {
-        Some((start, end)) => {
-            let lines: Vec<&str> = content.lines().collect();
-            let total = lines.len();
-            let start = start.max(1).min(total.max(1));
-            let end = end.min(total);
-            let body = if total > 0 && end >= start {
-                lines[start - 1..end].join("\n")
-            } else {
-                String::new()
-            };
-            (body, start, format!(" lines:{start}-{end}"))
-        }
-        None => (content.to_string(), 1, String::new()),
+    let (start_line, range_suffix) = match window {
+        Some((start, end)) => (start, format!(" lines:{start}-{end}")),
+        None => (1, String::new()),
     };
     let header = if crate::core::protocol::meta_visible() && !file_ref.is_empty() {
         format!(
@@ -166,7 +155,7 @@ pub(crate) fn format_anchored_output_window(
             "{short} {line_count}L{range_suffix} [anchored: N:hh|line → edit via ctx_patch]"
         )
     };
-    let annotated = crate::core::anchor::annotate(&body, start_line);
+    let annotated = crate::core::anchor::annotate(body, start_line);
     let output = format!("{header}\n{annotated}");
     let sent = count_tokens(&output);
     (output, sent)
@@ -305,7 +294,8 @@ pub(crate) fn process_mode_tuned(
         mode if mode.starts_with("anchored:") => {
             let range_str = &mode[9..];
             let (start, end) = parse_anchored_range(range_str, line_count);
-            format_anchored_output_window(file_ref, short, content, line_count, Some((start, end)))
+            let (body, start, end) = slice_window(content, start, end);
+            format_anchored_output_window(file_ref, short, &body, line_count, Some((start, end)))
         }
         "signatures" => render_signatures(content, ctx),
         "map" => render_map(content, ctx),
@@ -533,6 +523,22 @@ fn parse_anchored_range(range_str: &str, total: usize) -> (usize, usize) {
         let start = range_str.trim().parse::<usize>().unwrap_or(1).max(1);
         (start, total)
     }
+}
+
+/// Slices `content` to 1-based inclusive `[start, end]`, clamped to the
+/// file's real bounds. Returns the joined body and the clamped `(start, end)`
+/// actually served — shared by the in-memory `anchored:N-M` render path.
+fn slice_window(content: &str, start: usize, end: usize) -> (String, usize, usize) {
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+    let start = start.max(1).min(total.max(1));
+    let end = end.min(total);
+    let body = if total > 0 && end >= start {
+        lines[start - 1..end].join("\n")
+    } else {
+        String::new()
+    };
+    (body, start, end)
 }
 
 #[cfg(test)]

--- a/rust/src/tools/ctx_read/tests.rs
+++ b/rust/src/tools/ctx_read/tests.rs
@@ -1906,3 +1906,124 @@ fn gh775_cold_ranged_read_returns_only_window() {
 
     crate::test_env::remove_var("LEAN_CTX_SHOW_SAVINGS");
 }
+
+// ---------------------------------------------------------------------------
+// #811: the `anchored:N-M` disk-streaming short-circuit. A fresh, explicitly
+// windowed anchored read must never materialize the whole file — these tests
+// exercise `read_line_window`/`parse_disk_anchor_range` directly, and the
+// end-to-end case that motivated it: a file bigger than `LCTX_MAX_READ_BYTES`
+// must still serve a small anchored window instead of erroring "file too
+// large" (the bug that `read_file_lossy`'s own error message told the caller
+// to route around, but couldn't actually satisfy before this fix).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_disk_anchor_range_accepts_dash_form_only() {
+    assert_eq!(parse_disk_anchor_range("5-10"), Some((5, 10)));
+    assert_eq!(parse_disk_anchor_range("1-999999"), Some((1, 999_999)));
+    // Bare "N" (meaning "to EOF") needs a known total to resolve — the
+    // streaming path doesn't have one up front, so it declines rather than
+    // guess, and the caller falls back to the full-read path.
+    assert_eq!(parse_disk_anchor_range("5"), None);
+    assert_eq!(parse_disk_anchor_range("not-a-range"), None);
+}
+
+#[test]
+fn read_line_window_streams_only_the_requested_span() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("window.txt");
+    let body = (1..=50)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, format!("{body}\n")).unwrap();
+    let p = path.to_string_lossy().to_string();
+
+    let window = read_line_window(&p, 10, 12).expect("streamed read must succeed");
+    assert_eq!(window.total_lines, 50);
+    assert_eq!(window.start, 10);
+    assert_eq!(window.end, 12);
+    assert_eq!(window.body, "line 10\nline 11\nline 12");
+}
+
+#[test]
+fn read_line_window_clamps_end_to_eof() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("short.txt");
+    std::fs::write(&path, "a\nb\nc\n").unwrap();
+    let p = path.to_string_lossy().to_string();
+
+    let window = read_line_window(&p, 2, 999_999).expect("streamed read must succeed");
+    assert_eq!(window.total_lines, 3);
+    assert_eq!(window.end, 3, "end must clamp to the real EOF, not the sentinel");
+    assert_eq!(window.body, "b\nc");
+}
+
+/// The end-to-end regression case: a file over `LCTX_MAX_READ_BYTES` must
+/// still serve a bounded `anchored:N-M` read. Before #811's disk-streaming
+/// short-circuit, `handle_with_options_inner` always called `read_file_lossy`
+/// first regardless of mode, so a window request on an oversized file failed
+/// with the same "file too large" error as a `full` read — even though
+/// `read_file_lossy`'s own error message recommends a line-range read as the
+/// escape hatch.
+#[test]
+fn disk_windowed_anchored_read_serves_file_over_the_size_cap() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("huge.rs");
+    let body = (1..=500)
+        .map(|i| format!("fn function_number_{i}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, format!("{body}\n")).unwrap();
+    let p = path.to_string_lossy().to_string();
+    let real_size = std::fs::metadata(&path).unwrap().len();
+
+    crate::test_env::set_var("LCTX_MAX_READ_BYTES", "512");
+    assert!(
+        real_size > 512,
+        "fixture must exceed the test cap to exercise the regression"
+    );
+
+    // Sanity: an ordinary full read of the oversized file is rejected.
+    let full_err = read_file_lossy(&p);
+    assert!(full_err.is_err(), "full read must hit the size cap");
+
+    let mut cache = SessionCache::new();
+    let out = handle_with_options_inner(
+        &mut cache,
+        &p,
+        "anchored:5-7",
+        /* fresh */ true,
+        CrpMode::Off,
+        None,
+        ReadTuning::default(),
+        None,
+    );
+    crate::test_env::remove_var("LCTX_MAX_READ_BYTES");
+
+    assert_eq!(out.resolved_mode, "anchored:5-7");
+    assert!(
+        out.content.contains("function_number_5")
+            && out.content.contains("function_number_7"),
+        "must contain the requested window: {}",
+        out.content
+    );
+    assert!(
+        !out.content.contains("function_number_1()")
+            && !out.content.contains("function_number_500"),
+        "must NOT contain lines outside the window: {}",
+        out.content
+    );
+    assert!(
+        out.content.contains("500L"),
+        "header must report the file's true total line count: {}",
+        out.content
+    );
+    assert!(
+        !out.content.to_lowercase().contains("too large")
+            && !out.content.to_lowercase().contains("error"),
+        "must not surface the size-cap error for a bounded window: {}",
+        out.content
+    );
+}

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -871,9 +871,23 @@ fn lines_mode(start: i64, limit: Option<i64>) -> String {
     }
 }
 
+/// Build the `anchored:N-M` mode string for a resolved window (#811) — mirrors
+/// `lines_mode`, keeping the `anchored:` prefix so the render path re-attaches
+/// hash anchors to the window instead of falling back to plain numbered lines.
+fn anchored_lines_mode(start: i64, limit: Option<i64>) -> String {
+    match limit {
+        Some(l) => format!("anchored:{start}-{}", start + l - 1),
+        None => format!("anchored:{start}-999999"),
+    }
+}
+
 /// Apply a resolved line window to `mode`/`fresh`. An explicit non-lines mode
 /// (map/signatures/…) is never clobbered (#259), and `start_line=1` with no
-/// limit is a no-op so it cannot disturb an auto/explicit read (#253).
+/// limit is a no-op so it cannot disturb an auto/explicit read (#253). An
+/// explicit `anchored` mode is windowed in place (`anchored:N-M`, #811)
+/// instead of being collapsed to `lines:N-M` — that would silently drop the
+/// hash anchors the caller asked for, and previously let a bounded anchored
+/// read fall through to rendering (and erroring on) the whole file.
 fn apply_line_window(
     mode: &mut String,
     fresh: &mut bool,
@@ -889,7 +903,9 @@ fn apply_line_window(
         return;
     }
     *fresh = true;
-    if !explicit_mode || mode.starts_with("lines") {
+    if mode == "anchored" {
+        *mode = anchored_lines_mode(start, limit);
+    } else if !explicit_mode || mode.starts_with("lines") {
         *mode = lines_mode(start, limit);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #811. `ctx_read(mode="anchored", start_line=N, limit=M)` silently dropped the window and always materialized/hashed the whole file — which could overflow the output cap on large files even for a tiny requested span, and hard-failed outright on files over `LCTX_MAX_READ_BYTES` regardless of window size.

This now implements the [maintainer's planned fix](https://github.com/yvgude/lean-ctx/issues/811#issuecomment-4973127925): a fresh, explicitly windowed `anchored:N-M` read streams only the requested span directly off disk via `BufReader::lines()`, never materializing the whole file into memory or the session cache.

## Root cause

`apply_line_window` only rewrote implicit or already-`lines:`-prefixed modes to `lines:N-M`. An explicit `mode="anchored"` fell through untouched, so the window was lost before it ever reached the renderer — and even after windowing the render step, the read pipeline still called `read_file_lossy` to load the whole file first, which also hard-caps at `LCTX_MAX_READ_BYTES` — defeating `read_file_lossy`'s own error message, which recommends a line-range read as the escape hatch.

## Changes

- `tools/registered/ctx_read.rs`: an explicit `anchored` mode is windowed in place (`anchored:N-M`) via `anchored_lines_mode`, instead of being left un-windowed or collapsed to plain `lines:N-M` (which would silently drop the hash anchors `ctx_patch` needs).
- `tools/ctx_read/mod.rs`: new `read_line_window` streams the file with `BufReader::lines()`, collecting only the requested span while still counting every line (for the header's true total) without buffering the rest. `try_disk_anchored_window` wires it into `handle_with_options_inner` — gated on `fresh` (windowed reads always are, so this can never skip a cache hit that would otherwise fire) — and falls back to the existing full-read path on anything that isn't a clean streamed text read (binary file, invalid UTF-8, I/O error, or a preread already in hand), so behaviour never regresses.
- `tools/ctx_read/render.rs`: `format_anchored_output_window` now takes an already-sliced body instead of re-slicing full content itself, so both the disk-streaming path and the existing in-memory path (an `anchored:N-M` mode string reached via any other route) can feed it a window. `ReadMode::Anchored` becomes `Anchored(Option<LineRange>)` in `mode.rs` so `allows_raw_cap`/`counts_as_compressed` correctly classify `anchored:N-M` — otherwise the `#361` anti-inflation raw-cap would collapse a small windowed output back to the full raw file, reintroducing the materialization bug for small-enough files.

## Test plan

- [x] `cargo test --lib ctx_read -- --test-threads=1` → 140 passed, 0 failed (includes 6 new tests: 2 `mode.rs` classification tests, `parse_disk_anchor_range_accepts_dash_form_only`, `read_line_window_streams_only_the_requested_span`, `read_line_window_clamps_end_to_eof`, and the end-to-end regression `disk_windowed_anchored_read_serves_file_over_the_size_cap` — sets `LCTX_MAX_READ_BYTES` below a fixture's size and confirms `anchored:N-M` still serves the window where a full read is rejected)
- [x] `cargo test --lib` (whole workspace) → 7629 passed, 1 failed (`http_server::team::connectors::tests::sync_lands_in_searchable_store_end_to_end`, a BM25-index test unrelated to this change — untouched by this diff)
- [x] `cargo clippy --lib` → clean, no warnings
