### PR TITLE
fix(shell): allowlist pgrep + read-only process inspection and cleanup (#996)

### DIFF
--- a/rust/src/core/config/defaults_allowlist.rs
+++ b/rust/src/core/config/defaults_allowlist.rs
@@ -132,6 +132,15 @@ pub(crate) fn default_shell_allowlist() -> Vec<String> {
         "du",
         "df",
         "ps",
+        // #996: read-only process/system inspection — same safety class as
+        // the `ps`/`lsof` above (print state, mutate nothing). `pgrep`/`pidof`
+        // filter what `ps` already exposes; `nproc` drives `make -j$(nproc)`.
+        "pgrep",
+        "pidof",
+        "pstree",
+        "nproc",
+        "uptime",
+        "free",
         "lsof",
         "watch",
         "tee",
@@ -317,6 +326,22 @@ mod tests {
     fn c_and_cpp_compilers_are_in_the_default_allowlist() {
         let defaults = default_shell_allowlist();
         for tool in ["gcc", "cc", "clang", "g++", "c++", "clang++"] {
+            assert!(
+                defaults.contains(&tool.to_string()),
+                "{tool} must be in the default allowlist"
+            );
+        }
+    }
+
+    // #996: `pgrep` and its read-only inspection siblings are the same safety
+    // class as the already-defaulted `ps`/`lsof` (print state, mutate nothing).
+    // Process-signalling (kill/pkill) is intentionally NOT defaulted — it needs
+    // session-ownership scoping the allowlist can't express (per-binary, not
+    // per-target-PID), so it stays behind explicit opt-in.
+    #[test]
+    fn process_inspection_in_default_allowlist() {
+        let defaults = default_shell_allowlist();
+        for tool in ["pgrep", "pidof", "pstree", "nproc", "uptime", "free"] {
             assert!(
                 defaults.contains(&tool.to_string()),
                 "{tool} must be in the default allowlist"


### PR DESCRIPTION
Fixes #996.

## Problem

The default allowlist (`core/config/defaults_allowlist.rs`) already permits `ps`, `lsof`, `du`, `df`, `uname`, `id`, `whoami` — read-only system/process inspection — but `pgrep` is missing, so a routine "is this process still running?" check is rejected and needs an explicit `lean-ctx allow pgrep`. Hit organically while checking whether a runaway background `cargo` had been killed.

## Change

Add the missing **read-only** siblings (zero mutation, same class as `ps`/`lsof`):
`pgrep`, `pidof`, `pstree`, `nproc`, `uptime`, `free`.

Process-signalling (`kill`/`pkill`/`killall`) was in the first draft but is **dropped** per review: it needs session-ownership scoping the per-binary allowlist can't express (per-binary, not per-target-PID), so it stays behind explicit opt-in.

Interactive monitors (`top`/`htop`) excluded — not scriptable, interactive flags gated anyway. Verified `UNCONDITIONAL_BLOCKED` (`eval`/`exec`/`source`/`.`) is unaffected, so none of these bypass the dangerous-pattern gate.

## Tests

`cargo test --lib defaults_allowlist` → 5 passed. New `process_inspection_in_default_allowlist` asserts the six read-only tools are present; existing `no_duplicates` / `cloud_infra_tools_are_not_in_the_default_allowlist` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)