### PR TITLE
test(#885): guard anchored window survival across ctx_patch edits

### DIFF
--- a/rust/tests/issue_885_anchored_after_patch.rs
+++ b/rust/tests/issue_885_anchored_after_patch.rs
@@ -1,0 +1,107 @@
+//! Regression for #885 (fixed by #851/#843): a windowed `ctx_read(mode=anchored)`
+//! must keep windowing after the same file is edited via `ctx_patch`.
+use std::sync::Arc;
+
+use lean_ctx::core::cache::SessionCache;
+use lean_ctx::core::session::SessionState;
+use lean_ctx::server::tool_trait::{McpTool, ToolContext};
+use lean_ctx::tools::registered::ctx_patch::CtxPatchTool;
+use lean_ctx::tools::registered::ctx_read::CtxReadTool;
+use serde_json::json;
+use tokio::sync::RwLock;
+
+fn ctx_for(root: &std::path::Path, file: &str) -> ToolContext {
+    let cache = Arc::new(RwLock::new(SessionCache::new()));
+    let session = Arc::new(RwLock::new(SessionState::new()));
+    let mut resolved_paths = std::collections::HashMap::new();
+    resolved_paths.insert("path".to_string(), file.to_string());
+    ToolContext {
+        project_root: root.to_string_lossy().to_string(),
+        extra_roots: Vec::new(),
+        minimal: false,
+        resolved_paths,
+        crp_mode: lean_ctx::tools::CrpMode::Off,
+        cache: Some(cache),
+        session: Some(session),
+        tool_calls: None,
+        agent_id: None,
+        workflow: None,
+        ledger: None,
+        client_name: None,
+        pipeline_stats: None,
+        call_count: None,
+        autonomy: None,
+        pressure_snapshot: None,
+        path_errors: std::collections::HashMap::new(),
+        bm25_cache: None,
+        progress_sender: None,
+    }
+}
+
+/// Pull the `hash` for a 1-based line out of an anchored body (`N:hh|content`).
+fn anchor_hash_for_line(anchored: &str, line: usize) -> String {
+    let prefix = format!("{line}:");
+    for l in anchored.lines() {
+        if let Some(rest) = l.strip_prefix(&prefix)
+            && let Some((hash, _)) = rest.split_once('|')
+        {
+            return hash.to_string();
+        }
+    }
+    panic!("no anchor for line {line} in:\n{anchored}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anchored_window_survives_ctx_patch() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("grow.go");
+    let body: String = (1..=30).map(|i| format!("func f{i}() {{}}\n")).collect();
+    std::fs::write(&path, format!("package main\n\n{body}")).unwrap();
+    let p = path.to_string_lossy().to_string();
+    let ctx = ctx_for(dir.path(), &p);
+
+    let read_args = json!({ "path": p, "mode": "anchored", "start_line": 5, "limit": 3 })
+        .as_object()
+        .unwrap()
+        .clone();
+
+    // 1) anchored window before any edit — must window, and expose anchors.
+    let before = tokio::task::block_in_place(|| CtxReadTool.handle(&read_args, &ctx)).unwrap();
+    assert!(
+        before.text.lines().count() < 8,
+        "pre-edit anchored window must be small, got {} lines:\n{}",
+        before.text.lines().count(),
+        before.text
+    );
+    let hash5 = anchor_hash_for_line(&before.text, 5);
+
+    // 2) anchored ctx_patch — marks the path `recently_edited` in the tracker.
+    let patch = json!({
+        "path": p,
+        "op": "insert_after",
+        "line": 5,
+        "hash": hash5,
+        "new_text": "func inserted() {}"
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let pr = tokio::task::block_in_place(|| CtxPatchTool.handle(&patch, &ctx)).unwrap();
+    assert!(!pr.text.starts_with("ERROR"), "patch failed: {}", pr.text);
+
+    // 3) anchored window after the edit — must STILL window (the #885 bug).
+    let after = tokio::task::block_in_place(|| CtxReadTool.handle(&read_args, &ctx)).unwrap();
+    assert!(
+        after.text.lines().count() < 8,
+        "post-edit anchored window LEAKED the whole file: {} lines (mode={:?})\n{}",
+        after.text.lines().count(),
+        after.mode,
+        after.text
+    );
+    assert_eq!(
+        after.mode.as_deref(),
+        Some("anchored:5-7"),
+        "post-edit read must stay a windowed anchored read, got mode={:?}",
+        after.mode
+    );
+}


### PR DESCRIPTION
## What

Closes #885.

`ctx_read(mode=anchored)` with `start_line`/`limit` stopped windowing and dumped the whole file after that file was edited via `ctx_patch`.

## Root cause

An anchored `ctx_patch` calls `bounce_tracker::record_edit`, marking the path `recently_edited`. On the next read the context gate's bounce-prevention (`should_force_full`) then wants to force the read to `full`. The gate exempts *precise pinned* reads first — but that exemption was a string check:

```rust
if requested_mode == "diff" || requested_mode.starts_with("lines") { return no_change; }
```

`anchored` / `anchored:N-M` were not in that list, so a windowed anchored read got overridden to `full` and (via the `#361` raw cap) emitted the whole file as bare bytes.

This was already fixed on `main` by **#851 (fixes #843)**, which reclassifies the exemption off the typed `ReadMode::is_precise_pinned_read` (which includes `Anchored`). That fix is unreleased — the reported 3.9.10 binary predates it.

## This PR

Adds the missing **end-to-end** regression guard that #851 didn't have (its test drives the gate function directly with synthetic bounce state). The new test exercises the real handlers: `ctx_read(anchored, start_line, limit)` → `ctx_patch(insert_after)` → `ctx_read(...)`, asserting the second read stays `anchored:5-7` and returns a small window.

## Verification

- Passes on `main` (fix present).
- Reverting #851's exemption to the old `=="diff" || starts_with("lines")` check makes it **fail** — the whole file (`func f1..f30`) leaks — confirming it genuinely guards this bug.
- `cargo test --lib context_gate`: 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
