### PR TITLE
fix(ctx_shell): keep gh issue/run view body, drop head-only truncation

### DIFF
--- a/rust/src/core/patterns/gh.rs
+++ b/rust/src/core/patterns/gh.rs
@@ -193,7 +193,11 @@ fn compress_issue_list(output: &str) -> String {
 }
 
 fn compress_issue_view(output: &str) -> String {
-    compact_output(output, 15)
+    // #884: an issue's body is the payload; the metadata fields above it are
+    // boilerplate. Head-only truncation (`compact_output`) dropped the body
+    // wholesale on any issue longer than the field block, forcing a second
+    // `--json body` call. Keep head AND tail so the body survives.
+    compact_head_tail(output, 40, 40)
 }
 
 fn compress_run_list(output: &str) -> String {
@@ -225,7 +229,9 @@ fn compress_run_list(output: &str) -> String {
 }
 
 fn compress_run_view(output: &str) -> String {
-    compact_output(output, 15)
+    // #884: a run's failure summary lives at the tail — head-only truncation hid
+    // exactly the part the agent came for. Keep head AND tail.
+    compact_head_tail(output, 40, 40)
 }
 
 fn compress_repo(output: &str) -> String {
@@ -259,4 +265,75 @@ fn compact_output(text: &str, max: usize) -> String {
         lines[..max].join("\n"),
         lines.len() - max
     )
+}
+
+/// Head+tail compaction (#884): keep the first `head` and last `tail` non-empty
+/// lines, eliding only the middle. Unlike [`compact_output`] (head-only), this
+/// never drops the tail — used for single-record `view` output whose payload (an
+/// issue/PR body, a run's failure summary) follows the metadata header.
+fn compact_head_tail(text: &str, head: usize, tail: usize) -> String {
+    let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.len() <= head + tail {
+        return lines.join("\n");
+    }
+    let omitted = lines.len() - head - tail;
+    format!(
+        "{}\n... ({omitted} more lines)\n{}",
+        lines[..head].join("\n"),
+        lines[lines.len() - tail..].join("\n"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn issue_view_keeps_body_not_just_metadata() {
+        // gh issue view: a metadata field block then the body. Head-only
+        // truncation (`compact_output(_, 15)`) dropped the body entirely (#884).
+        let mut out = String::new();
+        for f in [
+            "title:\tSomething broke",
+            "state:\tOPEN",
+            "author:\tandig",
+            "labels:",
+            "comments:\t0",
+            "assignees:",
+            "projects:",
+            "milestone:",
+            "number:\t875",
+            "--",
+        ] {
+            out.push_str(f);
+            out.push('\n');
+        }
+        for i in 0..40 {
+            out.push_str(&format!("body line {i} - the actual payload\n"));
+        }
+        let compressed = compress_issue_view(&out);
+        assert!(
+            compressed.contains("body line 39 - the actual payload"),
+            "the end of the body must survive compaction: {compressed}"
+        );
+        assert!(
+            compressed.contains("title:\tSomething broke"),
+            "metadata head must still be present: {compressed}"
+        );
+    }
+
+    #[test]
+    fn head_tail_returns_small_output_verbatim() {
+        assert_eq!(compact_head_tail("a\nb\nc\n", 40, 40), "a\nb\nc");
+    }
+
+    #[test]
+    fn head_tail_elides_only_the_middle() {
+        let lines: String = (0..200).map(|i| format!("L{i}\n")).collect();
+        let out = compact_head_tail(&lines, 5, 5);
+        assert!(out.contains("L0") && out.contains("L4"));
+        assert!(out.contains("L195") && out.contains("L199"));
+        assert!(out.contains("... (190 more lines)"));
+        assert!(!out.contains("L100"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #884 — `gh issue view` / `gh run view` compression elided the body and forced a second call.

## Root cause

`gh` output is compressed by a dedicated pattern (`core/patterns/gh.rs`). `compress_issue_view` and `compress_run_view` both used **head-only** truncation, `compact_output(_, 15)` — keep the first 15 non-empty lines, drop the rest. But:

- `gh issue view` prints a metadata field block (`title:`, `state:`, `labels:`, …) *then* the body. The first 15 lines are all boilerplate, so the **body** was truncated away as `... (N more lines)`.
- `gh run view` ends with the failure summary — head-only truncation hid exactly the tail the agent came for.

Because the elision removed >70% of the output, it also tripped the `HighCompression` tee threshold, appending a `[compressed …: full output at …]` recovery pointer. Net effect on a short issue: compression saved nothing and cost an extra `--json body` round-trip.

## Fix

Switch both single-record `view` compressors to **head+tail** compaction (`compact_head_tail`): keep the first 40 and last 40 non-empty lines, eliding only the middle. The body / failure tail always survives; a pathologically long body still head/tail-truncates instead of vanishing. Small views fall under the size threshold and pass through verbatim — so no recovery-file pointer either. List / create / action compressors are unchanged (they have no body). `compress_pr_view`'s bespoke title/state/labels extractor is intentional and left as-is.

## Testing

```
cargo test --lib patterns::gh::
```

New tests: `issue_view_keeps_body_not_just_metadata`, `head_tail_returns_small_output_verbatim`, `head_tail_elides_only_the_middle` — all green.

End-to-end against a freshly built binary:

```
lean-ctx -c "gh issue view <N> --repo <owner>/<repo>"
```

Before (v3.9.10): body truncated to `... (17 more lines)` + tee pointer. After: full body returned, no pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
