### PR TITLE
fix(stats): aggregate split data dirs across dashboard and gain surfaces (#830)

### DIFF
--- a/rust/src/cli/dispatch/analytics/gain.rs
+++ b/rust/src/cli/dispatch/analytics/gain.rs
@@ -534,7 +534,7 @@ fn cmd_opportunity() {
     let history = crate::cli::common::load_shell_history();
     let result = crate::tools::ctx_discover::analyze_history(&history, 10);
 
-    let store = core::stats::load();
+    let store = core::stats::load_for_display();
     let optimized_cmds = store.total_commands;
 
     if result.missed_commands.is_empty() {

--- a/rust/src/core/stats/format/dashboard.rs
+++ b/rust/src/core/stats/format/dashboard.rs
@@ -221,7 +221,7 @@ pub fn format_gain_body() -> String {
 
 /// The standalone gain dashboard footer (contextual tip, Context OS, hints).
 pub fn format_gain_footer() -> String {
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
     let mut out = Vec::new();
     append_gain_footer(&mut out, &active_theme(), &store);
     out.join("\n")

--- a/rust/src/core/stats/format/views.rs
+++ b/rust/src/core/stats/format/views.rs
@@ -8,7 +8,7 @@ use super::super::model::CostModel;
 /// Renders a 30-day token savings bar chart with sparkline.
 pub fn format_gain_graph() -> String {
     let theme = active_theme();
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
     let rst = theme::rst();
     let bold = theme::bold();
     let dim = theme::dim();
@@ -93,7 +93,7 @@ pub fn format_gain_graph() -> String {
 #[allow(clippy::many_single_char_names)]
 pub fn format_gain_daily() -> String {
     let theme = active_theme();
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
     let rst = theme::rst();
     let bold = theme::bold();
     let dim = theme::dim();
@@ -217,6 +217,6 @@ pub fn format_gain_daily() -> String {
 
 /// Returns the full stats store as pretty-printed JSON.
 pub fn format_gain_json() -> String {
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
     serde_json::to_string_pretty(&store).unwrap_or_else(|_| "{}".to_string())
 }

--- a/rust/src/core/wrapped.rs
+++ b/rust/src/core/wrapped.rs
@@ -27,7 +27,7 @@ pub struct WrappedReport {
 
 impl WrappedReport {
     pub fn generate(period: &str) -> Self {
-        let store = stats::load();
+        let store = stats::load_for_display();
         let sessions = SessionState::list_sessions();
 
         let (gross_tokens_saved, tokens_input, total_commands) = match period {

--- a/rust/src/dashboard/routes/agents.rs
+++ b/rust/src/dashboard/routes/agents.rs
@@ -165,7 +165,7 @@ fn build_mcp_tools_json() -> String {
     // All-time per-tool aggregates from stats.json — the same source Home and
     // ROI use. The event log only holds the last N events, which silently
     // understated these counters as a pseudo all-time view (#492).
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
 
     let mut tool_stats: HashMap<String, ToolAgg> = HashMap::new();
 

--- a/rust/src/dashboard/routes/memory.rs
+++ b/rust/src/dashboard/routes/memory.rs
@@ -106,7 +106,7 @@ fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str
                         })
                 })
                 .unwrap_or_default();
-            let global = crate::core::stats::load();
+            let global = crate::core::stats::load_for_display();
             let g_cmds = global.total_commands;
             let g_input = global.total_input_tokens;
             let g_output = global.total_output_tokens;
@@ -136,7 +136,7 @@ fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str
         // session, newest first, so users with several IDE windows can see
         // which projects lean-ctx serves and how fresh each one is.
         "/api/workspaces" => {
-            let last_use = crate::core::stats::load()
+            let last_use = crate::core::stats::load_for_display()
                 .last_use
                 .as_deref()
                 .and_then(|lu| chrono::DateTime::parse_from_rfc3339(lu).ok())

--- a/rust/src/dashboard/routes/stats.rs
+++ b/rust/src/dashboard/routes/stats.rs
@@ -6,7 +6,10 @@ pub(super) fn handle(
 ) -> Option<(&'static str, &'static str, String)> {
     match path {
         "/api/stats" => {
-            let store = crate::core::stats::load();
+            // Aggregate across split data dirs (#500) so an MCP-server/CLI XDG
+            // split does not show a false `0` here while `lean-ctx gain` (which
+            // uses load_for_display) reports the real total.
+            let store = crate::core::stats::load_for_display();
             let mut value = serde_json::to_value(&store).unwrap_or_else(|_| serde_json::json!({}));
             if let Some(obj) = value.as_object_mut() {
                 let echo = crate::core::output_echo::load_stats();

--- a/rust/src/token_report.rs
+++ b/rust/src/token_report.rs
@@ -152,7 +152,7 @@ fn build_report(project_root_override: Option<&str>) -> Result<(TokenReport, Pat
         warnings.push("no active session found".to_string());
     }
 
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
     let last_snapshot = store.cep.scores.last().map(|s| CepSnapshot {
         timestamp: s.timestamp.clone(),
         score: s.score,

--- a/rust/src/tools/ctx_discover.rs
+++ b/rust/src/tools/ctx_discover.rs
@@ -155,7 +155,7 @@ fn measured_by_family(store: &StatsStore) -> HashMap<String, (u64, u64, u64)> {
 }
 
 pub fn analyze_history(history: &[String], limit: usize) -> DiscoverResult {
-    let store = crate::core::stats::load();
+    let store = crate::core::stats::load_for_display();
     analyze_history_with_stats(history, limit, &store)
 }
 

--- a/rust/src/tui/app.rs
+++ b/rust/src/tui/app.rs
@@ -121,7 +121,7 @@ struct FileHeat {
 
 impl AppState {
     fn new() -> Self {
-        let store = crate::core::stats::load();
+        let store = crate::core::stats::load_for_display();
         let heatmap = crate::core::heatmap::HeatMap::load();
         let files = heatmap
             .entries


### PR DESCRIPTION
## What

Fixes the dashboard **Home** view showing `0` tokens saved / `0` calls / `0%` compression while `lean-ctx gain` reports the real total on the same machine.

Closes #830.

## Why

`/api/stats` (and several other user-facing display surfaces) used the non-aggregating `core::stats::load()`, so a split MCP-server/CLI XDG data dir produced a false `0`. Meanwhile the **Gain score** comes from `GainEngine::load()` which already aggregates via `load_for_display()` (#500) — so a single dashboard view mixed aggregated and non-aggregated sources.

## Changes

Switch user-facing display readers to `load_for_display()`:

- **dashboard**: `/api/stats` (+ `channel_breakdown`), `routes/agents.rs`, `routes/memory.rs`
- **gain CLI**: `--deep` footer, `--graph`/daily views, `--opportunity`, `--wrapped` card
- **other surfaces**: `token_report.rs`, `tui/app.rs`, `tools/ctx_discover.rs`

Intentionally left on single-dir `load()` (correct as-is): `cloud_sync`, `cli/cloud`, `doctor`, `gain --raw`, and internal `stats::load` / `load_stats`.

## Testing

- `cargo build` / `cargo check` pass.
- Manual: with stats split across data dirs, dashboard Home totals now match `lean-ctx gain`.

## Notes

Pure display-path change — no change to how stats are recorded or persisted. Behaviour is identical when stats live in a single data dir.
