### PR TITLE
fix(memory): preserve items when reclaim archive fails

### DIFF
--- a/rust/src/core/cognition_loop.rs
+++ b/rust/src/core/cognition_loop.rs
@@ -120,8 +120,9 @@ pub fn run_cognition_loop(project_root: &str, max_steps: u8) -> CognitionLoopRep
         }
 
         if max_steps >= 8 {
-            let lifecycle = knowledge.run_memory_lifecycle(&policy);
-            report.facts_archived = lifecycle.archived_count as u32;
+            if let Ok(lifecycle) = knowledge.run_memory_lifecycle(&policy) {
+                report.facts_archived = lifecycle.archived_count as u32;
+            }
             // Step 8b (#3): complementary-learning-systems consolidation lifts the
             // confidence of related, frequently-retrieved facts.
             report.facts_consolidated = step_replay_consolidation(knowledge);

--- a/rust/src/core/knowledge/core.rs
+++ b/rust/src/core/knowledge/core.rs
@@ -12,7 +12,7 @@ impl ProjectKnowledge {
     pub fn run_memory_lifecycle(
         &mut self,
         policy: &MemoryPolicy,
-    ) -> crate::core::memory_lifecycle::LifecycleReport {
+    ) -> Result<crate::core::memory_lifecycle::LifecycleReport, String> {
         let cfg = crate::core::memory_lifecycle::LifecycleConfig::from_policy(policy);
         crate::core::memory_lifecycle::run_lifecycle(&mut self.facts, &cfg)
     }
@@ -353,7 +353,7 @@ impl ProjectKnowledge {
         // Lossless capacity reclaim (#995): keep the newest patterns and archive
         // the rest. The previous `truncate` kept the *oldest* patterns (it dropped
         // the just-pushed one once at the cap) and lost them permanently.
-        crate::core::memory_capacity::reclaim_store(
+        if let Err(error) = crate::core::memory_capacity::reclaim_store(
             crate::core::memory_archive::MemoryStore::Patterns,
             Some(&self.project_hash),
             &mut self.patterns,
@@ -366,7 +366,9 @@ impl ProjectKnowledge {
                     .then_with(|| a.pattern_type.cmp(&b.pattern_type))
                     .then_with(|| a.description.cmp(&b.description))
             },
-        );
+        ) {
+            tracing::warn!(%error, "pattern capacity reclaim failed");
+        }
         self.updated_at = Utc::now();
     }
 

--- a/rust/src/core/knowledge/format.rs
+++ b/rust/src/core/knowledge/format.rs
@@ -5,13 +5,13 @@ use crate::core::memory_policy::MemoryPolicy;
 impl ProjectKnowledge {
     /// Record one consolidated insight, then losslessly reclaim history to its
     /// capacity headroom. Returns the number of older insights archived (0 when
-    /// under cap). Was a hard `drain` that dropped old history permanently (#995).
+    /// under cap).
     pub fn consolidate(
         &mut self,
         summary: &str,
         session_ids: Vec<String>,
         policy: &MemoryPolicy,
-    ) -> usize {
+    ) -> Result<usize, String> {
         self.history.push(ConsolidatedInsight {
             summary: summary.to_string(),
             from_sessions: session_ids,
@@ -30,9 +30,9 @@ impl ProjectKnowledge {
                     .cmp(&a.timestamp)
                     .then_with(|| b.summary.cmp(&a.summary))
             },
-        );
+        )?;
         self.updated_at = chrono::Utc::now();
-        archived.len()
+        Ok(archived.len())
     }
 
     pub fn format_summary(&self) -> String {

--- a/rust/src/core/knowledge/mod.rs
+++ b/rust/src/core/knowledge/mod.rs
@@ -462,7 +462,8 @@ mod tests {
             "Migrated from REST to GraphQL",
             vec!["s1".into(), "s2".into()],
             &policy,
-        );
+        )
+        .expect("consolidation succeeds");
         assert_eq!(k.history.len(), 1);
         assert_eq!(k.history[0].from_sessions.len(), 2);
     }

--- a/rust/src/core/memory_capacity.rs
+++ b/rust/src/core/memory_capacity.rs
@@ -46,7 +46,8 @@ pub fn reclaim_preview(len: usize, max: usize, headroom_pct: f32, enabled: bool)
 /// archive + drop the tail down to [`reclaim_target`]. The dropped items are
 /// archived under `store`/`scope` *before* removal, so the reclaim is lossless
 /// and restorable. Returns the archived items. No-op when disabled, under cap,
-/// or `max == 0`.
+/// or `max == 0`. If persistence fails, returns the error and leaves `items`
+/// unchanged.
 pub fn reclaim_store<T, F>(
     store: MemoryStore,
     scope: Option<&str>,
@@ -55,40 +56,41 @@ pub fn reclaim_store<T, F>(
     headroom_pct: f32,
     enabled: bool,
     mut retention_cmp: F,
-) -> Vec<T>
+) -> Result<Vec<T>, String>
 where
     T: Serialize,
     F: FnMut(&T, &T) -> Ordering,
 {
     if !should_reclaim(items.len(), max, enabled) {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let target = reclaim_target(max, headroom_pct);
     let drop_count = items.len().saturating_sub(target);
     if drop_count == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     // Rank a copy of the indices by retention (best-kept first); the worst
-    // `drop_count` are evicted. Order-preserving: only the chosen indices are
-    // removed, so the kept items keep their original relative order and a reclaim
-    // never reshuffles the live store as a side effect. `sort_by` is stable, so
-    // ties resolve to original order for deterministic eviction.
+    // `drop_count` are evicted. `sort_by` is stable, so ties resolve to original
+    // order for deterministic eviction.
     let mut ranked: Vec<usize> = (0..items.len()).collect();
     ranked.sort_by(|&a, &b| retention_cmp(&items[a], &items[b]));
     let mut evict: Vec<usize> = ranked[target..].to_vec();
     evict.sort_unstable();
 
+    // Persist borrowed candidates before mutating the live store. Serializing
+    // references avoids requiring `T: Clone` while preserving archive order.
+    let candidates: Vec<&T> = evict.iter().map(|&idx| &items[idx]).collect();
+    archive_items(store, scope, &candidates, &ArchiveConfig::from_env())?;
+
+    // Order-preserving: only chosen indices are removed, so retained items keep
+    // their original relative order. Reverse removal avoids index shifts.
     let mut archived: Vec<T> = Vec::with_capacity(evict.len());
     for &idx in evict.iter().rev() {
         archived.push(items.remove(idx));
     }
-    archived.reverse(); // restore original order for the archived payload
-
-    if !archived.is_empty() {
-        let _ = archive_items(store, scope, &archived, &ArchiveConfig::from_env());
-    }
-    archived
+    archived.reverse();
+    Ok(archived)
 }
 
 #[cfg(test)]
@@ -164,7 +166,8 @@ mod tests {
                 0.25,
                 true,
                 |a, b| a.rank.cmp(&b.rank),
-            );
+            )
+            .expect("reclaim succeeds");
             // 8 -> keep 6, archive 2.
             assert_eq!(items.len(), 6);
             assert_eq!(archived.len(), 2);
@@ -192,7 +195,8 @@ mod tests {
                 0.25,
                 true,
                 |a, b| a.rank.cmp(&b.rank),
-            );
+            )
+            .expect("reclaim succeeds");
             assert!(archived.is_empty());
             assert_eq!(items.len(), 3);
         });
@@ -210,7 +214,8 @@ mod tests {
                 0.25,
                 false,
                 |a, b| a.rank.cmp(&b.rank),
-            );
+            )
+            .expect("reclaim succeeds");
             assert!(archived.is_empty());
             assert_eq!(
                 items.len(),
@@ -218,5 +223,34 @@ mod tests {
                 "disabled reclaim leaves the store untouched"
             );
         });
+    }
+
+    #[test]
+    fn reclaim_store_preserves_items_when_archive_persistence_fails() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let path = std::env::temp_dir().join(format!(
+            "lctx-capacity-file-{}-{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+        std::fs::write(&path, b"not a directory").expect("create blocking file");
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", path.to_str().unwrap());
+
+        let mut items: Vec<Item> = (0..8).map(|rank| Item { rank }).collect();
+        let original = items.clone();
+        let result = reclaim_store(
+            MemoryStore::Patterns,
+            Some("p"),
+            &mut items,
+            8,
+            0.25,
+            true,
+            |a, b| a.rank.cmp(&b.rank),
+        );
+
+        crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_err(), "archive persistence must fail");
+        assert_eq!(items, original, "failed reclaim must not mutate live items");
     }
 }

--- a/rust/src/core/memory_lifecycle.rs
+++ b/rust/src/core/memory_lifecycle.rs
@@ -559,7 +559,10 @@ fn truncate_chars(s: &str, max: usize) -> String {
     out
 }
 
-pub fn run_lifecycle(facts: &mut Vec<KnowledgeFact>, config: &LifecycleConfig) -> LifecycleReport {
+pub fn run_lifecycle(
+    facts: &mut Vec<KnowledgeFact>,
+    config: &LifecycleConfig,
+) -> Result<LifecycleReport, String> {
     let decayed = apply_confidence_decay(facts, config);
     let consolidated = consolidate_similar(facts, config.consolidation_similarity);
     let (compacted, archived) = compact(facts, config);
@@ -583,17 +586,17 @@ pub fn run_lifecycle(facts: &mut Vec<KnowledgeFact>, config: &LifecycleConfig) -
                 .cmp(&a.is_current())
                 .then_with(|| sort_fact_for_output(a, b))
         },
-    )
+    )?
     .len();
 
-    LifecycleReport {
+    Ok(LifecycleReport {
         decayed_count: decayed,
         consolidated_count: consolidated,
         archived_count: archived.len() + capacity_archived,
         compacted_count: compacted + capacity_archived,
         capacity_archived,
         remaining_facts: facts.len(),
-    }
+    })
 }
 
 /// Archive evicted facts (lossless). Facts keep the legacy global archive root
@@ -937,7 +940,7 @@ mod tests {
                 .map(|i| make_fact("finding", &format!("k{i}"), &format!("value {i}"), 0.8))
                 .collect();
 
-            let report = run_lifecycle(&mut facts, &config);
+            let report = run_lifecycle(&mut facts, &config).expect("lifecycle succeeds");
 
             // Hysteresis: at cap (8) → settle to headroom target (6), archive 2.
             assert_eq!(report.capacity_archived, 2);
@@ -961,7 +964,7 @@ mod tests {
             let low = make_fact("misc", "drop-low", "low salience", 0.6);
             let mut facts = vec![old, low, finding, decision];
 
-            let report = run_lifecycle(&mut facts, &config);
+            let report = run_lifecycle(&mut facts, &config).expect("lifecycle succeeds");
             let keys: Vec<&str> = facts.iter().map(|f| f.key.as_str()).collect();
 
             // 4 at cap → settle to 3; the expired fact sorts last (not current) and
@@ -1044,7 +1047,7 @@ mod tests {
             make_fact("ops", "deploy", "docker compose", 0.7),
         ];
 
-        let report = run_lifecycle(&mut facts, &config);
+        let report = run_lifecycle(&mut facts, &config).expect("lifecycle succeeds");
         assert!(report.remaining_facts <= config.max_facts);
         assert!(report.decayed_count > 0 || report.compacted_count > 0);
     }

--- a/rust/src/core/procedural_memory.rs
+++ b/rust/src/core/procedural_memory.rs
@@ -131,7 +131,7 @@ impl ProceduralStore {
         // always lossless (procedure eviction was already unconditional — it just
         // used to lose the dropped procedures). Same `retention_cmp` as the
         // consolidation capacity pass, so ranking is identical everywhere.
-        crate::core::memory_capacity::reclaim_store(
+        if let Err(error) = crate::core::memory_capacity::reclaim_store(
             crate::core::memory_archive::MemoryStore::Procedures,
             Some(&self.project_hash),
             &mut self.procedures,
@@ -139,7 +139,9 @@ impl ProceduralStore {
             crate::core::memory_lifecycle::DEFAULT_RECLAIM_HEADROOM_PCT,
             true,
             retention_cmp,
-        );
+        ) {
+            tracing::warn!(%error, "procedure capacity reclaim failed");
+        }
     }
 
     pub fn detect_patterns(&mut self, episodes: &[Episode], policy: &ProceduralPolicy) {

--- a/rust/src/tools/ctx_knowledge/consolidate.rs
+++ b/rust/src/tools/ctx_knowledge/consolidate.rs
@@ -146,11 +146,11 @@ fn run_consolidation_locked(
             s.id, task_desc, imported.findings, imported.decisions
         );
         // `consolidate` records the insight and losslessly reclaims history.
-        history_compacted += knowledge.consolidate(&summary, vec![s.id.clone()], policy);
+        history_compacted += knowledge.consolidate(&summary, vec![s.id.clone()], policy)?;
     }
 
     let lifecycle = if opts.run_lifecycle {
-        knowledge.run_memory_lifecycle(policy)
+        knowledge.run_memory_lifecycle(policy)?
     } else {
         LifecycleReport::default()
     };
@@ -160,8 +160,8 @@ fn run_consolidation_locked(
     // also compacts a pre-existing over-cap history when no session was imported.
     let mut patterns_compacted = 0usize;
     if opts.reclaim_stores {
-        patterns_compacted = reclaim_patterns(knowledge, policy);
-        history_compacted += reclaim_history(knowledge, policy);
+        patterns_compacted = reclaim_patterns(knowledge, policy)?;
+        history_compacted += reclaim_history(knowledge, policy)?;
     }
     let (procedures, procedure_capacity_target, procedures_compacted) = if opts.reclaim_stores {
         reclaim_procedures(&knowledge.project_hash, policy)?
@@ -307,7 +307,10 @@ fn has_new_session_items(session: &SessionState, watermark: Option<DateTime<Utc>
 }
 
 /// Lossless history capacity reclaim. Returns the number of insights archived.
-fn reclaim_history(knowledge: &mut ProjectKnowledge, policy: &MemoryPolicy) -> usize {
+fn reclaim_history(
+    knowledge: &mut ProjectKnowledge,
+    policy: &MemoryPolicy,
+) -> Result<usize, String> {
     reclaim_store(
         MemoryStore::History,
         Some(&knowledge.project_hash),
@@ -321,11 +324,14 @@ fn reclaim_history(knowledge: &mut ProjectKnowledge, policy: &MemoryPolicy) -> u
                 .then_with(|| b.summary.cmp(&a.summary))
         },
     )
-    .len()
+    .map(|archived| archived.len())
 }
 
 /// Lossless pattern capacity reclaim (newest kept). Returns the archived count.
-fn reclaim_patterns(knowledge: &mut ProjectKnowledge, policy: &MemoryPolicy) -> usize {
+fn reclaim_patterns(
+    knowledge: &mut ProjectKnowledge,
+    policy: &MemoryPolicy,
+) -> Result<usize, String> {
     reclaim_store(
         MemoryStore::Patterns,
         Some(&knowledge.project_hash),
@@ -340,7 +346,7 @@ fn reclaim_patterns(knowledge: &mut ProjectKnowledge, policy: &MemoryPolicy) -> 
                 .then_with(|| a.description.cmp(&b.description))
         },
     )
-    .len()
+    .map(|archived| archived.len())
 }
 
 /// Lossless procedure capacity reclaim. Returns `(remaining, target, archived)`.
@@ -364,6 +370,7 @@ fn reclaim_procedures(
         policy.lifecycle.reclaim_enabled,
         retention_cmp,
     );
+    let archived = archived?;
     let compacted = archived.len();
     if compacted > 0 {
         store


### PR DESCRIPTION
## Summary
- persist reclaim candidates before removing them from live memory stores
- propagate archive failures through lifecycle and consolidation paths
- preserve live item order and contents when archive persistence fails

## Tests
- `cargo test core::memory_capacity::tests --lib`
- `cargo test core::memory_lifecycle --lib`
- `cargo check --all-targets`
- `scripts/preflight.sh fast`

Fixes #990