### PR TITLE
fix(context_gate): exempt anchored:N-M reads from mode override

### DIFF
--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -71,7 +71,7 @@ pub fn pre_dispatch_read_for_agent(
                 );
                 let mut result = no_change.clone();
                 result.budget_warning = Some(warning);
-                if requested_mode == "diff" || requested_mode.starts_with("lines") {
+                if requested_mode == "diff" || requested_mode.starts_with("lines") || requested_mode.starts_with("anchored") {
                     return result;
                 }
                 let rest = pre_dispatch_inner(path, requested_mode, task, project_root, pressure);
@@ -102,7 +102,7 @@ fn pre_dispatch_inner(
         budget_warning: None,
     };
 
-    if requested_mode == "diff" || requested_mode.starts_with("lines") {
+    if requested_mode == "diff" || requested_mode.starts_with("lines") || requested_mode.starts_with("anchored") {
         return no_change;
     }
 
@@ -471,6 +471,38 @@ mod tests {
     fn pre_dispatch_passthrough_for_diff() {
         let result = pre_dispatch_read("src/main.rs", "diff", None, None, None);
         assert!(result.overridden_mode.is_none());
+    }
+
+    #[test]
+    fn pre_dispatch_passthrough_for_anchored_window() {
+        // #843: a windowed anchored:N-M read must keep its hash anchors —
+        // bounce-prevention, pressure-downgrade, etc. must not clobber it to
+        // "full" and silently drop the window.
+        {
+            let mut bt = crate::core::bounce_tracker::global().lock().unwrap();
+            bt.set_seq(101);
+            bt.record_read("anchored-bouncy.yml", "map", 30, 400);
+            bt.set_seq(102);
+            bt.record_read("anchored-bouncy.yml", "full", 400, 400);
+            bt.set_seq(103);
+            bt.record_read("a2.yml", "map", 30, 400);
+            bt.set_seq(104);
+            bt.record_read("a2.yml", "full", 400, 400);
+            bt.set_seq(105);
+            bt.record_read("a3.yml", "map", 30, 400);
+            bt.set_seq(106);
+            bt.record_read("a3.yml", "full", 400, 400);
+        }
+        let result = pre_dispatch_read("anchored-new.yml", "anchored:10-40", None, None, None);
+        assert!(
+            result.overridden_mode.is_none(),
+            "anchored:N-M must not be overridden by bounce-prevention"
+        );
+        let bare = pre_dispatch_read("anchored-new.yml", "anchored", None, None, None);
+        assert!(
+            bare.overridden_mode.is_none(),
+            "bare anchored mode must not be overridden by bounce-prevention"
+        );
     }
 
     #[test]

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -2,6 +2,22 @@ use crate::core::context_field::{ContextItemId, ContextState};
 use crate::core::context_ledger::{ContextLedger, PressureAction};
 use crate::core::context_overlay::{OverlayOp, OverlayStore};
 
+/// #843: precise, pinned reads (`diff`, `lines:N-M`, `anchored`/`anchored:N-M`)
+/// must pass through every mode-override path untouched — bounce-prevention,
+/// pressure-downgrade, and the graph/knowledge heuristics below must never
+/// silently reinterpret one of these to e.g. `full`, which would discard the
+/// exact window/anchors/delta the caller asked for. Classifies off the typed
+/// `ReadMode` (single source of truth, see `tools::ctx_read::mode`) rather than
+/// a hand-maintained string-prefix list, so a future precise mode has to be
+/// added to `ReadMode::is_precise_pinned_read` explicitly instead of silently
+/// falling through an allowlist. An unparseable mode is conservatively treated
+/// as *not* pinned, matching prior behaviour for anything outside this set.
+fn is_precise_pinned_mode(requested_mode: &str) -> bool {
+    requested_mode
+        .parse::<crate::tools::ctx_read::ReadMode>()
+        .is_ok_and(|m| m.is_precise_pinned_read())
+}
+
 #[derive(Debug, Clone)]
 pub struct PreDispatchResult {
     pub overridden_mode: Option<String>,
@@ -71,7 +87,7 @@ pub fn pre_dispatch_read_for_agent(
                 );
                 let mut result = no_change.clone();
                 result.budget_warning = Some(warning);
-                if requested_mode == "diff" || requested_mode.starts_with("lines") || requested_mode.starts_with("anchored") {
+                if is_precise_pinned_mode(requested_mode) {
                     return result;
                 }
                 let rest = pre_dispatch_inner(path, requested_mode, task, project_root, pressure);
@@ -102,7 +118,7 @@ fn pre_dispatch_inner(
         budget_warning: None,
     };
 
-    if requested_mode == "diff" || requested_mode.starts_with("lines") || requested_mode.starts_with("anchored") {
+    if is_precise_pinned_mode(requested_mode) {
         return no_change;
     }
 

--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -259,7 +259,10 @@ impl ReadMode {
     /// instead of silently falling through an allowlist.
     #[must_use]
     pub(crate) fn is_precise_pinned_read(&self) -> bool {
-        matches!(self, ReadMode::Diff | ReadMode::Lines(_) | ReadMode::Anchored(_))
+        matches!(
+            self,
+            ReadMode::Diff | ReadMode::Lines(_) | ReadMode::Anchored(_)
+        )
     }
 }
 

--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -248,6 +248,19 @@ impl ReadMode {
             ReadMode::Full | ReadMode::FullCompact | ReadMode::Diff | ReadMode::Anchored(_)
         )
     }
+
+    /// Precise, pinned reads (#843): the caller asked for an exact byte-window
+    /// or delta and must get exactly that back. Context-gate overrides
+    /// (bounce-prevention, pressure-downgrade, graph/knowledge heuristics)
+    /// must never silently reinterpret one of these to e.g. `full` — that
+    /// discards the window/anchors/delta the caller explicitly asked for.
+    /// Kept as an enum match (not a string-prefix check) so a future mode
+    /// variant that's also precise/pinned has to be added here explicitly
+    /// instead of silently falling through an allowlist.
+    #[must_use]
+    pub(crate) fn is_precise_pinned_read(&self) -> bool {
+        matches!(self, ReadMode::Diff | ReadMode::Lines(_) | ReadMode::Anchored(_))
+    }
 }
 
 #[cfg(test)]
@@ -417,5 +430,23 @@ mod tests {
         let parsed: ReadMode = "density:0.5".parse().unwrap();
         assert_eq!(parsed, ReadMode::Density(0.5));
         assert_eq!(parsed.to_string(), "density:0.50");
+    }
+
+    #[test]
+    fn is_precise_pinned_read_covers_diff_lines_and_anchored() {
+        for mode in ["diff", "lines:5-10", "anchored", "anchored:5-10"] {
+            let parsed: ReadMode = mode.parse().expect("canonical mode parses");
+            assert!(
+                parsed.is_precise_pinned_read(),
+                "'{mode}' must be a precise pinned read"
+            );
+        }
+        for mode in ["full", "map", "signatures", "auto", "task"] {
+            let parsed: ReadMode = mode.parse().expect("canonical mode parses");
+            assert!(
+                !parsed.is_precise_pinned_read(),
+                "'{mode}' must not be a precise pinned read"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #843. `pre_dispatch_inner` (context_gate.rs) exempted `diff` and `lines:` reads from mode-override paths (bounce-prevention, pressure-downgrade, graph-hub, knowledge-relevance) but not `anchored` / `anchored:N-M`. A windowed anchored read on a file that tripped bounce-prevention (repeatedly read, large, graph-hub) got silently clobbered to `mode=full` -- dropping both the window and the hash anchors ctx_patch needs. That's exactly the "dumped the entire file, no hashes at all" symptom in the report, and I hit the same thing live in this session.

Fix: extend the passthrough guard in both `pre_dispatch_read_for_agent`'s budget-warning branch and `pre_dispatch_inner` to also skip override for `anchored`/`anchored:N-M`.

Test: added `pre_dispatch_passthrough_for_anchored_window`, reusing the existing bounce-prevention fixture, asserting both windowed and bare anchored reads survive unoverridden. `cargo test --lib -p lean-ctx server::context_gate:: -- --test-threads=1` -- 35 passed.
