### PR TITLE
fix(shell): stop the terse dictionary from rewriting source and YAML (#980)

### DIFF
--- a/rust/src/core/patterns/mod.rs
+++ b/rust/src/core/patterns/mod.rs
@@ -345,10 +345,7 @@ const PATTERNS: &[(PatternMatcher, PatternHandler)] = &[
         },
         |c, output| ruby::compress(c, output),
     ),
-    (
-        |c| c.starts_with("grep ") || c.starts_with("rg "),
-        |_c, output| grep::compress(output),
-    ),
+    (|c| is_grep_family(c), |_c, output| grep::compress(output)),
     (
         |c| c.starts_with("find "),
         |_c, output| find::compress(output),
@@ -622,6 +619,24 @@ const PATTERNS: &[(PatternMatcher, PatternHandler)] = &[
         |c, output| deploy::compress(c, output),
     ),
 ];
+
+/// A grep-family search, bare or with arguments (#980).
+///
+/// The **bare** form matters: `proxy::compress::infer_command` synthesises the
+/// command `grep` (no arguments) from any tool named `*search*`/`*grep*`/
+/// `*find*`, and the previous `starts_with("grep ")` test — which requires a
+/// trailing space — never matched it. Those tool results therefore missed this
+/// compressor and fell into the generic terse pipeline, whose dictionary
+/// rewrites the source lines it finds (`error`→`err`, `context.Context`→
+/// `ctx.ctx`).
+fn is_grep_family(cmd: &str) -> bool {
+    let first = cmd.split_whitespace().next().unwrap_or("");
+    let base = first.rsplit('/').next().unwrap_or(first);
+    matches!(
+        base,
+        "grep" | "egrep" | "fgrep" | "rg" | "ag" | "ack" | "ugrep"
+    )
+}
 
 pub fn try_specific_pattern(cmd: &str, output: &str) -> Option<String> {
     let cl = cmd.to_ascii_lowercase();

--- a/rust/src/proxy/google.rs
+++ b/rust/src/proxy/google.rs
@@ -255,8 +255,15 @@ mod tests {
         // to the shared engine, so its output matches the name-routed engine
         // byte-for-byte (the contract that distinguishes this from `None`).
         // `infer_command`'s use of the name is unit-tested in `compress.rs`.
+        //
+        // #980: matches share one file so the `patterns::grep` compressor —
+        // which wins by grouping and capping matches *per file* — can shrink
+        // them. The previous fixture put each match in its own file, which only
+        // the generic terse pipeline could shrink, and that pipeline is exactly
+        // what must never see source lines (it rewrote `context.Context` to
+        // `ctx.ctx`). The routing contract under test is unchanged.
         let raw = (0..60)
-            .map(|i| format!("src/file_{i}.rs:{i}:    let matched = find(foo, bar, baz);"))
+            .map(|i| format!("src/matches.rs:{i}:    let matched = find(foo, bar, baz);"))
             .collect::<Vec<_>>()
             .join("\n");
         let routed = compress_tool_result(&raw, Some("search_files"));

--- a/rust/src/shell/compress/classification.rs
+++ b/rust/src/shell/compress/classification.rs
@@ -74,6 +74,12 @@ pub fn has_structural_output(command: &str) -> bool {
     if is_standalone_diff_command(command) {
         return true;
     }
+    // #980: grep-family matches are source lines. Owning them here hands them to
+    // the dedicated `patterns::grep` compressor and keeps them out of the terse
+    // dictionary, which has no code-awareness.
+    if is_source_search(command) {
+        return true;
+    }
     is_structural_git_command(command)
 }
 
@@ -207,20 +213,71 @@ fn is_http_client(command: &str) -> bool {
     )
 }
 
+/// Split a compound command into the segments that can each produce stdout,
+/// on `&&`, `||`, `;` and `|` (GH #980).
+///
+/// Classifying only `first_binary(command)` reads `cd` as the binary for
+/// `cd /repo && cat file.yaml`, so the file payload misses the allowlist and
+/// falls into the terse pipeline — the exact corruption the note on
+/// [`is_file_viewer`] says must never happen. [`is_structural_git_command`]
+/// already scans every token for the same reason; this gives the viewer path
+/// the same treatment.
+///
+/// Quote-blind by design: a `|` or `&&` inside a quoted pattern
+/// (`grep -rn "a|b" .`) yields extra segments, but the segment holding the
+/// binary still classifies, so the error can only ever be *more* verbatim,
+/// never less. For file payload that is the safe direction.
+fn command_segments(command: &str) -> impl Iterator<Item = &str> {
+    command
+        .split(['&', '|', ';'])
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+}
+
+/// True when any segment of `command` dumps file payload to stdout.
+///
+/// Segment-aware (#980): `cd /repo && cat file` is a file view, and so is
+/// `… | sed -n '10,50p' file`.
 fn is_file_viewer(command: &str) -> bool {
-    let first = first_binary(command);
+    command_segments(command).any(is_file_viewer_segment)
+}
+
+fn is_file_viewer_segment(segment: &str) -> bool {
+    let first = first_binary(segment);
     match first {
         "cat" | "bat" | "batcat" | "pygmentize" | "highlight" => true,
-        "head" | "tail" => !command.contains("-f") && !command.contains("--follow"),
+        "head" | "tail" => !segment.contains("-f") && !segment.contains("--follow"),
         // sed/awk are commonly used as range/pattern file viewers
         // (`sed -n '10,50p' file`, `awk '{print}' file`, GH #688). Their stdout
         // is file payload and must never enter the generic terse pipeline —
         // the dictionary layer word-substitutes code identifiers
         // (`function`→`fn`, `return`→`ret`) with no code-awareness. In-place
         // edit invocations are excluded: they print nothing to compress.
-        "sed" | "awk" | "gawk" | "mawk" | "nawk" => !has_in_place_flag(command),
+        "sed" | "awk" | "gawk" | "mawk" | "nawk" => !has_in_place_flag(segment),
         _ => false,
     }
+}
+
+/// Grep-family searches, whose matched lines are verbatim source (GH #980).
+///
+/// Routed to [`has_structural_output`], **not** [`is_verbatim_output`]: the
+/// dedicated `patterns::grep` compressor groups matches by file and caps them
+/// per file without ever touching line content, so search output stays
+/// compressible while the generic terse pipeline — which word-substitutes
+/// `error`→`err`, `return`→`ret` and collapses `context.Context`→`ctx.ctx` —
+/// never sees it.
+///
+/// Classifying these verbatim instead would also silently disable proxy
+/// compression for every search-type tool result, since `infer_command` maps any
+/// tool named `*search*`/`*grep*`/`*find*` onto the bare command `grep`.
+fn is_source_search(command: &str) -> bool {
+    command_segments(command).any(|segment| {
+        let first = first_binary(segment);
+        matches!(
+            first,
+            "grep" | "egrep" | "fgrep" | "rg" | "ag" | "ack" | "ugrep"
+        )
+    })
 }
 
 /// True when a sed/awk invocation carries an in-place edit flag: `-i`,

--- a/rust/src/shell/compress/tests.rs
+++ b/rust/src/shell/compress/tests.rs
@@ -374,6 +374,7 @@ mod passthrough_tests {
 
 #[cfg(test)]
 mod verbatim_output_tests {
+    use super::super::classification::has_structural_output;
     use super::super::classification::is_git_data_command;
     use super::super::classification::is_verbatim_output;
     use super::super::engine::compress_if_beneficial;
@@ -416,6 +417,56 @@ mod verbatim_output_tests {
     fn tail_follow_not_verbatim() {
         assert!(!is_verbatim_output("tail -f /var/log/syslog"));
         assert!(!is_verbatim_output("tail --follow server.log"));
+    }
+
+    /// GH #980 repro B: `cat` is allowlisted, but classification only read the
+    /// first token of the command string — `cd` — so the file payload fell
+    /// through into the terse pipeline and came back with its YAML indentation
+    /// stripped and lines deduplicated. For YAML, indentation *is* the
+    /// semantics, so the reported document was a different document.
+    #[test]
+    fn file_viewer_survives_cd_prefix() {
+        assert!(is_verbatim_output(
+            "cd /path/to/repo && cat tests/basics.yaml"
+        ));
+        assert!(is_verbatim_output("cd /repo; cat file.yaml"));
+        assert!(is_verbatim_output("cd /repo || cat fallback.yaml"));
+        assert!(is_verbatim_output("cd /repo && head -50 src/main.rs"));
+        assert!(is_verbatim_output(
+            "cd /repo && sed -n '10,50p' src/main.rs"
+        ));
+        // The pre-#980 behaviour, kept: a bare viewer is still verbatim.
+        assert!(is_verbatim_output("cat tests/basics.yaml"));
+    }
+
+    /// GH #980 repro A: grep matches are source lines. They must be owned by the
+    /// dedicated `patterns::grep` compressor (structural), never the generic
+    /// terse pipeline, whose dictionary returned Go as `error`→`err`,
+    /// `return`→`ret`, `context.Context`→`ctx.ctx`, `map[string]any`→`map[str]any`.
+    ///
+    /// Structural — deliberately *not* verbatim: `infer_command` maps every
+    /// `*search*`/`*grep*`/`*find*` tool name onto the bare command `grep`, so
+    /// classifying it verbatim would silently disable proxy compression for all
+    /// search-type tool results.
+    #[test]
+    fn grep_over_source_is_structural_not_terse() {
+        for cmd in [
+            "grep -rn \"NewPhoenixEVEth\" --include='*.go' .",
+            "rg NewPhoenixEVEth",
+            "ag pattern src/",
+            "ack pattern",
+            "egrep -rn pattern .",
+            // The bare form the proxy infers from a tool name.
+            "grep",
+            // Compound forms must hold too.
+            "cd /repo && grep -rn pattern .",
+            "cat file.go | grep func",
+        ] {
+            assert!(
+                has_structural_output(cmd),
+                "'{cmd}' must be structural so the terse dictionary never sees source lines"
+            );
+        }
     }
 
     /// GH #688 (severe): a `sed`/`awk` file dump must never enter the generic


### PR DESCRIPTION
Fixes #980.

Both repros verified end-to-end against the built binary vs installed 3.9.11.

## Repro A — `grep` over Go

```
$ grep -rn NewPhoenixEVEthFromConfig --include='*.go' .

OLD  40 matches in 1F:
     charger/phoenix-ev-eth.go (40):
       3: func NewPhoenixEVEthFromConfig0(ctx ctx.ctx, other map[str]any) (api.Charger, err) {

NEW  40 matches in 1F:
     charger/phoenix-ev-eth.go (40):
       3: func NewPhoenixEVEthFromConfig0(ctx context.Context, other map[string]any) (api.Charger, error) {
```

## Repro B — `cd … && cat` YAML

```
OLD  46 lines → 45 unique        NEW  interval: 0.1s
     interval: 0.1s                   (blank)
     title: Hello World               site:
     meters:                          ␣␣title: Hello World
     grid: grid                       ␣␣meters:
     ← indentation gone,         ← byte-exact match to disk
       `site:` dropped
```

## Three defects, not two

The issue identified the first two. Fixing them surfaced a third.

**1. Compound commands defeated the allowlist.** Classification read
`first_binary(command)` — the first whitespace token of the *whole* string — so
`cd /repo && cat file.yaml` classified as `cd`. `is_structural_git_command`
already scans every token for exactly this reason; `command_segments` (`&&`,
`||`, `;`, `|`) gives the viewer path the same treatment. Quote-blind by design:
a `|` inside a quoted pattern yields extra segments, but the segment holding the
binary still classifies, so the error can only ever be *more* verbatim — the safe
direction for file payload.

**2. grep-family searches were never classified.** Routed to
`has_structural_output`, **not** `is_verbatim_output` as the issue suggested.
There are three tiers, and the middle one is what this needs:

| tier | treatment |
|---|---|
| `is_verbatim_output` | no compression at all |
| `has_structural_output` | dedicated pattern compressor only — **never** the dictionary |
| everything else | generic terse pipeline ← the corruption |

`patterns::grep` groups matches per file and caps them without touching line
content, so tier 2 keeps the compression *and* drops the corruption:

| | bytes | content |
|---|---|---|
| raw | 5194 | correct |
| OLD | 1113 | **corrupted** |
| NEW | 1244 | correct |
| verbatim (as suggested) | 5194 | correct, 0% compression |

Correctness costs 131 bytes (2.5%), not the whole 76% saving.

**3. The proxy has been corrupting every agent's search results.** Verbatim
would also have silently disabled proxy compression for all search-type tool
results — which is how I found this. `patterns::grep`'s matcher required a
trailing space:

```rust
|c| c.starts_with("grep ") || c.starts_with("rg "),
```

but `proxy::compress::infer_command` synthesises the **bare** command `grep` from
any tool named `*search*`/`*grep*`/`*find*`. Bare `grep` never matched, so those
results skipped the grep compressor and went through the terse dictionary. The
blast radius is larger than #980 describes: not just this shell's output, but
every proxied agent's search results.

## The `proxy::google` fixture

Changed, and worth your scrutiny. It built 60 matches each in its **own** file —
a shape only the terse pipeline can shrink, since `patterns::grep` wins by
grouping *per file*. That fixture was passing precisely because the corrupting
path compressed it. The matches now share one file. The routing contract the test
asserts (tool name → shared engine, byte-for-byte) is untouched.

This does mean a real trade: scattered one-match-per-file searches now compress
less than before, because the only thing that used to shrink them was the
dictionary. Corrupted source is worse than larger output.

## Verification

- Both repros reproduced against installed 3.9.11 and confirmed fixed on this build.
- **Red-checked**: reverting `is_file_viewer` to first-token-only fails
  `file_viewer_survives_cd_prefix` and `grep_over_source_is_structural_not_terse`.
- 915 tests pass across `shell::compress`, `proxy::`, `core::patterns`.
- `cargo fmt` and `cargo clippy --lib --all-features -- -D warnings` clean.

One measurement note, in case it saves someone time: compression only engages on
**stdout**. Redirecting a comparison to a file suppresses it and makes both
binaries look clean — my first attempt at this fell for exactly that.

## Not addressed

The issue's closing point stands: the dictionary remains unsafe on any text that
might be source, and whitelisting viewers one binary at a time leaves the default
unsafe. `BPE_ALIGNED_RULES` already documents rules removed for breaking
compilability; `GENERAL`'s `error`/`return`/`context`/`function` are the same
hazard class. This PR fixes the routing, not that default. Related: #973
(the same dictionary rewriting file *paths* — `environment.rs` → `env.rs`).

**Pre-existing flakes** in full-suite runs, unrelated and varying between runs:
`node_e_blocked` (fixed by #976), plus `http_server::*`, `ipc::process`,
`core::addons::publish`. None touch compress/patterns/classification; all pass in
isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
