### PR TITLE
fix(atomic_fs): fsync the parent directory after the atomic rename

### DIFF
--- a/rust/src/core/atomic_fs.rs
+++ b/rust/src/core/atomic_fs.rs
@@ -71,7 +71,26 @@ pub(crate) fn try_atomic_write(
         let _ = std::fs::remove_file(&tmp);
         return Err(e);
     }
+
+    // #954: `f.sync_all()` above durably persists the temp file's *content*,
+    // but swapping it into `path` via `rename` is a directory-entry update —
+    // without also fsyncing the parent directory, a crash right after the
+    // rename can lose that directory-entry change on some filesystems, and
+    // the old file reappears despite the temp+rename having "completed".
+    #[cfg(unix)]
+    fsync_dir(parent);
+
     Ok(())
+}
+
+/// Best-effort `fsync` of a directory's inode so a preceding `rename`/`create`
+/// into it survives a crash (Unix only — opening a directory as a `File` for
+/// this purpose is not portable to Windows).
+#[cfg(unix)]
+fn fsync_dir(dir: &Path) {
+    if let Ok(f) = std::fs::File::open(dir) {
+        let _ = f.sync_all();
+    }
 }
 
 /// In-place overwrite of an existing file inode (`O_WRONLY|O_TRUNC`, plus
@@ -173,6 +192,15 @@ mod tests {
                 libc::EPERM
             )));
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fsync_dir_succeeds_on_a_real_directory() {
+        // #954: exercises the open+sync_all mechanics directly — must not
+        // panic or otherwise disrupt the caller (best-effort, errors ignored).
+        let dir = tempfile::tempdir().unwrap();
+        fsync_dir(dir.path());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #954. `try_atomic_write`'s crash-atomic temp+rename write `fsync`s the temp file's content (`f.sync_all()`) before the rename, but never `fsync`s the **parent directory** after the rename completes.

`rename(2)` swapping the temp file into place is a directory-entry update. On a crash or power loss right after the rename returns, that directory-entry change can still be lost on some filesystems if the directory inode itself was never fsynced — the old file can reappear even though the new file's *content* was already durably written. The content is durable, but the substitution isn't, despite the module doc's "crash-atomic temp+rename" claim.

- Added `fsync_dir` (Unix only — opening a directory as a `File` for this purpose isn't portable to Windows): opens the parent directory and calls `File::sync_all()` on it, best-effort (errors ignored), matching the existing treatment of the content `sync_all()`.
- Called right after a successful `rename`, inside `try_atomic_write`.

## Test plan
- [x] New test `fsync_dir_succeeds_on_a_real_directory` — exercises the open+sync_all mechanics directly on a real temp directory (crash-durability itself isn't something a unit test can observe).
- [x] `cargo test --lib core::atomic_fs` — all existing tests (including the read-only-directory fallback and no-leftover-temp-file checks) pass unchanged.
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`