### PR TITLE
refactor(content_cache): replace hand-rolled LRU scan with the lru crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1769,8 +1769,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2405,7 +2403,7 @@ dependencies = [
  "lettre",
  "libc",
  "libloading 0.8.9",
- "lru 0.12.5",
+ "lru",
  "lsp-types",
  "md-5 0.11.0",
  "memmap2",
@@ -2670,18 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3815,7 +3804,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.0",
+ "lru",
  "palette",
  "serde",
  "strum",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1159,7 +1159,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1293,7 +1293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1769,6 +1769,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2403,6 +2405,7 @@ dependencies = [
  "lettre",
  "libc",
  "libloading 0.8.9",
+ "lru 0.12.5",
  "lsp-types",
  "md-5 0.11.0",
  "memmap2",
@@ -2667,6 +2670,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
@@ -2909,7 +2921,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3803,7 +3815,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.18.0",
  "palette",
  "serde",
  "strum",
@@ -4200,7 +4212,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4259,7 +4271,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4917,7 +4929,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6486,7 +6498,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -228,7 +228,7 @@ anyhow = "1.0"
 regex = "1.12"
 walkdir = "2.5"
 ignore = "0.4"
-lru = "0.12"
+lru = "0.18.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -228,6 +228,7 @@ anyhow = "1.0"
 regex = "1.12"
 walkdir = "2.5"
 ignore = "0.4"
+lru = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2.0"

--- a/rust/src/core/content_cache.rs
+++ b/rust/src/core/content_cache.rs
@@ -22,11 +22,12 @@
 //!   eviction orchestrator can [`clear`] the cache on `UnloadIndices` /
 //!   `EmergencyDrop`.
 
-use std::collections::HashMap;
 use std::fs::Metadata;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
+
+use lru::LruCache;
 
 /// Default resident byte budget when `LEAN_CTX_CONTENT_CACHE_MB` is unset.
 const DEFAULT_BUDGET_MB: usize = 128;
@@ -64,15 +65,19 @@ impl FileState {
 struct Entry {
     state: FileState,
     content: Arc<str>,
-    /// Logical clock tick of the last hit/insert — drives approximate LRU.
-    last_used: u64,
 }
 
 struct Cache {
-    map: HashMap<PathBuf, Entry>,
+    /// Unbounded by entry count — eviction is driven by `total_bytes` vs
+    /// `budget_bytes` below, not by a capacity `lru::LruCache` would enforce on
+    /// its own. `LruCache` gives O(1) recency tracking and O(1) LRU-victim
+    /// lookup (`pop_lru`), replacing a hand-rolled `last_used` clock plus an
+    /// O(n) `min_by_key` scan per eviction — the scan was rare per insert as
+    /// originally noted, but `trim_oldest_percent` called it in a loop, making
+    /// a big trim O(n²) over the resident set.
+    map: LruCache<PathBuf, Entry>,
     total_bytes: usize,
     budget_bytes: usize,
-    clock: u64,
     hits: u64,
     misses: u64,
     inserts: u64,
@@ -82,10 +87,9 @@ struct Cache {
 impl Cache {
     fn new(budget_bytes: usize) -> Self {
         Self {
-            map: HashMap::new(),
+            map: LruCache::unbounded(),
             total_bytes: 0,
             budget_bytes,
-            clock: 0,
             hits: 0,
             misses: 0,
             inserts: 0,
@@ -93,31 +97,19 @@ impl Cache {
         }
     }
 
-    fn tick(&mut self) -> u64 {
-        self.clock += 1;
-        self.clock
-    }
-
     fn remove_entry(&mut self, path: &Path) {
-        if let Some(old) = self.map.remove(path) {
+        if let Some(old) = self.map.pop(path) {
             self.total_bytes = self.total_bytes.saturating_sub(old.content.len());
         }
     }
 
-    /// Evict approximate-LRU entries until the budget is satisfied. Eviction
-    /// only runs after an over-budget insert, so the `O(n)` min-scan is rare and
-    /// dwarfed by the disk reads it prevents.
+    /// Evict LRU entries until the budget is satisfied. O(1) per eviction.
     fn evict_to_budget(&mut self) {
-        while self.total_bytes > self.budget_bytes && !self.map.is_empty() {
-            let Some(victim) = self
-                .map
-                .iter()
-                .min_by_key(|(_, e)| e.last_used)
-                .map(|(p, _)| p.clone())
-            else {
+        while self.total_bytes > self.budget_bytes {
+            let Some((_, victim)) = self.map.pop_lru() else {
                 break;
             };
-            self.remove_entry(&victim);
+            self.total_bytes = self.total_bytes.saturating_sub(victim.content.len());
             self.evictions += 1;
         }
     }
@@ -160,23 +152,23 @@ pub fn get(path: &Path, current: FileState) -> Option<Arc<str>> {
         return None;
     }
     let mut c = lock();
-    let Some(entry) = c.map.get(path) else {
+    // `peek` (not `get`) first: a stale hit must not promote to MRU on its way
+    // to being evicted.
+    let Some(entry) = c.map.peek(path) else {
         c.misses += 1;
         return None;
     };
-    let matches = entry.state == current;
-    if !matches {
+    if entry.state != current {
         // Stale version cached — drop it so we don't keep paying for it.
         c.remove_entry(path);
         c.misses += 1;
         return None;
     }
-    let tick = c.tick();
     c.hits += 1;
-    // The entry is present under the lock we still hold, but degrade gracefully
-    // instead of panicking on the read hot path if that invariant ever changes.
-    let entry = c.map.get_mut(path)?;
-    entry.last_used = tick;
+    // `get` promotes to MRU; present under the lock we still hold, but degrade
+    // gracefully instead of panicking on the read hot path if that invariant
+    // ever changes.
+    let entry = c.map.get(path)?;
     Some(Arc::clone(&entry.content))
 }
 
@@ -194,15 +186,7 @@ pub fn insert(path: &Path, state: FileState, content: Arc<str>) {
         return;
     }
     c.remove_entry(path);
-    let tick = c.tick();
-    c.map.insert(
-        path.to_path_buf(),
-        Entry {
-            state,
-            content,
-            last_used: tick,
-        },
-    );
+    c.map.put(path.to_path_buf(), Entry { state, content });
     c.total_bytes += len;
     c.inserts += 1;
     if c.total_bytes > c.budget_bytes {
@@ -251,15 +235,10 @@ pub fn trim_oldest_percent(percent: u8) {
     let pct = (percent.min(100)) as usize;
     let target_evictions = c.map.len() * pct / 100;
     for _ in 0..target_evictions {
-        let Some(victim) = c
-            .map
-            .iter()
-            .min_by_key(|(_, e)| e.last_used)
-            .map(|(p, _)| p.clone())
-        else {
+        let Some((_, victim)) = c.map.pop_lru() else {
             break;
         };
-        c.remove_entry(&victim);
+        c.total_bytes = c.total_bytes.saturating_sub(victim.content.len());
         c.evictions += 1;
     }
 }


### PR DESCRIPTION
Found in a `/ponytail-audit` pass (finding #13).

`content_cache`'s eviction hand-rolled LRU via a `last_used: u64` clock field per entry plus a `.min_by_key()` O(n) scan over the whole map to find the eviction victim. The code's own comment dismissed this as "rare and dwarfed by the disk reads it prevents" -- true for `evict_to_budget` (runs once per over-budget insert), but `trim_oldest_percent` calls that same O(n) scan **in a loop**, making a large trim O(n^2) over the resident set.

## Fix

Swap the `HashMap` + manual clock for `lru::LruCache` (unbounded by entry count -- eviction stays driven by the existing byte-budget check, not a count-based capacity). `get()` now `peek()`s before promoting so a stale hit doesn't get marked recently-used on its way to being evicted. `evict_to_budget`/`trim_oldest_percent` both become O(1) per eviction via `pop_lru()`.

## Test plan
- [x] `cargo test -p lean-ctx content_cache::` -- 5/5 pass
- [x] `cargo test --lib -p lean-ctx` (full suite) -- 7698 passed, 0 failed
- [x] `cargo fmt --check`, `cargo clippy --lib --tests -- -D warnings` -- clean