### PR TITLE
fix(dashboard): keep commander trail expansion attached to files

### DIFF
--- a/rust/src/dashboard/static/components/cockpit-commander.js
+++ b/rust/src/dashboard/static/components/cockpit-commander.js
@@ -447,8 +447,8 @@ class CockpitCommander extends HTMLElement {
 
       // Expandable trail row (power mode)
       if (this._powerMode && r.source_trail && r.source_trail.length > 0) {
-        const expanded = this._expandedTrails.has(idx);
-        h += '<tr class="cmdr-trail-toggle" data-trail-idx="' + idx + '">';
+        const expanded = this._expandedTrails.has(r.path);
+        h += '<tr class="cmdr-trail-toggle" data-trail-path="' + pd + '">';
         h += '<td colspan="' + (this._powerMode ? 12 : 6) + '" style="padding:2px 12px;font-size:10px;cursor:pointer;color:var(--muted)">';
         h += (expanded ? '\u25bc' : '\u25b6') + ' Why in context? (' + r.source_trail.length + ')';
         h += '</td></tr>';
@@ -507,11 +507,11 @@ class CockpitCommander extends HTMLElement {
 
     this.querySelectorAll('.cmdr-trail-toggle').forEach(row => {
       row.addEventListener('click', () => {
-        const idx = parseInt(row.getAttribute('data-trail-idx'), 10);
-        if (this._expandedTrails.has(idx)) {
-          this._expandedTrails.delete(idx);
+        const path = decodeURIComponent(row.getAttribute('data-trail-path'));
+        if (this._expandedTrails.has(path)) {
+          this._expandedTrails.delete(path);
         } else {
-          this._expandedTrails.add(idx);
+          this._expandedTrails.add(path);
         }
         this.render();
       });

--- a/rust/src/dashboard/static/tests/cockpit-commander.test.js
+++ b/rust/src/dashboard/static/tests/cockpit-commander.test.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for stable Commander source-trail expansion (#834).
+ * Run with: node rust/src/dashboard/static/tests/cockpit-commander.test.js
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const componentPath = path.join(__dirname, '..', 'components', 'cockpit-commander.js');
+const source = fs.readFileSync(componentPath, 'utf8').replace(
+  'export { CockpitCommander };',
+  'globalThis.CockpitCommander = CockpitCommander;'
+);
+
+class HTMLElement {}
+const context = {
+  console,
+  customElements: { define() {} },
+  document: { addEventListener() {}, querySelector() { return null; } },
+  HTMLElement,
+  window: {},
+};
+context.globalThis = context;
+vm.runInNewContext(source, context, { filename: componentPath });
+
+const commander = new context.CockpitCommander();
+commander._powerMode = true;
+commander._data = {
+  items: [
+    {
+      path: '/workspace/a.rs',
+      mode: 'full',
+      tokens_sent: 10,
+      eviction_score: 0.1,
+      source_trail: [{ type: 'read', detail: 'trail-a' }],
+    },
+    {
+      path: '/workspace/b.rs',
+      mode: 'map',
+      tokens_sent: 20,
+      eviction_score: 0.2,
+      source_trail: [{ type: 'read', detail: 'trail-b' }],
+    },
+  ],
+};
+commander._expandedTrails.add('/workspace/b.rs');
+
+function assertStableExpansion(sortDir) {
+  commander._sortKey = 'path';
+  commander._sortDir = sortDir;
+  const html = commander._renderPressureTable();
+  const encodedPath = encodeURIComponent('/workspace/b.rs');
+
+  if (!html.includes(`data-trail-path="${encodedPath}"`)) {
+    throw new Error(`${sortDir}: trail toggle is not keyed by the file path`);
+  }
+  if (!html.includes('trail-b')) {
+    throw new Error(`${sortDir}: expanded file lost its source trail`);
+  }
+  if (html.includes('trail-a')) {
+    throw new Error(`${sortDir}: expansion moved to a different file`);
+  }
+}
+
+assertStableExpansion('asc');
+assertStableExpansion('desc');
+commander._modeFilter = 'map';
+assertStableExpansion('asc');
+console.log('PASS: source-trail expansion remains keyed by path after sorting');


### PR DESCRIPTION
Fixes #834

## Summary
- key expanded Commander source trails by stable file path instead of rendered row index
- encode the path in the trail toggle attribute and decode it in the click handler
- add a regression scenario covering sort and filter rerenders

## Validation
- node rust/src/dashboard/static/tests/cockpit-commander.test.js
- node rust/src/dashboard/static/tests/cockpit-compression.test.js
- git diff --check