### PR TITLE
fix(ctx_patch): trim description back under the 160-token per-tool ceiling

### DIFF
--- a/rust/src/tools/registered/ctx_patch.rs
+++ b/rust/src/tools/registered/ctx_patch.rs
@@ -27,7 +27,7 @@ impl McpTool for CtxPatchTool {
              set_line(path, line, hash, new_text) | insert_after(path, line, hash, new_text) | delete(path, line, hash).\n\
              replace_symbol(path, name, new_body) | create(path, new_text) | replace_all(path, find, replace, dry_run?).\n\
              Batch: ops:[{op, path, ...}] — not replace_symbol/replace_all.\n\
-             CONFLICT = stale anchors, re-read. NEVER patch by line number alone (no hash → error).",
+             CONFLICT = stale anchors, re-read. NEVER patch by line number alone.",
             json!({
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Problem

`main` is red. #942 reworded the `ctx_patch` tool description ("clearer patch description"), pushing it to **161 tokens** — over the 160-token per-tool ceiling that `tests/intensive_benchmarks.rs::bench_tool_descriptions_token_count` enforces:

```
tests/intensive_benchmarks.rs:173: Tool 'ctx_patch' description should be <160 tokens, got 161
```

The `Test` job on all three OS and the `Output-Quality Gate (eval A/B)` fail on this panic, so every open PR inherits a red base (surfaced while babysitting #994 / #998).

## Fix

Drop the redundant `(no hash → error)` parenthetical from the final line of the description. The consequence it spells out is already implied by:

- the preceding `NEVER patch by line number alone`,
- `CONFLICT = stale anchors, re-read`, and
- the `line=42, hash=a1b2` example earlier in the same string.

Actual drops to ~155, restoring the per-#290 "a tool or two" slack over the ceiling. No behavior change — description text only.

## Test

`cargo test --test intensive_benchmarks bench_tool_descriptions_token_count` → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)