### PR TITLE
fix(codex): use permissionDecisionReason for denies

### DIFF
--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -1206,7 +1206,7 @@ fn codex_deny_output(original_cmd: &str) -> String {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
-            "reason": msg
+            "permissionDecisionReason": msg
         }
     })
     .to_string()

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -483,7 +483,11 @@ fn codex_deny_output_with_nested_quotes_is_valid_json() {
     let parsed: serde_json::Value =
         serde_json::from_str(&output).expect("codex_deny_output must be valid JSON");
     assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
-    let reason = parsed["hookSpecificOutput"]["reason"]
+    assert!(
+        parsed["hookSpecificOutput"].get("reason").is_none(),
+        "Codex rejects unknown fields in hookSpecificOutput"
+    );
+    let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
         .as_str()
         .unwrap_or("");
     assert!(


### PR DESCRIPTION
## Summary

Codex rejects the replace-mode deny response because `hookSpecificOutput` expects `permissionDecisionReason`; lean-ctx currently emits an unsupported nested `reason` field. The result is `hook returned invalid pre-tool-use JSON output` on non-rewritable Bash calls.

Use the Codex field name and update the regression test to reject the old nested key. Follow-up to #809.

## Test plan

- `cargo fmt --check`
- `cargo test --lib hook_handlers::tests --quiet` (122 passed)
- `cargo test --test shell_and_agent_tests codex_pretooluse --quiet` (2 passed)
- Representative Codex deny payload emits `permissionDecisionReason`
- `scripts/preflight.sh fast` reaches three existing Clippy `collapsible_match` errors in `core/patterns/spark.rs` and `proxy_setup.rs`; no diagnostics point to the changed files
