### PR TITLE
fix(#887): name extra_roots/allow_paths in the agent-visible path-jail rejection

### DIFF
--- a/docs/reference/appendix-paths-and-config.md
+++ b/docs/reference/appendix-paths-and-config.md
@@ -194,7 +194,7 @@ they overlap, so here is exactly what each one does:
 | Knob | Effect | Use when |
 |------|--------|----------|
 | `allow_paths = ["…"]` (root key) | **Adds** directories to PathJail's whitelist. Tools may read/edit under them, but `ctx_tree`/`ctx_search` do **not** scan them. | One extra directory needs to be readable/editable (e.g. a shared skills folder). |
-| `extra_roots = ["…"]` (root key) | Same whitelist effect as `allow_paths` **plus** multi-root scanning: `ctx_tree`, `ctx_search`, overview treat them as additional project roots. | Multi-repo workspaces. |
+| `extra_roots = ["…"]` (root key) | Same whitelist effect as `allow_paths` **plus** multi-root scanning: `ctx_tree`, `ctx_search`, overview treat them as additional project roots. | Multi-repo workspaces; agent-harness memory/state dirs outside the project (e.g. Claude Code's `~/.claude/projects/<slug>/memory/`). |
 | `path_jail = false` (root key) | **Disables PathJail entirely** — every absolute path is allowed. | Sandboxed environments (bwrap, containers, VMs) where the OS is the boundary. |
 | `allow_ide_config_dirs = true` (root key) | **Adds every supported editor's config dir** to the read whitelist — registry-derived (`~/.cursor`, VS Code, Cline/Roo, JetBrains, …). Opt-in; exposes other agents' sessions/credentials. | Letting the agent manage MCP setup across editors. |
 

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -445,10 +445,17 @@ pub fn jail_path_with_roots(
                     ". Hint: set LEAN_CTX_ALLOW_PATH={dir} for read-write access \
                      (colon-separated for multiple: /path/a:/path/b), \
                      LEAN_CTX_READ_ONLY_ROOTS={dir} for read-only, \
-                     or add entries to allow_paths = [\"{dir}\"] in ~/.config/lean-ctx/config.toml"
+                     or add entries to allow_paths = [\"{dir}\"] or extra_roots = [\"{dir}\"] \
+                     in ~/.config/lean-ctx/config.toml"
                 )
             } else {
-                String::new()
+                // Agents otherwise get a bare rejection and shell out to work
+                // around the jail; name the config keys the same way the
+                // shell-allowlist block message names its key. The env-var and
+                // config-path detail above stays meta-gated (#540, #887).
+                ". Fix (additive): add the directory to extra_roots or allow_paths in \
+                 ~/.config/lean-ctx/config.toml — `lean-ctx doctor` shows the config in effect"
+                    .to_string()
             };
             // An untrusted workspace's project-local `allow_paths` is silently
             // withheld; always surface that reason (the stderr warning is
@@ -812,6 +819,30 @@ mod tests {
         assert!(
             err.to_string().contains("path escapes project root"),
             "error should mention escape: {err}"
+        );
+    }
+
+    // GH #887: over MCP (meta hints gated off) the rejection was bare, so
+    // agents shelled out to work around the jail instead of widening it via
+    // config. The agent-visible error must name the sanctioned config keys.
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn escape_error_names_config_keys_without_meta() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        crate::test_env::remove_var("LEAN_CTX_META");
+        crate::test_env::remove_var("LEAN_CTX_DIAGNOSTICS");
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("root");
+        let other = tmp.path().join("other");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(other.join("b.txt"), "no").unwrap();
+
+        let err = jail_path(&other.join("b.txt"), &root).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("extra_roots") && msg.contains("allow_paths"),
+            "agent-visible escape error should name the config keys: {msg}"
         );
     }
 


### PR DESCRIPTION
Closes #887.

Over MCP the meta hint is gated off (#540), so agents got a bare `path escapes project root: PATH (root: ROOT)` and shelled out (e.g. python via ctx_shell) to work around the jail instead of widening it via config — defeating the write-safety rails. This appends a minimal, agent-visible pointer naming the sanctioned config keys, the same pattern as the shell-allowlist block message, which names its key unconditionally:

```
… (root: /project). Fix (additive): add the directory to extra_roots or allow_paths in ~/.config/lean-ctx/config.toml — `lean-ctx doctor` shows the config in effect
```

- The env-var / config-path detail (LEAN_CTX_ALLOW_PATH, missing-config warning) stays meta-gated as before; untrusted-workspace and missing-config notices are unchanged.
- The meta hint now mentions `extra_roots` alongside `allow_paths`.
- Docs: the paths appendix table gains agent-harness memory dirs (Claude Code `~/.claude/projects/<slug>/memory/`) as an `extra_roots` use case.
- Test: `escape_error_names_config_keys_without_meta` locks the agent-visible keys in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)