### PR TITLE
perf(redaction): cache compiled exclude_patterns regexes

### DIFF
--- a/rust/src/core/redaction.rs
+++ b/rust/src/core/redaction.rs
@@ -21,7 +21,7 @@ pub fn redact_text_if_enabled(input: &str) -> String {
     if !redaction_enabled_for_active_role() {
         return input.to_string();
     }
-    redact_text_with_excludes(input, &config_exclude_patterns())
+    redact_text_with_excludes(input, config_exclude_patterns().as_slice())
 }
 
 /// #718: unquoted identifier or property-access chains (`SvelteKit`,
@@ -295,13 +295,43 @@ pub fn redact_text_with_excludes(input: &str, excludes: &[regex::Regex]) -> Stri
 
 /// Compile the configured `exclude_patterns` (#718). Invalid regexes are
 /// skipped — a broken exclude must never disable redaction.
-pub fn config_exclude_patterns() -> Vec<regex::Regex> {
-    crate::core::config::Config::load()
-        .secret_detection
-        .exclude_patterns
-        .iter()
-        .filter_map(|p| regex::Regex::new(p).ok())
-        .collect()
+///
+/// #952: regex compilation — the expensive part of this call — used to run
+/// on every redaction call (`ctx_read`, `ctx_shell`, `ctx_execute` all funnel
+/// through `redact_text_if_enabled`) regardless of whether the config had
+/// changed. Cached here, keyed on `Arc::ptr_eq` against the config `Arc`:
+/// `Config::load_arc` returns the *same* `Arc` when the underlying config
+/// content hash is unchanged, so a real config edit is exactly what
+/// invalidates this cache too — no separate change-detection needed.
+pub fn config_exclude_patterns() -> std::sync::Arc<Vec<regex::Regex>> {
+    type Cache = Option<(
+        std::sync::Arc<crate::core::config::Config>,
+        std::sync::Arc<Vec<regex::Regex>>,
+    )>;
+    static CACHE: std::sync::Mutex<Cache> = std::sync::Mutex::new(None);
+
+    let cfg = crate::core::config::Config::load_arc();
+
+    if let Ok(guard) = CACHE.lock()
+        && let Some((cached_cfg, patterns)) = &*guard
+        && std::sync::Arc::ptr_eq(cached_cfg, &cfg)
+    {
+        return std::sync::Arc::clone(patterns);
+    }
+
+    let compiled = std::sync::Arc::new(
+        cfg.secret_detection
+            .exclude_patterns
+            .iter()
+            .filter_map(|p| regex::Regex::new(p).ok())
+            .collect::<Vec<_>>(),
+    );
+
+    if let Ok(mut guard) = CACHE.lock() {
+        *guard = Some((cfg, std::sync::Arc::clone(&compiled)));
+    }
+
+    compiled
 }
 
 /// Apply caller-supplied policy redaction patterns on top of the built-in
@@ -332,6 +362,18 @@ pub fn redact_with_patterns(input: &str, patterns: &[(String, regex::Regex)]) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- #952: exclude_patterns compilation cache ---
+
+    #[test]
+    fn config_exclude_patterns_reuses_compiled_regexes_when_config_unchanged() {
+        let first = config_exclude_patterns();
+        let second = config_exclude_patterns();
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "unchanged config must reuse the cached compiled patterns, not recompile"
+        );
+    }
 
     #[test]
     fn redacts_bearer_token() {


### PR DESCRIPTION
## Summary

Closes #952. `redact_text_if_enabled` — the hot path for `ctx_read`, `ctx_shell`, and `ctx_execute` output — called `config_exclude_patterns()` on every single call, and that function recompiled every `[secret_detection].exclude_patterns` regex from scratch each time. The built-in redaction rules are already cached in `OnceLock`s via the `static_regex!` macro, but the user-configured excludes were not, even though config rarely changes between calls.

- `config_exclude_patterns()` now returns `Arc<Vec<regex::Regex>>` and caches the compiled list behind a `Mutex`.
- The cache key is `Arc::ptr_eq` against the `Arc<Config>` from `Config::load_arc()` — `load_arc` already has its own content-hash cache and returns the *same* `Arc` when the config file is unchanged, and a *new* one when it changes. Piggybacking on that identity means a real config edit is exactly what invalidates the compiled-regex cache too, with no separate change-detection logic needed.
- Only caller (`redact_text_if_enabled`) updated to `config_exclude_patterns().as_slice()`.

## Test plan
- [x] New test `config_exclude_patterns_reuses_compiled_regexes_when_config_unchanged` — two back-to-back calls must return the same `Arc` (no recompilation).
- [x] `cargo test --lib core::redaction` — all existing redaction tests pass unchanged.
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`

Note: a full `cargo test --lib` run shows 1-2 unrelated flaky failures (`shell_allowlist` tests checking for `python3`/`node` on PATH, and a BM25-index sync test) under heavy parallelism — confirmed pre-existing by reproducing them on a clean `main` checkout with this change stashed out; not caused by this PR.