### PR TITLE
fix(context_ledger): bound pinned/stale pressure and decouple remaining_tokens from it

### DIFF
--- a/rust/src/core/context_ledger.rs
+++ b/rust/src/core/context_ledger.rs
@@ -498,10 +498,23 @@ impl ContextLedger {
             .count();
         let pinned_pressure = pinned_count as f64 * 0.02;
         let stale_penalty = stale_count as f64 * 0.01;
-        let effective_utilization = (utilization + pinned_pressure + stale_penalty).min(1.0);
+        // Pinned/stale entries reduce eviction flexibility, so they nudge
+        // pressure upward — but the nudge must stay bounded. Without a cap, a
+        // long session where many entries end up Pinned (e.g. via GWT
+        // ignition, #6) can alone drive utilization to 100% regardless of
+        // actual token usage.
+        const MAX_STATE_PRESSURE: f64 = 0.2;
+        let effective_utilization =
+            (utilization + (pinned_pressure + stale_penalty).min(MAX_STATE_PRESSURE)).min(1.0);
 
-        let effective_used = (effective_utilization * self.window_size as f64).round() as usize;
-        let remaining = self.window_size.saturating_sub(effective_used);
+        // `remaining_tokens` is a literal token-budget figure consumed by
+        // dashboards and the deficit-suggestion auto-loader
+        // (`context_deficit.rs`) as "how much room is actually left" — it
+        // must track real usage, not the heuristic-boosted
+        // `effective_utilization`, or a heavily-pinned/stale session reports
+        // 0 remaining (and silently starves auto-loading) while tokens of
+        // real headroom are still free.
+        let remaining = self.window_size.saturating_sub(self.total_tokens_sent);
 
         let recommendation = if effective_utilization > 0.9 {
             PressureAction::EvictLeastRelevant
@@ -1003,6 +1016,35 @@ mod tests {
             ledger.pressure().recommendation,
             PressureAction::EvictLeastRelevant
         );
+    }
+
+    /// Regression: a session where many entries are Pinned (e.g. via GWT
+    /// ignition over a long session) must not report `remaining_tokens: 0`
+    /// nor 100% utilization when actual token usage is moderate. The pinned
+    /// nudge must stay bounded, and `remaining_tokens` must track real usage.
+    #[test]
+    fn pinned_pressure_does_not_zero_out_remaining_tokens() {
+        let mut ledger = ContextLedger::with_window_size(200_000);
+        // ~59% raw utilization, matching the real-world repro.
+        ledger.record("hot.rs", "full", 118_762, 118_762);
+        for i in 0..32 {
+            let path = format!("pinned_{i}.rs");
+            ledger.record(&path, "full", 100, 100);
+            ledger.set_state(&path, ContextState::Pinned);
+        }
+
+        let pressure = ledger.pressure();
+        assert!(
+            pressure.utilization < 1.0,
+            "32 pinned entries alone must not saturate utilization to 100%, got {}",
+            pressure.utilization
+        );
+        assert!(
+            pressure.remaining_tokens > 0,
+            "real token headroom must not be reported as zero"
+        );
+        // total_tokens_sent = 118762 + 32*100 = 121962; window 200000.
+        assert_eq!(pressure.remaining_tokens, 200_000 - 121_962);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `ContextPressure::pressure()` added an **uncapped** `pinned_pressure` (0.02/entry) and `stale_penalty` (0.01/entry) on top of raw token utilization before clamping to 100%. On a long session where GWT ignition (`ignite_high_salience()`) keeps permanently promoting salience outliers to `Pinned` (no un-pin/decay path), the pinned count grows unbounded and alone can drive `effective_utilization` to 100% regardless of real token usage.
- `remaining_tokens` was derived from that same capped `effective_utilization` instead of real usage, so a heavily-pinned session reports `remaining_tokens: 0` — which also silently starves `context_deficit.rs`'s auto-suggestion feature (it uses `remaining_tokens` as a literal token budget).
- Cap the pinned/stale nudge at 0.2 (20 points) and compute `remaining_tokens` directly from `window_size - total_tokens_sent`. `pressure.recommendation` keeps using the bounded `effective_utilization`, so pinned/stale items still nudge compression/eviction decisions earlier — just without lying about literal remaining capacity.

Fixes #895

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib core::context_ledger::` — 38 passed, including new regression test `pinned_pressure_does_not_zero_out_remaining_tokens` reproducing the real repro data (32/65 pinned, 118.8k/200k tokens)
- [x] `cargo test --lib core::degradation_policy::` / `core::context_deficit::` / `core::intent_router::` — downstream consumers of `remaining_tokens`, all green
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`
