### PR TITLE
fix: model action-conditional requireds in ctx_callgraph/expand/graph/knowledge (#1008)

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -81,7 +81,7 @@ action=callers|callees symbol='fn' → every call site with file:line.
 action=trace from→to finds the path between two symbols (depth=N).
 For end-to-end flow understanding use ctx_compose FIRST.
 
-Parameters: `action`, `depth`, `file`, `from`, `symbol`, `to`
+Parameters: `action`*, `depth`, `file`, `from`, `symbol`, `to`
 
 ## `ctx_checkpoint`
 
@@ -339,7 +339,7 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
 action=gotcha trigger='X' resolution='Y' for known pitfalls.
 mode=semantic|exact for recall. category groups related facts.
 
-Parameters: `action`*, `as_of`, `category`, `confidence`, `dry_run`, `examples`, `format`, `key`, `limit`, `merge`, `mode`, `path`, `pattern_type`, `query`, `resolution`, `severity`, `store`, `trigger`, `value`
+Parameters: `action`*, `as_of`, `category`, `confidence`, `content`, `dry_run`, `examples`, `format`, `key`, `limit`, `merge`, `mode`, `path`, `pattern_type`, `query`, `resolution`, `severity`, `store`, `trigger`, `value`
 
 ## `ctx_ledger`
 

--- a/rust/src/tool_defs/mod.rs
+++ b/rust/src/tool_defs/mod.rs
@@ -112,6 +112,14 @@ pub fn normalize_for_strict_validators(schema: &mut Map<String, Value>) {
             }
         }
     }
+    // #1008: action-conditional requireds are expressed with `allOf` of
+    // `if`/`then`(/`else`) branches — recurse into those sub-schemas too so any
+    // nested object/array positions get the same strict-validator guarantees.
+    for keyword in ["if", "then", "else"] {
+        if let Some(Value::Object(sub)) = schema.get_mut(keyword) {
+            normalize_for_strict_validators(sub);
+        }
+    }
 }
 
 pub const CORE_TOOL_NAMES: &[&str] = &[

--- a/rust/src/tools/registered/ctx_callgraph.rs
+++ b/rust/src/tools/registered/ctx_callgraph.rs
@@ -31,7 +31,12 @@ impl McpTool for CtxCallgraphTool {
                     "depth": { "type": "integer", "minimum": 1, "maximum": 5 },
                     "from": { "type": "string" },
                     "to": { "type": "string" }
-                }
+                },
+                "required": ["action"],
+                "allOf": [
+                    { "if": { "properties": { "action": { "enum": ["callers", "callees", "risk"] } }, "required": ["action"] }, "then": { "required": ["symbol"] } },
+                    { "if": { "properties": { "action": { "const": "trace" } }, "required": ["action"] }, "then": { "required": ["from", "to"] } }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_expand.rs
+++ b/rust/src/tools/registered/ctx_expand.rs
@@ -33,7 +33,11 @@ impl McpTool for CtxExpandTool {
                     "json_path": { "type": "string", "description": "e.g. data.items.0" },
                     "query": { "type": "string" },
                     "session_id": { "type": "string" }
-                }
+                },
+                "allOf": [
+                    { "if": { "properties": { "action": { "const": "search_all" } }, "required": ["action"] }, "then": { "required": ["query"] } },
+                    { "if": { "not": { "properties": { "action": { "enum": ["list", "search_all"] } }, "required": ["action"] } }, "then": { "required": ["id"] } }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_graph.rs
+++ b/rust/src/tools/registered/ctx_graph.rs
@@ -39,7 +39,11 @@ impl McpTool for CtxGraphTool {
                     "since": { "type": "string", "description": "Git ref (default HEAD~1)" },
                     "project_root": { "type": "string" }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    { "if": { "properties": { "action": { "enum": ["related", "symbol", "impact", "neighbors", "explain", "path"] } }, "required": ["action"] }, "then": { "required": ["path"] } },
+                    { "if": { "properties": { "action": { "const": "path" } }, "required": ["action"] }, "then": { "required": ["path", "to"] } }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_knowledge.rs
+++ b/rust/src/tools/registered/ctx_knowledge.rs
@@ -37,6 +37,7 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
                     "category": { "type": "string", "description": "Fact category" },
                     "key": { "type": "string" },
                     "value": { "type": "string" },
+                    "content": { "type": "string", "description": "remember: alias for value" },
                     "query": { "type": "string", "description": "Query for recall/search/relate/restore" },
                     "mode": { "type": "string", "description": "auto|exact|semantic|hybrid" },
                     "as_of": { "type": "string", "description": "YYYY-MM-DD date filter" },
@@ -50,7 +51,13 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
                     "path": { "type": "string", "description": "export/import: bundle directory (OKF) or file path" },
                     "merge": { "type": "string", "description": "import: replace|append|skip-existing (default skip-existing)" }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    { "if": { "properties": { "action": { "const": "remember" } }, "required": ["action"] }, "then": { "required": ["category"], "anyOf": [{ "required": ["value"] }, { "required": ["content"] }] } },
+                    { "if": { "properties": { "action": { "const": "pattern" } }, "required": ["action"] }, "then": { "required": ["value"] } },
+                    { "if": { "properties": { "action": { "const": "search" } }, "required": ["action"] }, "then": { "required": ["query"] } },
+                    { "if": { "properties": { "action": { "const": "gotcha" } }, "required": ["action"] }, "then": { "required": ["trigger", "resolution"] } }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/mod.rs
+++ b/rust/src/tools/registered/mod.rs
@@ -81,6 +81,9 @@ pub mod ctx_workflow;
 pub mod plugin_tool;
 pub mod shell_alias;
 
+#[cfg(test)]
+mod schema_qa_tests;
+
 /// Resolve a relative path against session state (sync version).
 /// Must be called within `tokio::task::block_in_place`.
 pub(crate) fn resolve_path_sync(

--- a/rust/src/tools/registered/schema_qa_tests.rs
+++ b/rust/src/tools/registered/schema_qa_tests.rs
@@ -1,7 +1,7 @@
-//! #1008 schema QA: guards that action-driven `ctx_*` tools keep modelling
-//! their action-conditional `required` fields, so a dropped conditional fails CI.
+//! #1008 schema QA: compiles each action-driven tool's published JSONSchema and
+//! asserts it accepts good calls and rejects action-conditional bad ones.
 
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use super::ctx_callgraph::CtxCallgraphTool;
 use super::ctx_expand::CtxExpandTool;
@@ -9,103 +9,84 @@ use super::ctx_graph::CtxGraphTool;
 use super::ctx_knowledge::CtxKnowledgeTool;
 use crate::server::tool_trait::McpTool;
 
-fn schema_of(tool: &dyn McpTool) -> Value {
-    let def = tool.tool_def();
-    Value::Object((*def.input_schema).clone())
-}
-
-fn required(schema: &Value) -> Vec<String> {
-    schema
-        .get("required")
-        .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-        .unwrap_or_default()
-}
-
-/// Does an `allOf` branch select `action` (via `if.properties.action`
-/// const/enum) and require every field in `needs` (via `then.required`)?
-fn models_conditional(schema: &Value, action: &str, needs: &[&str]) -> bool {
-    let Some(branches) = schema.get("allOf").and_then(Value::as_array) else {
-        return false;
-    };
-    branches.iter().any(|b| {
-        let selects = b
-            .get("if")
-            .and_then(|i| i.get("properties"))
-            .and_then(|p| p.get("action"))
-            .is_some_and(|a| {
-                a.get("const").and_then(Value::as_str) == Some(action)
-                    || a.get("enum")
-                        .and_then(Value::as_array)
-                        .is_some_and(|e| e.iter().any(|x| x.as_str() == Some(action)))
-            });
-        if !selects {
-            return false;
-        }
-        let then_req: Vec<&str> = b
-            .get("then")
-            .and_then(|t| t.get("required"))
-            .and_then(Value::as_array)
-            .map(|a| a.iter().filter_map(Value::as_str).collect())
-            .unwrap_or_default();
-        needs.iter().all(|n| then_req.contains(n))
-    })
-}
-
-/// Any `allOf` branch whose `then.required` contains `field` — for the
-/// `ctx_expand` default-retrieve rule, which selects via `if.not`.
-fn some_then_requires(schema: &Value, field: &str) -> bool {
-    schema
-        .get("allOf")
-        .and_then(Value::as_array)
-        .is_some_and(|branches| {
-            branches.iter().any(|b| {
-                b.get("then")
-                    .and_then(|t| t.get("required"))
-                    .and_then(Value::as_array)
-                    .is_some_and(|r| r.iter().any(|v| v.as_str() == Some(field)))
-            })
-        })
+/// Compile a tool's advertised input schema (the one MCP hosts receive) into a
+/// validator, so the tests exercise real validation, not schema structure.
+fn validator(tool: &dyn McpTool) -> jsonschema::Validator {
+    let schema = Value::Object((*tool.tool_def().input_schema).clone());
+    jsonschema::validator_for(&schema).expect("tool schema must be a valid JSONSchema")
 }
 
 #[test]
-fn callgraph_models_action_conditionals() {
-    let s = schema_of(&CtxCallgraphTool);
-    assert!(required(&s).contains(&"action".to_string()), "action must be required");
-    for a in ["callers", "callees", "risk"] {
-        assert!(models_conditional(&s, a, &["symbol"]), "{a} must require symbol");
-    }
-    assert!(models_conditional(&s, "trace", &["from", "to"]), "trace must require from+to");
-}
-
-#[test]
-fn expand_models_action_conditionals() {
-    let s = schema_of(&CtxExpandTool);
-    assert!(models_conditional(&s, "search_all", &["query"]), "search_all must require query");
-    // retrieve is the default action; its rule selects via `if.not`, so assert
-    // some branch requires `id` (an empty ctx_expand({}) must be invalid).
-    assert!(some_then_requires(&s, "id"), "retrieve path must require id");
-}
-
-#[test]
-fn graph_models_action_conditionals() {
-    let s = schema_of(&CtxGraphTool);
-    assert!(required(&s).contains(&"action".to_string()), "action must be required");
-    for a in ["symbol", "neighbors", "impact"] {
-        assert!(models_conditional(&s, a, &["path"]), "{a} must require path");
-    }
-    assert!(models_conditional(&s, "path", &["path", "to"]), "path action must require path+to");
-}
-
-#[test]
-fn knowledge_models_action_conditionals() {
-    let s = schema_of(&CtxKnowledgeTool);
-    assert!(required(&s).contains(&"action".to_string()), "action must be required");
-    assert!(models_conditional(&s, "remember", &["category"]), "remember must require category");
-    assert!(models_conditional(&s, "search", &["query"]), "search must require query");
-    assert!(models_conditional(&s, "pattern", &["value"]), "pattern must require value");
+fn callgraph_enforces_action_conditionals() {
+    let v = validator(&CtxCallgraphTool);
+    assert!(v.is_valid(&json!({"action": "callers", "symbol": "f"})));
+    assert!(v.is_valid(&json!({"action": "trace", "from": "a", "to": "b"})));
+    assert!(!v.is_valid(&json!({})), "action is required");
     assert!(
-        models_conditional(&s, "gotcha", &["trigger", "resolution"]),
-        "gotcha must require trigger+resolution"
+        !v.is_valid(&json!({"action": "callers"})),
+        "callers needs symbol"
+    );
+    assert!(
+        !v.is_valid(&json!({"action": "trace", "from": "a"})),
+        "trace needs to"
+    );
+}
+
+#[test]
+fn expand_enforces_action_conditionals() {
+    let v = validator(&CtxExpandTool);
+    assert!(
+        v.is_valid(&json!({"id": "F1"})),
+        "documented retrieve-by-id call"
+    );
+    assert!(v.is_valid(&json!({"action": "list"})));
+    assert!(v.is_valid(&json!({"action": "search_all", "query": "x"})));
+    assert!(!v.is_valid(&json!({})), "empty retrieve needs id");
+    assert!(
+        !v.is_valid(&json!({"action": "search_all"})),
+        "search_all needs query"
+    );
+}
+
+#[test]
+fn graph_enforces_action_conditionals() {
+    let v = validator(&CtxGraphTool);
+    assert!(v.is_valid(&json!({"action": "symbol", "path": "f.rs::g"})));
+    assert!(v.is_valid(&json!({"action": "path", "path": "a", "to": "b"})));
+    assert!(v.is_valid(&json!({"action": "status"})));
+    assert!(!v.is_valid(&json!({})), "action is required");
+    assert!(
+        !v.is_valid(&json!({"action": "symbol"})),
+        "symbol needs path"
+    );
+    assert!(
+        !v.is_valid(&json!({"action": "path", "path": "a"})),
+        "path needs to"
+    );
+}
+
+#[test]
+fn knowledge_enforces_action_conditionals() {
+    let v = validator(&CtxKnowledgeTool);
+    assert!(v.is_valid(&json!({"action": "remember", "category": "c", "value": "v"})));
+    assert!(v.is_valid(&json!({"action": "remember", "category": "c", "content": "v"})));
+    assert!(v.is_valid(&json!({"action": "gotcha", "trigger": "t", "resolution": "r"})));
+    assert!(v.is_valid(&json!({"action": "status"})));
+    assert!(!v.is_valid(&json!({})), "action is required");
+    assert!(
+        !v.is_valid(&json!({"action": "remember", "category": "c"})),
+        "needs value/content"
+    );
+    assert!(
+        !v.is_valid(&json!({"action": "remember", "value": "v"})),
+        "remember needs category"
+    );
+    assert!(
+        !v.is_valid(&json!({"action": "search"})),
+        "search needs query"
+    );
+    assert!(
+        !v.is_valid(&json!({"action": "gotcha", "trigger": "t"})),
+        "gotcha needs resolution"
     );
 }

--- a/rust/src/tools/registered/schema_qa_tests.rs
+++ b/rust/src/tools/registered/schema_qa_tests.rs
@@ -1,0 +1,111 @@
+//! #1008 schema QA: guards that action-driven `ctx_*` tools keep modelling
+//! their action-conditional `required` fields, so a dropped conditional fails CI.
+
+use serde_json::Value;
+
+use super::ctx_callgraph::CtxCallgraphTool;
+use super::ctx_expand::CtxExpandTool;
+use super::ctx_graph::CtxGraphTool;
+use super::ctx_knowledge::CtxKnowledgeTool;
+use crate::server::tool_trait::McpTool;
+
+fn schema_of(tool: &dyn McpTool) -> Value {
+    let def = tool.tool_def();
+    Value::Object((*def.input_schema).clone())
+}
+
+fn required(schema: &Value) -> Vec<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default()
+}
+
+/// Does an `allOf` branch select `action` (via `if.properties.action`
+/// const/enum) and require every field in `needs` (via `then.required`)?
+fn models_conditional(schema: &Value, action: &str, needs: &[&str]) -> bool {
+    let Some(branches) = schema.get("allOf").and_then(Value::as_array) else {
+        return false;
+    };
+    branches.iter().any(|b| {
+        let selects = b
+            .get("if")
+            .and_then(|i| i.get("properties"))
+            .and_then(|p| p.get("action"))
+            .is_some_and(|a| {
+                a.get("const").and_then(Value::as_str) == Some(action)
+                    || a.get("enum")
+                        .and_then(Value::as_array)
+                        .is_some_and(|e| e.iter().any(|x| x.as_str() == Some(action)))
+            });
+        if !selects {
+            return false;
+        }
+        let then_req: Vec<&str> = b
+            .get("then")
+            .and_then(|t| t.get("required"))
+            .and_then(Value::as_array)
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        needs.iter().all(|n| then_req.contains(n))
+    })
+}
+
+/// Any `allOf` branch whose `then.required` contains `field` — for the
+/// `ctx_expand` default-retrieve rule, which selects via `if.not`.
+fn some_then_requires(schema: &Value, field: &str) -> bool {
+    schema
+        .get("allOf")
+        .and_then(Value::as_array)
+        .is_some_and(|branches| {
+            branches.iter().any(|b| {
+                b.get("then")
+                    .and_then(|t| t.get("required"))
+                    .and_then(Value::as_array)
+                    .is_some_and(|r| r.iter().any(|v| v.as_str() == Some(field)))
+            })
+        })
+}
+
+#[test]
+fn callgraph_models_action_conditionals() {
+    let s = schema_of(&CtxCallgraphTool);
+    assert!(required(&s).contains(&"action".to_string()), "action must be required");
+    for a in ["callers", "callees", "risk"] {
+        assert!(models_conditional(&s, a, &["symbol"]), "{a} must require symbol");
+    }
+    assert!(models_conditional(&s, "trace", &["from", "to"]), "trace must require from+to");
+}
+
+#[test]
+fn expand_models_action_conditionals() {
+    let s = schema_of(&CtxExpandTool);
+    assert!(models_conditional(&s, "search_all", &["query"]), "search_all must require query");
+    // retrieve is the default action; its rule selects via `if.not`, so assert
+    // some branch requires `id` (an empty ctx_expand({}) must be invalid).
+    assert!(some_then_requires(&s, "id"), "retrieve path must require id");
+}
+
+#[test]
+fn graph_models_action_conditionals() {
+    let s = schema_of(&CtxGraphTool);
+    assert!(required(&s).contains(&"action".to_string()), "action must be required");
+    for a in ["symbol", "neighbors", "impact"] {
+        assert!(models_conditional(&s, a, &["path"]), "{a} must require path");
+    }
+    assert!(models_conditional(&s, "path", &["path", "to"]), "path action must require path+to");
+}
+
+#[test]
+fn knowledge_models_action_conditionals() {
+    let s = schema_of(&CtxKnowledgeTool);
+    assert!(required(&s).contains(&"action".to_string()), "action must be required");
+    assert!(models_conditional(&s, "remember", &["category"]), "remember must require category");
+    assert!(models_conditional(&s, "search", &["query"]), "search must require query");
+    assert!(models_conditional(&s, "pattern", &["value"]), "pattern must require value");
+    assert!(
+        models_conditional(&s, "gotcha", &["trigger", "resolution"]),
+        "gotcha must require trigger+resolution"
+    );
+}


### PR DESCRIPTION
## Problem
Fixes #1008 (follow-up to #1005). These action-driven `ctx_*` tools declared little or nothing in `required`, so malformed calls passed schema validation and only failed at runtime — e.g. `ctx_callgraph({})` and `ctx_expand({})` both validate but can't do anything.

## Fix
Model the mode/action-conditional requirements with JSONSchema `allOf` + `if/then` (draft 2020-12):

- **ctx_callgraph**: require `action`; `callers`/`callees`/`risk` need `symbol`; `trace` needs `from`+`to`.
- **ctx_expand**: `search_all` needs `query`; the default `retrieve` path needs `id` (selected via `if.not`, so `ctx_expand({})` is now invalid while the documented `ctx_expand(id=…)` stays legal without an explicit action).
- **ctx_graph**: `related`/`symbol`/`impact`/`neighbors`/`explain`/`path` need `path`; `action=path` also needs `to`.
- **ctx_knowledge**: `remember` needs `category` + (`value`|`content`); `pattern` needs `value`; `search` needs `query`; `gotcha` needs `trigger`+`resolution`. Adds the `content` alias to the schema.

The requireds were derived from each tool's actual runtime checks, not just the issue's summary (e.g. `remember` really needs `category` too; bare `recall` stays valid).

These schemas are **declarative** — the server does not enforce them. They let MCP hosts and the model infer valid call shapes and reject bad calls early.

`normalize_for_strict_validators` now recurses into `if`/`then`/`else` so the new conditional sub-schemas keep the strict-validator guarantees (the `required: []` / `items: {}` injection for OpenAI/SGLang-style backends).

## QA step
Per @andig's request on the issue to make this a QA step for future schema changes, adds `schema_qa_tests.rs`: a regression test that locks each tool's conditional requireds in place, so a future schema edit that drops one fails CI instead of only surfacing at runtime.

## Scope
`ctx_search` / `ctx_execute` conditional modeling (named in #1005's tally) remains open follow-up.

## Tests
4 new schema-QA tests; 229 related tool/schema/normalizer tests pass. Existing behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)