### PR TITLE
fix(shell): skip tee spill + banner when compression elided nothing (#992)

### DIFF
--- a/rust/src/shell/tee_policy.rs
+++ b/rust/src/shell/tee_policy.rs
@@ -16,12 +16,13 @@ use crate::core::config::TeeMode;
 ///
 /// - `Never` never tees.
 /// - `Always` tees any non-blank output.
-/// - `Failures` tees exactly when the command failed (`exit_code != 0`).
+/// - `Failures` tees when the command failed (`exit_code != 0`) **and**
+///   compression actually elided something.
 /// - `HighCompression` (the default) is a *superset* of `Failures`: it tees on
-///   failure **and** when compression removed >70% of a sizable output. As the
-///   default it guarantees the MCP-free recovery path — a real raw file — exists
-///   for both the cases an agent actually re-reads: failures and heavily-digested
-///   successful runs.
+///   an elided failure **and** when compression removed >70% of a sizable
+///   output. As the default it guarantees the MCP-free recovery path — a real
+///   raw file — exists for both the cases an agent actually re-reads: failures
+///   and heavily-digested successful runs.
 pub(crate) fn should_tee(
     mode: &TeeMode,
     exit_code: i32,
@@ -32,12 +33,20 @@ pub(crate) fn should_tee(
     if blank_output {
         return false;
     }
+    // #992: compression removed nothing → the inline output *is* the full
+    // output. Teeing writes a byte-identical file and hangs a recovery banner
+    // on it that points at nothing; agents read "full output at …" as
+    // truncation and burn a round trip retrieving bytes they already hold.
+    // Every eliding path in the compressor is gated on a strictly lower token
+    // count, so "no savings" implies "nothing elided" — a sound gate, not a
+    // heuristic.
+    let elided = compressed_tokens < original_tokens;
     match mode {
         TeeMode::Never => false,
         TeeMode::Always => true,
-        TeeMode::Failures => exit_code != 0,
+        TeeMode::Failures => exit_code != 0 && elided,
         TeeMode::HighCompression => {
-            exit_code != 0
+            (exit_code != 0 && elided)
                 || (original_tokens > 100 && savings_pct(original_tokens, compressed_tokens) > 70.0)
         }
     }
@@ -71,13 +80,32 @@ mod tests {
     #[test]
     fn failures_mode_is_exit_code_based_not_substring() {
         // A non-zero exit tees regardless of how terse / non-"error" the text is
-        // (the old substring gate missed `fatal:`, `permission denied`, …).
-        assert!(should_tee(&TeeMode::Failures, 1, false, 5, 5));
-        assert!(should_tee(&TeeMode::Failures, 127, false, 5, 5));
+        // (the old substring gate missed `fatal:`, `permission denied`, …) — as
+        // long as compression actually elided something worth recovering.
+        assert!(should_tee(&TeeMode::Failures, 1, false, 500, 50));
+        assert!(should_tee(&TeeMode::Failures, 127, false, 500, 50));
         // Success never tees, even with large output.
         assert!(!should_tee(&TeeMode::Failures, 0, false, 9999, 10));
         // A blank failure has nothing worth saving.
         assert!(!should_tee(&TeeMode::Failures, 1, true, 0, 0));
+    }
+
+    /// #992: a failure whose output was not compressed at all is already inline
+    /// in full. Teeing it would write a byte-identical file and point a
+    /// "full output at …" banner at content the agent already has — which reads
+    /// as truncation and provokes a wasted recovery round trip.
+    #[test]
+    fn failure_without_elision_does_not_tee() {
+        // The reported repro: `echo hi; grep -q zzzznotfound /etc/hosts` — 0%
+        // compression, exit 1, complete output inline.
+        assert!(!should_tee(&TeeMode::Failures, 1, false, 5, 5));
+        assert!(!should_tee(&TeeMode::HighCompression, 1, false, 5, 5));
+        // Compression that *grew* the output (framing/markers) elided nothing.
+        assert!(!should_tee(&TeeMode::Failures, 1, false, 5, 9));
+        assert!(!should_tee(&TeeMode::HighCompression, 127, false, 5, 9));
+        // `Always` is an explicit operator opt-in to archive everything, so it
+        // still tees — the 0% gate is about not lying, not about never saving.
+        assert!(should_tee(&TeeMode::Always, 1, false, 5, 5));
     }
 
     #[test]
@@ -92,11 +120,11 @@ mod tests {
 
     #[test]
     fn high_compression_is_a_superset_of_failures() {
-        // As the default tee mode, HighCompression must still tee failures (so the
-        // raw-file recovery path exists for them) even when output is tiny and
-        // barely compressed — exactly the case `Failures` covered before.
-        assert!(should_tee(&TeeMode::HighCompression, 1, false, 5, 5));
-        assert!(should_tee(&TeeMode::HighCompression, 127, false, 5, 5));
+        // As the default tee mode, HighCompression must still tee elided
+        // failures (so the raw-file recovery path exists for them) even when the
+        // output is small — exactly the case `Failures` covered before.
+        assert!(should_tee(&TeeMode::HighCompression, 1, false, 500, 50));
+        assert!(should_tee(&TeeMode::HighCompression, 127, false, 500, 50));
         // A blank failure still has nothing worth saving.
         assert!(!should_tee(&TeeMode::HighCompression, 1, true, 0, 0));
     }


### PR DESCRIPTION
Fixes #992.

## Problem

On a non-zero exit, `ctx_shell` teed the full output and appended a recovery banner **even at 0% compression** — when the inline output already *is* the full output. The banner (`full output at …`) is the same phrasing used for genuinely spilled output, so an agent reads inline output as truncated and burns a round trip recovering bytes it already holds.

Repro (from the issue, verified on 3.9.11):

```
ctx_shell(command: "echo hi; grep -q zzzznotfound /etc/hosts")
→ [compressed 0%: full output at …/tee/…log — read it directly …]
```

The tee file is 3 bytes (`hi\n`) — byte-identical to the inline output.

## Fix

Gate the tee on compression actually eliding something. `should_tee` (the SSOT both the CLI and MCP paths call) gains `elided = compressed_tokens < original_tokens`; the `Failures` arm and the failure arm of `HighCompression` now require it.

Every eliding path in the compressor returns only when the token count strictly drops, so "no savings" implies "nothing elided" — a sound gate, not a heuristic. `Always` still tees (explicit archive-everything opt-in); the >70% successful-run path is unchanged.

## Scope

The spill *decision* only. Killing the spill removes the repro entirely. The `read it directly (no MCP)` wording being unfollowable under the shipped `Read`-deny config is #987-class and left separate, as the issue suggests.

## Tests

`cargo test --lib tee_policy` → 8 passed. New `failure_without_elision_does_not_tee` covers the repro plus the `Always` opt-in still teeing; the two tests that encoded the old "tee any failure" contract were updated to elided sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)