### PR TITLE
feat(ctx_refactor): replace_symbol accepts path alongside name to scope ambiguous symbols

### DIFF
--- a/rust/src/tools/ctx_refactor/mod.rs
+++ b/rust/src/tools/ctx_refactor/mod.rs
@@ -284,7 +284,18 @@ fn container_matches_ancestor(name: &str, ancestor: &str) -> bool {
 /// Resolve a `name_path` (`Class/method` or bare `name`) to a single symbol via
 /// the tree-sitter index (spec v2a §3/§5.3). Disambiguates a qualified path by
 /// enclosing-range containment (ancestor symbol's line span contains the leaf's).
-pub(crate) fn resolve_name_path(name_path: &str, project_root: &str) -> Result<Resolved, String> {
+///
+/// `file_filter` (#845) narrows candidates to files whose path *contains* the
+/// given substring — the caller's `path` arg (e.g. `MyClass.cs`) — before the
+/// ambiguity check runs, so a common method name (`Dispose`, `ToString`) that
+/// exists in many classes across a large repo can be resolved with `name` +
+/// `path` in one call instead of a NO_SYMBOL/AMBIGUOUS_SYMBOL round trip
+/// followed by a fallback to `path`+`line`.
+pub(crate) fn resolve_name_path(
+    name_path: &str,
+    project_root: &str,
+    file_filter: Option<&str>,
+) -> Result<Resolved, String> {
     use crate::core::graph_provider;
     let open = graph_provider::open_or_build(project_root)
         .ok_or_else(|| "NO_SYMBOL: no symbol index available".to_string())?;
@@ -297,7 +308,7 @@ pub(crate) fn resolve_name_path(name_path: &str, project_root: &str) -> Result<R
 
     // Exact-name leaf candidates (case-sensitive — the index may substring-match).
     let mut leaves: Vec<_> = gp
-        .find_symbols(leaf, None, None)
+        .find_symbols(leaf, file_filter, None)
         .into_iter()
         .filter(|s| s.name == leaf)
         .collect();
@@ -305,7 +316,7 @@ pub(crate) fn resolve_name_path(name_path: &str, project_root: &str) -> Result<R
     if segments.len() >= 2 {
         let ancestor = segments[segments.len() - 2];
         let parents: Vec<_> = gp
-            .find_symbols(ancestor, None, None)
+            .find_symbols(ancestor, file_filter, None)
             .into_iter()
             .filter(|s| container_matches_ancestor(&s.name, ancestor))
             .collect();
@@ -319,9 +330,15 @@ pub(crate) fn resolve_name_path(name_path: &str, project_root: &str) -> Result<R
     }
 
     match leaves.len() {
-        0 => Err(format!(
-            "NO_SYMBOL: '{name_path}' did not resolve to any indexed symbol"
-        )),
+        0 => Err(if file_filter.is_some() {
+            format!(
+                "NO_SYMBOL: '{name_path}' did not resolve to any indexed symbol under a path \
+                 matching '{}'",
+                file_filter.unwrap_or_default()
+            )
+        } else {
+            format!("NO_SYMBOL: '{name_path}' did not resolve to any indexed symbol")
+        }),
         1 => Ok(Resolved {
             rel_path: leaves[0].file.clone(),
             start_line: leaves[0].start_line,
@@ -337,6 +354,11 @@ pub(crate) fn resolve_name_path(name_path: &str, project_root: &str) -> Result<R
                     "  {}:{} (L{}-{})\n",
                     s.file, s.name, s.start_line, s.end_line
                 ));
+            }
+            if file_filter.is_none() {
+                msg.push_str(
+                    "  (pass path=\"<file>\" alongside name to scope resolution to one file)\n",
+                );
             }
             Err(msg)
         }
@@ -449,7 +471,17 @@ fn handle_symbol_edit(action: &str, args: &Value, project_root: &str) -> String 
     let (rel_path, start_line, end_line) = if let Some(np) =
         args.get("name_path").and_then(Value::as_str)
     {
-        match resolve_name_path(np, project_root) {
+        // #845: a caller-supplied `path` alongside `name`/`name_path` scopes
+        // resolution to that file, so a common method name (Dispose, ToString)
+        // that's ambiguous repo-wide can still resolve in one call. Filter on
+        // the *basename* only (not the full path): the caller's `path` may be
+        // rooted differently than the index (e.g. a linked git worktree vs.
+        // the main checkout the index was built from — see the
+        // WORKTREE_MISMATCH check below), and basenames still match across
+        // roots while full-path substring matching would not.
+        let file_filter = explicit_path
+            .and_then(|p| std::path::Path::new(p).file_name().and_then(|f| f.to_str()));
+        match resolve_name_path(np, project_root, file_filter) {
             Ok(r) => {
                 // #803 WORKTREE SAFETY: when the caller also provided `path`,
                 // verify the index-resolved file matches the caller's target.

--- a/rust/src/tools/ctx_refactor/ops.rs
+++ b/rust/src/tools/ctx_refactor/ops.rs
@@ -11,7 +11,17 @@ pub(super) fn resolve_rename_target(
     project_root: &str,
 ) -> Result<(String, usize, usize), String> {
     if let Some(np) = args.get("name_path").and_then(Value::as_str) {
-        let r = resolve_name_path(np, project_root)?;
+        // #845: a caller-supplied `path` alongside `name_path` scopes
+        // resolution to that file, so a common method name that's ambiguous
+        // repo-wide can still resolve in one call. Basename only — see the
+        // matching comment in mod.rs::handle_symbol_edit for why (worktree
+        // roots differ from the index's).
+        let file_filter = args
+            .get("path")
+            .and_then(Value::as_str)
+            .and_then(|p| std::path::Path::new(p).file_name())
+            .and_then(|f| f.to_str());
+        let r = resolve_name_path(np, project_root, file_filter)?;
         Ok((r.rel_path, r.start_line, r.end_line))
     } else {
         let path = args
@@ -456,7 +466,7 @@ pub(super) fn resolve_move_target(
             })
         }
         (None, Some(parent_np)) => {
-            let r = resolve_name_path(parent_np, project_root)?; // NO_SYMBOL / AMBIGUOUS_SYMBOL
+            let r = resolve_name_path(parent_np, project_root, None)?; // NO_SYMBOL / AMBIGUOUS_SYMBOL
             let abs =
                 crate::core::path_resolve::resolve_tool_path(Some(project_root), None, &r.rel_path)
                     .map_err(|e| {
@@ -829,7 +839,7 @@ pub(super) fn resolve_reformat_scope(
             Err("INVALID_TARGET: set exactly one of 'name_path' or 'path' for reformat".to_string())
         }
         (Some(np), None) => {
-            let r = resolve_name_path(np, project_root)?; // NO_SYMBOL / AMBIGUOUS_SYMBOL
+            let r = resolve_name_path(np, project_root, None)?; // NO_SYMBOL / AMBIGUOUS_SYMBOL
             let abs =
                 crate::core::path_resolve::resolve_tool_path(Some(project_root), None, &r.rel_path)
                     .map_err(|e| format!("INVALID_TARGET: path blocked by jail: {e}"))?;

--- a/rust/src/tools/ctx_refactor/tests.rs
+++ b/rust/src/tools/ctx_refactor/tests.rs
@@ -222,7 +222,7 @@ fn resolve_name_path_unique_class() {
     .unwrap();
     let root = proj.to_string_lossy().to_string();
 
-    let r = super::resolve_name_path("UniqueZqWidget", &root).expect("unique resolution");
+    let r = super::resolve_name_path("UniqueZqWidget", &root, None).expect("unique resolution");
     assert!(r.rel_path.ends_with("lib.rs"), "got: {}", r.rel_path);
     assert!(r.end_line >= r.start_line && r.start_line > 0);
 
@@ -251,7 +251,7 @@ fn resolve_name_path_unknown_is_no_symbol() {
     .unwrap();
     let root = proj.to_string_lossy().to_string();
 
-    let err = super::resolve_name_path("ZzzNoSuchSymbol123", &root).unwrap_err();
+    let err = super::resolve_name_path("ZzzNoSuchSymbol123", &root, None).unwrap_err();
     assert!(err.starts_with("NO_SYMBOL"), "got: {err}");
 
     crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
@@ -283,7 +283,7 @@ fn resolve_name_path_trait_impl_method() {
     .unwrap();
     let root = proj.to_string_lossy().to_string();
 
-    let r = super::resolve_name_path("RenderBridge/execute", &root)
+    let r = super::resolve_name_path("RenderBridge/execute", &root, None)
         .expect("trait-impl method should resolve");
     assert!(r.rel_path.ends_with("lib.rs"), "got: {}", r.rel_path);
     // Muss auf den Impl-Methoden-Body zeigen (Zeile >= 3), nicht auf das
@@ -333,7 +333,7 @@ fn resolve_name_path_inherent_impl_method() {
     .unwrap();
     let root = proj.to_string_lossy().to_string();
 
-    let r = super::resolve_name_path("RenderBridge/run", &root)
+    let r = super::resolve_name_path("RenderBridge/run", &root, None)
         .expect("inherent-impl method should still resolve");
     assert!(r.rel_path.ends_with("lib.rs"), "got: {}", r.rel_path);
     assert!(r.start_line >= 2 && r.end_line >= r.start_line);
@@ -386,9 +386,19 @@ fn resolve_name_path_ambiguous_trait_impls() {
     // "RenderBridge/execute": two segments → container_matches_ancestor runs for each hit.
     // "A for RenderBridge" and "B for RenderBridge" both match ancestor "RenderBridge",
     // producing two distinct hits (src/a.rs and src/b.rs) → AMBIGUOUS_SYMBOL.
-    let err = super::resolve_name_path("RenderBridge/execute", &root)
+    let err = super::resolve_name_path("RenderBridge/execute", &root, None)
         .expect_err("two trait impls (cross-file) with same method must be ambiguous");
     assert!(err.starts_with("AMBIGUOUS_SYMBOL"), "got: {err}");
+    assert!(
+        err.contains("pass path="),
+        "unscoped ambiguity error should hint at the path= scoping option: {err}"
+    );
+
+    // #845: the same repo-wide-ambiguous name resolves cleanly once a
+    // file_filter (the caller's `path` arg) narrows it to one file.
+    let r = super::resolve_name_path("RenderBridge/execute", &root, Some("a.rs"))
+        .expect("file_filter should disambiguate to the single match in a.rs");
+    assert!(r.rel_path.ends_with("a.rs"), "got: {}", r.rel_path);
 
     crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
 }
@@ -770,7 +780,7 @@ fn handle_replace_symbol_worktree_mismatch_blocks_write() {
     .unwrap();
 
     // The symbol resolves via the main-root index to "src/lib.rs".
-    let resolved = super::resolve_name_path("worktree_canary_zz", &root);
+    let resolved = super::resolve_name_path("worktree_canary_zz", &root, None);
     assert!(resolved.is_ok(), "symbol should resolve: {resolved:?}");
 
     // Caller provides a path inside the worktree that differs from the
@@ -819,4 +829,58 @@ fn handle_replace_symbol_same_path_succeeds() {
     assert!(out.contains("replace_symbol_body applied"), "got: {out}");
     let after = std::fs::read_to_string(dir.path().join("a.rs")).unwrap();
     assert!(after.contains("fn new()"), "file: {after}");
+}
+
+/// #845: `name_path` + `path` scopes an otherwise repo-wide-ambiguous symbol
+/// name to one file — the end-to-end `ctx_refactor(action="replace_symbol_body")`
+/// path, not just the isolated `resolve_name_path` unit.
+#[test]
+fn handle_replace_symbol_with_name_and_path_scopes_ambiguous_symbol() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let tmp = tempfile::tempdir().unwrap();
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&data).unwrap();
+    crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.to_string_lossy().to_string());
+
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(proj.join("src")).unwrap();
+    std::fs::write(
+        proj.join("Cargo.toml"),
+        "[package]\nname=\"x\"\nversion=\"0.0.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(proj.join("src/a.rs"), "fn shared() {\n  1\n}\n").unwrap();
+    std::fs::write(proj.join("src/b.rs"), "fn shared() {\n  2\n}\n").unwrap();
+    let root = proj.to_string_lossy().to_string();
+
+    // Unscoped: "shared" exists in both a.rs and b.rs -> AMBIGUOUS_SYMBOL.
+    let ambiguous_args = serde_json::json!({
+        "action": "replace_symbol_body",
+        "name_path": "shared",
+        "new_body": "fn shared() {\n  NEW\n}"
+    });
+    let ambiguous_out = super::handle(&ambiguous_args, &root, "");
+    assert!(
+        ambiguous_out.contains("AMBIGUOUS_SYMBOL"),
+        "got: {ambiguous_out}"
+    );
+
+    // Scoped via `path`: resolves to a.rs only, b.rs is untouched.
+    let scoped_args = serde_json::json!({
+        "action": "replace_symbol_body",
+        "name_path": "shared",
+        "path": "src/a.rs",
+        "new_body": "fn shared() {\n  NEW\n}"
+    });
+    let out = super::handle(&scoped_args, &root, "");
+    assert!(out.contains("replace_symbol_body applied"), "got: {out}");
+    let after_a = std::fs::read_to_string(proj.join("src/a.rs")).unwrap();
+    assert!(after_a.contains("NEW"), "a.rs: {after_a}");
+    let after_b = std::fs::read_to_string(proj.join("src/b.rs")).unwrap();
+    assert!(
+        !after_b.contains("NEW"),
+        "b.rs must be untouched: {after_b}"
+    );
+
+    crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
 }


### PR DESCRIPTION
Fixes #845.

`resolve_name_path` resolved a symbol name project-wide with no scoping option, so a common method name (`Dispose`, `ToString`, `Equals` -- routine in large .NET/Java codebases) hit `AMBIGUOUS_SYMBOL` against every match repo-wide even when the caller already knew exactly which file to target. The caller's `path` arg was already accepted on the wire (`ctx_patch`'s `symbol.rs` already passed it through), but only ever used *after* successful resolution, as the `#803` worktree-mismatch safety check -- never to narrow the candidate set during resolution itself.

## Fix

`graph_provider::find_symbols` already takes a `file_filter` parameter; `resolve_name_path` just never threaded it through.

- `resolve_name_path(name_path, project_root, file_filter)` -- new optional third parameter narrows both the leaf-name lookup and the ancestor/container lookup (for qualified `Class/method` paths) before the ambiguity check runs.
- Filters on the **basename** of the caller's `path`, not the full path: the caller's path may be rooted differently than the symbol index (e.g. a linked git worktree vs. the main checkout the index was built from), and basenames still match across roots while full-path substring matching would silently fail closed and turn a resolvable symbol into `NO_SYMBOL`.
- Wired into `handle_symbol_edit` (the action `ctx_patch`'s `replace_symbol` delegates to) and `resolve_rename_target` (rename shares the exact same `name_path`-vs-`path` shape, so the same gap existed there).
- `resolve_move_target`/`resolve_reformat_scope` keep `file_filter=None` -- those actions already reject `name_path`+`path` together as invalid input, so there's no caller-supplied path to scope with.
- `AMBIGUOUS_SYMBOL`'s error message now hints at the new `path=` option when the caller didn't already supply one.

## Test plan
- [x] New unit test: `resolve_name_path` with a `file_filter` narrows a two-file ambiguous match to the correct one
- [x] New end-to-end test: `ctx_refactor(action="replace_symbol_body")` -- `name_path` alone is ambiguous, `name_path`+`path` resolves and edits only the targeted file, the other file is untouched
- [x] `cargo test -p lean-ctx tools::ctx_refactor::` -- 52/52 pass (up from 50), including the pre-existing worktree-mismatch test (basename filtering doesn't interfere with cross-root detection)
- [x] `cargo test --lib -p lean-ctx` (full suite) -- 7696 passed (one `node_e_blocked` failure under parallel execution is a pre-existing shared-env flake, confirmed passing in isolation, unrelated)
- [x] `cargo fmt --check`, `cargo clippy --lib --tests -- -D warnings` -- clean