### PR TITLE
fix(read): keep lines: multi-select pinned instead of dumping the whole file (#971)

### DIFF
--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -254,13 +254,24 @@ fn estimate_read_tokens(path: &str, mode: &str) -> usize {
         "diff" => full_tokens / 10,
         _ if mode.starts_with("lines:") => {
             if let Some(range) = mode.strip_prefix("lines:") {
-                let parts: Vec<&str> = range.split('-').collect();
-                if parts.len() == 2 {
-                    let start = parts[0].parse::<usize>().unwrap_or(1);
-                    let end = parts[1].parse::<usize>().unwrap_or(start + 100);
-                    (end.saturating_sub(start) + 1) * 10
-                } else {
+                // #971: comma is multi-select. Splitting the whole payload on
+                // '-' yields 3 parts for `620-622,1214-1218` and fell through to
+                // the whole-file tenth; sum the selected spans instead.
+                let mut selected = 0usize;
+                for part in range.split(',') {
+                    let part = part.trim();
+                    selected += if let Some((s, e)) = part.split_once('-') {
+                        let start = s.trim().parse::<usize>().unwrap_or(1);
+                        let end = e.trim().parse::<usize>().unwrap_or(start + 100);
+                        end.saturating_sub(start) + 1
+                    } else {
+                        1
+                    };
+                }
+                if selected == 0 {
                     full_tokens / 10
+                } else {
+                    selected * 10
                 }
             } else {
                 full_tokens / 10
@@ -520,6 +531,52 @@ mod tests {
         assert!(
             bare.overridden_mode.is_none(),
             "bare anchored mode must not be overridden by bounce-prevention"
+        );
+    }
+
+    #[test]
+    fn pre_dispatch_passthrough_for_lines_multi_select() {
+        // #971: `lines:A-B,C-D` is a precise pinned window exactly like
+        // `lines:A-B`, but it parsed as Malformed, so `is_precise_pinned_mode`
+        // reported "not pinned" and bounce-prevention rewrote an 8-line request
+        // into a full-file read. Exercises the edit-forced branch, which is what
+        // the field report actually hit (a ctx_patch anchored edit immediately
+        // before the read).
+        {
+            let mut bt = crate::core::bounce_tracker::global()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            bt.set_seq(201);
+            bt.record_edit("multi-select-971.rs");
+            bt.set_seq(202);
+        }
+
+        // Precondition: the tracker really is armed for this path, so the
+        // assertions below cannot pass vacuously.
+        let forced = pre_dispatch_read("multi-select-971.rs", "map", None, None, None);
+        assert_eq!(
+            forced.overridden_mode.as_deref(),
+            Some("full"),
+            "precondition: a recent edit must force a non-pinned mode to full"
+        );
+
+        let multi = pre_dispatch_read(
+            "multi-select-971.rs",
+            "lines:620-622,1214-1218",
+            None,
+            None,
+            None,
+        );
+        assert!(
+            multi.overridden_mode.is_none(),
+            "lines:A-B,C-D must not be overridden by bounce-prevention (#971)"
+        );
+
+        // Control: the single-range form was already protected.
+        let single = pre_dispatch_read("multi-select-971.rs", "lines:620-622", None, None, None);
+        assert!(
+            single.overridden_mode.is_none(),
+            "lines:A-B must not be overridden by bounce-prevention"
         );
     }
 

--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -93,6 +93,16 @@ pub(crate) enum ReadMode {
     Diff,
     /// Line window — `"lines:start-end"`.
     Lines(LineRange),
+    /// Comma multi-select — `"lines:5,10-20"` (#971).
+    ///
+    /// The parts are validated but kept verbatim rather than re-derived into
+    /// `Vec<LineRange>`. The window semantics live in
+    /// `render::extract_line_range`, which reads the raw mode string, so a
+    /// structured payload here would have no consumer — and it could not
+    /// round-trip: a bare `5` selects *line 5*, which no `LineRange` spells
+    /// without becoming `5-5`. Validation is what this type owes its callers;
+    /// interpretation belongs to the renderer.
+    LinesMulti(String),
     /// Target-density compression — `"density:0.NN"`.
     Density(f64),
 }
@@ -116,6 +126,29 @@ impl fmt::Display for ParseModeError {
 }
 
 impl std::error::Error for ParseModeError {}
+
+/// Validate a comma multi-select payload (`"5,10-20"`) and return it verbatim
+/// (#971).
+///
+/// Each part must be a bare line `N` or a span `N-M`, so garbage still fails
+/// exactly as it does for a single range. Before this existed, a comma payload
+/// hit [`parse_line_range`]'s `split_once('-')` and left `"622,1214-1218"` for
+/// `parse::<u32>()`, making the whole mode unparseable — which silently cost it
+/// [`ReadMode::is_precise_pinned_read`] and let bounce-prevention rewrite a
+/// window request to `full`.
+fn parse_line_multi(payload: &str) -> Result<String, ParseModeError> {
+    let malformed = || ParseModeError::Malformed(format!("lines:{payload}"));
+    for part in payload.split(',') {
+        let part = part.trim();
+        if let Some((start, end)) = part.split_once('-') {
+            start.trim().parse::<u32>().map_err(|_| malformed())?;
+            end.trim().parse::<u32>().map_err(|_| malformed())?;
+        } else {
+            part.parse::<u32>().map_err(|_| malformed())?;
+        }
+    }
+    Ok(payload.to_string())
+}
 
 /// Parse the payload of a `lines:` mode (`"5-10"`, `"5-999999"`, or a bare
 /// `"5"` meaning "from line 5 to EOF").
@@ -151,7 +184,12 @@ impl FromStr for ReadMode {
             "diff" => ReadMode::Diff,
             other => {
                 if let Some(payload) = other.strip_prefix("lines:") {
-                    ReadMode::Lines(parse_line_range(payload)?)
+                    // #971: a comma payload is a multi-select, not a span.
+                    if payload.contains(',') {
+                        ReadMode::LinesMulti(parse_line_multi(payload)?)
+                    } else {
+                        ReadMode::Lines(parse_line_range(payload)?)
+                    }
                 } else if let Some(payload) = other.strip_prefix("anchored:") {
                     ReadMode::Anchored(Some(parse_line_range(payload)?))
                 } else if let Some(payload) = other.strip_prefix("density:") {
@@ -185,6 +223,7 @@ impl fmt::Display for ReadMode {
             ReadMode::Anchored(None) => "anchored",
             ReadMode::Anchored(Some(range)) => return write!(f, "anchored:{range}"),
             ReadMode::Lines(range) => return write!(f, "lines:{range}"),
+            ReadMode::LinesMulti(payload) => return write!(f, "lines:{payload}"),
             // Matches the handler's historical `format!("density:{:.2}", …)`.
             ReadMode::Density(target) => return write!(f, "density:{target:.2}"),
         };
@@ -208,6 +247,7 @@ impl ReadMode {
         !matches!(
             self,
             ReadMode::Lines(_)
+                | ReadMode::LinesMulti(_)
                 | ReadMode::Reference
                 | ReadMode::Diff
                 | ReadMode::Raw
@@ -261,7 +301,7 @@ impl ReadMode {
     pub(crate) fn is_precise_pinned_read(&self) -> bool {
         matches!(
             self,
-            ReadMode::Diff | ReadMode::Lines(_) | ReadMode::Anchored(_)
+            ReadMode::Diff | ReadMode::Lines(_) | ReadMode::LinesMulti(_) | ReadMode::Anchored(_)
         )
     }
 }
@@ -396,6 +436,71 @@ mod tests {
             "lines:5".parse::<ReadMode>().unwrap(),
             ReadMode::Lines(LineRange::to_eof(5))
         );
+    }
+
+    // --- #971: comma multi-select ---
+
+    #[test]
+    fn comma_multi_select_parses() {
+        // The exact payload from #971, plus the form the tool description
+        // documents (`lines:5,10-20`) — both used to be Malformed.
+        assert_eq!(
+            "lines:620-622,1214-1218".parse::<ReadMode>().unwrap(),
+            ReadMode::LinesMulti("620-622,1214-1218".to_string())
+        );
+        assert_eq!(
+            "lines:5,10-20".parse::<ReadMode>().unwrap(),
+            ReadMode::LinesMulti("5,10-20".to_string())
+        );
+    }
+
+    #[test]
+    fn comma_multi_select_round_trips_byte_identically() {
+        // The module contract: Display reproduces the canonical string exactly.
+        for mode in ["lines:5,10-20", "lines:620-622,1214-1218", "lines:1,2,3"] {
+            assert_eq!(mode.parse::<ReadMode>().unwrap().to_string(), mode);
+        }
+    }
+
+    #[test]
+    fn comma_multi_select_is_pinned_and_never_capped() {
+        // The #971 regression in one place: an unparseable mode was treated as
+        // not-pinned, which let bounce-prevention rewrite the window to `full`,
+        // and opted it into the #361 raw cap that `lines:` must never get. Both
+        // must hold for the comma form exactly as for `lines:N-M`.
+        let multi: ReadMode = "lines:620-622,1214-1218".parse().unwrap();
+        assert!(
+            multi.is_precise_pinned_read(),
+            "a comma multi-select is still a precise pinned read (#843)"
+        );
+        assert!(
+            !multi.allows_raw_cap(),
+            "a comma multi-select is a selection view and is never raw-capped (#361)"
+        );
+        // Classified identically to the single-range form.
+        let single: ReadMode = "lines:620-622".parse().unwrap();
+        assert_eq!(
+            multi.is_precise_pinned_read(),
+            single.is_precise_pinned_read()
+        );
+        assert_eq!(multi.allows_raw_cap(), single.allows_raw_cap());
+        assert_eq!(multi.counts_as_compressed(), single.counts_as_compressed());
+        assert_eq!(multi.is_lossy_summary(), single.is_lossy_summary());
+        assert_eq!(
+            multi.is_compressed_cacheable(),
+            single.is_compressed_cacheable()
+        );
+    }
+
+    #[test]
+    fn malformed_multi_select_still_rejected() {
+        // Validation must not weaken: garbage in a part fails as before.
+        for mode in ["lines:5,abc", "lines:5-x,10", "lines:5,,10", "lines:5,10-"] {
+            assert!(
+                mode.parse::<ReadMode>().is_err(),
+                "'{mode}' must not parse as a valid multi-select"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #971. Root-cause analysis and the deterministic repro are in
[this comment](https://github.com/yvgude/lean-ctx/issues/971#issuecomment-4999947488).

## The bug

`ctx_read(mode="lines:620-622,1214-1218")` returned the **entire file** — 1,703
lines when 8 were asked for.

Comma multi-select is implemented by the renderer (`extract_line_range` splits on
`,` and handles bare lines and spans), documented in the tool description, and
has its own hint constant (`LINES_COMMA_HINT`). But `ReadMode::from_str` never
learned it:

```rust
fn parse_line_range(payload: &str) -> Result<LineRange, ParseModeError> {
    if let Some((a, b)) = payload.split_once('-') {
        let start = a.trim().parse::<u32>()...;
        let end   = b.trim().parse::<u32>()...;   // "622,1214-1218" → Err
```

So the mode renders correctly but is **unparseable as a `ReadMode`** — and the
documented example `lines:5,10-20` fails identically (`a = "5,10"`).

Three guards keyed on the typed mode then misclassify it:

| guard | on parse failure | consequence |
|---|---|---|
| `is_precise_pinned_mode` | `is_ok_and` → **not pinned** | #843's "must pass through every mode-override path untouched" silently voided; bounce-prevention rewrites the window to `full` |
| `mode_allows_raw_cap` | `map_or(true, …)` → **capped** | opts `lines:` into the #361 raw cap its own doc forbids ("replacing them with the whole file would be wrong, not cheaper") |
| `estimate_read_tokens` | `split('-')` → 3 parts | agent budget charged a whole-file tenth |

The trigger is a `ctx_patch` **anchored** edit to the same file just before the
read (`record_edit` → `should_force_full`). That is why it looked intermittent:
a fresh scratch file has no edit history, and a *native* write never calls
`record_edit`. `op="replace_all"` does not arm it either.

The failure is inverted relative to the tool's purpose: the reads that most
deserve a narrow window — right after editing — are exactly the ones converted
to a full-file dump. The only signal was a footer on the **last line** of a 65 KB
payload:

```
[mode overridden: lines:620-622,1214-1218 -> full, reason=bounce-prevention]
```

which truncating clients never show.

## The fix

Adds `ReadMode::LinesMulti(String)`, classified identically to `Lines`.

**Why a validated payload and not `Vec<LineRange>`** (which the issue suggested):

- It would have no consumer. The renderer owns the window semantics and reads
  the raw mode string; nothing destructures `ReadMode::Lines` outside `mode.rs`.
- It cannot satisfy the module's byte-identical `Display` contract. A bare `5` in
  a multi-select selects *line 5*, which no `LineRange` spells without becoming
  `5-5`, so `lines:5,10-20` would round-trip to `lines:5-5,10-20`.

Validation is what this type owes its callers; interpretation belongs to the
renderer. Garbage still errors (`lines:5,abc`, `lines:5-x,10`, `lines:5,,10`,
`lines:5,10-`).

`estimate_read_tokens` now sums the selected spans instead of splitting the whole
payload on `-`.

## Verification

- Regression test at the real entry point (`pre_dispatch_read`) asserts a comma
  window survives a preceding anchored edit — covering the exact combination no
  existing test did. It carries a **precondition assert** (`map` on the same path
  *must* still be forced to `full`) so it cannot pass vacuously.
- **Red-checked**: reverting only the parser branch fails it with
  `lines:A-B,C-D must not be overridden by bounce-prevention (#971)`, while the
  precondition and the single-range control still pass.
- Round-trip, classification-parity, and malformed-payload tests in `mode.rs`.
- `cargo fmt` and `cargo clippy --lib --all-features -- -D warnings` clean.

**Scope note:** verified at `pre_dispatch_read` rather than through a live MCP
server, because the MCP server runs the *installed* binary rather than the
working tree — which is #970, filed separately from this same session.

**Pre-existing suite flakes**, unrelated and untouched by this change:
`python_c_blocked`, `node_e_blocked` (they read
`LEAN_CTX_SHELL_ALLOW_INLINE_SCRIPTS` without taking `test_env_lock()`), plus two
`http_server` tests. Given `224b92c6e` ("pull back v3.9.11 release — CI must be
green first"), the env-lock ones may be worth their own issue; I have a
one-line-per-test fix ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
