### PR TITLE
fix(doctor): warn when the checkout version differs from the running binary (#970)

### DIFF
--- a/rust/src/doctor/checks/environment.rs
+++ b/rust/src/doctor/checks/environment.rs
@@ -720,3 +720,154 @@ pub(crate) fn mcp_server_cwd_outcome() -> Outcome {
         }
     }
 }
+
+/// The lean-ctx version declared by a lean-ctx *source checkout* rooted at
+/// `dir`, or `None` when `dir` is not one.
+///
+/// Returns `None` for the overwhelmingly common case — a user's own project —
+/// so the skew check stays silent for everyone except people hacking on
+/// lean-ctx itself. The manifest is a workspace root whose `[package]` is not
+/// the first table, so it is parsed rather than scanned for the first
+/// `version =`. The `name` guard keeps an unrelated `rust/Cargo.toml` from
+/// being read as a lean-ctx checkout.
+fn checkout_version(dir: &std::path::Path) -> Option<String> {
+    // Only the two fields that matter; serde ignores the rest of the manifest.
+    // `toml::from_str` (not `str::parse`) — `Value`'s `FromStr` parses a single
+    // TOML *value*, so it reads `[workspace]` as an array literal and then errors
+    // with "expected nothing", silently yielding None for every real manifest.
+    #[derive(serde::Deserialize)]
+    struct Manifest {
+        package: Option<Package>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Package {
+        name: String,
+        version: String,
+    }
+
+    let manifest = ["rust/Cargo.toml", "Cargo.toml"]
+        .iter()
+        .map(|rel| dir.join(rel))
+        .find(|p| p.is_file())?;
+    let text = std::fs::read_to_string(manifest).ok()?;
+    let package = toml::from_str::<Manifest>(&text).ok()?.package?;
+    (package.name == "lean-ctx").then_some(package.version)
+}
+
+/// Renders the skew verdict. Split from [`checkout_version_skew_outcome`] so the
+/// comparison is testable without a real checkout on disk.
+fn skew_outcome(checkout: Option<&str>, running: &str) -> Outcome {
+    match checkout {
+        None => Outcome {
+            ok: true,
+            line: format!("{BOLD}Checkout version{RST}  {DIM}(not a lean-ctx checkout){RST}"),
+        },
+        Some(version) if version == running => Outcome {
+            ok: true,
+            line: format!(
+                "{BOLD}Checkout version{RST}  {GREEN}matches running binary{RST}  {DIM}{version}{RST}"
+            ),
+        },
+        Some(version) => Outcome {
+            ok: false,
+            line: format!(
+                "{BOLD}Checkout version{RST}  {YELLOW}differs from running binary{RST}  {DIM}This binary is lean-ctx {running}; the checkout here is {version}. ctx_* tool calls are served by the installed binary, so they do NOT exercise your working tree — a source change can look verified when the tool never ran it. Verify with `cargo test` or ./target/debug/lean-ctx instead.{RST}"
+            ),
+        },
+    }
+}
+
+/// Warn when the checkout being edited is not the code answering `ctx_*` calls
+/// (#970).
+///
+/// When you develop lean-ctx *with* lean-ctx, the MCP server is the installed
+/// binary while the source under edit is the checkout. Nothing at the call site
+/// distinguishes them, so verification silently reports on the wrong build — in
+/// the dangerous direction, a working-tree fix appears confirmed by a tool that
+/// never executed it.
+///
+/// Deliberately not gated on `LEAN_CTX_MCP_SERVER`: `doctor` is normally run
+/// from a terminal, not from the MCP process, so gating it there would hide the
+/// warning from exactly the person who needs it.
+pub(crate) fn checkout_version_skew_outcome() -> Outcome {
+    let checkout = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| checkout_version(&cwd));
+    skew_outcome(checkout.as_deref(), env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod skew_tests {
+    use super::{checkout_version, skew_outcome};
+
+    #[test]
+    fn matching_version_passes() {
+        let out = skew_outcome(Some("3.9.11"), "3.9.11");
+        assert!(out.ok, "same version must not warn: {}", out.line);
+    }
+
+    #[test]
+    fn differing_version_warns_and_names_both() {
+        let out = skew_outcome(Some("3.9.10"), "3.9.11");
+        assert!(!out.ok, "version skew must warn");
+        assert!(
+            out.line.contains("3.9.10"),
+            "must name the checkout version"
+        );
+        assert!(out.line.contains("3.9.11"), "must name the running binary");
+    }
+
+    #[test]
+    fn non_checkout_stays_silent() {
+        let out = skew_outcome(None, "3.9.11");
+        assert!(out.ok, "a user's own project must never warn: {}", out.line);
+    }
+
+    #[test]
+    fn checkout_version_reads_workspace_manifest_not_first_table() {
+        // The real manifest is a workspace root: `[workspace]` precedes
+        // `[package]`, and the members carry their own `version`. A naive "first
+        // version = line" scan reads the wrong one.
+        let tmp = tempfile::tempdir().unwrap();
+        let rust = tmp.path().join("rust");
+        std::fs::create_dir_all(&rust).unwrap();
+        std::fs::write(
+            rust.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/sdk\"]\n\n[package]\nname = \"lean-ctx\"\nversion = \"9.9.9\"\n",
+        )
+        .unwrap();
+        assert_eq!(checkout_version(tmp.path()).as_deref(), Some("9.9.9"));
+    }
+
+    #[test]
+    fn unrelated_rust_project_is_not_a_lean_ctx_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"some-other-crate\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        assert_eq!(checkout_version(tmp.path()), None);
+    }
+
+    #[test]
+    fn real_repo_manifest_is_recognised() {
+        // The negative cases below pass for either reason — a parser that returns
+        // None for *every* manifest satisfies them too, which is exactly the bug
+        // this check shipped with first (`str::parse::<toml::Value>()` reads a
+        // single value, not a document). Only asserting against the real manifest
+        // proves the check can ever actually fire.
+        let crate_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        assert_eq!(
+            checkout_version(crate_root).as_deref(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "lean-ctx's own manifest must be recognised as a lean-ctx checkout"
+        );
+    }
+
+    #[test]
+    fn missing_manifest_is_not_a_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(checkout_version(tmp.path()), None);
+    }
+}

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -603,6 +603,10 @@ pub fn run() -> u32 {
     let mcp_cwd = mcp_server_cwd_outcome();
     board.check(&mcp_cwd);
 
+    // #970: checkout/binary version skew (only fires inside a lean-ctx checkout)
+    let skew = checkout_version_skew_outcome();
+    board.check(&skew);
+
     // LSP servers (optional, informational)
     println!("\n  {BOLD}{WHITE}LSP (optional — for ctx_refactor):{RST}");
     let lsp_outcomes = lsp_server_outcomes();

--- a/rust/src/doctor/report.rs
+++ b/rust/src/doctor/report.rs
@@ -11,8 +11,8 @@
 use serde::Serialize;
 
 use super::checks::{
-    capacity_warnings, mcp_config_outcome, mcp_server_cwd_outcome, shell_aliases_outcome,
-    skill_files_outcome,
+    capacity_warnings, checkout_version_skew_outcome, mcp_config_outcome, mcp_server_cwd_outcome,
+    shell_aliases_outcome, skill_files_outcome,
 };
 use super::common::{path_in_path_env, resolve_lean_ctx_binary};
 use super::deprecations::deprecations_outcome;
@@ -166,6 +166,10 @@ pub fn health_report() -> HealthReport {
     let mcp_cwd = mcp_server_cwd_outcome();
     if !mcp_cwd.ok {
         warnings.push(strip_ansi(&mcp_cwd.line));
+    }
+    let skew = checkout_version_skew_outcome();
+    if !skew.ok {
+        warnings.push(strip_ansi(&skew.line));
     }
 
     let level = HealthReport::classify(passed, total, !warnings.is_empty());


### PR DESCRIPTION
Fixes #970.

## The problem

Developing lean-ctx *with* lean-ctx means the MCP server is the **installed**
binary while the source under edit is the checkout. Nothing at the call site
distinguishes them, so `ctx_*` verification silently reports on the wrong build.

The benign direction wastes time; the dangerous direction is a working-tree fix
**appearing verified by a tool that never executed it**. This is not
hypothetical — it cost real debugging time on #931: the heredoc repro was run
through the installed 3.9.11, passed cleanly, and nearly led to the conclusion
that the bug did not exist, while the 3.9.10 checkout genuinely still had it.

## The fix

A `Checkout version` check beside the existing `MCP server CWD` check, using the
same `Outcome` pattern:

| Situation | Result |
|---|---|
| Not a lean-ctx checkout (i.e. every normal user) | ✓ silent — `(not a lean-ctx checkout)` |
| Checkout matches the running binary | ✓ `matches running binary  3.9.11` |
| Checkout differs | ✗ names both versions, points at `cargo test` / `./target/debug/lean-ctx` |

## Verified end-to-end

Not just unit tests — run against the built binary:

```
# 1. in-repo, 3.9.11 checkout vs 3.9.11 binary
✓  Checkout version  matches running binary  3.9.11

# 2. synthetic 3.9.10 checkout vs 3.9.11 binary (reproduces the #931 trap)
✗  Checkout version  differs from running binary  This binary is lean-ctx
   3.9.11; the checkout here is 3.9.10. ctx_* tool calls are served by the
   installed binary, so they do NOT exercise your working tree — a source
   change can look verified when the tool never ran it. Verify with
   `cargo test` or ./target/debug/lean-ctx instead.

# 3. an unrelated Rust project
✓  Checkout version  (not a lean-ctx checkout)
```

## Two decisions worth reviewing

**Not gated on `LEAN_CTX_MCP_SERVER`.** `doctor` is normally run from a terminal,
not from the MCP process, so gating it there would hide the warning from exactly
the person who needs it. The cost: it renders as a red ✗ (consistent with
`mcp_server_cwd_outcome`), so a maintainer with a deliberately older checkout
sees a failing check. Happy to downgrade it to an advisory-only ⚠ if you'd
rather it not move the score.

**`toml::from_str`, not `str::parse::<toml::Value>()`.** `Value`'s `FromStr`
parses a single TOML *value*, so it reads the workspace root's leading
`[workspace]` table as an array literal and errors with "expected nothing" —
silently returning `None` for every real manifest and making the check dead code.
My first implementation had exactly this bug, and the negative tests did not
catch it: a parser that always returns `None` satisfies "returns None for a
non-checkout" too. `real_repo_manifest_is_recognised` asserts against lean-ctx's
own manifest and fails instantly on that class of bug.

## Tests

7 new tests in `skew_tests`, covering match / skew / non-checkout, the workspace
manifest shape (`[package]` is not the first table), an unrelated crate, a
missing manifest, and the real repo manifest. `cargo fmt` and
`cargo clippy --lib --all-features -- -D warnings` clean.

**Note on the suite:** `cargo test --lib` on this branch shows `python_c_blocked`
and `node_e_blocked` failing intermittently. They are **pre-existing on
`main`** and unrelated to this change (doctor cannot reach `shell_allowlist`) —
they read `LEAN_CTX_SHELL_ALLOW_INLINE_SCRIPTS` without taking
`data_dir::test_env_lock()`, so the opt-in tests leak into them under
parallelism. Given `224b92c6e` ("pull back v3.9.11 release — CI must be green
first"), that may be worth its own issue; I have a one-line-per-test fix ready
if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
