### PR TITLE
fix(index): adapt batches to memory headroom

### DIFF
--- a/rust/src/core/bm25_index/build.rs
+++ b/rust/src/core/bm25_index/build.rs
@@ -28,27 +28,18 @@ pub(super) const PARALLEL_MIN_FILES: usize = 32;
 /// so every file in the batch is live in RAM simultaneously.
 const MAX_BATCH_FILES: usize = 500;
 
-/// Lower bound — below this the rayon overhead dominates.
-const MIN_BATCH_FILES: usize = 50;
+/// Minimum progress unit under low headroom.
+const MIN_BATCH_FILES: usize = 1;
 
-/// Conservative estimate of peak transient memory per file during parallel
-/// preparation: file content (~20 KB avg) + tree-sitter chunks + lowered
-/// token vectors. Files up to 2 MB are admitted, but the average is far lower.
-const EST_TRANSIENT_PER_FILE: u64 = 150_000;
+/// Conservative estimate of peak transient memory per file during preparation.
+const EST_TRANSIENT_PER_FILE: u64 = 256 * 1024;
 
-/// Computes the effective batch size based on current memory headroom.
-/// Returns a value in `[MIN_BATCH_FILES, MAX_BATCH_FILES]` that keeps the
-/// estimated peak transient allocation within the guardian's hard threshold.
-fn effective_batch_size() -> usize {
-    let headroom = match (
-        crate::core::memory_guard::rss_limit_bytes(),
-        crate::core::memory_guard::get_rss_bytes(),
-    ) {
-        (Some(limit), Some(rss)) => limit.saturating_mul(2).saturating_sub(rss),
-        _ => return MAX_BATCH_FILES,
-    };
-    let by_headroom = (headroom / EST_TRANSIENT_PER_FILE).min(MAX_BATCH_FILES as u64) as usize;
-    by_headroom.clamp(MIN_BATCH_FILES, MAX_BATCH_FILES)
+fn effective_batch_size(max_files: usize) -> usize {
+    crate::core::memory_guard::adaptive_batch_size(
+        MIN_BATCH_FILES,
+        max_files.min(MAX_BATCH_FILES).max(1),
+        EST_TRANSIENT_PER_FILE,
+    )
 }
 
 const MAX_FILE_SIZE_BYTES: u64 = 2 * 1024 * 1024;
@@ -129,6 +120,9 @@ fn prepare_file(
     rel: &str,
     content_hint: &HashMap<String, String>,
 ) -> Option<PreparedFile> {
+    if crate::core::memory_guard::abort_requested() {
+        return None;
+    }
     let abs = root.join(rel);
     let state = IndexedFileState::from_path(&abs)?;
     if state.size_bytes > MAX_FILE_SIZE_BYTES {
@@ -170,6 +164,10 @@ fn prepare_file(
         }
     };
 
+    if crate::core::memory_guard::abort_requested() {
+        return None;
+    }
+
     let mut chunks = extract_chunks(rel, &content);
     chunks.sort_by(|a, b| {
         a.start_line
@@ -199,6 +197,9 @@ fn prepare_incremental_file(
     content_hint: &HashMap<String, String>,
     rel: &str,
 ) -> Option<PreparedFile> {
+    if crate::core::memory_guard::abort_requested() {
+        return None;
+    }
     let abs = root.join(rel);
     let state = IndexedFileState::from_path(&abs)?;
 
@@ -207,6 +208,9 @@ fn prepare_incremental_file(
         && let Some(chunks) = old_by_file.get(rel)
         && chunks.first().is_some_and(|c| !c.content.is_empty())
     {
+        if crate::core::memory_guard::abort_requested() {
+            return None;
+        }
         return Some(PreparedFile {
             rel: rel.to_string(),
             state,
@@ -231,7 +235,7 @@ impl BM25Index {
         content_hint: &HashMap<String, String>,
         files: &[String],
     ) -> Self {
-        Self::build_parallel_batched(root, content_hint, files, effective_batch_size())
+        Self::build_parallel_batched(root, content_hint, files, MAX_BATCH_FILES)
     }
 
     /// Batch-size-injectable core of [`Self::build_parallel`] so the multi-batch
@@ -243,16 +247,15 @@ impl BM25Index {
         batch_size: usize,
     ) -> Self {
         let mut index = Self::new();
-        // Batched fan-out (#685): each batch is an order-preserving
-        // `par_iter().collect()` merged immediately, so peak transient state is
-        // one batch instead of the whole corpus, and the guardian gets a say
-        // between batches. `chunks()` keeps the sorted file order — identical
-        // output to the sequential path.
-        for (batch_no, batch) in files.chunks(batch_size.max(1)).enumerate() {
-            if parallel_build_must_stop("bm25", batch_no * batch_size) {
+        let max_batch_size = batch_size.max(1).min(MAX_BATCH_FILES);
+        let mut files_done = 0;
+        while files_done < files.len() {
+            if parallel_build_must_stop("bm25", files_done) {
                 break;
             }
-            let prepared: Vec<Option<PreparedFile>> = batch
+            let adaptive_size = effective_batch_size(max_batch_size);
+            let batch_end = (files_done + adaptive_size).min(files.len());
+            let prepared: Vec<Option<PreparedFile>> = files[files_done..batch_end]
                 .par_iter()
                 .map(|rel| prepare_file(root, rel, content_hint))
                 .collect();
@@ -262,11 +265,8 @@ impl BM25Index {
                 }
                 index.files.insert(pf.rel, pf.state);
             }
-            // Reclaim freed transient state immediately so RSS does not
-            // accumulate across batches due to jemalloc page retention.
-            if batch_no > 0 {
-                crate::core::memory_guard::jemalloc_purge();
-            }
+            files_done = batch_end;
+            crate::core::memory_guard::jemalloc_purge();
         }
         index.finalize();
         index
@@ -291,15 +291,14 @@ impl BM25Index {
         let empty_hint: HashMap<String, String> = HashMap::new();
 
         let mut index = Self::new();
-        // Batched fan-out (#685) — see `build_parallel`. `chunks()` keeps the
-        // input file order, so the merge sees files exactly as the sequential
-        // rebuild iterates them — the foundation of identical output.
-        let batch_size = effective_batch_size();
-        for (batch_no, batch) in files.chunks(batch_size).enumerate() {
-            if parallel_build_must_stop("bm25-incr", batch_no * batch_size) {
+        let mut files_done = 0;
+        while files_done < files.len() {
+            if parallel_build_must_stop("bm25-incr", files_done) {
                 break;
             }
-            let prepared: Vec<Option<PreparedFile>> = batch
+            let batch_size = effective_batch_size(MAX_BATCH_FILES);
+            let batch_end = (files_done + batch_size).min(files.len());
+            let prepared: Vec<Option<PreparedFile>> = files[files_done..batch_end]
                 .par_iter()
                 .map(|rel| prepare_incremental_file(root, prev, old_by_file, &empty_hint, rel))
                 .collect();
@@ -309,9 +308,8 @@ impl BM25Index {
                 }
                 index.files.insert(pf.rel, pf.state);
             }
-            if batch_no > 0 {
-                crate::core::memory_guard::jemalloc_purge();
-            }
+            files_done = batch_end;
+            crate::core::memory_guard::jemalloc_purge();
         }
         index.finalize();
         index

--- a/rust/src/core/bm25_index/build.rs
+++ b/rust/src/core/bm25_index/build.rs
@@ -31,13 +31,16 @@ const MAX_BATCH_FILES: usize = 500;
 /// Minimum progress unit under low headroom.
 const MIN_BATCH_FILES: usize = 1;
 
-/// Conservative estimate of peak transient memory per file during preparation.
+/// Conservative estimate of peak transient memory per file during BM25
+/// preparation: file content (~20 KB avg) + tree-sitter chunks + lowered
+/// token vectors + content-cache Arc. Higher than graph-scan because
+/// chunk extraction and tokenization run concurrently per batch element.
 const EST_TRANSIENT_PER_FILE: u64 = 256 * 1024;
 
 fn effective_batch_size(max_files: usize) -> usize {
     crate::core::memory_guard::adaptive_batch_size(
         MIN_BATCH_FILES,
-        max_files.min(MAX_BATCH_FILES).max(1),
+        max_files.clamp(1, MAX_BATCH_FILES),
         EST_TRANSIENT_PER_FILE,
     )
 }
@@ -208,9 +211,6 @@ fn prepare_incremental_file(
         && let Some(chunks) = old_by_file.get(rel)
         && chunks.first().is_some_and(|c| !c.content.is_empty())
     {
-        if crate::core::memory_guard::abort_requested() {
-            return None;
-        }
         return Some(PreparedFile {
             rel: rel.to_string(),
             state,
@@ -238,16 +238,17 @@ impl BM25Index {
         Self::build_parallel_batched(root, content_hint, files, MAX_BATCH_FILES)
     }
 
-    /// Batch-size-injectable core of [`Self::build_parallel`] so the multi-batch
-    /// merge path is testable without a 2000-file corpus.
+    /// Batch-size-injectable core of [`Self::build_parallel`]. `max_batch_size`
+    /// caps the upper bound; actual batch sizes adapt to RSS headroom each
+    /// iteration. Testable without a 2000-file corpus.
     pub(super) fn build_parallel_batched(
         root: &Path,
         content_hint: &HashMap<String, String>,
         files: &[String],
-        batch_size: usize,
+        max_batch_size: usize,
     ) -> Self {
         let mut index = Self::new();
-        let max_batch_size = batch_size.max(1).min(MAX_BATCH_FILES);
+        let max_batch_size = max_batch_size.clamp(1, MAX_BATCH_FILES);
         let mut files_done = 0;
         while files_done < files.len() {
             if parallel_build_must_stop("bm25", files_done) {

--- a/rust/src/core/graph_index/edges.rs
+++ b/rust/src/core/graph_index/edges.rs
@@ -39,9 +39,10 @@ fn build_edges_with_cache(index: &mut ProjectIndex, content_cache: &HashMap<Stri
     let resolver_ctx =
         import_resolver::ResolverContext::new(root_path, file_paths.clone(), content_cache);
 
-    // #934 + #790: fan out in 500-file batches with memory pressure checks
-    // between them. Under pressure, fall back to sequential with 1000-file checks.
+    // Fan-out adapts before every batch to current guardian headroom.
     const EDGE_BATCH_SIZE: usize = 500;
+    const EDGE_MIN_BATCH_FILES: usize = 1;
+    const EDGE_EST_TRANSIENT_PER_FILE: u64 = 256 * 1024;
     // #790: flush edges into index.edges after each batch instead of
     // accumulating all FileEdges in a Vec. Only type_inputs (C#/Java/Go/Kotlin)
     // are retained across batches for the cross-file type_ref pass.
@@ -60,43 +61,33 @@ fn build_edges_with_cache(index: &mut ProjectIndex, content_cache: &HashMap<Stri
             }
         };
 
-    if crate::core::memory_guard::is_under_pressure() {
-        for (i, rel_path) in file_paths.iter().enumerate() {
-            if i.is_multiple_of(1000) && crate::core::memory_guard::is_under_pressure() {
-                tracing::warn!(
-                    "[graph_index: stopping edge-building at file {i}/{} due to memory pressure]",
-                    file_paths.len()
-                );
-                break;
-            }
-            let fe = resolve_file_edges(rel_path, content_cache, &resolver_ctx, root_path);
-            index.edges.extend(fe.edges);
-            if let Some(ti) = fe.type_input {
-                type_inputs.push(ti);
-            }
+    let mut files_done = 0;
+    while files_done < file_paths.len() {
+        if crate::core::memory_guard::abort_requested() {
+            tracing::warn!(
+                "[graph_index: aborting edge-building after {files_done} files due to critical memory pressure]"
+            );
+            break;
         }
-    } else {
-        for (batch_no, batch) in file_paths.chunks(EDGE_BATCH_SIZE).enumerate() {
-            if crate::core::memory_guard::abort_requested() {
-                tracing::warn!(
-                    "[graph_index: aborting edge-building at batch {batch_no} due to critical memory pressure]",
-                );
-                break;
-            }
-            if crate::core::memory_guard::is_under_pressure() {
-                tracing::warn!(
-                    "[graph_index: stopping edge-building at batch {batch_no} due to memory pressure]",
-                );
-                break;
-            }
-            let batch_results: Vec<FileEdges> = batch
-                .par_iter()
-                .map(|rel_path| {
-                    resolve_file_edges(rel_path, content_cache, &resolver_ctx, root_path)
-                })
-                .collect();
-            flush_batch(batch_results, index, &mut type_inputs);
+        if crate::core::memory_guard::is_under_pressure() {
+            tracing::warn!(
+                "[graph_index: stopping edge-building after {files_done} files due to memory pressure]"
+            );
+            break;
         }
+        let batch_size = crate::core::memory_guard::adaptive_batch_size(
+            EDGE_MIN_BATCH_FILES,
+            EDGE_BATCH_SIZE,
+            EDGE_EST_TRANSIENT_PER_FILE,
+        );
+        let batch_end = (files_done + batch_size).min(file_paths.len());
+        let batch_results: Vec<FileEdges> = file_paths[files_done..batch_end]
+            .par_iter()
+            .map(|rel_path| resolve_file_edges(rel_path, content_cache, &resolver_ctx, root_path))
+            .collect();
+        flush_batch(batch_results, index, &mut type_inputs);
+        files_done = batch_end;
+        crate::core::memory_guard::jemalloc_purge();
     }
 
     // Cross-file type-reference edges for C#/Java same-namespace usage (GH #398).
@@ -156,6 +147,10 @@ fn resolve_file_edges(
         type_input: None,
     };
 
+    if crate::core::memory_guard::abort_requested() {
+        return out;
+    }
+
     let content = if let Some(cached) = content_cache.get(rel_path) {
         std::borrow::Cow::Borrowed(cached.as_str())
     } else {
@@ -170,6 +165,10 @@ fn resolve_file_edges(
             Err(_) => return out,
         }
     };
+
+    if crate::core::memory_guard::abort_requested() {
+        return out;
+    }
 
     let ext = Path::new(rel_path)
         .extension()

--- a/rust/src/core/graph_index/edges.rs
+++ b/rust/src/core/graph_index/edges.rs
@@ -42,7 +42,10 @@ fn build_edges_with_cache(index: &mut ProjectIndex, content_cache: &HashMap<Stri
     // Fan-out adapts before every batch to current guardian headroom.
     const EDGE_BATCH_SIZE: usize = 500;
     const EDGE_MIN_BATCH_FILES: usize = 1;
-    const EDGE_EST_TRANSIENT_PER_FILE: u64 = 256 * 1024;
+    // Import resolution + deep analysis per file: content (often from cache,
+    // so only the Cow overhead) + resolved-import strings + DeepAnalysis.
+    // Heavier than scan because deep_queries::analyze is O(n_imports).
+    const EDGE_EST_TRANSIENT_PER_FILE: u64 = 320 * 1024;
     // #790: flush edges into index.edges after each batch instead of
     // accumulating all FileEdges in a Vec. Only type_inputs (C#/Java/Go/Kotlin)
     // are retained across batches for the cross-file type_ref pass.

--- a/rust/src/core/graph_index/mod.rs
+++ b/rust/src/core/graph_index/mod.rs
@@ -783,10 +783,10 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
     };
     const MAX_ENTRIES_VISITED: usize = 500_000;
     const MAX_FILE_SIZE_BYTES: u64 = 2 * 1024 * 1024; // 2 MB per file
-    /// #790: per-batch size for the phase-2 fan-out. Lowered from 2000 to 500
-    /// (matching BM25's MAX_BATCH_FILES) — 2000-file batches hold ~40 MB of
-    /// ScanFileResult content inside par_iter().collect() with no pressure check.
+    /// Maximum phase-2 fan-out. Actual batches shrink with guardian headroom.
     const SCAN_BATCH_FILES: usize = 500;
+    const SCAN_MIN_BATCH_FILES: usize = 1;
+    const SCAN_EST_TRANSIENT_PER_FILE: u64 = 256 * 1024;
     let scan_deadline = std::time::Instant::now() + std::time::Duration::from_mins(5);
 
     // #934: two-phase scan. Phase 1 walks the tree sequentially (cheap; it
@@ -904,25 +904,32 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
         &target_rels,
     );
     let parallel = admission.parallel_ok && !crate::core::memory_guard::is_under_pressure();
-    for (batch_no, batch) in targets.chunks(SCAN_BATCH_FILES).enumerate() {
-        // #790: check pressure on EVERY batch including batch 0 — previously
-        // batch 0 always ran unchecked, allowing 2000 (now 500) files to allocate
-        // freely even when the system was already under pressure.
+    let mut files_done = 0;
+    while files_done < targets.len() {
         if crate::core::memory_guard::abort_requested() {
             tracing::warn!(
-                "[graph_index: aborting scan after {} files due to critical memory pressure]",
-                batch_no * SCAN_BATCH_FILES
+                "[graph_index: aborting scan after {files_done} files due to critical memory pressure]"
             );
             break;
         }
         if crate::core::memory_guard::is_under_pressure() {
             tracing::warn!(
-                "[graph_index: stopping scan after {} files due to memory pressure]",
-                batch_no * SCAN_BATCH_FILES
+                "[graph_index: stopping scan after {files_done} files due to memory pressure]"
             );
             break;
         }
-        let results = process_scan_targets(batch, &old_files, existing.as_ref(), parallel);
+        let batch_size = crate::core::memory_guard::adaptive_batch_size(
+            SCAN_MIN_BATCH_FILES,
+            SCAN_BATCH_FILES,
+            SCAN_EST_TRANSIENT_PER_FILE,
+        );
+        let batch_end = (files_done + batch_size).min(targets.len());
+        let results = process_scan_targets(
+            &targets[files_done..batch_end],
+            &old_files,
+            existing.as_ref(),
+            parallel,
+        );
         for r in results {
             if r.reused {
                 reused += 1;
@@ -933,13 +940,13 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
             for (key, sym) in r.symbols {
                 index.symbols.insert(key, sym);
             }
-            // #790: stop caching file contents once the budget is exceeded;
-            // the edge builder falls back to disk reads on cache misses.
             if content_cache_bytes < CONTENT_CACHE_MAX_BYTES {
                 content_cache_bytes += r.content.len();
                 content_cache.insert(r.rel, r.content);
             }
         }
+        files_done = batch_end;
+        crate::core::memory_guard::jemalloc_purge();
     }
 
     build_edges_cached(&mut index, &content_cache);
@@ -986,6 +993,9 @@ fn process_scan_file(
     old_files: &OldFileSymbols,
     existing: Option<&ProjectIndex>,
 ) -> Option<ScanFileResult> {
+    if crate::core::memory_guard::abort_requested() {
+        return None;
+    }
     let content = std::fs::read_to_string(file_path).ok()?;
     let hash = compute_hash(&content);
 
@@ -1001,6 +1011,10 @@ fn process_scan_file(
             content,
             reused: true,
         });
+    }
+
+    if crate::core::memory_guard::abort_requested() {
+        return None;
     }
 
     let sigs = signatures::extract_signatures(&content, ext);

--- a/rust/src/core/graph_index/mod.rs
+++ b/rust/src/core/graph_index/mod.rs
@@ -786,7 +786,10 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
     /// Maximum phase-2 fan-out. Actual batches shrink with guardian headroom.
     const SCAN_BATCH_FILES: usize = 500;
     const SCAN_MIN_BATCH_FILES: usize = 1;
-    const SCAN_EST_TRANSIENT_PER_FILE: u64 = 256 * 1024;
+    // Per-file scan: content string (~20 KB avg) + SHA-256 state +
+    // signature extraction + line/token counts. Lighter than BM25
+    // because no chunk splitting or lowered-token vectors are built.
+    const SCAN_EST_TRANSIENT_PER_FILE: u64 = 192 * 1024;
     let scan_deadline = std::time::Instant::now() + std::time::Duration::from_mins(5);
 
     // #934: two-phase scan. Phase 1 walks the tree sequentially (cheap; it

--- a/rust/src/core/memory_guard.rs
+++ b/rust/src/core/memory_guard.rs
@@ -70,6 +70,66 @@ pub fn rss_limit_bytes() -> Option<u64> {
     Some(sys_ram / 100 * u64::from(pct))
 }
 
+/// Computes a memory-bounded work batch from current RSS and the guardian's
+/// hard threshold (1.5× the configured base limit). Falls back to `max_files`
+/// when RSS is unavailable. The lower bound keeps progress deterministic while
+/// allowing callers to reduce in-flight work substantially under low headroom.
+pub(crate) fn adaptive_batch_size(
+    min_files: usize,
+    max_files: usize,
+    estimated_bytes_per_file: u64,
+) -> usize {
+    let headroom = match (rss_limit_bytes(), get_rss_bytes()) {
+        (Some(limit), Some(rss)) => hard_headroom_bytes(limit, rss),
+        _ => return max_files.max(1),
+    };
+    batch_size_for_headroom(headroom, min_files, max_files, estimated_bytes_per_file)
+}
+
+fn hard_headroom_bytes(base_limit: u64, rss: u64) -> u64 {
+    base_limit
+        .saturating_mul(3)
+        .saturating_div(2)
+        .saturating_sub(rss)
+}
+
+fn batch_size_for_headroom(
+    headroom_bytes: u64,
+    min_files: usize,
+    max_files: usize,
+    estimated_bytes_per_file: u64,
+) -> usize {
+    let min_files = min_files.max(1);
+    let max_files = max_files.max(min_files);
+    let estimate = estimated_bytes_per_file.max(1);
+    let by_headroom = (headroom_bytes / estimate).min(max_files as u64) as usize;
+    by_headroom.clamp(min_files, max_files)
+}
+
+#[cfg(test)]
+mod adaptive_batch_tests {
+    use super::{batch_size_for_headroom, hard_headroom_bytes};
+
+    #[test]
+    fn hard_headroom_uses_guardian_hard_threshold() {
+        assert_eq!(hard_headroom_bytes(1_000, 1_100), 400);
+        assert_eq!(hard_headroom_bytes(1_000, 1_500), 0);
+        assert_eq!(hard_headroom_bytes(1_000, 2_000), 0);
+    }
+
+    #[test]
+    fn batch_size_tracks_headroom_and_bounds() {
+        assert_eq!(batch_size_for_headroom(1_000, 1, 500, 100), 10);
+        assert_eq!(batch_size_for_headroom(0, 1, 500, 100), 1);
+        assert_eq!(batch_size_for_headroom(100_000, 1, 500, 100), 500);
+    }
+
+    #[test]
+    fn batch_size_sanitizes_zero_bounds_and_estimate() {
+        assert_eq!(batch_size_for_headroom(0, 0, 0, 0), 1);
+    }
+}
+
 /// Recorded peak RSS since process start.
 pub fn peak_rss_bytes() -> u64 {
     PEAK_RSS.load(Ordering::Relaxed)


### PR DESCRIPTION
## Summary

- recompute graph scan, edge-build, and BM25 batch sizes before every batch
- size in-flight work against remaining RSS headroom below the guardian Hard threshold
- reduce minimum progress unit to one file under constrained memory
- add cooperative abort checks before expensive reads, parsing, and tokenization
- purge allocator pages after each completed batch

Follow-up to the phase-serialization fix in #918.

## Validation

- `cargo fmt --check`
- `cargo check --lib`
- `cargo test --lib core::memory_guard::adaptive_batch_tests` (3 passed)
- `cargo test --lib core::bm25_index::tests` (33 passed)
- `cargo test --lib core::graph_index::tests` (45 passed)
- `cargo test --lib core::index_orchestrator::tests` (12 passed)

Closes #922

Flyweight/FileId deduplication is tracked separately in #923.