### PR TITLE
fix(shell): stop agent_wrapper::rebuild() from corrupting heredocs

### DIFF
--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -854,10 +854,17 @@ fn resolve_segment_leaves(
             resolve_segment_leaves(&inner_seg, depth + 1, out)?;
         }
     }
-    // Anything else (incl. `( … ) trailing`, brace groups, leftover delimiters) is
-    // pushed verbatim: base-extraction below sees a first token like `(ls)` or `{`
-    // that cannot match any allowlist entry, so it is blocked. `cmd (sub)` without
-    // a separator is a shell syntax error, so no executable leaf escapes here.
+    // Anything else (incl. `( … ) trailing`, leftover delimiters) is pushed
+    // verbatim: base-extraction below sees a first token like `(ls)` that
+    // cannot match any allowlist entry, so it is blocked. `cmd (sub)` without
+    // a separator is a shell syntax error, so no executable leaf escapes
+    // here. A `{ cmd; }` brace group is the one exception: split_on_operators
+    // already shields it with `brace_depth` the same way `( … )` is shielded
+    // with `paren_depth`, so it survives as one leaf here, and
+    // extract_base_from_segment (below) skips the leading `{` token to find
+    // the real base command inside — no recursion needed like subshells get,
+    // since `cd`/env changes inside `{ }` must persist to the caller (#939,
+    // agent_wrapper::rebuild's cwd-tracking wrapper).
     out.push(s.to_string());
     Ok(())
 }
@@ -1289,6 +1296,11 @@ fn split_on_operators(command: &str) -> Vec<&str> {
     let mut in_single_quote = false;
     let mut in_double_quote = false;
     let mut paren_depth: u32 = 0;
+    // #939: brace groups (`{ cmd; }`) need the same operator-shielding as
+    // `( cmd )` subshells — otherwise a `}` that closes a `{` opened on an
+    // earlier physical line (e.g. after heredoc-body stripping collapses the
+    // body between them) is misread as its own bare command segment.
+    let mut brace_depth: u32 = 0;
 
     while i < len {
         let ch = bytes[i];
@@ -1336,12 +1348,20 @@ fn split_on_operators(command: &str) -> Vec<&str> {
                 paren_depth = paren_depth.saturating_sub(1);
                 i += 1;
             }
-            b'\n' | b'\r' | b';' if paren_depth == 0 => {
+            b'{' => {
+                brace_depth += 1;
+                i += 1;
+            }
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                i += 1;
+            }
+            b'\n' | b'\r' | b';' if paren_depth == 0 && brace_depth == 0 => {
                 segments.push(&command[start..i]);
                 i += 1;
                 start = i;
             }
-            b'&' if paren_depth == 0 => {
+            b'&' if paren_depth == 0 && brace_depth == 0 => {
                 if i + 1 < len && bytes[i + 1] == b'&' {
                     // &&
                     segments.push(&command[start..i]);
@@ -1360,7 +1380,7 @@ fn split_on_operators(command: &str) -> Vec<&str> {
                     start = i;
                 }
             }
-            b'|' if paren_depth == 0 => {
+            b'|' if paren_depth == 0 && brace_depth == 0 => {
                 if i + 1 < len && bytes[i + 1] == b'|' {
                     // ||
                     segments.push(&command[start..i]);
@@ -1406,7 +1426,15 @@ fn extract_base_from_segment(segment: &str) -> String {
     }
 
     let tokens = shell_tokenize(cmd_part);
-    let first_token = tokens.first().map_or("", std::string::String::as_str);
+    // #939: a leading `{` brace-group token (e.g. from
+    // `agent_wrapper::rebuild`'s `{ <real command>\n} && pwd ...` wrapping)
+    // is not itself a command — skip it so the base extracted is the real
+    // command inside the group, not the brace.
+    let mut token_iter = tokens.iter();
+    let first_token = match token_iter.next().map(String::as_str) {
+        Some("{") => token_iter.next().map_or("", String::as_str),
+        other => other.unwrap_or(""),
+    };
 
     first_token
         .rsplit('/')

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -1067,6 +1067,31 @@ fn extract_base_quoted_path() {
     assert_eq!(r, "git");
 }
 
+// #939: agent_wrapper::rebuild() now wraps the real command in a `{ ... }`
+// brace group before appending its cwd-tracking suffix (fixes heredoc
+// corruption). The allowlist must see through that wrapper to the real base
+// command, not block on the literal `{` token.
+#[test]
+fn extract_base_sees_through_leading_brace_group() {
+    let r = extract_base_from_segment("{ cat <<'EOF'\n}");
+    assert_eq!(r, "cat", "must resolve to the real command, not '{{'");
+}
+
+#[test]
+fn enforce_allowlist_allows_rebuilt_brace_wrapped_command() {
+    // `pwd` (the cwd-tracking companion segment rebuild() appends) must be
+    // allowlisted too — same requirement any agent-wrapped command already
+    // had, heredoc or not; not special-cased by this fix.
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "cat,pwd");
+    let cmd = "{ cat <<'EOF'\nhello\nEOF\n} && pwd -P >| /tmp/claude-brace-cwd";
+    let result = super::enforce_shell_allowlist(cmd);
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+    assert!(
+        result.is_ok(),
+        "a rebuilt brace-wrapped allowlisted command must not be newly blocked: {result:?}"
+    );
+}
+
 // --- security checks with quoted paths ---
 
 #[test]

--- a/rust/src/shell/agent_wrapper.rs
+++ b/rust/src/shell/agent_wrapper.rs
@@ -65,9 +65,17 @@ impl Unwrapped {
     /// restore: the shell hook already runs inside the cwd the host spawned the
     /// command in, so only the trailing snapshot has to survive.
     pub(crate) fn rebuild(&self) -> String {
+        // #939: bare concatenation (`{inner} && pwd ...`) corrupts `inner`
+        // when its last line is a heredoc terminator (the terminator must be
+        // the ENTIRE line to match, so appending text after it breaks the
+        // heredoc) or a `#` comment (which silently swallows the appended
+        // `&& pwd ...`, so cwd tracking stops working). A brace group with an
+        // explicit newline before the closing `}` puts inner's last line
+        // alone on its own line unconditionally, so both cases are safe —
+        // the group's exit status is inner's, so `&&` gating is unchanged.
         match &self.cwd_snapshot {
-            Some(file) => format!("{} && pwd -P >| {file}", self.inner),
-            None if self.stdout_cwd => format!("{} && pwd", self.inner),
+            Some(file) => format!("{{ {}\n}} && pwd -P >| {file}", self.inner),
+            None if self.stdout_cwd => format!("{{ {}\n}} && pwd", self.inner),
             None => self.inner.clone(),
         }
     }
@@ -365,7 +373,7 @@ mod tests {
         // No `eval` survives — the allowlist's hard block can no longer fire.
         assert!(!rebuilt.contains("eval "), "eval must be gone: {rebuilt}");
         assert!(rebuilt.ends_with("&& pwd -P >| /tmp/claude-87b7-cwd"));
-        assert!(rebuilt.starts_with("/home/u/.local"));
+        assert!(rebuilt.starts_with("{ /home/u/.local"));
     }
 
     #[test]
@@ -378,7 +386,63 @@ mod tests {
         assert_eq!(u.cwd_snapshot.as_deref(), Some("/tmp/claude-aa11-cwd"));
         assert_eq!(
             u.rebuild(),
-            "cargo build --release && pwd -P >| /tmp/claude-aa11-cwd"
+            "{ cargo build --release\n} && pwd -P >| /tmp/claude-aa11-cwd"
+        );
+    }
+
+    // --- heredoc-corruption fix: rebuild() must never fuse the cwd-tracking
+    // suffix onto inner's last line (breaks heredoc terminators, silently
+    // swallowed by trailing `#` comments) ---
+
+    #[test]
+    fn rebuild_preserves_heredoc_terminator_with_file_snapshot() {
+        let cmd = "shopt -u extglob 2>/dev/null || true && eval 'cat <<'\"'\"'EOF'\"'\"'\nhello\nEOF' < /dev/null && pwd -P >| /tmp/claude-hd1-cwd";
+        let u = unwrap_agent_wrapper(cmd).expect("must detect heredoc wrapper");
+        assert_eq!(u.inner, "cat <<'EOF'\nhello\nEOF");
+        let rebuilt = u.rebuild();
+        // The heredoc terminator line must be exactly "EOF" — nothing appended
+        // after it on that line, or the shell never recognizes the delimiter.
+        let terminator_line = rebuilt.lines().nth(2).expect("rebuilt has 3+ lines");
+        assert_eq!(
+            terminator_line, "EOF",
+            "heredoc terminator must be alone on its line: {rebuilt:?}"
+        );
+        assert_eq!(
+            rebuilt,
+            "{ cat <<'EOF'\nhello\nEOF\n} && pwd -P >| /tmp/claude-hd1-cwd"
+        );
+    }
+
+    #[test]
+    fn rebuild_preserves_heredoc_terminator_stdout_cwd() {
+        let cmd = "setopt NO_EXTENDED_GLOB NO_BARE_GLOB_QUAL 2>/dev/null || true && eval 'cat <<'\"'\"'EOF'\"'\"'\nhello\nEOF' < /dev/null && pwd";
+        let u = unwrap_agent_wrapper(cmd).expect("must detect heredoc zsh-sandbox wrapper");
+        assert_eq!(u.inner, "cat <<'EOF'\nhello\nEOF");
+        assert!(u.stdout_cwd);
+        let rebuilt = u.rebuild();
+        let terminator_line = rebuilt.lines().nth(2).expect("rebuilt has 3+ lines");
+        assert_eq!(
+            terminator_line, "EOF",
+            "heredoc terminator must be alone on its line: {rebuilt:?}"
+        );
+        assert_eq!(rebuilt, "{ cat <<'EOF'\nhello\nEOF\n} && pwd");
+    }
+
+    #[test]
+    fn rebuild_does_not_swallow_trailing_comment_pwd() {
+        // A `#` comment as inner's last line must not silently consume the
+        // appended `&& pwd ...` (comments run to end-of-line in shell).
+        let u = Unwrapped {
+            inner: "echo hi # a trailing comment".to_string(),
+            cwd_snapshot: Some("/tmp/claude-cmt-cwd".to_string()),
+            stdout_cwd: false,
+        };
+        let rebuilt = u.rebuild();
+        let last_line = rebuilt.lines().last().expect("rebuilt has a last line");
+        assert!(
+            last_line.trim_start().starts_with("}")
+                && last_line.contains("&& pwd -P >| /tmp/claude-cmt-cwd"),
+            "cwd-tracking suffix must not be swallowed by the comment: {rebuilt:?}"
         );
     }
 
@@ -481,7 +545,7 @@ mod tests {
         );
         assert_eq!(
             rebuilt,
-            "lean-ctx -c 'git status' && pwd -P >| /tmp/claude-9f3c-cwd"
+            "{ lean-ctx -c 'git status'\n} && pwd -P >| /tmp/claude-9f3c-cwd"
         );
     }
 
@@ -545,7 +609,7 @@ mod tests {
         let cmd = "setopt NO_EXTENDED_GLOB NO_BARE_GLOB_QUAL 2>/dev/null || true && eval 'git status' < /dev/null && pwd";
         let u = unwrap_agent_wrapper(cmd).unwrap();
         let rebuilt = u.rebuild();
-        assert_eq!(rebuilt, "git status && pwd");
+        assert_eq!(rebuilt, "{ git status\n} && pwd");
         assert!(!rebuilt.contains("eval "), "eval must be gone: {rebuilt}");
         assert!(
             !rebuilt.contains("setopt"),
@@ -565,7 +629,7 @@ mod tests {
         let u = unwrap_agent_wrapper(cmd).expect("must detect pwd -P variant");
         assert_eq!(u.inner, "ls -la");
         assert!(u.stdout_cwd);
-        assert_eq!(u.rebuild(), "ls -la && pwd");
+        assert_eq!(u.rebuild(), "{ ls -la\n} && pwd");
     }
 
     // --- #745 v3: pwd - variant (lone dash flag) ---
@@ -576,7 +640,7 @@ mod tests {
         let u = unwrap_agent_wrapper(cmd).expect("must detect pwd - variant");
         assert_eq!(u.inner, "echo hi");
         assert!(u.stdout_cwd);
-        assert_eq!(u.rebuild(), "echo hi && pwd");
+        assert_eq!(u.rebuild(), "{ echo hi\n} && pwd");
     }
 
     // --- #745 v3: unquoted eval arg (eval pwd instead of eval 'pwd') ---
@@ -606,7 +670,7 @@ mod tests {
         let u = unwrap_agent_wrapper(cmd).expect("must unwrap sandbox-exec wrapper");
         assert_eq!(u.inner, "echo");
         assert!(u.stdout_cwd);
-        assert_eq!(u.rebuild(), "echo && pwd");
+        assert_eq!(u.rebuild(), "{ echo\n} && pwd");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `agent_wrapper::rebuild()` string-concatenated its cwd-tracking suffix
  (`&& pwd -P >| <file>` / `&& pwd`) directly onto the last line of the
  real command, with no newline. When that last line was a heredoc
  terminator, the appended text broke the delimiter match; when it was a
  `#` comment, the suffix was silently swallowed. Fixes #939.
- The fix wraps the real command in a `{ ...\n}` brace group so its last
  line always sits alone before the appended suffix (standard POSIX
  `{ cmd; } && cmd2`, preserves `&&` exit-status gating). A brace group
  (not a subshell) is required because `cd`/env changes made by the real
  command must still be visible to the trailing `pwd`.
- That requires two small companion fixes in the shell allowlist so a
  restricted allowlist doesn't newly block every rebuilt command on the
  literal `{`/`}` tokens: `split_on_operators` now shields `{ ... }` the
  same way it already shields `( ... )` (`paren_depth` → + `brace_depth`),
  and `extract_base_from_segment` skips a leading `{` token.

## Test plan

- [x] `cd rust && cargo test --lib agent_wrapper shell_allowlist -- --test-threads=1` — 222 passed, 0 failed (includes 3 new heredoc/comment regression tests in `agent_wrapper.rs` and 2 new allowlist brace-group tests in `shell_allowlist/tests.rs`; every pre-existing test asserting an exact `rebuild()` output string was updated to the new shape)
- [x] `cd rust && cargo test --lib shell_allowlist` (full module, unfiltered) — 189 passed, 0 failed
- [x] End-to-end against the built release binary, reproducing the exact reported scaffold shape for both the file-snapshot and stdout-cwd wrapper variants — heredoc content correct, exit code matches an unwrapped control run, cwd-snapshot file written correctly
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --all-features` (rustdoc -D warnings)
- [x] Windows cross-compile check (`--target x86_64-pc-windows-gnu`)
- [x] `cargo test --all-features` (full `--lib`, single-threaded): 3 pre-existing failures unrelated to this change (`server::roots::*`, `ipc::process::*` — environment-specific, tied to the local `$HOME`; confirmed via a clean-worktree A/B test against unmodified `origin/main` before making any changes)

## Notes for reviewers

- Risk areas: `split_on_operators`/`extract_base_from_segment` are shared,
  security-relevant infrastructure — the `brace_depth` addition mirrors
  the existing `paren_depth` pattern exactly, and the leading-`{`-skip in
  `extract_base_from_segment` only changes behavior when the *first*
  token is literally `{`, which no real command name starts with.
- Backwards compatibility: `rebuild()`'s output shape changes for every
  wrapped command (heredoc or not), not just the buggy case — the brace
  group is unconditional, for a simpler, single code path rather than
  special-casing heredocs. Confirmed this doesn't change observable
  behavior (exit status, stdout, cwd-tracking) via the end-to-end runs
  above.
- Docs updated: inline doc comments at each change site explain the why;
  no user-facing docs reference this internal mechanism.
