### PR TITLE
fix(ci): resolve clippy -D warnings failures on main

### DIFF
--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -1033,8 +1033,7 @@ mod tests {
         if state.exists() {
             assert!(
                 result.is_ok(),
-                "tee-file path under lean-ctx state dir must be auto-allowed: {:?}",
-                result
+                "tee-file path under lean-ctx state dir must be auto-allowed: {result:?}"
             );
         }
         std::fs::remove_dir_all(&fake_root).ok();

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -1370,8 +1370,7 @@ fn enforce_allows_project_root_binary_path() {
     crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
     assert!(
         result.is_ok(),
-        "project-root binary path must be auto-allowed: {:?}",
-        result
+        "project-root binary path must be auto-allowed: {result:?}"
     );
 }
 
@@ -1397,8 +1396,7 @@ fn python3_inline_allowed_with_opt_in() {
     crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
     assert!(
         result.is_ok(),
-        "python3 -c must be allowed with opt-in: {:?}",
-        result
+        "python3 -c must be allowed with opt-in: {result:?}"
     );
 }
 
@@ -1413,7 +1411,6 @@ fn node_eval_allowed_with_opt_in() {
     crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
     assert!(
         result.is_ok(),
-        "node -e must be allowed with opt-in: {:?}",
-        result
+        "node -e must be allowed with opt-in: {result:?}"
     );
 }

--- a/rust/src/core/tool_health.rs
+++ b/rust/src/core/tool_health.rs
@@ -598,9 +598,11 @@ mod tests {
     fn shell_alias_inherits_ctx_shell_usage_838() {
         let shell_tool = tool("shell");
         let mut usage = CostStore::default();
-        let mut tc = ToolCost::default();
-        tc.total_calls = 42;
-        tc.last_used = Some("2026-07-15".to_string());
+        let tc = ToolCost {
+            total_calls: 42,
+            last_used: Some("2026-07-15".to_string()),
+            ..ToolCost::default()
+        };
         usage.tools.insert("ctx_shell".to_string(), tc);
         let report = build_report(
             &[shell_tool],

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -1174,7 +1174,7 @@ mod exec_tests {
     }
 
     /// #806: piped stdin must be forwarded to the child via Stdio::piped()
-    /// + relay, not nulled. Tests the relay pattern: write data to child
+    /// and relayed, not nulled. Tests the relay pattern: write data to child
     /// stdin, close it (EOF), child reads and exits.
     #[cfg(unix)]
     #[test]

--- a/rust/src/tools/ctx_refactor/tests.rs
+++ b/rust/src/tools/ctx_refactor/tests.rs
@@ -771,7 +771,7 @@ fn handle_replace_symbol_worktree_mismatch_blocks_write() {
 
     // The symbol resolves via the main-root index to "src/lib.rs".
     let resolved = super::resolve_name_path("worktree_canary_zz", &root);
-    assert!(resolved.is_ok(), "symbol should resolve: {:?}", resolved);
+    assert!(resolved.is_ok(), "symbol should resolve: {resolved:?}");
 
     // Caller provides a path inside the worktree that differs from the
     // index-resolved location — this must be caught.


### PR DESCRIPTION
CI's Clippy job (`RUSTFLAGS=-Dwarnings`) is failing on `main` HEAD (934477bc) -- found while babysitting #851/#857, unrelated to either PR's diff. Confirmed by checking out clean `main` and running `cargo clippy --lib --tests -- -D warnings` directly: 7 pre-existing errors across 4-5 files neither PR touches.

## Fix

Purely mechanical clippy fixes, no behavior change:
- `uninlined_format_args` (6 sites): `"...{:?}", x` -> `"...{x:?}"` in test assert! messages
- `field_reassign_with_default` (1 site): struct-literal init instead of `Default::default()` + field mutation
- `doc_lazy_continuation` (1 site): a doc-comment continuation line starting with `+` was parsed by rustdoc as an unindented markdown list item -- reworded to avoid the leading `+`

Files: `core/shell_allowlist/tests.rs`, `core/tool_health.rs`, `core/pathjail.rs`, `shell/exec.rs`, `tools/ctx_refactor/tests.rs`.

## Test plan
- [x] `cargo clippy --lib --tests -p lean-ctx -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo test --lib -p lean-ctx` -- 7691 passed, 0 failed