### PR TITLE
fix(atomic_fs): use MoveFileExW for an atomic replace on Windows

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -455,6 +455,7 @@ windows-sys = { version = "0.61", features = [
   "Win32_System_Threading",
   "Win32_Security",
   "Win32_System_Pipes",
+  "Win32_Storage_FileSystem",
 ] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/rust/src/core/atomic_fs.rs
+++ b/rust/src/core/atomic_fs.rs
@@ -58,18 +58,57 @@ pub(crate) fn try_atomic_write(
         let _ = std::fs::set_permissions(&tmp, perms.clone());
     }
 
+    // #956: on Windows, `rename` fails outright if `path` already exists, so
+    // this used to `remove_file(path)` first and rename second — two
+    // non-atomic syscalls. A reader landing in that window sees ENOENT for a
+    // file that "exists", and a process that dies after the remove but
+    // before the rename loses the original file for good while the temp file
+    // is left behind orphaned. `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`
+    // performs the swap as one atomic operation, matching what `rename(2)`
+    // already gives us for free on Unix.
     #[cfg(windows)]
-    {
-        if path.exists() {
-            let _ = std::fs::remove_file(path);
-        }
+    if let Err(e) = windows_replace(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
 
+    #[cfg(not(windows))]
     if let Err(e) = std::fs::rename(&tmp, path) {
         // Don't leave a half-written temp behind before the caller decides
         // whether to fall back.
         let _ = std::fs::remove_file(&tmp);
         return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Atomically replace `path` with `tmp` via `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`
+/// — the Windows equivalent of POSIX `rename(2)`'s implicit replace-if-exists.
+/// Plain `std::fs::rename` on Windows fails when the destination exists, which
+/// is why callers used to `remove_file` first; that left a window where the
+/// destination didn't exist at all (#956).
+#[cfg(windows)]
+fn windows_replace(tmp: &Path, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_REPLACE_EXISTING, MoveFileExW};
+
+    fn to_wide(p: &Path) -> Vec<u16> {
+        p.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let tmp_w = to_wide(tmp);
+    let path_w = to_wide(path);
+
+    // SAFETY: both buffers are valid, NUL-terminated UTF-16 strings kept alive
+    // for the duration of this call; `MoveFileExW` does not retain either
+    // pointer afterward. Failure is reported via the return value.
+    let ok = unsafe { MoveFileExW(tmp_w.as_ptr(), path_w.as_ptr(), MOVEFILE_REPLACE_EXISTING) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #956. `try_atomic_write` handled Windows separately because plain `std::fs::rename` fails there when the destination already exists: `remove_file(path)` first, then `rename(tmp, path)` second — two non-atomic syscalls.

Between those two calls:
- a concurrent reader opening `path` saw `ENOENT` for a file that should still exist from the caller's perspective;
- a process dying after the `remove_file` but before the `rename` permanently lost the original file — the new content was stranded in an orphaned temp file with no way back.

This undermined the "crash-atomic temp+rename" guarantee the module documents, specifically on Windows.

- Replaced the `remove_file` + `rename` pair with a single `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)` call — the Win32 atomic replace-if-exists move, matching what `rename(2)` already gives for free on POSIX.
- Added the `Win32_Storage_FileSystem` `windows-sys` feature needed for `MoveFileExW`/`MOVEFILE_REPLACE_EXISTING`.
- The non-Windows path is unchanged (`std::fs::rename`), just moved under an explicit `#[cfg(not(windows))]` to sit next to the new `#[cfg(windows)]` branch.

## Test plan
- [x] `cargo build --lib` (native/Unix target) — unaffected code path, existing behavior preserved.
- [x] `cargo check --lib --target x86_64-pc-windows-gnu` — the new `windows_replace`/`MoveFileExW` code type-checks (added the `x86_64-pc-windows-gnu` target locally via `rustup target add` to verify this, since this box can't build for Windows otherwise).
- [x] `cargo clippy --lib --target x86_64-pc-windows-gnu` — no new lints in `atomic_fs.rs` (pre-existing, unrelated clippy findings in other Windows-only files like `shell/platform.rs` and `ipc/process.rs` were already present before this change and are out of scope here).
- [x] `cargo test --lib core::atomic_fs` (native) — existing `try_atomic_write_creates_and_replaces` test already exercises "replace an existing file", which is exactly the scenario this fix targets; it isn't `cfg`-gated, so it also covers the new Windows path when CI runs on a Windows runner.
- [x] `cargo fmt --check`, `cargo clippy --lib -- -D warnings` (native) — clean.