### PR TITLE
perf(graph): intern PropertyGraph file paths

### DIFF
--- a/rust/src/core/community/graph.rs
+++ b/rust/src/core/community/graph.rs
@@ -189,9 +189,11 @@ pub(super) fn cohesion_of(graph: &AdjGraph, members: &[usize]) -> f64 {
 }
 
 fn query_files(conn: &Connection) -> Vec<String> {
-    let Ok(mut stmt) =
-        conn.prepare("SELECT DISTINCT file_path FROM nodes WHERE kind = 'file' ORDER BY file_path")
-    else {
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT DISTINCT p.path
+         FROM nodes n JOIN paths p ON p.id = n.file_id
+         WHERE n.kind = 'file' ORDER BY p.path",
+    ) else {
         tracing::warn!("community: failed to prepare file query");
         return Vec::new();
     };
@@ -205,13 +207,15 @@ fn query_files(conn: &Connection) -> Vec<String> {
 
 fn query_file_edges(conn: &Connection) -> Vec<(String, String, f64)> {
     let sql = "
-        SELECT DISTINCT n1.file_path, n2.file_path, e.kind
+        SELECT DISTINCT p1.path, p2.path, e.kind
         FROM edges e
         JOIN nodes n1 ON e.source_id = n1.id
         JOIN nodes n2 ON e.target_id = n2.id
+        JOIN paths p1 ON p1.id = n1.file_id
+        JOIN paths p2 ON p2.id = n2.file_id
         WHERE n1.kind = 'file' AND n2.kind = 'file'
-          AND n1.file_path != n2.file_path
-        ORDER BY n1.file_path, n2.file_path
+          AND n1.file_id != n2.file_id
+        ORDER BY p1.path, p2.path
     ";
     let Ok(mut stmt) = conn.prepare(sql) else {
         tracing::warn!("community: failed to prepare edge query");

--- a/rust/src/core/context_package/builder.rs
+++ b/rust/src/core/context_package/builder.rs
@@ -444,7 +444,7 @@ impl PackageBuilder {
 fn export_graph_nodes(graph: &crate::core::property_graph::CodeGraph) -> Vec<GraphNodeExport> {
     let conn = graph.connection();
     let Ok(mut stmt) =
-        conn.prepare("SELECT kind, name, file_path, line_start, line_end, metadata FROM nodes")
+        conn.prepare("SELECT n.kind, n.name, p.path, n.line_start, n.line_end, n.metadata FROM nodes n JOIN paths p ON p.id = n.file_id")
     else {
         tracing::warn!("ctxpkg: failed to prepare graph nodes query");
         return Vec::new();
@@ -479,10 +479,12 @@ fn export_graph_nodes(graph: &crate::core::property_graph::CodeGraph) -> Vec<Gra
 fn export_graph_edges(graph: &crate::core::property_graph::CodeGraph) -> Vec<GraphEdgeExport> {
     let conn = graph.connection();
     let sql = "
-        SELECT n1.file_path, n1.name, n2.file_path, n2.name, e.kind, e.metadata
+        SELECT p1.path, n1.name, p2.path, n2.name, e.kind, e.metadata
         FROM edges e
         JOIN nodes n1 ON e.source_id = n1.id
         JOIN nodes n2 ON e.target_id = n2.id
+        JOIN paths p1 ON p1.id = n1.file_id
+        JOIN paths p2 ON p2.id = n2.file_id
     ";
     let Ok(mut stmt) = conn.prepare(sql) else {
         tracing::warn!("ctxpkg: failed to prepare graph edges query");

--- a/rust/src/core/pagerank.rs
+++ b/rust/src/core/pagerank.rs
@@ -18,9 +18,11 @@ impl PageRankInput {
         let mut files: HashSet<String> = HashSet::new();
         let mut forward: HashMap<String, Vec<String>> = HashMap::new();
 
-        if let Ok(mut stmt) =
-            conn.prepare("SELECT DISTINCT file_path FROM nodes WHERE kind = 'file'")
-            && let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0))
+        if let Ok(mut stmt) = conn.prepare(
+            "SELECT DISTINCT p.path
+             FROM nodes n JOIN paths p ON p.id = n.file_id
+             WHERE n.kind = 'file'",
+        ) && let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0))
         {
             for f in rows.flatten() {
                 files.insert(f);
@@ -28,12 +30,14 @@ impl PageRankInput {
         }
 
         let edge_sql = "
-            SELECT DISTINCT n1.file_path, n2.file_path
+            SELECT DISTINCT p1.path, p2.path
             FROM edges e
             JOIN nodes n1 ON e.source_id = n1.id
             JOIN nodes n2 ON e.target_id = n2.id
+            JOIN paths p1 ON p1.id = n1.file_id
+            JOIN paths p2 ON p2.id = n2.file_id
             WHERE n1.kind = 'file' AND n2.kind = 'file'
-              AND n1.file_path != n2.file_path
+              AND n1.file_id != n2.file_id
         ";
         if let Ok(mut stmt) = conn.prepare(edge_sql)
             && let Ok(rows) = stmt.query_map([], |row| {

--- a/rust/src/core/property_graph/file_catalog.rs
+++ b/rust/src/core/property_graph/file_catalog.rs
@@ -13,10 +13,11 @@ pub struct FileCatalogEntry {
 
 pub(super) fn upsert(conn: &Connection, entry: &FileCatalogEntry) -> anyhow::Result<()> {
     let exports_json = serde_json::to_string(&entry.exports).unwrap_or_else(|_| "[]".to_string());
+    let file_id = super::path_id::intern(conn, &entry.path)?;
     conn.execute(
-        "INSERT INTO file_catalog (path, hash, language, line_count, token_count, exports, summary)
+        "INSERT INTO file_catalog (file_id, hash, language, line_count, token_count, exports, summary)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-         ON CONFLICT(path) DO UPDATE SET
+         ON CONFLICT(file_id) DO UPDATE SET
              hash = excluded.hash,
              language = excluded.language,
              line_count = excluded.line_count,
@@ -24,7 +25,7 @@ pub(super) fn upsert(conn: &Connection, entry: &FileCatalogEntry) -> anyhow::Res
              exports = excluded.exports,
              summary = excluded.summary",
         params![
-            entry.path,
+            file_id.raw(),
             entry.hash,
             entry.language,
             entry.line_count as i64,
@@ -38,8 +39,9 @@ pub(super) fn upsert(conn: &Connection, entry: &FileCatalogEntry) -> anyhow::Res
 
 pub(super) fn get(conn: &Connection, path: &str) -> anyhow::Result<Option<FileCatalogEntry>> {
     let mut stmt = conn.prepare(
-        "SELECT path, hash, language, line_count, token_count, exports, summary
-         FROM file_catalog WHERE path = ?1",
+        "SELECT p.path, f.hash, f.language, f.line_count, f.token_count, f.exports, f.summary
+         FROM file_catalog f JOIN paths p ON p.id = f.file_id
+         WHERE p.path = ?1",
     )?;
 
     let result = stmt
@@ -66,7 +68,9 @@ pub(super) fn count(conn: &Connection) -> anyhow::Result<usize> {
 }
 
 pub(super) fn all_paths(conn: &Connection) -> anyhow::Result<Vec<String>> {
-    let mut stmt = conn.prepare("SELECT path FROM file_catalog ORDER BY path")?;
+    let mut stmt = conn.prepare(
+        "SELECT p.path FROM file_catalog f JOIN paths p ON p.id = f.file_id ORDER BY p.path",
+    )?;
     let paths = stmt
         .query_map([], |row| row.get(0))?
         .filter_map(Result::ok)

--- a/rust/src/core/property_graph/mod.rs
+++ b/rust/src/core/property_graph/mod.rs
@@ -10,6 +10,7 @@ mod edge;
 pub mod file_catalog;
 mod meta;
 mod node;
+mod path_id;
 mod queries;
 mod schema;
 pub mod snapshot;
@@ -76,7 +77,8 @@ fn migrate_if_needed(project_root: &str, new_dir: &Path) {
 ///   graph stamped by an engine that predates the mirror fix must rebuild.
 /// - `4`: same-package `type_ref` edges extended to Go (directory-scoped) and
 ///   Kotlin (GH #398 bug class); graphs built before they existed must rebuild.
-pub const GRAPH_ENGINE_VERSION: u32 = 4;
+/// - `5`: PropertyGraph file paths use interned IDs; pre-ID databases rebuild.
+pub const GRAPH_ENGINE_VERSION: u32 = 5;
 
 /// `true` when the persisted graph was built by an engine older than
 /// [`GRAPH_ENGINE_VERSION`] — or predates the version stamp entirely (missing or
@@ -270,7 +272,7 @@ impl CodeGraph {
 
     pub fn clear(&self) -> anyhow::Result<()> {
         self.conn.execute_batch(
-            "DELETE FROM edges; DELETE FROM nodes; DELETE FROM file_catalog; \
+            "DELETE FROM edges; DELETE FROM nodes; DELETE FROM file_catalog; DELETE FROM paths; \
              DELETE FROM cross_source_edges;",
         )?;
         Ok(())
@@ -281,8 +283,9 @@ impl CodeGraph {
     /// so rebuilding the code graph never drops lateral provider hints, which
     /// live in their own table and are repopulated on a separate ingest cycle.
     pub fn clear_code_graph(&self) -> anyhow::Result<()> {
-        self.conn
-            .execute_batch("DELETE FROM edges; DELETE FROM nodes; DELETE FROM file_catalog;")?;
+        self.conn.execute_batch(
+            "DELETE FROM edges; DELETE FROM nodes; DELETE FROM file_catalog; DELETE FROM paths;",
+        )?;
         Ok(())
     }
 

--- a/rust/src/core/property_graph/node.rs
+++ b/rust/src/core/property_graph/node.rs
@@ -139,17 +139,18 @@ impl Node {
 }
 
 pub(super) fn upsert(conn: &Connection, node: &Node) -> anyhow::Result<i64> {
+    let file_id = super::path_id::intern(conn, &node.file_path)?;
     conn.execute(
-        "INSERT INTO nodes (kind, name, file_path, line_start, line_end, metadata)
+        "INSERT INTO nodes (kind, name, file_id, line_start, line_end, metadata)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-         ON CONFLICT(kind, name, file_path) DO UPDATE SET
+         ON CONFLICT(kind, name, file_id) DO UPDATE SET
             line_start = excluded.line_start,
             line_end = excluded.line_end,
             metadata = excluded.metadata",
         params![
             node.kind.as_str(),
             node.name,
-            node.file_path,
+            file_id.raw(),
             node.line_start.map(|v| v as i64),
             node.line_end.map(|v| v as i64),
             node.metadata,
@@ -157,8 +158,8 @@ pub(super) fn upsert(conn: &Connection, node: &Node) -> anyhow::Result<i64> {
     )?;
 
     let id: i64 = conn.query_row(
-        "SELECT id FROM nodes WHERE kind = ?1 AND name = ?2 AND file_path = ?3",
-        params![node.kind.as_str(), node.name, node.file_path],
+        "SELECT id FROM nodes WHERE kind = ?1 AND name = ?2 AND file_id = ?3",
+        params![node.kind.as_str(), node.name, file_id.raw()],
         |row| row.get(0),
     )?;
 
@@ -168,8 +169,9 @@ pub(super) fn upsert(conn: &Connection, node: &Node) -> anyhow::Result<i64> {
 pub(super) fn get_by_path(conn: &Connection, file_path: &str) -> anyhow::Result<Option<Node>> {
     let result = conn
         .query_row(
-            "SELECT id, kind, name, file_path, line_start, line_end, metadata
-             FROM nodes WHERE kind = 'file' AND file_path = ?1",
+            "SELECT n.id, n.kind, n.name, p.path, n.line_start, n.line_end, n.metadata
+             FROM nodes n JOIN paths p ON p.id = n.file_id
+             WHERE n.kind = 'file' AND p.path = ?1",
             params![file_path],
             |row| {
                 Ok(Node {
@@ -194,8 +196,9 @@ pub(super) fn get_by_symbol(
 ) -> anyhow::Result<Option<Node>> {
     let result = conn
         .query_row(
-            "SELECT id, kind, name, file_path, line_start, line_end, metadata
-             FROM nodes WHERE name = ?1 AND file_path = ?2 AND kind != 'file'",
+            "SELECT n.id, n.kind, n.name, p.path, n.line_start, n.line_end, n.metadata
+             FROM nodes n JOIN paths p ON p.id = n.file_id
+             WHERE n.name = ?1 AND p.path = ?2 AND n.kind != 'file'",
             params![name, file_path],
             |row| {
                 Ok(Node {
@@ -215,11 +218,17 @@ pub(super) fn get_by_symbol(
 
 pub(super) fn remove_by_file(conn: &Connection, file_path: &str) -> anyhow::Result<()> {
     conn.execute(
-        "DELETE FROM edges WHERE source_id IN (SELECT id FROM nodes WHERE file_path = ?1)
-         OR target_id IN (SELECT id FROM nodes WHERE file_path = ?1)",
+        "DELETE FROM edges WHERE source_id IN (
+             SELECT n.id FROM nodes n JOIN paths p ON p.id = n.file_id WHERE p.path = ?1
+         ) OR target_id IN (
+             SELECT n.id FROM nodes n JOIN paths p ON p.id = n.file_id WHERE p.path = ?1
+         )",
         params![file_path],
     )?;
-    conn.execute("DELETE FROM nodes WHERE file_path = ?1", params![file_path])?;
+    conn.execute(
+        "DELETE FROM nodes WHERE file_id = (SELECT id FROM paths WHERE path = ?1)",
+        params![file_path],
+    )?;
     Ok(())
 }
 
@@ -231,19 +240,19 @@ pub(super) fn find_symbols(
 ) -> anyhow::Result<Vec<Node>> {
     let name_lower = name.to_lowercase();
     let mut sql = String::from(
-        "SELECT id, kind, name, file_path, line_start, line_end, metadata
-         FROM nodes WHERE kind != 'file'
+        "SELECT n.id, n.kind, n.name, p.path, n.line_start, n.line_end, n.metadata
+         FROM nodes n JOIN paths p ON p.id = n.file_id WHERE n.kind != 'file'
          AND LOWER(name) LIKE '%' || ?1 || '%'",
     );
     let mut param_idx = 2;
     if file_filter.is_some() {
-        sql.push_str(&format!(" AND file_path LIKE '%' || ?{param_idx} || '%'"));
+        sql.push_str(&format!(" AND p.path LIKE '%' || ?{param_idx} || '%'"));
         param_idx += 1;
     }
     if kind_filter.is_some() {
         sql.push_str(&format!(" AND kind = ?{param_idx}"));
     }
-    sql.push_str(" ORDER BY file_path, line_start LIMIT 100");
+    sql.push_str(" ORDER BY p.path, n.line_start LIMIT 100");
 
     let mut stmt = conn.prepare(&sql)?;
 
@@ -293,9 +302,9 @@ pub(super) fn resolve_symbol_def_files(
     name: &str,
 ) -> anyhow::Result<Vec<String>> {
     let mut stmt = conn.prepare(
-        "SELECT DISTINCT file_path FROM nodes
-         WHERE kind = 'symbol' AND name = ?1 AND file_path != ''
-         ORDER BY file_path",
+        "SELECT DISTINCT p.path FROM nodes n JOIN paths p ON p.id = n.file_id
+         WHERE n.kind = 'symbol' AND n.name = ?1 AND p.path != ''
+         ORDER BY p.path",
     )?;
     let rows = stmt.query_map(params![name], |row| row.get::<_, String>(0))?;
     let mut out = Vec::new();
@@ -310,9 +319,9 @@ pub(super) fn resolve_symbol_def_files(
 /// that the call-graph builder needs (replacing `ProjectIndex::symbols`).
 pub(super) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<Node>> {
     let mut stmt = conn.prepare(
-        "SELECT id, kind, name, file_path, line_start, line_end, metadata
-         FROM nodes WHERE kind != 'file'
-         ORDER BY file_path, line_start",
+        "SELECT n.id, n.kind, n.name, p.path, n.line_start, n.line_end, n.metadata
+         FROM nodes n JOIN paths p ON p.id = n.file_id WHERE n.kind != 'file'
+         ORDER BY p.path, n.line_start",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok(Node {
@@ -361,10 +370,12 @@ pub(super) fn all_edges_flat(
     // non-existent `e.weight` made this query error out, so PG `edges()` always
     // returned empty (#682.3). Compute the weight from the kind instead.
     let mut stmt = conn.prepare(
-        "SELECT n1.file_path, n2.file_path, e.kind
+        "SELECT p1.path, p2.path, e.kind
          FROM edges e
          JOIN nodes n1 ON e.source_id = n1.id
          JOIN nodes n2 ON e.target_id = n2.id
+         JOIN paths p1 ON p1.id = n1.file_id
+         JOIN paths p2 ON p2.id = n2.file_id
          WHERE n1.kind = 'file' AND n2.kind = 'file'",
     )?;
     let rows = stmt.query_map([], |row| {

--- a/rust/src/core/property_graph/path_id.rs
+++ b/rust/src/core/property_graph/path_id.rs
@@ -1,0 +1,68 @@
+//! SQLite-backed file-path flyweights for the PropertyGraph.
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+/// Compact graph-local handle for one canonical path in the `paths` table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct FileId(i64);
+
+impl FileId {
+    pub(crate) fn raw(self) -> i64 {
+        self.0
+    }
+}
+
+/// Resolve or create the stable ID for `path` within this graph database.
+pub(crate) fn intern(conn: &Connection, path: &str) -> anyhow::Result<FileId> {
+    conn.execute(
+        "INSERT INTO paths (path) VALUES (?1) ON CONFLICT(path) DO NOTHING",
+        params![path],
+    )?;
+    let id = conn.query_row(
+        "SELECT id FROM paths WHERE path = ?1",
+        params![path],
+        |row| row.get(0),
+    )?;
+    Ok(FileId(id))
+}
+
+#[allow(dead_code)]
+pub(crate) fn get(conn: &Connection, path: &str) -> anyhow::Result<Option<FileId>> {
+    Ok(conn
+        .query_row(
+            "SELECT id FROM paths WHERE path = ?1",
+            params![path],
+            |row| row.get(0).map(FileId),
+        )
+        .optional()?)
+}
+
+#[allow(dead_code)]
+pub(crate) fn resolve(conn: &Connection, id: FileId) -> anyhow::Result<Option<String>> {
+    Ok(conn
+        .query_row(
+            "SELECT path FROM paths WHERE id = ?1",
+            params![id.raw()],
+            |row| row.get(0),
+        )
+        .optional()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::property_graph::CodeGraph;
+
+    #[test]
+    fn intern_deduplicates_and_round_trips() {
+        let graph = CodeGraph::open_in_memory().unwrap();
+        let first = intern(graph.connection(), "src/lib.rs").unwrap();
+        let second = intern(graph.connection(), "src/lib.rs").unwrap();
+        assert_eq!(first, second);
+        assert_eq!(get(graph.connection(), "src/lib.rs").unwrap(), Some(first));
+        assert_eq!(
+            resolve(graph.connection(), first).unwrap().as_deref(),
+            Some("src/lib.rs")
+        );
+    }
+}

--- a/rust/src/core/property_graph/queries.rs
+++ b/rust/src/core/property_graph/queries.rs
@@ -50,12 +50,14 @@ pub fn edge_weight(kind: &str) -> f64 {
 /// Files that depend on `file_path` via structural edges (imports, calls, type_ref, etc.).
 pub(super) fn dependents(conn: &Connection, file_path: &str) -> anyhow::Result<Vec<String>> {
     let sql = format!(
-        "SELECT DISTINCT n_src.file_path
+        "SELECT DISTINCT p_src.path
          FROM edges e
          JOIN nodes n_src ON e.source_id = n_src.id
          JOIN nodes n_tgt ON e.target_id = n_tgt.id
-         WHERE n_tgt.file_path = ?1
-           AND n_src.file_path != ?1
+         JOIN paths p_src ON p_src.id = n_src.file_id
+         JOIN paths p_tgt ON p_tgt.id = n_tgt.file_id
+         WHERE p_tgt.path = ?1
+           AND p_src.path != ?1
            AND e.kind IN ({STRUCTURAL_EDGE_KINDS})"
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -73,12 +75,14 @@ pub(super) fn dependents(conn: &Connection, file_path: &str) -> anyhow::Result<V
 /// Files that `file_path` depends on via structural edges.
 pub(super) fn dependencies(conn: &Connection, file_path: &str) -> anyhow::Result<Vec<String>> {
     let sql = format!(
-        "SELECT DISTINCT n_tgt.file_path
+        "SELECT DISTINCT p_tgt.path
          FROM edges e
          JOIN nodes n_src ON e.source_id = n_src.id
          JOIN nodes n_tgt ON e.target_id = n_tgt.id
-         WHERE n_src.file_path = ?1
-           AND n_tgt.file_path != ?1
+         JOIN paths p_src ON p_src.id = n_src.file_id
+         JOIN paths p_tgt ON p_tgt.id = n_tgt.file_id
+         WHERE p_src.path = ?1
+           AND p_tgt.path != ?1
            AND e.kind IN ({STRUCTURAL_EDGE_KINDS})"
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -203,15 +207,17 @@ pub fn related_files(
     limit: usize,
 ) -> anyhow::Result<Vec<(String, f64)>> {
     let sql = format!(
-        "SELECT n_other.file_path, e.kind
+        "SELECT p_other.path, e.kind
          FROM edges e
          JOIN nodes n_self ON (e.source_id = n_self.id OR e.target_id = n_self.id)
          JOIN nodes n_other ON (
              (e.source_id = n_other.id AND e.target_id = n_self.id)
              OR (e.target_id = n_other.id AND e.source_id = n_self.id)
          )
-         WHERE n_self.file_path = ?1
-           AND n_other.file_path != ?1
+         JOIN paths p_self ON p_self.id = n_self.file_id
+         JOIN paths p_other ON p_other.id = n_other.file_id
+         WHERE p_self.path = ?1
+           AND p_other.path != ?1
            AND e.kind IN ({STRUCTURAL_EDGE_KINDS})"
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -242,7 +248,8 @@ pub fn file_connectivity(
     let mut stmt_out = conn.prepare(
         "SELECT e.kind, COUNT(*)
          FROM edges e JOIN nodes n ON e.source_id = n.id
-         WHERE n.file_path = ?1
+         JOIN paths p ON p.id = n.file_id
+         WHERE p.path = ?1
          GROUP BY e.kind",
     )?;
     let rows = stmt_out.query_map(params![file_path], |row| {
@@ -256,7 +263,8 @@ pub fn file_connectivity(
     let mut stmt_in = conn.prepare(
         "SELECT e.kind, COUNT(*)
          FROM edges e JOIN nodes n ON e.target_id = n.id
-         WHERE n.file_path = ?1
+         JOIN paths p ON p.id = n.file_id
+         WHERE p.path = ?1
          GROUP BY e.kind",
     )?;
     let rows = stmt_in.query_map(params![file_path], |row| {
@@ -274,12 +282,14 @@ fn build_weighted_reverse_graph(
     conn: &Connection,
 ) -> anyhow::Result<HashMap<String, Vec<(String, f64)>>> {
     let sql = format!(
-        "SELECT n_tgt.file_path, n_src.file_path, e.kind
+        "SELECT p_tgt.path, p_src.path, e.kind
          FROM edges e
          JOIN nodes n_src ON e.source_id = n_src.id
          JOIN nodes n_tgt ON e.target_id = n_tgt.id
+         JOIN paths p_src ON p_src.id = n_src.file_id
+         JOIN paths p_tgt ON p_tgt.id = n_tgt.file_id
          WHERE e.kind IN ({STRUCTURAL_EDGE_KINDS})
-           AND n_src.file_path != n_tgt.file_path"
+           AND p_src.path != p_tgt.path"
     );
     let mut stmt = conn.prepare(&sql)?;
 
@@ -313,12 +323,14 @@ fn build_weighted_reverse_graph(
 
 fn build_forward_graph(conn: &Connection) -> anyhow::Result<HashMap<String, Vec<String>>> {
     let sql = format!(
-        "SELECT DISTINCT n_src.file_path, n_tgt.file_path
+        "SELECT DISTINCT p_src.path, p_tgt.path
          FROM edges e
          JOIN nodes n_src ON e.source_id = n_src.id
          JOIN nodes n_tgt ON e.target_id = n_tgt.id
+         JOIN paths p_src ON p_src.id = n_src.file_id
+         JOIN paths p_tgt ON p_tgt.id = n_tgt.file_id
          WHERE e.kind IN ({STRUCTURAL_EDGE_KINDS})
-           AND n_src.file_path != n_tgt.file_path"
+           AND p_src.path != p_tgt.path"
     );
     let mut stmt = conn.prepare(&sql)?;
 

--- a/rust/src/core/property_graph/schema.rs
+++ b/rust/src/core/property_graph/schema.rs
@@ -2,7 +2,31 @@
 
 use rusqlite::Connection;
 
+fn has_column(conn: &Connection, table: &str, column: &str) -> anyhow::Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let columns = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for name in columns {
+        if name? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// The PropertyGraph is derived data. Replace pre-FileId code tables in place;
+/// callers rebuild them because the engine-version bump marks the graph stale.
+fn migrate_legacy_paths(conn: &Connection) -> anyhow::Result<()> {
+    if has_column(conn, "nodes", "file_path")? {
+        conn.execute_batch("DROP TABLE IF EXISTS edges; DROP TABLE nodes;")?;
+    }
+    if has_column(conn, "file_catalog", "path")? {
+        conn.execute_batch("DROP TABLE file_catalog;")?;
+    }
+    Ok(())
+}
+
 pub(super) fn initialize(conn: &Connection) -> anyhow::Result<()> {
+    migrate_legacy_paths(conn)?;
     conn.execute_batch(
         "
         PRAGMA journal_mode = WAL;
@@ -12,25 +36,30 @@ pub(super) fn initialize(conn: &Connection) -> anyhow::Result<()> {
         PRAGMA mmap_size   = 268435456;
         PRAGMA temp_store  = MEMORY;
 
+        CREATE TABLE IF NOT EXISTS paths (
+            id   INTEGER PRIMARY KEY,
+            path TEXT NOT NULL UNIQUE
+        );
+
         CREATE TABLE IF NOT EXISTS nodes (
             id         INTEGER PRIMARY KEY AUTOINCREMENT,
             kind       TEXT NOT NULL,
             name       TEXT NOT NULL,
-            file_path  TEXT NOT NULL,
+            file_id    INTEGER NOT NULL REFERENCES paths(id),
             line_start INTEGER,
             line_end   INTEGER,
             metadata   TEXT,
-            UNIQUE(kind, name, file_path)
+            UNIQUE(kind, name, file_id)
         );
 
         CREATE INDEX IF NOT EXISTS idx_nodes_file
-            ON nodes(file_path);
+            ON nodes(file_id);
         CREATE INDEX IF NOT EXISTS idx_nodes_name
             ON nodes(name);
         CREATE INDEX IF NOT EXISTS idx_nodes_kind
             ON nodes(kind);
         CREATE INDEX IF NOT EXISTS idx_nodes_kind_file
-            ON nodes(kind, file_path);
+            ON nodes(kind, file_id);
 
         CREATE TABLE IF NOT EXISTS edges (
             id        INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -53,7 +82,7 @@ pub(super) fn initialize(conn: &Connection) -> anyhow::Result<()> {
             ON edges(target_id, kind);
 
         CREATE TABLE IF NOT EXISTS file_catalog (
-            path        TEXT PRIMARY KEY,
+            file_id     INTEGER PRIMARY KEY REFERENCES paths(id),
             hash        TEXT NOT NULL,
             language    TEXT NOT NULL DEFAULT '',
             line_count  INTEGER NOT NULL DEFAULT 0,
@@ -100,6 +129,7 @@ mod tests {
         assert!(tables.contains(&"edges".to_string()));
         assert!(tables.contains(&"file_catalog".to_string()));
         assert!(tables.contains(&"cross_source_edges".to_string()));
+        assert!(tables.contains(&"paths".to_string()));
     }
 
     #[test]
@@ -107,5 +137,35 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         initialize(&conn).unwrap();
         initialize(&conn).unwrap();
+    }
+
+    #[test]
+    fn legacy_path_schema_is_replaced() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE nodes (
+                id INTEGER PRIMARY KEY, kind TEXT NOT NULL,
+                name TEXT NOT NULL, file_path TEXT NOT NULL
+             );
+             CREATE TABLE edges (
+                id INTEGER PRIMARY KEY, source_id INTEGER NOT NULL,
+                target_id INTEGER NOT NULL, kind TEXT NOT NULL
+             );
+             CREATE TABLE file_catalog (path TEXT PRIMARY KEY, hash TEXT NOT NULL);
+             INSERT INTO nodes VALUES (1, 'file', 'old.rs', 'old.rs');
+             INSERT INTO file_catalog VALUES ('old.rs', 'hash');",
+        )
+        .unwrap();
+
+        initialize(&conn).unwrap();
+        initialize(&conn).unwrap();
+
+        assert!(has_column(&conn, "nodes", "file_id").unwrap());
+        assert!(!has_column(&conn, "nodes", "file_path").unwrap());
+        assert!(has_column(&conn, "file_catalog", "file_id").unwrap());
+        let nodes: i64 = conn
+            .query_row("SELECT COUNT(*) FROM nodes", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(nodes, 0);
     }
 }

--- a/rust/src/core/property_graph/snapshot.rs
+++ b/rust/src/core/property_graph/snapshot.rs
@@ -204,7 +204,8 @@ fn resolve_endpoint(
     let conn = graph.connection();
     let found: Option<i64> = conn
         .query_row(
-            "SELECT id FROM nodes WHERE kind = ?1 AND file_path = ?2 AND name = ?3",
+            "SELECT n.id FROM nodes n JOIN paths p ON p.id = n.file_id
+             WHERE n.kind = ?1 AND p.path = ?2 AND n.name = ?3",
             params![identity.0, identity.1, identity.2],
             |row| row.get(0),
         )

--- a/rust/src/core/property_graph/snapshot.rs
+++ b/rust/src/core/property_graph/snapshot.rs
@@ -69,7 +69,7 @@ impl DriftReport {
 fn collect_nodes(graph: &CodeGraph) -> anyhow::Result<Vec<SnapNode>> {
     let conn = graph.connection();
     let mut stmt =
-        conn.prepare("SELECT kind, file_path, name, line_start, line_end, metadata FROM nodes")?;
+        conn.prepare("SELECT n.kind, p.path, n.name, n.line_start, n.line_end, n.metadata FROM nodes n JOIN paths p ON p.id = n.file_id")?;
     let mut nodes: Vec<SnapNode> = stmt
         .query_map([], |row| {
             Ok(SnapNode {
@@ -90,11 +90,13 @@ fn collect_edges(graph: &CodeGraph) -> anyhow::Result<Vec<SnapEdge>> {
     let conn = graph.connection();
     let mut stmt = conn.prepare(
         "SELECT e.kind, e.metadata,
-                s.kind, s.file_path, s.name,
-                t.kind, t.file_path, t.name
+                s.kind, sp.path, s.name,
+                t.kind, tp.path, t.name
          FROM edges e
          JOIN nodes s ON s.id = e.source_id
-         JOIN nodes t ON t.id = e.target_id",
+         JOIN nodes t ON t.id = e.target_id
+         JOIN paths sp ON sp.id = s.file_id
+         JOIN paths tp ON tp.id = t.file_id",
     )?;
     let mut edges: Vec<SnapEdge> = stmt
         .query_map([], |row| {

--- a/rust/src/core/smells.rs
+++ b/rust/src/core/smells.rs
@@ -114,7 +114,7 @@ pub fn summarize(findings: &[SmellFinding]) -> Vec<SmellSummary> {
 /// dynamic/re-export usage rather than true death (see GH #365).
 fn detect_dead_code(conn: &Connection) -> Vec<SmellFinding> {
     let sql = "
-        SELECT n.name, n.file_path, n.line_start,
+        SELECT n.name, p.path, n.line_start,
                EXISTS(
                    SELECT 1 FROM edges e2
                    WHERE e2.source_id = n.id AND e2.kind = 'exports'
@@ -124,18 +124,19 @@ fn detect_dead_code(conn: &Connection) -> Vec<SmellFinding> {
                    JOIN nodes f ON f.id = e3.target_id
                    WHERE e3.kind = 'imports'
                      AND f.kind = 'file'
-                     AND f.file_path = n.file_path
+                     AND f.file_id = n.file_id
                ) AS file_imported
         FROM nodes n
+        JOIN paths p ON p.id = n.file_id
         WHERE n.kind = 'symbol'
-          AND n.file_path NOT LIKE '%test%'
-          AND n.file_path NOT LIKE '%spec%'
+          AND p.path NOT LIKE '%test%'
+          AND p.path NOT LIKE '%spec%'
           AND n.name NOT IN ('main', 'new', 'default', 'fmt', 'drop', '<module>')
           AND n.id NOT IN (
               SELECT DISTINCT e.target_id FROM edges e
               WHERE e.kind IN ('calls', 'type_ref', 'imports')
           )
-        ORDER BY n.file_path, n.line_start
+        ORDER BY p.path, n.line_start
         LIMIT 200
     ";
     let mut findings = Vec::new();
@@ -186,9 +187,10 @@ fn detect_dead_code(conn: &Connection) -> Vec<SmellFinding> {
 
 fn detect_long_functions(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
     let sql = format!(
-        "SELECT n.name, n.file_path, n.line_start,
+        "SELECT n.name, p.path, n.line_start,
                 (n.line_end - n.line_start) AS span
          FROM nodes n
+        JOIN paths p ON p.id = n.file_id
          WHERE n.kind = 'symbol'
            AND n.line_start IS NOT NULL
            AND n.line_end IS NOT NULL
@@ -209,9 +211,10 @@ fn detect_long_functions(conn: &Connection, threshold: usize) -> Vec<SmellFindin
 
 fn detect_long_files(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
     let sql = format!(
-        "SELECT n.name, n.file_path, NULL,
+        "SELECT n.name, p.path, NULL,
                 CAST(n.metadata AS INTEGER) AS line_count
          FROM nodes n
+        JOIN paths p ON p.id = n.file_id
          WHERE n.kind = 'file'
            AND n.metadata IS NOT NULL
            AND CAST(n.metadata AS INTEGER) > {threshold}
@@ -231,10 +234,11 @@ fn detect_long_files(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
 
 fn detect_god_files(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
     let sql = format!(
-        "SELECT COUNT(*) AS sym_count, n.file_path
+        "SELECT COUNT(*) AS sym_count, p.path
          FROM nodes n
+        JOIN paths p ON p.id = n.file_id
          WHERE n.kind = 'symbol'
-         GROUP BY n.file_path
+         GROUP BY p.path
          HAVING sym_count > {threshold}
          ORDER BY sym_count DESC
          LIMIT 50"
@@ -265,8 +269,9 @@ fn detect_god_files(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
 
 fn detect_fan_out(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
     let sql = format!(
-        "SELECT n.name, n.file_path, n.line_start, COUNT(e.id) AS call_count
+        "SELECT n.name, p.path, n.line_start, COUNT(e.id) AS call_count
          FROM nodes n
+        JOIN paths p ON p.id = n.file_id
          JOIN edges e ON e.source_id = n.id AND e.kind = 'calls'
          WHERE n.kind = 'symbol'
          GROUP BY n.id
@@ -287,8 +292,9 @@ fn detect_fan_out(conn: &Connection, threshold: usize) -> Vec<SmellFinding> {
 
 fn detect_duplicate_definitions(conn: &Connection) -> Vec<SmellFinding> {
     let sql = "
-        SELECT n.name, GROUP_CONCAT(n.file_path, ', ') AS files, COUNT(*) AS cnt
+        SELECT n.name, GROUP_CONCAT(p.path, ', ') AS files, COUNT(*) AS cnt
         FROM nodes n
+        JOIN paths p ON p.id = n.file_id
         WHERE n.kind = 'symbol'
           AND n.name NOT IN ('new', 'default', 'fmt', 'from', 'into', 'drop', 'clone', 'eq')
         GROUP BY n.name
@@ -326,11 +332,12 @@ fn detect_duplicate_definitions(conn: &Connection) -> Vec<SmellFinding> {
 
 fn detect_untested(conn: &Connection) -> Vec<SmellFinding> {
     let sql = "
-        SELECT n.name, n.file_path, n.line_start
+        SELECT n.name, p.path, n.line_start
         FROM nodes n
+        JOIN paths p ON p.id = n.file_id
         WHERE n.kind = 'symbol'
-          AND n.file_path NOT LIKE '%test%'
-          AND n.file_path NOT LIKE '%spec%'
+          AND p.path NOT LIKE '%test%'
+          AND p.path NOT LIKE '%spec%'
           AND n.metadata LIKE '%export%'
           AND n.id NOT IN (
               SELECT DISTINCT e.source_id FROM edges e WHERE e.kind = 'tested_by'
@@ -338,7 +345,7 @@ fn detect_untested(conn: &Connection) -> Vec<SmellFinding> {
           AND n.id NOT IN (
               SELECT DISTINCT e.target_id FROM edges e WHERE e.kind = 'tested_by'
           )
-        ORDER BY n.file_path, n.line_start
+        ORDER BY p.path, n.line_start
         LIMIT 100
     ";
     query_findings(
@@ -365,10 +372,11 @@ fn detect_cyclomatic_complexity(conn: &Connection) -> Vec<SmellFinding> {
 #[cfg(not(feature = "tree-sitter"))]
 fn detect_cyclomatic_heuristic(conn: &Connection) -> Vec<SmellFinding> {
     let sql = "
-        SELECT n.name, n.file_path, n.line_start,
+        SELECT n.name, p.path, n.line_start,
                (n.line_end - n.line_start) AS span,
                (SELECT COUNT(*) FROM edges e WHERE e.source_id = n.id AND e.kind = 'calls') AS calls
         FROM nodes n
+        JOIN paths p ON p.id = n.file_id
         WHERE n.kind = 'symbol'
           AND n.line_start IS NOT NULL
           AND n.line_end IS NOT NULL
@@ -428,11 +436,12 @@ fn detect_cyclomatic_tree_sitter(conn: &Connection) -> Vec<SmellFinding> {
     const ERR_CC: u32 = 21;
 
     let sql = "
-        SELECT DISTINCT n.file_path
+        SELECT DISTINCT p.path
         FROM nodes n
+        JOIN paths p ON p.id = n.file_id
         WHERE n.kind = 'symbol'
-          AND n.file_path IS NOT NULL
-          AND length(trim(n.file_path)) > 0
+          AND p.path IS NOT NULL
+          AND length(trim(p.path)) > 0
         LIMIT 400
     ";
     let mut paths = Vec::new();

--- a/rust/src/tools/ctx_architecture.rs
+++ b/rust/src/tools/ctx_architecture.rs
@@ -70,13 +70,15 @@ fn load_graph_data(graph: &CodeGraph) -> Result<GraphData, String> {
     let conn = &graph.connection();
     let mut stmt = conn
         .prepare(
-            "SELECT DISTINCT n_src.file_path, n_tgt.file_path
+            "SELECT DISTINCT p_src.path, p_tgt.path
          FROM edges e
          JOIN nodes n_src ON e.source_id = n_src.id
          JOIN nodes n_tgt ON e.target_id = n_tgt.id
+         JOIN paths p_src ON p_src.id = n_src.file_id
+         JOIN paths p_tgt ON p_tgt.id = n_tgt.file_id
          WHERE e.kind = 'imports'
            AND n_src.kind = 'file' AND n_tgt.kind = 'file'
-           AND n_src.file_path != n_tgt.file_path",
+           AND n_src.file_id != n_tgt.file_id",
         )
         .map_err(|e| format!("{e}"))?;
 
@@ -99,7 +101,11 @@ fn load_graph_data(graph: &CodeGraph) -> Result<GraphData, String> {
     }
 
     let mut file_stmt = conn
-        .prepare("SELECT DISTINCT file_path FROM nodes WHERE kind = 'file'")
+        .prepare(
+            "SELECT DISTINCT p.path
+             FROM nodes n JOIN paths p ON p.id = n.file_id
+             WHERE n.kind = 'file'",
+        )
         .map_err(|e| format!("{e}"))?;
     let file_rows = file_stmt
         .query_map([], |row| row.get::<_, String>(0))

--- a/rust/src/tools/ctx_overview.rs
+++ b/rust/src/tools/ctx_overview.rs
@@ -304,14 +304,16 @@ fn graph_hotspot_rows(project_root: &str, gp: &GraphProvider) -> Vec<(String, us
     if let Ok(graph) = crate::core::property_graph::CodeGraph::open(project_root) {
         let sql = "
             WITH edge_files AS (
-              SELECT e.kind AS kind, ns.file_path AS fp
+              SELECT e.kind AS kind, ps.path AS fp
               FROM edges e
               JOIN nodes ns ON e.source_id = ns.id
+              JOIN paths ps ON ps.id = ns.file_id
               WHERE e.kind IN ('imports', 'calls')
               UNION ALL
-              SELECT e.kind, nt.file_path
+              SELECT e.kind, pt.path
               FROM edges e
               JOIN nodes nt ON e.target_id = nt.id
+              JOIN paths pt ON pt.id = nt.file_id
               WHERE e.kind IN ('imports', 'calls')
             )
             SELECT fp,

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -717,7 +717,6 @@ COMMIT_MSG"
         }
     }
 
-
     // --- GH #931: unquoted heredoc body > must not trip redirect scanner ---
 
     #[test]

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -715,35 +715,35 @@ COMMIT_MSG"
                 "search result file{i} should be preserved in output"
             );
         }
+    }
 
-        // --- GH #931: unquoted heredoc body > must not trip redirect scanner ---
+    // --- GH #931: unquoted heredoc body > must not trip redirect scanner ---
 
-        #[test]
-        fn unquoted_heredoc_gt_in_body_not_blocked() {
-            let cmd = "psql <<SQL\nSELECT * FROM t WHERE x > 0;\nSQL";
-            assert!(
-                validate_command(cmd).is_none(),
-                "unquoted heredoc body with > must not be flagged as redirect"
-            );
-        }
+    #[test]
+    fn unquoted_heredoc_gt_in_body_not_blocked() {
+        let cmd = "psql <<SQL\nSELECT * FROM t WHERE x > 0;\nSQL";
+        assert!(
+            validate_command(cmd).is_none(),
+            "unquoted heredoc body with > must not be flagged as redirect"
+        );
+    }
 
-        #[test]
-        fn unquoted_heredoc_append_in_body_not_blocked() {
-            let cmd = "cat <<END\nline with >> inside\nEND";
-            assert!(
-                validate_command(cmd).is_none(),
-                "unquoted heredoc body with >> must not be flagged"
-            );
-        }
+    #[test]
+    fn unquoted_heredoc_append_in_body_not_blocked() {
+        let cmd = "cat <<END\nline with >> inside\nEND";
+        assert!(
+            validate_command(cmd).is_none(),
+            "unquoted heredoc body with >> must not be flagged"
+        );
+    }
 
-        #[test]
-        fn real_redirect_after_heredoc_still_blocked() {
-            let cmd = "cat <<EOF > /tmp/../evil.txt\ndata\nEOF";
-            assert!(
-                validate_command(cmd).is_some(),
-                "redirect OUTSIDE heredoc body must still block"
-            );
-        }
+    #[test]
+    fn real_redirect_after_heredoc_still_blocked() {
+        let cmd = "cat <<EOF > /tmp/../evil.txt\ndata\nEOF";
+        assert!(
+            validate_command(cmd).is_some(),
+            "redirect OUTSIDE heredoc body must still block"
+        );
     }
 
     // --- GH #931: unquoted heredoc body > must not trip redirect scanner ---

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -717,34 +717,6 @@ COMMIT_MSG"
         }
     }
 
-    // --- GH #931: unquoted heredoc body > must not trip redirect scanner ---
-
-    #[test]
-    fn unquoted_heredoc_gt_in_body_not_blocked() {
-        let cmd = "psql <<SQL\nSELECT * FROM t WHERE x > 0;\nSQL";
-        assert!(
-            validate_command(cmd).is_none(),
-            "unquoted heredoc body with > must not be flagged as redirect"
-        );
-    }
-
-    #[test]
-    fn unquoted_heredoc_append_in_body_not_blocked() {
-        let cmd = "cat <<END\nline with >> inside\nEND";
-        assert!(
-            validate_command(cmd).is_none(),
-            "unquoted heredoc body with >> must not be flagged"
-        );
-    }
-
-    #[test]
-    fn real_redirect_after_heredoc_still_blocked() {
-        let cmd = "cat <<EOF > /tmp/../evil.txt\ndata\nEOF";
-        assert!(
-            validate_command(cmd).is_some(),
-            "redirect OUTSIDE heredoc body must still block"
-        );
-    }
 
     // --- GH #931: unquoted heredoc body > must not trip redirect scanner ---
 


### PR DESCRIPTION
## Summary
- intern PropertyGraph paths in a SQLite `paths` table
- store compact path IDs in nodes and file catalog
- preserve string APIs and snapshot compatibility
- rebuild legacy derived graph schemas through engine version 5

## Validation
- `cargo fmt --check`
- `cargo check --lib`
- `cargo test --lib core::property_graph` (35 passed)
- `cargo test --lib core::graph_provider` (9 passed)
- `cargo clippy --lib -- -W clippy::all`

Benchmarks are handled separately.

Closes #923