### PR TITLE
chore(deps): drop unused direct memmap2 dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2405,7 +2405,6 @@ dependencies = [
  "libloading 0.8.9",
  "lsp-types",
  "md-5 0.11.0",
- "memmap2",
  "moka",
  "ndarray",
  "ort",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -370,7 +370,6 @@ rayon = "1.12"
 moka = { version = "0.12", features = ["sync"] }
 postcard = { version = "1.1", features = ["use-std"] }
 zstd = "0.13"
-memmap2 = "0.9"
 lsp-types = "0.97"
 fs2 = "0.4"
 unicode-width = "0.2"


### PR DESCRIPTION
Found in a `/ponytail-audit` pass (finding #9).

`memmap2 = "0.9"` had zero use sites anywhere in `rust/src`, `rust/crates`, or `rust/tests` -- our own code never called it directly.

Note: `memmap2` remains in `Cargo.lock` as a transitive dependency of `resvg` -> `fontconfig-parser` (the optional SVG-rendering stack), so this doesn't shrink the compiled dependency tree or build time -- it only removes a dead, unused explicit version pin (cargo already resolves the transitive constraint on its own without our redundant pin).

## Test plan
- [x] `cargo build --lib -p lean-ctx` -- clean
- [x] `cargo test --lib -p lean-ctx` -- 7696 passed, 0 failed