### PR TITLE
docs(edit_io): document the residual TOCTOU window in the preimage guard

### DIFF
--- a/rust/src/tools/ctx_edit.rs
+++ b/rust/src/tools/ctx_edit.rs
@@ -453,6 +453,9 @@ fn do_replace(
             crate::core::code_health::gate::GateOutcome::Allow(notice) => notice,
         };
 
+    // #960: a point-in-time check, not a held lock — see
+    // ensure_preimage_still_matches' doc for the residual window between
+    // this check and the write below.
     if let Err(e) = ensure_preimage_still_matches(path, &pre.fp, cap) {
         return (e, CacheEffect::None);
     }
@@ -566,6 +569,9 @@ fn handle_create(file_path: &str, content: &str, params: &EditParams) -> (String
         if let Err(e) = verify_expected_preimage(&pre, params) {
             return (e, CacheEffect::None);
         }
+        // #960: a point-in-time check, not a held lock — see
+        // ensure_preimage_still_matches' doc for the residual window between
+        // this check and the write below.
         if let Err(e) = ensure_preimage_still_matches(path, &pre.fp, cap) {
             return (e, CacheEffect::None);
         }

--- a/rust/src/tools/ctx_patch/mod.rs
+++ b/rust/src/tools/ctx_patch/mod.rs
@@ -205,6 +205,9 @@ pub fn run_io(params: &PatchParams, _last_mode: &str) -> (String, CacheEffect) {
     };
 
     // TOCTOU guard: confirm the file did not change between read and write.
+    // #960: a point-in-time check, not a held lock — see
+    // ensure_preimage_still_matches' doc for the residual window between
+    // this check and the write below.
     if let Err(e) = ensure_preimage_still_matches(path, &pre.fp, cap) {
         return (e, CacheEffect::None);
     }

--- a/rust/src/tools/edit_io.rs
+++ b/rust/src/tools/edit_io.rs
@@ -15,6 +15,10 @@
 //! One implementation = one audited boundary. `ctx_edit` (`str_replace`) and
 //! `ctx_patch` (anchored) both apply through these functions, so a fix here
 //! protects both tools at once.
+//!
+//! **Known limitation (#960):** the TOCTOU guard is a point-in-time check,
+//! not a held lock — see [`ensure_preimage_still_matches`] for the residual
+//! window between that check and the atomic write it gates.
 
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -158,6 +162,19 @@ pub(crate) fn read_preimage(
 /// Re-reads the file and confirms its fingerprint still equals `expected`
 /// (TOCTOU guard): a concurrent writer between the preimage read and the write
 /// is detected here so the edit aborts instead of clobbering newer bytes.
+///
+/// **Residual window (#960, accepted limitation):** this is a point-in-time
+/// check, not a held lock — it only detects a write that already happened
+/// *before* this call returns. Callers still compute `new_content` and hand
+/// it to [`write_atomic_bytes_with_permissions`] afterward; nothing guards
+/// that gap. An external editor writing to `path` between this check
+/// succeeding and the temp+rename completing is not detected, and its write
+/// is silently overwritten. Acceptable for lean-ctx's single-writer-daemon
+/// model — the MCP server is the only intended writer of files it edits — but
+/// a real gap if an external editor (or a second lean-ctx instance) writes to
+/// the same file concurrently. Closing it fully would need a held file lock
+/// (e.g. `flock`) spanning check-through-rename, more machinery than the
+/// mono-writer case warrants today.
 pub(crate) fn ensure_preimage_still_matches(
     path: &Path,
     expected: &FileFingerprint,


### PR DESCRIPTION
## Summary

Closes #960. `ensure_preimage_still_matches` validates the preimage hash before the write, but nothing holds a lock across the interval between that check and the subsequent `rename`. An external editor writing to the same file in that narrow window isn't detected — only modifications that happened *before* the check are caught.

This is documentation only, no behavior change — closing the gap fully would need a held file lock (e.g. `flock`) spanning check-through-rename, more machinery than lean-ctx's current single-writer-daemon model (the MCP server is the only intended writer of files it edits) warrants today.

- `ensure_preimage_still_matches`'s doc comment now states plainly that it's a point-in-time check, not a held lock, and spells out the residual window and the accepted trade-off.
- The module-level doc in `edit_io.rs` cross-references this limitation.
- Each of the three call sites (`ctx_patch::run_io`, `ctx_edit::do_replace`, `ctx_edit::handle_create`) gets a short inline pointer back to the documented limitation, so a reader sees the caveat without needing to jump to the definition.

## Test plan
- [x] `cargo build --lib`, `cargo test --lib` (`edit_io::`, `ctx_edit::`, `ctx_patch::`) — doc-only change, all existing tests pass unchanged.
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings`