### PR TITLE
refactor: recover from poisoned mutexes instead of unwrap()-panicking

### DIFF
--- a/rust/src/core/addons/bootstrap.rs
+++ b/rust/src/core/addons/bootstrap.rs
@@ -630,7 +630,9 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn ensure_installed_runs_manager_then_verifies() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = std::env::temp_dir().join(format!("leanctx-boot-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         let marker = tmp.join("installed.marker");
@@ -663,7 +665,9 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn ensure_installed_propagates_manager_failure() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = std::env::temp_dir().join(format!("leanctx-boot-fail-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         let fake_uv = tmp.join("uv");
@@ -699,7 +703,9 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn ensure_installed_preflights_a_missing_manager() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let tmp = std::env::temp_dir().join(format!("leanctx-boot-miss-{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
         let missing = tmp.join("uv-not-here");

--- a/rust/src/core/bm25_cache.rs
+++ b/rust/src/core/bm25_cache.rs
@@ -225,7 +225,9 @@ mod tests {
         let _ = get_or_load(&cache, tmp1.path());
         let idx2 = get_or_load(&cache, tmp2.path());
 
-        let guard = cache.lock().unwrap();
+        let guard = cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let entry = guard.as_ref().unwrap();
         assert_eq!(entry.root, tmp2.path());
         assert_eq!(entry.index.doc_count, idx2.doc_count);

--- a/rust/src/core/datadog_push.rs
+++ b/rust/src/core/datadog_push.rs
@@ -288,7 +288,9 @@ mod tests {
     /// baseline → delta → tags assertions must not run as parallel tests.
     #[test]
     fn baseline_then_deltas_then_tags() {
-        *BASELINE.lock().unwrap() = None;
+        *BASELINE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
 
         // Cycle 1: baseline only, nothing submitted.
         assert!(build_series(1000).is_empty());

--- a/rust/src/core/path_locks.rs
+++ b/rust/src/core/path_locks.rs
@@ -80,7 +80,9 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 barrier.wait();
                 let lock = per_file_lock(path);
-                let _guard = lock.lock().unwrap();
+                let _guard = lock
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 let active = counter.fetch_add(1, Ordering::SeqCst) + 1;
                 max_concurrent.fetch_max(active, Ordering::SeqCst);
                 std::thread::sleep(std::time::Duration::from_millis(5));
@@ -111,7 +113,9 @@ mod tests {
                 let path = format!("/tmp/path_locks_parallel_{i}.txt");
                 barrier.wait();
                 let lock = per_file_lock(&path);
-                let _guard = lock.lock().unwrap();
+                let _guard = lock
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 let active = counter.fetch_add(1, Ordering::SeqCst) + 1;
                 max_concurrent.fetch_max(active, Ordering::SeqCst);
                 std::thread::sleep(std::time::Duration::from_millis(5));

--- a/rust/src/dashboard/tests.rs
+++ b/rust/src/dashboard/tests.rs
@@ -36,7 +36,9 @@ fn open_mode_flag_parses_all_variants() {
 
 #[test]
 fn open_mode_env_is_used_when_no_flag() {
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     crate::test_env::set_var("LEAN_CTX_DASHBOARD_OPEN", "none");
     assert_eq!(resolve_open_mode(None), DashboardOpen::None);
     crate::test_env::set_var("LEAN_CTX_DASHBOARD_OPEN", "vscode");

--- a/rust/src/doctor/workspace_scope.rs
+++ b/rust/src/doctor/workspace_scope.rs
@@ -234,7 +234,9 @@ mod tests {
     fn with_cwd<T>(dir: &std::path::Path, f: impl FnOnce() -> T) -> T {
         use std::sync::Mutex;
         static LOCK: Mutex<()> = Mutex::new(());
-        let _guard = LOCK.lock().unwrap();
+        let _guard = LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::current_dir().unwrap();
         std::env::set_current_dir(dir).unwrap();
         let out = f();

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -495,7 +495,9 @@ mod tests {
         // bounce-prevention, pressure-downgrade, etc. must not clobber it to
         // "full" and silently drop the window.
         {
-            let mut bt = crate::core::bounce_tracker::global().lock().unwrap();
+            let mut bt = crate::core::bounce_tracker::global()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             bt.set_seq(101);
             bt.record_read("anchored-bouncy.yml", "map", 30, 400);
             bt.set_seq(102);
@@ -530,7 +532,9 @@ mod tests {
     #[test]
     fn pre_dispatch_bounce_prevention_forces_full() {
         {
-            let mut bt = crate::core::bounce_tracker::global().lock().unwrap();
+            let mut bt = crate::core::bounce_tracker::global()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             bt.set_seq(1);
             bt.record_read("src/bouncy.yml", "map", 30, 400);
             bt.set_seq(2);

--- a/rust/src/tools/registered/ctx_read_inline_tests.rs
+++ b/rust/src/tools/registered/ctx_read_inline_tests.rs
@@ -51,7 +51,9 @@ fn per_file_lock_serializes_concurrent_access() {
         let path = path.to_string();
         handles.push(std::thread::spawn(move || {
             let lock = per_file_lock(&path);
-            let _guard = lock.lock().unwrap();
+            let _guard = lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let active = counter.fetch_add(1, Ordering::SeqCst) + 1;
             max_concurrent.fetch_max(active, Ordering::SeqCst);
             std::thread::sleep(std::time::Duration::from_millis(10));
@@ -78,7 +80,9 @@ fn per_file_lock_allows_parallel_different_paths() {
         let path = format!("/tmp/test_parallel_{i}.txt");
         handles.push(std::thread::spawn(move || {
             let lock = per_file_lock(&path);
-            let _guard = lock.lock().unwrap();
+            let _guard = lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let active = counter.fetch_add(1, Ordering::SeqCst) + 1;
             max_concurrent.fetch_max(active, Ordering::SeqCst);
             std::thread::sleep(std::time::Duration::from_millis(50));

--- a/rust/src/tools/registered/ctx_read_repo_param_tests.rs
+++ b/rust/src/tools/registered/ctx_read_repo_param_tests.rs
@@ -23,7 +23,9 @@ async fn repo_param_resolves_against_repo_root_no_cache_collision() {
     let alias_b = "test-repo-696-b";
     {
         let manager = crate::core::multi_repo::global_manager();
-        let mut mgr = manager.lock().unwrap();
+        let mut mgr = manager
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         mgr.add_root(&dir_a.path().to_string_lossy(), Some(alias_a))
             .unwrap();
         mgr.add_root(&dir_b.path().to_string_lossy(), Some(alias_b))
@@ -85,7 +87,9 @@ async fn repo_param_unknown_alias_errors_with_known_aliases() {
 
     {
         let manager = crate::core::multi_repo::global_manager();
-        let mut mgr = manager.lock().unwrap();
+        let mut mgr = manager
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = tempfile::tempdir().unwrap();
         mgr.add_root(&dir.path().to_string_lossy(), Some("test-repo-696-known"))
             .ok();


### PR DESCRIPTION
## Summary

- Replace the 15 remaining `.lock().unwrap()` call sites (all in test code, spread across 9 files) with `.lock().unwrap_or_else(std::sync::PoisonError::into_inner)`, matching the recovery convention already used throughout production code (e.g. `core/path_locks.rs`'s own `per_file_lock`).
- A panic while holding one of these locks would otherwise poison the mutex; every subsequent `.unwrap()` on it then panics too, turning one failing test into a pile of unrelated-looking panics for the rest of that test run.
- No behavior change outside of panic-recovery — non-poisoned paths are identical.

Fixes #911

## Test plan

- [x] `cargo build --lib --tests`
- [x] `cargo test --lib` — 7685 passed, 0 failed, 10 ignored (full suite, since the change touches test helpers across 9 files)
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --tests -- -D warnings`