### PR TITLE
fix(ctx_read): guard windowed anchored:N-M reads against full-file dumps

### DIFF
--- a/rust/src/tools/ctx_read/tests_windowed.rs
+++ b/rust/src/tools/ctx_read/tests_windowed.rs
@@ -84,3 +84,61 @@ fn disk_windowed_anchored_read_serves_file_over_the_size_cap() {
         out.content
     );
 }
+
+/// #875: a windowed `anchored:N-M` read served through the two-phase
+/// (`preread`-supplied) slow path must still return only that window with its
+/// `N:hh|` hash anchors — never fall through to a full-file dump. The
+/// disk-streaming short-circuit (#811) only fires on the fast path, where no
+/// preread is in hand; the slow path (spawned-thread read under lock
+/// contention) hands `handle_with_options_inner` the whole file as `preread`,
+/// so `try_disk_anchored_window` bows out and the window must instead be cut
+/// and anchored by `process_mode_tuned`. Before the anchored:N-M arm existed
+/// there, this path dumped the entire file with no anchors — the exact symptom
+/// #875 reported after the first windowed read.
+#[test]
+fn windowed_anchored_read_via_preread_slow_path_stays_windowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("big.rs");
+    let body = (1..=200)
+        .map(|i| format!("fn function_number_{i}() {{}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, format!("{body}\n")).unwrap();
+    let p = path.to_string_lossy().to_string();
+    let preread = std::fs::read_to_string(&path).unwrap();
+
+    let mut cache = SessionCache::new();
+    let out = handle_with_options_inner(
+        &mut cache,
+        &p,
+        "anchored:109-118",
+        /* fresh */ true,
+        CrpMode::Off,
+        None,
+        ReadTuning::default(),
+        Some(preread),
+    );
+
+    assert_eq!(out.resolved_mode, "anchored:109-118");
+    assert!(
+        out.content.contains("function_number_109") && out.content.contains("function_number_118"),
+        "must contain the requested window: {}",
+        out.content
+    );
+    assert!(
+        !out.content.contains("function_number_50") && !out.content.contains("function_number_200"),
+        "must NOT dump lines outside the window: {}",
+        out.content
+    );
+    // Each served line keeps its `N:hh|` hash anchor (edit-ready for ctx_patch).
+    assert!(
+        out.content.contains("\n109:") && out.content.contains("118:"),
+        "windowed lines must keep N:hh| anchors: {}",
+        out.content
+    );
+    assert!(
+        out.content.contains("200L"),
+        "header must report the file's true total line count: {}",
+        out.content
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #875 — `ctx_read(mode="anchored")` windowed reads dropping anchors and dumping the whole file on subsequent calls.

**Root cause** (already fixed on `main`, not yet released): the context gate could override a windowed `anchored:N-M` read to `full` on the 2nd+ read of a file (bounce-prevention / pressure-downgrade), silently discarding the window and its `N:hh|` anchors. That override was closed by #851/#843, which classify `diff` / `lines:N-M` / `anchored:N-M` as *precise pinned* reads exempt from mode override. The reporter runs **v3.9.10, which predates #851**, so they still see the failure.

## What this PR adds

The gate override is guarded at the unit level (`pre_dispatch_passthrough_for_anchored_window`), but the **handler's two-phase slow path** — where a `preread` is supplied under lock contention — was not covered end to end. On that path `try_disk_anchored_window` (#811) intentionally bows out (it only fires when no preread is in hand), so the window must be cut and anchored by `process_mode_tuned` instead. This adds a regression test that drives exactly that path and asserts:

- resolved mode stays `anchored:109-118`
- only the requested window is returned (no out-of-window lines)
- every served line keeps its `N:hh|` hash anchor (edit-ready for `ctx_patch`)
- the header still reports the file's true total line count

This locks the reporter's exact symptom — subsequent windowed reads returning the entire file with no anchors — closed across both read paths.

## Testing

```
cargo test --lib ctx_read::
```

New test `windowed_anchored_read_via_preread_slow_path_stays_windowed` passes; existing anchored/window tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
