### PR TITLE
fix(shell): kill the child immediately when output truncation hits

### DIFF
--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -1,5 +1,7 @@
 use std::io::{self, IsTerminal, Read, Write};
 use std::process::{Child, Command, Output, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::core::config;
 use crate::core::slow_log;
@@ -26,7 +28,15 @@ fn wait_with_limits(
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
     let start = std::time::Instant::now();
+    // Set by either reader thread the instant it hits its byte limit, so the
+    // main loop below can kill the child right away instead of waiting out
+    // the rest of `timeout`. Once a reader thread stops draining its pipe, a
+    // child that keeps writing (and doesn't die from EPIPE/SIGPIPE — e.g. it
+    // ignores the signal, or there's no such thing on Windows) just blocks
+    // on a full pipe until the full timeout finally kills it.
+    let truncated = Arc::new(AtomicBool::new(false));
 
+    let stdout_truncated_flag = Arc::clone(&truncated);
     let stdout_handle = std::thread::spawn(move || {
         let Some(mut pipe) = stdout_pipe else {
             return (Vec::new(), false);
@@ -40,6 +50,7 @@ fn wait_with_limits(
                     if buf.len() + n > max_bytes {
                         let remaining = max_bytes.saturating_sub(buf.len());
                         buf.extend_from_slice(&chunk[..remaining]);
+                        stdout_truncated_flag.store(true, Ordering::Relaxed);
                         return (buf, true);
                     }
                     buf.extend_from_slice(&chunk[..n]);
@@ -51,6 +62,7 @@ fn wait_with_limits(
         (buf, false)
     });
 
+    let stderr_truncated_flag = Arc::clone(&truncated);
     let stderr_handle = std::thread::spawn(move || {
         let Some(mut pipe) = stderr_pipe else {
             return Vec::new();
@@ -63,6 +75,7 @@ fn wait_with_limits(
                 Ok(0) => break,
                 Ok(n) => {
                     if buf.len() + n > STDERR_LIMIT {
+                        stderr_truncated_flag.store(true, Ordering::Relaxed);
                         break;
                     }
                     buf.extend_from_slice(&chunk[..n]);
@@ -76,10 +89,11 @@ fn wait_with_limits(
 
     let mut timed_out = false;
     loop {
-        if start.elapsed() > timeout {
+        let hit_timeout = start.elapsed() > timeout;
+        if hit_timeout || truncated.load(Ordering::Relaxed) {
             kill_child(&mut child, kill_group);
             let _ = child.wait();
-            timed_out = true;
+            timed_out = hit_timeout;
             break;
         }
         match child.try_wait() {
@@ -1106,6 +1120,33 @@ mod exec_tests {
             stdout.len(),
             &stdout[stdout.len().saturating_sub(80)..]
         );
+    }
+
+    #[test]
+    fn wait_with_limits_kills_promptly_on_truncation() {
+        // GH #948: once the reader thread hit max_bytes it used to just
+        // stop draining the pipe and let the main loop poll until the full
+        // `timeout` elapsed, even though truncation had already happened.
+        // `yes` writes effectively unbounded output; with a tiny byte limit
+        // and a timeout far longer than a prompt kill should ever take, a
+        // regression here would make this run close to the 20s timeout.
+        let child = std::process::Command::new("yes")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let start = std::time::Instant::now();
+        let output =
+            super::wait_with_limits(child, 4096, std::time::Duration::from_secs(20), false);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "truncation should kill promptly, took {elapsed:?} (timeout was 20s)"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("[lean-ctx: output truncated"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #948. `wait_with_limits`'s reader threads stop draining their pipe as soon as they hit their byte limit (`max_bytes` for stdout, `STDERR_LIMIT` for stderr) — they just return. The main loop, though, only killed the child on the timeout elapsing or the child exiting on its own; truncation alone didn't trigger a kill. A child that keeps writing after truncation (doesn't die from EPIPE/SIGPIPE — e.g. it explicitly ignores the signal, or there's no such thing on Windows) blocks on the now-undrained pipe and the whole call only returns once the *entire* configured `timeout` elapses, instead of right after truncation was already known.

- Added a shared `Arc<AtomicBool>` (`truncated`) between the two reader threads and the main polling loop.
- Either reader thread sets it the instant it hits its own limit (right where it already builds the truncated buffer to return/break).
- The main loop's condition changed from `if start.elapsed() > timeout` to `if hit_timeout || truncated.load(Ordering::Relaxed)` — truncation now triggers the same `kill_child` + `wait` path a timeout does, immediately.
- `timed_out` (used later to decide whether to append the stdout truncation notice) is only set `true` when it was actually the timeout that fired, not a truncation-triggered kill — no behavior change there, since `stdout_truncated` from the join already covers the stdout-truncation case for that notice.

This is scoped narrowly to the immediate-kill mechanism so it doesn't depend on the (separate, still-unmerged) stderr-notice fix in #947 or the `false`-fallback fix in #945 — all three land independently.

## Test plan
- [x] New test `wait_with_limits_kills_promptly_on_truncation` — pipes `yes` (effectively unbounded stdout) through a tiny `max_bytes` and a 20s timeout, asserts the call returns in well under 3s.
- [x] `cargo test --lib exec_tests` — all existing `wait_with_limits` tests pass unchanged.
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`