### PR TITLE
fix(shell): route grep to structural, not verbatim — restores search compression, fixes red main (#980)

### DIFF
--- a/rust/src/core/patterns/mod.rs
+++ b/rust/src/core/patterns/mod.rs
@@ -345,10 +345,7 @@ const PATTERNS: &[(PatternMatcher, PatternHandler)] = &[
         },
         |c, output| ruby::compress(c, output),
     ),
-    (
-        |c| c.starts_with("grep ") || c.starts_with("rg "),
-        |_c, output| grep::compress(output),
-    ),
+    (|c| is_grep_family(c), |_c, output| grep::compress(output)),
     (
         |c| c.starts_with("find "),
         |_c, output| find::compress(output),
@@ -622,6 +619,25 @@ const PATTERNS: &[(PatternMatcher, PatternHandler)] = &[
         |c, output| deploy::compress(c, output),
     ),
 ];
+
+/// A grep-family search, bare or with arguments (#980).
+///
+/// The **bare** form is what makes this load-bearing:
+/// `proxy::compress::infer_command` synthesises the command `grep` (no
+/// arguments) from any tool named `*search*`/`*grep*`/`*find*`, and the previous
+/// `starts_with("grep ")` test — requiring a trailing space — never matched it.
+/// Those tool results missed this compressor and fell into the generic terse
+/// pipeline, whose dictionary rewrites the source lines it finds
+/// (`context.Context`→`ctx.Context`, `error`→`err`, `return`→`ret`). The proxy
+/// was corrupting every proxied agent's search results, not just this shell's.
+fn is_grep_family(cmd: &str) -> bool {
+    let first = cmd.split_whitespace().next().unwrap_or("");
+    let base = first.rsplit('/').next().unwrap_or(first);
+    matches!(
+        base,
+        "grep" | "egrep" | "fgrep" | "rg" | "ag" | "ack" | "ugrep" | "sift"
+    )
+}
 
 pub fn try_specific_pattern(cmd: &str, output: &str) -> Option<String> {
     let cl = cmd.to_ascii_lowercase();

--- a/rust/src/proxy/compress.rs
+++ b/rust/src/proxy/compress.rs
@@ -323,6 +323,42 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// #980: a search tool result must come back *correct*, not merely smaller.
+    ///
+    /// `infer_command` maps any `*search*`/`*grep*`/`*find*` tool name onto the
+    /// bare command `grep`, so this is the path every proxied agent's search
+    /// results take. Nothing asserted their content before — only their size —
+    /// which is why the terse dictionary could rewrite them unnoticed. Both
+    /// halves matter and are asserted together: correctness would be trivially
+    /// satisfied by not compressing at all, and compression alone is what the
+    /// corrupting path already provided.
+    #[test]
+    fn search_tool_result_is_compressed_without_corrupting_source() {
+        let raw = (0..60)
+            .map(|i| {
+                format!(
+                    "src/h.go:{i}:func handler{i}(ctx context.Context) (api.Result, error) \
+                     {{ return doWork(ctx) }}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let out = compress_tool_result(&raw, Some("search_files"));
+
+        assert!(
+            out.len() < raw.len(),
+            "search results must still compress ({} -> {})",
+            raw.len(),
+            out.len()
+        );
+        for keyword in ["context.Context", "(api.Result, error)", "return"] {
+            assert!(
+                out.contains(keyword),
+                "the terse dictionary rewrote `{keyword}` out of a search result:\n{out}"
+            );
+        }
+    }
+
     #[test]
     fn short_content_unchanged() {
         let short = "hello world";

--- a/rust/src/proxy/google.rs
+++ b/rust/src/proxy/google.rs
@@ -255,8 +255,15 @@ mod tests {
         // to the shared engine, so its output matches the name-routed engine
         // byte-for-byte (the contract that distinguishes this from `None`).
         // `infer_command`'s use of the name is unit-tested in `compress.rs`.
+        // #980: matches share one file so the `patterns::grep` compressor —
+        // which wins by grouping and capping matches *per file* — can shrink
+        // them. Each match previously had its own file, a shape only the generic
+        // terse pipeline could shrink, and that pipeline is exactly what must
+        // never see source lines. The routing contract under test is unchanged;
+        // `search_tool_result_is_compressed_without_corrupting_source` in
+        // `proxy::compress` covers the content side.
         let raw = (0..60)
-            .map(|i| format!("src/file_{i}.rs:{i}:    let matched = find(foo, bar, baz);"))
+            .map(|i| format!("src/matches.rs:{i}:    let matched = find(foo, bar, baz);"))
             .collect::<Vec<_>>()
             .join("\n");
         let routed = compress_tool_result(&raw, Some("search_files"));

--- a/rust/src/shell/compress/classification.rs
+++ b/rust/src/shell/compress/classification.rs
@@ -74,7 +74,39 @@ pub fn has_structural_output(command: &str) -> bool {
     if is_standalone_diff_command(command) {
         return true;
     }
+    if is_source_search(command) {
+        return true;
+    }
     is_structural_git_command(command)
+}
+
+/// Grep-family searches, whose matched lines are verbatim source (#980).
+///
+/// Structural rather than verbatim, deliberately. `patterns::grep` groups
+/// matches by file and caps them per file **without touching line content**, so
+/// this tier keeps search output compressed *and* keeps it away from the terse
+/// dictionary (`error`→`err`, `return`→`ret`, `context.Context`→`ctx.Context`).
+///
+/// This is the one route that serves both callers. The proxy's `infer_command`
+/// synthesises a bare `grep` from any tool named `*search*`/`*grep*`/`*find*`:
+/// classifying grep verbatim strands those results with no compression, while
+/// exempting the bare form from verbatim strands them in the terse pipeline and
+/// corrupts them. Structural serves both, so the classification never has to
+/// discriminate on argument count.
+///
+/// Segment-aware for the same reason [`is_verbatim_compound_tail`] is: a
+/// `cd /repo && grep …` must classify on the segment that produces stdout.
+fn is_source_search(command: &str) -> bool {
+    command
+        .split(['&', '|', ';'])
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .any(|segment| {
+            matches!(
+                first_binary(segment),
+                "grep" | "egrep" | "fgrep" | "rg" | "ag" | "ack" | "ugrep" | "sift"
+            )
+        })
 }
 
 /// Returns true for commands where the output IS the purpose of the command.
@@ -231,12 +263,12 @@ fn is_file_viewer(command: &str) -> bool {
     let first = first_binary(command);
     match first {
         "cat" | "bat" | "batcat" | "pygmentize" | "highlight" => true,
-        // #980: grep-family output is source code / structured search results.
-        // Guard: a bare `"grep"` (no arguments) arrives from the proxy's
-        // `infer_command` for tool names like `search_files` — these proxy
-        // payloads benefit from structural compression, so only match when the
-        // command carries at least one argument (a real shell invocation).
-        "grep" | "rg" | "ag" | "ack" | "sift" => command.split_whitespace().count() > 1,
+        // #980: grep-family is deliberately NOT here. It routes to
+        // `has_structural_output` via `is_source_search`, which keeps the
+        // dedicated `patterns::grep` compressor (dictionary-free) for *both* the
+        // bare `grep` the proxy's `infer_command` synthesises and a real
+        // `grep -rn pattern src/`. Both forms then compress and neither reaches
+        // the terse dictionary, so no argument-count discrimination is needed.
         "head" | "tail" => !command.contains("-f") && !command.contains("--follow"),
         // sed/awk are commonly used as range/pattern file viewers
         // (`sed -n '10,50p' file`, `awk '{print}' file`, GH #688). Their stdout
@@ -926,10 +958,27 @@ mod verbatim_classification_tests {
 
     // #980: grep-family must be classified as verbatim.
     #[test]
-    fn grep_is_verbatim() {
-        assert!(is_verbatim_output("grep -rn 'fn main' src/"));
-        assert!(is_verbatim_output("rg 'TODO' --type rust"));
-        assert!(is_verbatim_output("ag 'pattern' src/"));
+    fn grep_is_structural_not_terse() {
+        // Structural, not verbatim: `patterns::grep` compresses the matches
+        // without touching line content, so both halves hold — the dictionary
+        // never sees source, and search output still shrinks. The bare form is
+        // included because that is what the proxy's `infer_command` produces,
+        // and it must take the same route as a real invocation.
+        for cmd in [
+            "grep -rn 'fn main' src/",
+            "rg 'TODO' --type rust",
+            "ag 'pattern' src/",
+            "grep",
+        ] {
+            assert!(
+                has_structural_output(cmd),
+                "'{cmd}' must be structural so the dictionary never sees source lines"
+            );
+            assert!(
+                !is_verbatim_output(cmd),
+                "'{cmd}' must stay compressible via patterns::grep"
+            );
+        }
     }
 
     // #980: `cd /repo && cat file` — last compound segment is a file viewer.
@@ -942,8 +991,9 @@ mod verbatim_classification_tests {
     }
 
     #[test]
-    fn compound_cd_then_grep_is_verbatim() {
-        assert!(is_verbatim_output("cd /repo && grep -n 'error' log.txt"));
+    fn compound_cd_then_grep_is_structural() {
+        assert!(has_structural_output("cd /repo && grep -n 'error' log.txt"));
+        assert!(has_structural_output("cat file.go | grep func"));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to `5288c8b64` (#980). That commit fixed the corruption — Repro A and B are both clean on `main`. This addresses two things it left behind. Details and measurements in [this comment](https://github.com/yvgude/lean-ctx/issues/980#issuecomment-5001787345).

Supersedes #983, which predated your fix and conflicted; closing that one.

## 1. `main` is red right now

`proxy::google::tests::recent_response_routes_tool_name_to_compressor` fails deterministically, in isolation — not a flake:

| commit | result |
|---|---|
| `c88130885` (`5288c8b64~1`) | ok |
| `5288c8b64` | **FAILED** — `fixture must be compressible` |

CI hasn't flagged it yet: the run on `5288c8b64` was **cancelled** (superseded), and the run on `04fb85eb8` is still `in_progress`. The `success` currently visible on `main` is the *Security Check* workflow, not CI.

## 2. Search results stopped compressing

`proxy::compress::infer_command` synthesises the **bare** command `grep` from any tool named `*search*`/`*grep*`/`*find*`. With grep in `is_file_viewer`, that is `is_verbatim_output` → `truncate_verbatim` → no compression — for every search-type tool result flowing through the proxy, not just this shell's.

Measured, 60 matches in one file:

| | bytes | content |
|---|---|---|
| raw | 5923 | correct |
| 3.9.11 (before your fix) | 898 | **corrupted** — `ctx ctx.ctx) (api.Result, err) { ret … }` |
| `main` (grep verbatim) | 5923 | correct, **0% compression** |
| **this branch** | **1029** | **correct** |

## The fix: structural, not verbatim

grep belongs in the middle tier:

| tier | treatment |
|---|---|
| `is_verbatim_output` | no compression at all |
| `has_structural_output` | dedicated pattern compressor — **never** the dictionary |
| everything else | generic terse pipeline ← the corruption |

`patterns::grep` groups matches per file and caps them **without touching line content** — it is already dictionary-free. So the middle tier keeps the compression *and* keeps the dictionary away from source. Verbatim was the blunter instrument, and its cost was the whole saving.

Verified on this branch (`grep -rn` over 60 Go functions):

```
60 matches in 1F:
src/matches.go (60):
  3: func handler0(ctx context.Context) (api.Result, error) { return doWork(ctx) }
      ↑ grouped/compressed        ↑ context.Context, error, return all intact
```

`cd /repo && cat file.yaml` remains byte-exact. Your `is_verbatim_compound_tail` is kept as-is.

## Also fixes the reason the proxy corrupted search results at all

`patterns::grep`'s matcher required a trailing space:

```rust
|c| c.starts_with("grep ") || c.starts_with("rg "),
```

so the bare `grep` from `infer_command` never reached the grep compressor and fell through to the terse pipeline — even before #980. That is a latent bug with a wider blast radius than #980 describes: **the proxy has been corrupting every proxied agent's search results**, not only this shell's output. Now matched on the first token, bare or with args.

## The fixture change, which deserves scrutiny

`proxy::google`'s fixture put each of its 60 matches in its **own** file — a shape `patterns::grep` cannot shrink, because it wins by grouping *per file*. It was passing precisely because the corrupting path compressed it. The matches now share one file; the routing contract it asserts (tool name → shared engine, byte-for-byte) is untouched.

Honest trade: scattered one-match-per-file searches now compress less than they did in 3.9.11, because the only thing that shrank them was the dictionary. Corrupted source is worse than larger output.

## Two tests changed

`grep_is_verbatim` → `grep_is_structural_not_terse`, and `compound_cd_then_grep_is_verbatim` → `compound_cd_then_grep_is_structural`. Your intent — the dictionary must never see grep output — is preserved and now asserted from both sides (`has_structural_output` true, `is_verbatim_output` false, so it stays compressible). If you'd rather keep verbatim and fix the fixture instead, say so and I'll close this; the red test still needs one of the two.

## Verification

- 924 tests pass across `shell::compress`, `proxy::`, `core::patterns`; the red test on `main` is green.
- Repros re-verified end-to-end against the built binary.
- `cargo fmt` and `cargo clippy --lib --all-features -- -D warnings` clean.

One measurement note that cost me an hour: compression only engages on **stdout**. Redirecting a before/after comparison to a file suppresses it and makes both binaries look identical.

## Still open

The dictionary remains unsafe on any text that might be source — `GENERAL`'s `error`/`return`/`context`/`function` are the same hazard class `BPE_ALIGNED_RULES` already documents removals for. This fixes routing, not that default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
