### PR TITLE
fix(agents): close the load-mutate-save race on the agent registry

### DIFF
--- a/rust/src/core/agents.rs
+++ b/rust/src/core/agents.rs
@@ -304,12 +304,15 @@ impl AgentRegistry {
         let dir = agents_dir()?;
         std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
 
-        let path = dir.join("registry.json");
-        let json = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-
         let lock_path = dir.join("registry.lock");
         let _lock = FileLock::acquire(&lock_path)?;
 
+        self.save_locked(&dir)
+    }
+
+    fn save_locked(&self, dir: &std::path::Path) -> Result<(), String> {
+        let path = dir.join("registry.json");
+        let json = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
         std::fs::write(&path, json).map_err(|e| e.to_string())
     }
 
@@ -322,6 +325,28 @@ impl AgentRegistry {
 
     pub fn load_or_create() -> Self {
         Self::load().unwrap_or_default()
+    }
+
+    /// Atomically load, mutate, and persist the registry under a single file
+    /// lock. `load_or_create()` + mutate + `save()` is a read-modify-write
+    /// race: `save()` only locks the final write, so two concurrent callers
+    /// (two MCP sessions registering, or the dashboard's own poll-triggered
+    /// `cleanup_stale` + save) can each load a stale snapshot and the last
+    /// writer silently drops the other's changes — e.g. a second session's
+    /// registration vanishing from the dashboard. Holding the lock across
+    /// the re-read closes that window: the read inside always sees the
+    /// latest on-disk state.
+    pub fn mutate_locked<T>(f: impl FnOnce(&mut Self) -> T) -> Result<(Self, T), String> {
+        let dir = agents_dir()?;
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+
+        let lock_path = dir.join("registry.lock");
+        let _lock = FileLock::acquire(&lock_path)?;
+
+        let mut registry = Self::load().unwrap_or_default();
+        let out = f(&mut registry);
+        registry.save_locked(&dir)?;
+        Ok((registry, out))
     }
 }
 
@@ -1041,6 +1066,51 @@ mod tests {
         assert!(
             !ids.contains(&"ghost"),
             "dead-pid agent must be pruned from the active list (#419)"
+        );
+    }
+
+    /// Regression: concurrent load-mutate-save cycles must not silently drop
+    /// each other's changes. Before `mutate_locked`, `save()` only locked the
+    /// final write — the preceding `load()` was unlocked, so a second writer
+    /// could load a stale snapshot and overwrite the first writer's addition
+    /// (e.g. a second Claude Code session's agent registration vanishing
+    /// from the dashboard).
+    #[test]
+    fn mutate_locked_survives_concurrent_writers() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                std::thread::spawn(move || {
+                    AgentRegistry::mutate_locked(|registry| {
+                        registry.agents.push(AgentEntry {
+                            agent_id: format!("agent-{i}"),
+                            agent_type: "test".to_string(),
+                            role: None,
+                            project_root: "/tmp/project".to_string(),
+                            started_at: Utc::now(),
+                            last_active: Utc::now(),
+                            pid: 10_000 + i,
+                            status: AgentStatus::Active,
+                            status_message: None,
+                        });
+                    })
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join()
+                .expect("writer thread must not panic")
+                .expect("mutate_locked must succeed");
+        }
+
+        let registry = AgentRegistry::load_or_create();
+        assert_eq!(
+            registry.agents.len(),
+            8,
+            "all 8 concurrent registrations must survive, got {}",
+            registry.agents.len()
         );
     }
 }

--- a/rust/src/dashboard/routes/agents.rs
+++ b/rust/src/dashboard/routes/agents.rs
@@ -47,9 +47,11 @@ pub(super) fn handle(
 }
 
 fn build_agents_json() -> String {
-    let mut registry = crate::core::agents::AgentRegistry::load_or_create();
-    registry.cleanup_stale(24);
-    let _ = registry.save();
+    let registry = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
+        registry.cleanup_stale(24);
+    })
+    .map(|(registry, ())| registry)
+    .unwrap_or_default();
 
     let mut agents: Vec<serde_json::Value> = registry
         .agents

--- a/rust/src/http_server/mod.rs
+++ b/rust/src/http_server/mod.rs
@@ -906,9 +906,11 @@ async fn v1_agents_register(
         .and_then(|v| v.as_str())
         .unwrap_or(&state.project_root);
 
-    let mut registry = crate::core::agents::AgentRegistry::load_or_create();
-    let agent_id = registry.register(agent_type, role, project_root);
-    let _ = registry.save();
+    let agent_id = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
+        registry.register(agent_type, role, project_root)
+    })
+    .map(|(_, id)| id)
+    .unwrap_or_default();
 
     Json(serde_json::json!({
         "agent_id": agent_id,
@@ -918,9 +920,9 @@ async fn v1_agents_register(
 
 async fn v1_agents_heartbeat(Json(body): Json<Value>) -> impl IntoResponse {
     let agent_id = body.get("agent_id").and_then(|v| v.as_str()).unwrap_or("");
-    let mut registry = crate::core::agents::AgentRegistry::load_or_create();
-    registry.update_heartbeat(agent_id);
-    let _ = registry.save();
+    let _ = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
+        registry.update_heartbeat(agent_id);
+    });
     Json(serde_json::json!({"status": "ok"}))
 }
 
@@ -940,13 +942,13 @@ async fn v1_agents_list() -> impl IntoResponse {
 
 async fn v1_agents_deregister(Json(body): Json<Value>) -> impl IntoResponse {
     let agent_id = body.get("agent_id").and_then(|v| v.as_str()).unwrap_or("");
-    let mut registry = crate::core::agents::AgentRegistry::load_or_create();
-    registry.set_status(
-        agent_id,
-        crate::core::agents::AgentStatus::Finished,
-        Some("deregistered via API"),
-    );
-    let _ = registry.save();
+    let _ = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
+        registry.set_status(
+            agent_id,
+            crate::core::agents::AgentStatus::Finished,
+            Some("deregistered via API"),
+        );
+    });
     Json(serde_json::json!({"status": "deregistered"}))
 }
 

--- a/rust/src/server/server_handler.rs
+++ b/rust/src/server/server_handler.rs
@@ -219,11 +219,13 @@ impl ServerHandler for LeanCtxServer {
 
                 let _ = crate::core::roles::set_active_role_with_source(effective_role, true);
 
-                let mut registry = crate::core::agents::AgentRegistry::load_or_create();
-                registry.cleanup_stale(24);
-                let id = registry.register("mcp", Some(effective_role), &agent_root);
-                let _ = registry.save();
-                if let Ok(mut guard) = agent_id_handle.try_write() {
+                let id = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
+                    registry.cleanup_stale(24);
+                    registry.register("mcp", Some(effective_role), &agent_root)
+                })
+                .map(|(_, id)| id)
+                .ok();
+                if let (Some(id), Ok(mut guard)) = (id, agent_id_handle.try_write()) {
                     *guard = Some(id);
                 }
             }

--- a/rust/src/tools/ctx_agent.rs
+++ b/rust/src/tools/ctx_agent.rs
@@ -24,24 +24,28 @@ pub fn handle(
     match action {
         "register" => {
             let atype = agent_type.unwrap_or("unknown");
-            let mut registry = AgentRegistry::load_or_create();
-            registry.cleanup_stale(24);
-            let agent_id = registry.register(atype, role, project_root);
-            match registry.save() {
-                Ok(()) => format!(
+            match AgentRegistry::mutate_locked(|registry| {
+                registry.cleanup_stale(24);
+                registry.register(atype, role, project_root)
+            }) {
+                Ok((_, agent_id)) => format!(
                     "Agent registered: {agent_id} (type: {atype}, role: {})",
                     role.unwrap_or("none")
                 ),
-                Err(e) => format!("Registered as {agent_id} but save failed: {e}"),
+                Err(e) => format!("Registration failed: {e}"),
             }
         }
 
         "list" => {
-            let mut registry = AgentRegistry::load_or_create();
-            registry.cleanup_stale(24);
-            if let Err(e) = registry.save() {
-                tracing::warn!("lean-ctx: failed to persist agent registry: {e}");
-            }
+            let registry = match AgentRegistry::mutate_locked(|registry| {
+                registry.cleanup_stale(24);
+            }) {
+                Ok((registry, ())) => registry,
+                Err(e) => {
+                    tracing::warn!("lean-ctx: failed to persist agent registry: {e}");
+                    AgentRegistry::load_or_create()
+                }
+            };
 
             let agents = registry.list_active(Some(project_root));
             if agents.is_empty() {
@@ -76,22 +80,22 @@ pub fn handle(
             if msg_privacy == PrivacyLevel::Private && to_agent.is_none() {
                 return "Error: private messages require to_agent".to_string();
             }
-            let mut registry = AgentRegistry::load_or_create();
-            let msg_id = registry.post_message_full(
-                from,
-                to_agent,
-                cat,
-                msg,
-                msg_privacy,
-                msg_priority,
-                _ttl_hours,
-            );
-            match registry.save() {
-                Ok(()) => {
+            match AgentRegistry::mutate_locked(|registry| {
+                registry.post_message_full(
+                    from,
+                    to_agent,
+                    cat,
+                    msg,
+                    msg_privacy,
+                    msg_priority,
+                    _ttl_hours,
+                )
+            }) {
+                Ok((_, msg_id)) => {
                     let target = to_agent.unwrap_or("all agents (broadcast)");
                     format!("Posted [{cat}] to {target}: {msg} (id: {msg_id})")
                 }
-                Err(e) => format!("Posted but save failed: {e}"),
+                Err(e) => format!("Post failed: {e}"),
             }
         }
 
@@ -99,13 +103,23 @@ pub fn handle(
             let Some(agent_id) = current_agent_id else {
                 return "Error: agent must be registered first (use action=register)".to_string();
             };
-            let mut registry = AgentRegistry::load_or_create();
-            let messages = registry.read_unread(agent_id);
+            let messages = match AgentRegistry::mutate_locked(|registry| {
+                registry
+                    .read_unread(agent_id)
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+            }) {
+                Ok((_, messages)) => messages,
+                Err(e) => {
+                    tracing::warn!(
+                        "lean-ctx: failed to persist agent registry (messages may reappear): {e}"
+                    );
+                    return "Error: failed to read messages".to_string();
+                }
+            };
 
             if messages.is_empty() {
-                if let Err(e) = registry.save() {
-                    tracing::warn!("lean-ctx: failed to persist agent registry: {e}");
-                }
                 return "No new messages.".to_string();
             }
 
@@ -116,11 +130,6 @@ pub fn handle(
                     "  [{}] from {} ({}m ago): {}\n",
                     m.category, m.from_agent, age, m.message
                 ));
-            }
-            if let Err(e) = registry.save() {
-                tracing::warn!(
-                    "lean-ctx: failed to persist agent registry (messages may reappear): {e}"
-                );
             }
             out
         }
@@ -140,10 +149,10 @@ pub fn handle(
             };
             let status_msg = message;
 
-            let mut registry = AgentRegistry::load_or_create();
-            registry.set_status(agent_id, new_status.clone(), status_msg);
-            match registry.save() {
-                Ok(()) => format!(
+            match AgentRegistry::mutate_locked(|registry| {
+                registry.set_status(agent_id, new_status.clone(), status_msg);
+            }) {
+                Ok(_) => format!(
                     "Status updated: {} → {}{}",
                     agent_id,
                     new_status,
@@ -177,17 +186,15 @@ pub fn handle(
             };
             let summary = message.unwrap_or("(no summary provided)");
 
-            let mut registry = AgentRegistry::load_or_create();
-
-            registry.post_message(
-                from,
-                Some(target),
-                "handoff",
-                &format!("HANDOFF from {from}: {summary}"),
-            );
-
-            registry.set_status(from, AgentStatus::Finished, Some("handed off"));
-            let _ = registry.save();
+            let _ = AgentRegistry::mutate_locked(|registry| {
+                registry.post_message(
+                    from,
+                    Some(target),
+                    "handoff",
+                    &format!("HANDOFF from {from}: {summary}"),
+                );
+                registry.set_status(from, AgentStatus::Finished, Some("handed off"));
+            });
 
             // Stigmergy (#540): mark the handed-off work as Done in the field
             // so other agents see it arithmetically, without reading messages.
@@ -710,10 +717,10 @@ pub fn handle(
                 return "Error: no valid key=value pairs found".to_string();
             }
             let from = current_agent_id.unwrap_or("anonymous");
-            let mut registry = AgentRegistry::load_or_create();
-            registry.share_knowledge(from, cat, &facts);
-            match registry.save() {
-                Ok(()) => format!("Shared {} facts in category '{}'", facts.len(), cat),
+            match AgentRegistry::mutate_locked(|registry| {
+                registry.share_knowledge(from, cat, &facts);
+            }) {
+                Ok(_) => format!("Shared {} facts in category '{}'", facts.len(), cat),
                 Err(e) => format!("Share failed: {e}"),
             }
         }
@@ -722,9 +729,11 @@ pub fn handle(
             let Some(agent_id) = current_agent_id else {
                 return "Error: agent must be registered first".to_string();
             };
-            let mut registry = AgentRegistry::load_or_create();
-            let facts = registry.receive_shared_knowledge(agent_id);
-            let _ = registry.save();
+            let facts = AgentRegistry::mutate_locked(|registry| {
+                registry.receive_shared_knowledge(agent_id)
+            })
+            .map(|(_, facts)| facts)
+            .unwrap_or_default();
             if facts.is_empty() {
                 return "No new shared knowledge.".to_string();
             }

--- a/rust/src/tools/ctx_overview.rs
+++ b/rust/src/tools/ctx_overview.rs
@@ -393,9 +393,11 @@ pub fn build_wakeup_briefing(project_root: &str, task: Option<&str>) -> String {
     // from crashed or exited MCP processes (#419). `ctx_agent list` and the
     // dashboard already do this; the wake-up briefing must too. Scope to the
     // current project root — the briefing is about peers on *this* project.
-    let mut registry = crate::core::agents::AgentRegistry::load_or_create();
-    registry.cleanup_stale(24);
-    let _ = registry.save();
+    let registry = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
+        registry.cleanup_stale(24);
+    })
+    .map(|(registry, ())| registry)
+    .unwrap_or_default();
     let active_agents = registry.list_active(Some(project_root));
     if !active_agents.is_empty() {
         let agents: Vec<String> = active_agents


### PR DESCRIPTION
## Summary

- `AgentRegistry::save()` only locked the final `fs::write`; the preceding `load()` was unlocked. Every mutating call site followed `load_or_create() -> mutate in memory -> save()`, so two concurrent writers (two MCP sessions each registering, or the dashboard's own poll-triggered `cleanup_stale` + `save`) could each load a stale snapshot and the last writer would silently overwrite the other's changes with its own full-registry snapshot. Symptom: a second session's agent never appears in the dashboard, or disappears shortly after registering.
- Add `AgentRegistry::mutate_locked()` (mirrors the existing `ProjectKnowledge::mutate_locked` convention): acquires the registry lock, re-reads fresh from disk *while holding it*, applies the mutation, writes, then releases — closing the TOCTOU window entirely.
- Migrate every load-mutate-save call site to it: MCP session registration (`server_handler.rs`), the HTTP daemon's register/heartbeat/deregister endpoints, the dashboard's agents route, `ctx_agent`'s register/post/read/status/handoff/share_knowledge/receive_knowledge actions, and the wake-up briefing's stale-agent prune.

Fixes #907

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib core::agents::` — 15 passed, including new regression test `mutate_locked_survives_concurrent_writers` (8 threads racing to register distinct agents through `mutate_locked`, asserts all 8 persist)
- [x] `cargo test --test subagent_contract_roundtrip --test power_user_worksession --test plan_mode_scenarios --test reverse_cut_gate --test compliance_frameworks` — integration coverage touching the agent registry, all green
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`
