### PR TITLE
fix(config): gate gitignore override on workspace trust

### DIFF
--- a/rust/src/core/config/merge.rs
+++ b/rust/src/core/config/merge.rs
@@ -101,8 +101,10 @@ impl Config {
         }
         // Index filters (#735): repo-local excludes extend the global list; a
         // repo-local include set (the stricter, corpus-defining axis) replaces
-        // the global one; gitignore handling can only be switched off locally
-        // (same only-tighten pattern as the bool flags above).
+        // the global one. Disabling gitignore respect is trust-gated: it widens
+        // the indexed/searchable surface, so an untrusted repo's
+        // `respect_gitignore = false` is reset by `strip_sensitive_overrides` and
+        // this branch only lands from a trusted local config.
         if !local.index.exclude.is_empty() {
             self.index.exclude.extend(local.index.exclude);
         }

--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -918,6 +918,12 @@ fn strip_sensitive_overrides(local: &mut Config) -> Vec<&'static str> {
         local.permission_inheritance = None;
         withheld.push("permission_inheritance");
     }
+    strip_tool_surface_sensitive_overrides(local, &mut withheld);
+
+    withheld
+}
+
+fn strip_tool_surface_sensitive_overrides(local: &mut Config, withheld: &mut Vec<&'static str>) {
     if !local.disabled_tools.is_empty() {
         local.disabled_tools.clear();
         withheld.push("disabled_tools");
@@ -934,8 +940,15 @@ fn strip_sensitive_overrides(local: &mut Config) -> Vec<&'static str> {
         local.default_tool_categories.clear();
         withheld.push("default_tool_categories");
     }
-
-    withheld
+    // Disabling gitignore respect widens the indexed/searchable surface
+    // (gitignored files become visible to ctx_search) -- a boundary an
+    // untrusted repo must not relax. is_secret_like still guards obvious
+    // secrets, but private/gitignored files that do not match that heuristic
+    // would otherwise leak.
+    if !local.index.respect_gitignore {
+        local.index.respect_gitignore = true;
+        withheld.push("index.respect_gitignore");
+    }
 }
 
 /// Names of the SECURITY-sensitive overrides a project-local `.lean-ctx.toml`

--- a/rust/src/core/config/tests.rs
+++ b/rust/src/core/config/tests.rs
@@ -940,6 +940,27 @@ mod extra_roots_tests {
     }
 
     #[test]
+    fn merge_local_untrusted_withholds_gitignore_disable() {
+        let mut untrusted = Config::default();
+        assert!(untrusted.index.respect_gitignore);
+        untrusted.merge_local("[index]\nrespect_gitignore = false\n", false);
+        assert!(
+            untrusted.index.respect_gitignore,
+            "untrusted workspace must not disable gitignore respect"
+        );
+
+        let mut trusted = Config::default();
+        trusted.merge_local("[index]\nrespect_gitignore = false\n", true);
+        assert!(
+            !trusted.index.respect_gitignore,
+            "trusted workspace may disable gitignore respect"
+        );
+
+        let withheld = local_sensitive_overrides("[index]\nrespect_gitignore = false\n");
+        assert!(withheld.contains(&"index.respect_gitignore"));
+    }
+
+    #[test]
     fn allow_symlink_roots_follows_extra_roots_trust_semantics() {
         // #596 premium: the symlink write-through allowlist is security-sensitive,
         // so an untrusted workspace's entry is withheld while a trusted one applies.


### PR DESCRIPTION
Fixes #833

## Summary
- prevent untrusted local config from setting index.respect_gitignore = false
- keep trusted local config able to disable gitignore respect intentionally
- surface index.respect_gitignore in sensitive override reporting

## Validation
- cargo fmt --check
- cargo test --lib merge_local_untrusted_withholds_gitignore_disable