### PR TITLE
fix(web): pin DNS resolution to close SSRF rebinding window in ctx_url_read

### DIFF
--- a/rust/src/core/web/fetch.rs
+++ b/rust/src/core/web/fetch.rs
@@ -131,13 +131,18 @@ pub fn post(
 }
 
 fn build_agent(timeout_secs: u64) -> ureq::Agent {
-    crate::core::http_client::ureq_agent(
-        ureq::config::Config::builder()
-            .tls_config(crate::core::http_client::platform_tls_config())
-            .timeout_global(Some(Duration::from_secs(timeout_secs)))
-            .max_redirects(0)
-            .http_status_as_error(false)
-            .build(),
+    // #ssrf-rebinding: use the SSRF-pinning resolver instead of the plain
+    // `http_client::ureq_agent` helper — see `url_guard::SsrfSafeResolver`.
+    let config = ureq::config::Config::builder()
+        .tls_config(crate::core::http_client::platform_tls_config())
+        .timeout_global(Some(Duration::from_secs(timeout_secs)))
+        .max_redirects(0)
+        .http_status_as_error(false)
+        .build();
+    ureq::Agent::with_parts(
+        config,
+        ureq::unversioned::transport::DefaultConnector::default(),
+        url_guard::SsrfSafeResolver::default(),
     )
 }
 

--- a/rust/src/core/web/url_guard.rs
+++ b/rust/src/core/web/url_guard.rs
@@ -8,6 +8,11 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 
+use ureq::config::Config;
+use ureq::http::Uri;
+use ureq::unversioned::resolver::{DefaultResolver, ResolvedSocketAddrs, Resolver};
+use ureq::unversioned::transport::NextTimeout;
+
 /// Reasons a URL is refused before fetching.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UrlError {
@@ -168,6 +173,36 @@ pub fn ip_is_blocked(ip: IpAddr) -> bool {
     }
 }
 
+/// A [`ureq::unversioned::resolver::Resolver`] that pins DNS resolution to the
+/// exact lookup used for the SSRF check.
+///
+/// [`SafeUrl::ensure_resolves_safely`] and ureq's own resolver each perform an
+/// independent DNS lookup, which opens a rebinding window: a hostile resolver
+/// with a short TTL can answer the first (validation) query with a public
+/// address and the second (connect) query with a blocked one (e.g. the cloud
+/// metadata IP or loopback). Passing this resolver to the `ureq::Agent` makes
+/// resolution and validation the same lookup, so there is no second query left
+/// to rebind.
+#[derive(Debug, Default)]
+pub struct SsrfSafeResolver {
+    inner: DefaultResolver,
+}
+
+impl Resolver for SsrfSafeResolver {
+    fn resolve(
+        &self,
+        uri: &Uri,
+        config: &Config,
+        timeout: NextTimeout,
+    ) -> Result<ResolvedSocketAddrs, ureq::Error> {
+        let addrs = self.inner.resolve(uri, config, timeout)?;
+        if addrs.iter().any(|addr| ip_is_blocked(addr.ip())) {
+            return Err(ureq::Error::HostNotFound);
+        }
+        Ok(addrs)
+    }
+}
+
 fn v4_is_blocked(v4: Ipv4Addr) -> bool {
     let o = v4.octets();
     v4.is_loopback()
@@ -280,5 +315,36 @@ mod tests {
     fn ensure_resolves_safely_allows_literal_public_ip() {
         let u = validate("http://8.8.8.8/").unwrap();
         assert!(u.ensure_resolves_safely().is_ok());
+    }
+
+    // --- SSRF-rebinding: resolver pinning ---
+
+    fn no_timeout() -> NextTimeout {
+        use ureq::unversioned::transport::time::Duration;
+        NextTimeout {
+            after: Duration::NotHappening,
+            reason: ureq::Timeout::Global,
+        }
+    }
+
+    #[test]
+    fn ssrf_safe_resolver_blocks_loopback_hostname() {
+        // `localhost` resolves via the OS hosts file to 127.0.0.1 with no
+        // network access, so this exercises the real DefaultResolver lookup
+        // path — a stand-in for a DNS-rebinding response that only appears
+        // blocked at the moment of connection, not at the earlier
+        // `ensure_resolves_safely` check.
+        let resolver = SsrfSafeResolver::default();
+        let uri: Uri = "http://localhost:80/".parse().unwrap();
+        let config = Config::default();
+        assert!(resolver.resolve(&uri, &config, no_timeout()).is_err());
+    }
+
+    #[test]
+    fn ssrf_safe_resolver_allows_literal_public_ip() {
+        let resolver = SsrfSafeResolver::default();
+        let uri: Uri = "http://8.8.8.8:80/".parse().unwrap();
+        let config = Config::default();
+        assert!(resolver.resolve(&uri, &config, no_timeout()).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Closes #936. `ctx_url_read`'s SSRF guard validated a URL's DNS resolution once (`SafeUrl::ensure_resolves_safely`), but the actual request re-resolved the hostname independently when `ureq` opened the connection — two separate lookups, which is a TOCTOU window for DNS rebinding: a hostile resolver with a short TTL can answer the validation query with a public IP and the connect query with `169.254.169.254` (cloud metadata) or `127.0.0.1`.

- Added `SsrfSafeResolver` in `rust/src/core/web/url_guard.rs`, a `ureq::unversioned::resolver::Resolver` that wraps ureq's `DefaultResolver` and rejects blocked addresses at the exact moment ureq is about to connect — resolution and validation are now the same atomic lookup.
- Wired it into `fetch.rs::build_agent`, used by both `fetch()` (GET, including every re-validated redirect hop) and `post()`.
- The earlier `ensure_resolves_safely()` pre-check is kept for a fast, clear error message before any request is attempted; the resolver is now the actual security boundary enforced at connect time.

## Test plan
- [x] `cargo test --lib url_guard::` — includes two new regression tests: `ssrf_safe_resolver_blocks_loopback_hostname` (resolves `localhost` through the real resolver and asserts rejection) and `ssrf_safe_resolver_allows_literal_public_ip`.
- [x] `cargo test --lib fetch::` — existing redirect-resolution tests unaffected.
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`