### PR TITLE
fix: resolve open tool correctness and security issues

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -286,7 +286,7 @@ File-level dependency graph queries.
 action=symbol path="file.rs::fnName" returns the DEFINITION (not usages — use ctx_search for references). neighbors=imports±direction, impact=reverse-dep blast radius, path from→to=dependency chain, diff since=HEAD~1=git change impact, diagram kind=deps|calls (Mermaid).
 For understanding code use ctx_compose FIRST.
 
-Parameters: `action`*, `depth`, `format`, `kind`, `path`, `project_root`, `since`, `to`
+Parameters: `action`, `depth`, `format`, `kind`, `path`, `project_root`, `since`, `to`
 
 ## `ctx_handoff`
 
@@ -339,7 +339,7 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
 action=gotcha trigger='X' resolution='Y' for known pitfalls.
 mode=semantic|exact for recall. category groups related facts.
 
-Parameters: `action`*, `as_of`, `category`, `confidence`, `dry_run`, `examples`, `format`, `key`, `limit`, `merge`, `mode`, `path`, `pattern_type`, `query`, `resolution`, `severity`, `store`, `trigger`, `value`
+Parameters: `action`*, `as_of`, `category`, `confidence`, `content`, `dry_run`, `examples`, `format`, `key`, `limit`, `merge`, `mode`, `path`, `pattern_type`, `query`, `resolution`, `severity`, `store`, `trigger`, `value`
 
 ## `ctx_ledger`
 
@@ -440,7 +440,7 @@ replace_symbol(path, name, new_body) | create(path, new_text) | replace_all(path
 Batch: ops:[{op, path, ...}] — not replace_symbol/replace_all.
 CONFLICT = stale anchors, re-read. Line-only patch (no hash) → error.
 
-Parameters: `dry_run`, `end_hash`, `end_line`, `find`, `hash`, `line`, `name`, `new_body`, `new_text`, `op`, `ops`, `path`*, `replace`, `start_hash`, `start_line`
+Parameters: `dry_run`, `end_hash`, `end_line`, `find`, `hash`, `line`, `name`, `new_body`, `new_text`, `op`, `ops`, `path`, `replace`, `start_hash`, `start_line`
 
 ## `ctx_plan`
 
@@ -523,7 +523,7 @@ Parameters: `format`
 
 ## `ctx_read`
 
-Read source files. mode REQUIRED — choose by intent (see `mode` below).
+Read source files. mode recommended — choose by intent (see `mode` below); defaults to auto when omitted.
 To UNDERSTAND code run ctx_compose FIRST; ctx_read after it identified files.
 anchored → edit by reference via ctx_patch (no exact-recall).
 
@@ -600,7 +600,7 @@ Parameters: `action`*, `agent`
 
 ## `ctx_search`
 
-Search code; `action` picks the engine (default regex). regex(pattern) | semantic(query, by meaning) | symbol(name, AST-exact; or handle=path#name@Lline) | reindex | find_related(file_path,line). anchored=true tags hits for ctx_patch. queries:[{pattern}] for batch. Run ctx_compose FIRST.
+Search code: regex(pattern, default) | semantic(query) | symbol(name|handle) | reindex | find_related(file_path,line). anchored=true enables ctx_patch refs; queries batches regex searches. Run ctx_compose FIRST.
 
 Parameters: `action`, `anchored`, `exclude`, `exclude_pattern`, `file`, `file_path`, `handle`, `include`, `kind`, `line`, `max_results`, `mode`, `name`, `path`, `paths`, `pattern`, `queries`, `query`, `top_k`
 

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -81,7 +81,7 @@ action=callers|callees symbol='fn' → every call site with file:line.
 action=trace from→to finds the path between two symbols (depth=N).
 For end-to-end flow understanding use ctx_compose FIRST.
 
-Parameters: `action`, `depth`, `file`, `from`, `symbol`, `to`
+Parameters: `action`*, `depth`, `file`, `from`, `symbol`, `to`
 
 ## `ctx_checkpoint`
 
@@ -209,8 +209,7 @@ Parameters: `create`, `new_string`*, `old_string`, `path`*, `replace_all`
 
 Run code in sandbox (11 languages) — use when conditionals, multi-line or cross-language transforms.
 ANTIPATTERN: for simple one-liners, prefer ctx_shell (lower overhead, auto-compressed).
-language=shell is the trusted script path: no allowlist, by design (not an escape hatch) —
-use for multi-line scripts, pipelines, or commands ctx_shell blocks.
+language=shell supports multi-line scripts but shares ctx_shell's security policy.
 action=code (default) for one-shot; action=batch for parallel multi-language;
 action=file to process a project file (extension auto-detects).
 Pass intent to focus large output and save tokens. Languages: javascript,
@@ -286,7 +285,7 @@ File-level dependency graph queries.
 action=symbol path="file.rs::fnName" returns the DEFINITION (not usages — use ctx_search for references). neighbors=imports±direction, impact=reverse-dep blast radius, path from→to=dependency chain, diff since=HEAD~1=git change impact, diagram kind=deps|calls (Mermaid).
 For understanding code use ctx_compose FIRST.
 
-Parameters: `action`, `depth`, `format`, `kind`, `path`, `project_root`, `since`, `to`
+Parameters: `action`*, `depth`, `format`, `kind`, `path`, `project_root`, `since`, `to`
 
 ## `ctx_handoff`
 
@@ -433,14 +432,9 @@ Parameters: `action`, `description`, `path`
 
 ## `ctx_patch`
 
-Hash-anchored edit. ALWAYS ctx_read(mode="anchored") first → lines like 42:a1b2|code (line=42, hash=a1b2).
-replace_lines(path, start_line, start_hash, end_line, end_hash, new_text) — ALL required.
-set_line(path, line, hash, new_text) | insert_after(path, line, hash, new_text) | delete(path, line, hash).
-replace_symbol(path, name, new_body) | create(path, new_text) | replace_all(path, find, replace, dry_run?).
-Batch: ops:[{op, path, ...}] — not replace_symbol/replace_all.
-CONFLICT = stale anchors, re-read. Line-only patch (no hash) → error.
+Safe file edit. Anchored ops use line+hash from ctx_read(mode="anchored"); CONFLICT means re-read. replace_unique(path,old_text,new_text) is a no-read, exact unique replacement. replace_symbol/create/replace_all and cross-file ops[] supported.
 
-Parameters: `dry_run`, `end_hash`, `end_line`, `find`, `hash`, `line`, `name`, `new_body`, `new_text`, `op`, `ops`, `path`, `replace`, `start_hash`, `start_line`
+Parameters: `dry_run`, `end_hash`, `end_line`, `find`, `hash`, `line`, `name`, `new_body`, `new_text`, `old_text`, `op`, `ops`, `path`, `replace`, `start_hash`, `start_line`
 
 ## `ctx_plan`
 

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -568,7 +568,8 @@ pub fn cmd_find(args: &[String]) {
     let substring = raw_pattern.to_lowercase();
 
     let mut found = false;
-    for entry in ignore::WalkBuilder::new(path)
+    let walk_root = crate::core::walk_filter::explicit_walk_root(std::path::Path::new(path));
+    for entry in ignore::WalkBuilder::new(&walk_root)
         .hidden(true)
         .git_ignore(true)
         .git_global(true)

--- a/rust/src/core/conversation.rs
+++ b/rust/src/core/conversation.rs
@@ -6,8 +6,12 @@
 //! chats served by one daemon, so without scoping a file delivered in chat A
 //! could be stubbed for a re-read in chat B (which never received it).
 //!
-//! Cursor's hooks write the live conversation id to `active_transcript.json`
-//! (2h TTL); we read it via [`crate::hook_handlers::load_active_transcript`] but
+//! Cursor's hooks write the live conversation id to `active_transcript.json`;
+//! hosts without one (Claude Code / Codex / CodeBuddy) supply a per-session
+//! `session_id` instead, which `load_active_transcript` returns as the scope id
+//! so a new session never inherits a prior one's stubs (#1004). Either way it
+//! carries a 2h TTL and we read it via
+//! [`crate::hook_handlers::load_active_transcript`] but
 //! cache it behind a short TTL so the read hot path never stats+parses a file on
 //! every call. The last-known-good value is retained across a transient refresh
 //! miss, so a momentary read failure never spuriously invalidates valid stubs.

--- a/rust/src/core/pathutil.rs
+++ b/rust/src/core/pathutil.rs
@@ -27,7 +27,7 @@ pub fn safe_canonicalize(path: &Path) -> std::io::Result<PathBuf> {
 /// Raw realpath + Windows-verbatim strip, with **no** TCC guard. Internal sink
 /// shared by [`safe_canonicalize`] (which gates it behind `may_probe_path`) and
 /// [`canonicalize_secure`] (which never gates it).
-fn canonicalize_raw(path: &Path) -> std::io::Result<PathBuf> {
+pub(crate) fn canonicalize_raw(path: &Path) -> std::io::Result<PathBuf> {
     let canon = std::fs::canonicalize(path)?;
     Ok(strip_verbatim(canon))
 }

--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -1613,7 +1613,8 @@ fn allowlist_block_message(base: &str) -> String {
          Or disable the allowlist entirely: set  shell_allowlist = []\n\
          Or turn off all shell gating (you own the risk): set  shell_security = \"off\"  \
          (or env LEAN_CTX_SHELL_SECURITY=off) — compression still applies.\n\
-         Do NOT retry this command — it will fail again with the same error.\n         For multi-line scripts or complex pipelines: use ctx_execute(language=\"shell\") instead — \n         it is the sanctioned path for script execution without allowlist restrictions."
+         Do NOT reroute through ctx_execute(language=\"shell\"): both tools enforce the same \
+         policy. Allow the command explicitly or change shell_security deliberately."
     );
 
     if crate::core::config::cloud_infra_commands().contains(&base) {

--- a/rust/src/core/walk_filter.rs
+++ b/rust/src/core/walk_filter.rs
@@ -23,6 +23,23 @@ const VENDOR_DIR_NAMES: &[&str] = &["node_modules", "__pycache__", "bower_compon
 /// `pyvenv.cfg`, so a source folder that happens to be called `venv` survives.
 const VENV_DIR_NAMES: &[&str] = &[".venv", "venv"];
 
+/// Resolve an explicitly requested Windows directory junction before handing it
+/// to `ignore::WalkBuilder`. The walker can treat a reparse-point root as a
+/// leaf, while normal file reads transparently follow it (#1003). Canonicalizing
+/// only the already-jailed root preserves the rule that nested links are never
+/// followed and strips Windows' verbatim prefix for `ignore` compatibility.
+pub fn explicit_walk_root(root: &std::path::Path) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        return crate::core::pathutil::canonicalize_raw(root)
+            .unwrap_or_else(|_| root.to_path_buf());
+    }
+    #[cfg(not(windows))]
+    {
+        root.to_path_buf()
+    }
+}
+
 /// Returns `true` when `entry` is a vendor/dependency directory that should
 /// never be descended into during a scan.
 pub fn is_vendor_dir(entry: &ignore::DirEntry) -> bool {

--- a/rust/src/hook_handlers/observe.rs
+++ b/rust/src/hook_handlers/observe.rs
@@ -479,11 +479,7 @@ pub fn load_detected_model() -> Option<(String, usize)> {
     Some((model, window))
 }
 
-fn persist_transcript_path(
-    path: &str,
-    conversation_id: Option<&str>,
-    session_id: Option<&str>,
-) {
+fn persist_transcript_path(path: &str, conversation_id: Option<&str>, session_id: Option<&str>) {
     let Ok(data_dir) = crate::core::data_dir::lean_ctx_data_dir() else {
         return;
     };

--- a/rust/src/hook_handlers/observe.rs
+++ b/rust/src/hook_handlers/observe.rs
@@ -147,11 +147,21 @@ fn parse_observe_event(input: &str) -> Option<ObserveEvent> {
         .filter(|t| !t.is_empty())
         .map(String::from);
 
+    // Claude Code / Codex / CodeBuddy carry a per-session `session_id` but no
+    // `conversation_id`. Persisting it lets the read-cache scope a session's
+    // deliveries the same way Cursor's `conversation_id` does, so a new session
+    // never inherits a prior one's `[unchanged]` stubs (#1004).
+    let session_id = v
+        .get("session_id")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
     if let Some(ref m) = model {
         persist_detected_model(m);
     }
     if let Some(ref tp) = transcript_path {
-        persist_transcript_path(tp, conversation_id.as_deref());
+        persist_transcript_path(tp, conversation_id.as_deref(), session_id.as_deref());
     }
 
     let mut event = detect_event_type(&v, ts)?;
@@ -469,7 +479,11 @@ pub fn load_detected_model() -> Option<(String, usize)> {
     Some((model, window))
 }
 
-fn persist_transcript_path(path: &str, conversation_id: Option<&str>) {
+fn persist_transcript_path(
+    path: &str,
+    conversation_id: Option<&str>,
+    session_id: Option<&str>,
+) {
     let Ok(data_dir) = crate::core::data_dir::lean_ctx_data_dir() else {
         return;
     };
@@ -481,6 +495,7 @@ fn persist_transcript_path(path: &str, conversation_id: Option<&str>) {
     let payload = serde_json::json!({
         "transcript_path": path,
         "conversation_id": conversation_id,
+        "session_id": session_id,
         "updated_at": ts,
     });
     if let Ok(json) = serde_json::to_string_pretty(&payload) {
@@ -497,9 +512,13 @@ pub fn load_active_transcript() -> Option<(String, Option<String>)> {
     let content = std::fs::read_to_string(&path).ok()?;
     let v: serde_json::Value = serde_json::from_str(&content).ok()?;
     let tp = v.get("transcript_path")?.as_str()?.to_string();
+    // Prefer Cursor's `conversation_id`; fall back to the host `session_id`
+    // (Claude Code / Codex / CodeBuddy) so the read-cache still has a per-session
+    // identity to scope stubs against (#1004).
     let conv = v
         .get("conversation_id")
         .and_then(|c| c.as_str())
+        .or_else(|| v.get("session_id").and_then(|s| s.as_str()))
         .map(String::from);
     let updated = v.get("updated_at")?.as_u64()?;
     let now = std::time::SystemTime::now()
@@ -767,5 +786,25 @@ mod tests {
     fn session_start_skipped_for_non_session_event() {
         let v = serde_json::json!({ "hook_event_name": "PreToolUse", "session_id": "x" });
         assert!(!session_start_honours_additional_context(&v));
+    }
+
+    /// #1004: a Claude/Codex/CodeBuddy payload has no `conversation_id`, so the
+    /// persisted `session_id` must surface as the scope id — otherwise the read
+    /// cache sees `None` and a new session inherits the prior one's stubs.
+    #[test]
+    fn session_id_is_used_as_scope_id_when_no_conversation_id() {
+        let _dir = crate::core::data_dir::isolated_data_dir();
+        persist_transcript_path("/tmp/x/abc.jsonl", None, Some("sess-abc"));
+        let (_, conv) = load_active_transcript().expect("marker just written");
+        assert_eq!(conv.as_deref(), Some("sess-abc"));
+    }
+
+    /// Cursor's `conversation_id` still wins when both are present.
+    #[test]
+    fn conversation_id_wins_over_session_id() {
+        let _dir = crate::core::data_dir::isolated_data_dir();
+        persist_transcript_path("/tmp/x/abc.jsonl", Some("conv-1"), Some("sess-abc"));
+        let (_, conv) = load_active_transcript().expect("marker just written");
+        assert_eq!(conv.as_deref(), Some("conv-1"));
     }
 }

--- a/rust/src/proxy/sse_keepalive.rs
+++ b/rust/src/proxy/sse_keepalive.rs
@@ -41,7 +41,17 @@ where
     S: Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
     E: Send + 'static,
 {
-    let interval = keepalive_interval();
+    keepalive_stream_with_interval(inner, keepalive_interval())
+}
+
+fn keepalive_stream_with_interval<S, E>(
+    inner: S,
+    interval: Duration,
+) -> impl Stream<Item = Result<Bytes, E>> + Send + Unpin
+where
+    S: Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
+    E: Send + 'static,
+{
     Box::pin(futures::stream::unfold(
         (inner, interval),
         |(mut inner, interval)| async move {
@@ -60,11 +70,10 @@ mod tests {
 
     #[tokio::test]
     async fn keepalive_injected_during_idle() {
-        unsafe { std::env::set_var("LEAN_CTX_PROXY_SSE_KEEPALIVE_SECS", "1") };
         let (mut tx, rx) = futures::channel::mpsc::channel::<Result<Bytes, std::io::Error>>(8);
         let stream = rx.map(|item| item);
 
-        let mut wrapped = keepalive_stream(Box::pin(stream));
+        let mut wrapped = keepalive_stream_with_interval(Box::pin(stream), Duration::from_secs(1));
 
         let item = tokio::time::timeout(Duration::from_secs(3), wrapped.next())
             .await

--- a/rust/src/tool_defs/mod.rs
+++ b/rust/src/tool_defs/mod.rs
@@ -202,3 +202,49 @@ pub fn is_full_mode() -> bool {
         || std::env::var("LEAN_CTX_LAZY_TOOLS")
             .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("false"))
 }
+
+#[cfg(test)]
+mod conditional_schema_tests {
+    use super::*;
+
+    #[test]
+    fn action_dispatched_tools_publish_conditional_requirements() {
+        let tools = crate::server::registry::build_registry().tool_defs();
+        for name in [
+            "ctx_callgraph",
+            "ctx_expand",
+            "ctx_graph",
+            "ctx_search",
+            "ctx_execute",
+        ] {
+            let tool = tools
+                .iter()
+                .find(|tool| tool.name.as_ref() == name)
+                .unwrap_or_else(|| panic!("missing tool {name}"));
+            let branches = tool
+                .input_schema
+                .get("oneOf")
+                .and_then(Value::as_array)
+                .unwrap_or_else(|| panic!("{name} must publish oneOf action branches"));
+            assert!(branches.len() >= 2, "{name} needs multiple action branches");
+            assert!(
+                branches.iter().all(|branch| branch.get("required").is_some()
+                    || branch.get("anyOf").is_some()),
+                "{name} action branches must declare required inputs"
+            );
+        }
+
+        let knowledge = tools
+            .iter()
+            .find(|tool| tool.name.as_ref() == "ctx_knowledge")
+            .expect("ctx_knowledge registered");
+        assert!(
+            knowledge
+                .input_schema
+                .get("allOf")
+                .and_then(Value::as_array)
+                .is_some_and(|branches| branches.len() >= 3),
+            "ctx_knowledge must condition remember/search/gotcha inputs"
+        );
+    }
+}

--- a/rust/src/tool_defs/mod.rs
+++ b/rust/src/tool_defs/mod.rs
@@ -112,6 +112,11 @@ pub fn normalize_for_strict_validators(schema: &mut Map<String, Value>) {
             }
         }
     }
+    for keyword in ["if", "then", "else", "not"] {
+        if let Some(Value::Object(sub)) = schema.get_mut(keyword) {
+            normalize_for_strict_validators(sub);
+        }
+    }
 }
 
 pub const CORE_TOOL_NAMES: &[&str] = &[
@@ -201,50 +206,4 @@ pub fn is_full_mode() -> bool {
     std::env::var("LEAN_CTX_FULL_TOOLS").is_ok_and(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
         || std::env::var("LEAN_CTX_LAZY_TOOLS")
             .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("false"))
-}
-
-#[cfg(test)]
-mod conditional_schema_tests {
-    use super::*;
-
-    #[test]
-    fn action_dispatched_tools_publish_conditional_requirements() {
-        let tools = crate::server::registry::build_registry().tool_defs();
-        for name in [
-            "ctx_callgraph",
-            "ctx_expand",
-            "ctx_graph",
-            "ctx_search",
-            "ctx_execute",
-        ] {
-            let tool = tools
-                .iter()
-                .find(|tool| tool.name.as_ref() == name)
-                .unwrap_or_else(|| panic!("missing tool {name}"));
-            let branches = tool
-                .input_schema
-                .get("oneOf")
-                .and_then(Value::as_array)
-                .unwrap_or_else(|| panic!("{name} must publish oneOf action branches"));
-            assert!(branches.len() >= 2, "{name} needs multiple action branches");
-            assert!(
-                branches.iter().all(|branch| branch.get("required").is_some()
-                    || branch.get("anyOf").is_some()),
-                "{name} action branches must declare required inputs"
-            );
-        }
-
-        let knowledge = tools
-            .iter()
-            .find(|tool| tool.name.as_ref() == "ctx_knowledge")
-            .expect("ctx_knowledge registered");
-        assert!(
-            knowledge
-                .input_schema
-                .get("allOf")
-                .and_then(Value::as_array)
-                .is_some_and(|branches| branches.len() >= 3),
-            "ctx_knowledge must condition remember/search/gotcha inputs"
-        );
-    }
 }

--- a/rust/src/tools/ctx_execute.rs
+++ b/rust/src/tools/ctx_execute.rs
@@ -11,6 +11,11 @@ pub fn handle(
     intent: Option<&str>,
     timeout: Option<u64>,
 ) -> (String, ShellOutcome) {
+    if language.eq_ignore_ascii_case("shell")
+        && let Err(message) = crate::core::shell_allowlist::check_shell_allowlist(code)
+    {
+        return (message.to_string(), ShellOutcome::Blocked);
+    }
     let result = sandbox::execute(language, code, timeout);
     (
         format_result(&result, intent),
@@ -81,6 +86,19 @@ pub fn handle_file(
 /// results. The outcome carries the first non-zero exit code (0 when all
 /// tasks succeeded), so one failing task marks the whole batch as failed.
 pub fn handle_batch(items: &[(String, String)]) -> (String, ShellOutcome) {
+    for (index, (language, code)) in items.iter().enumerate() {
+        if language.eq_ignore_ascii_case("shell")
+            && let Err(message) = crate::core::shell_allowlist::check_shell_allowlist(code)
+        {
+            return (
+                format!(
+                    "batch item {} blocked by shell policy:\n{message}",
+                    index + 1
+                ),
+                ShellOutcome::Blocked,
+            );
+        }
+    }
     let results = sandbox::batch_execute(items);
     let mut output = Vec::new();
 
@@ -281,6 +299,36 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
+    fn shell_execution_cannot_bypass_ctx_shell_allowlist() {
+        crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
+        let (result, outcome) = handle("shell", "definitely_not_allowed_command", None, None);
+        crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+        assert_eq!(outcome, ShellOutcome::Blocked);
+        assert!(
+            result.contains("shell allowlist"),
+            "unexpected result: {result}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn shell_batch_is_preflighted_before_any_item_runs() {
+        crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
+        let items = vec![
+            ("shell".to_string(), "echo safe".to_string()),
+            (
+                "shell".to_string(),
+                "definitely_not_allowed_command".to_string(),
+            ),
+        ];
+        let (result, outcome) = handle_batch(&items);
+        crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+        assert_eq!(outcome, ShellOutcome::Blocked);
+        assert!(result.contains("batch item 2 blocked"));
+    }
+
+    #[test]
     fn detect_language_from_path() {
         assert_eq!(detect_language_from_extension("test.py"), "python");
         assert_eq!(detect_language_from_extension("test.js"), "javascript");
@@ -336,8 +384,8 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     fn batch_with_failing_task_reports_failure() {
         let items = vec![
-            ("shell".to_string(), "echo ok".to_string()),
-            ("shell".to_string(), "exit 3".to_string()),
+            ("python".to_string(), "print('ok')".to_string()),
+            ("python".to_string(), "raise SystemExit(3)".to_string()),
         ];
         let (_, outcome) = handle_batch(&items);
         assert_eq!(

--- a/rust/src/tools/ctx_glob.rs
+++ b/rust/src/tools/ctx_glob.rs
@@ -28,7 +28,9 @@ pub fn handle(
     allow_secret_paths: bool,
     max_results: usize,
 ) -> (String, usize) {
-    let root = Path::new(dir);
+    let requested_root = Path::new(dir);
+    let walk_root = crate::core::walk_filter::explicit_walk_root(requested_root);
+    let root = walk_root.as_path();
     if !root.exists() {
         return (format!("ERROR: {dir} does not exist"), 0);
     }
@@ -251,5 +253,25 @@ mod tests {
             })
             .collect();
         assert!(file_lines.len() <= 5, "should respect max_results");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn glob_walks_explicit_directory_reparse_root() {
+        use std::os::windows::fs::symlink_dir;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("junction");
+        std::fs::create_dir_all(&target).expect("target");
+        std::fs::write(target.join("visible.rs"), "fn visible() {}\n").expect("fixture");
+        if symlink_dir(&target, &link).is_err() {
+            return;
+        }
+        let (out, _) = handle("**/*.rs", &link.to_string_lossy(), true, true, 20);
+        assert!(
+            out.contains("visible.rs"),
+            "junction root must be traversed: {out}"
+        );
     }
 }

--- a/rust/src/tools/ctx_tree.rs
+++ b/rust/src/tools/ctx_tree.rs
@@ -13,7 +13,9 @@ pub fn handle(
     show_hidden: bool,
     respect_gitignore: bool,
 ) -> (String, usize) {
-    let root = Path::new(path);
+    let requested_root = Path::new(path);
+    let walk_root = crate::core::walk_filter::explicit_walk_root(requested_root);
+    let root = walk_root.as_path();
     if root.is_file() {
         let parent = root
             .parent()
@@ -250,6 +252,27 @@ mod tests {
         assert!(
             opt_out.contains("node_modules"),
             "respect_gitignore=false must reveal vendor dirs: {opt_out}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn tree_walks_explicit_directory_reparse_root() {
+        use std::os::windows::fs::symlink_dir;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("target");
+        let link = tmp.path().join("junction");
+        std::fs::create_dir_all(&target).expect("target");
+        std::fs::write(target.join("visible.rs"), "fn visible() {}\n").expect("fixture");
+        if symlink_dir(&target, &link).is_err() {
+            // Windows hosts without Developer Mode cannot create this fixture.
+            return;
+        }
+        let (out, _) = handle(&link.to_string_lossy(), 2, false, true);
+        assert!(
+            out.contains("visible.rs"),
+            "junction root must be traversed: {out}"
         );
     }
 }

--- a/rust/src/tools/registered/ctx_callgraph.rs
+++ b/rust/src/tools/registered/ctx_callgraph.rs
@@ -31,7 +31,17 @@ impl McpTool for CtxCallgraphTool {
                     "depth": { "type": "integer", "minimum": 1, "maximum": 5 },
                     "from": { "type": "string" },
                     "to": { "type": "string" }
-                }
+                },
+                "oneOf": [
+                    {
+                        "properties": { "action": { "enum": ["callers", "callees", "risk"] } },
+                        "required": ["symbol"]
+                    },
+                    {
+                        "properties": { "action": { "const": "trace" } },
+                        "required": ["action", "from", "to"]
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_callgraph.rs
+++ b/rust/src/tools/registered/ctx_callgraph.rs
@@ -32,15 +32,10 @@ impl McpTool for CtxCallgraphTool {
                     "from": { "type": "string" },
                     "to": { "type": "string" }
                 },
-                "oneOf": [
-                    {
-                        "properties": { "action": { "enum": ["callers", "callees", "risk"] } },
-                        "required": ["symbol"]
-                    },
-                    {
-                        "properties": { "action": { "const": "trace" } },
-                        "required": ["action", "from", "to"]
-                    }
+                "required": ["action"],
+                "allOf": [
+                    { "if": { "properties": { "action": { "enum": ["callers", "callees", "risk"] } }, "required": ["action"] }, "then": { "required": ["symbol"] } },
+                    { "if": { "properties": { "action": { "const": "trace" } }, "required": ["action"] }, "then": { "required": ["from", "to"] } }
                 ]
             }),
         )

--- a/rust/src/tools/registered/ctx_execute.rs
+++ b/rust/src/tools/registered/ctx_execute.rs
@@ -56,7 +56,21 @@ impl McpTool for CtxExecuteTool {
                         "type": "string",
                         "description": "File path for action=file (language auto-detected)."
                     }
-                }
+                },
+                "oneOf": [
+                    {
+                        "properties": { "action": { "enum": ["code"] } },
+                        "required": ["language", "code"]
+                    },
+                    {
+                        "properties": { "action": { "const": "batch" } },
+                        "required": ["action", "items"]
+                    },
+                    {
+                        "properties": { "action": { "const": "file" } },
+                        "required": ["action", "path"]
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_execute.rs
+++ b/rust/src/tools/registered/ctx_execute.rs
@@ -19,8 +19,7 @@ impl McpTool for CtxExecuteTool {
             "ctx_execute",
             "Run code in sandbox (11 languages) — use when conditionals, multi-line or cross-language transforms.\n\
              ANTIPATTERN: for simple one-liners, prefer ctx_shell (lower overhead, auto-compressed).\n\
-             language=shell is the trusted script path: no allowlist, by design (not an escape hatch) —\n\
-             use for multi-line scripts, pipelines, or commands ctx_shell blocks.\n\
+             language=shell supports multi-line scripts but shares ctx_shell's security policy.\n\
              action=code (default) for one-shot; action=batch for parallel multi-language;\n\
              action=file to process a project file (extension auto-detects).\n\
              Pass intent to focus large output and save tokens. Languages: javascript,\n\

--- a/rust/src/tools/registered/ctx_expand.rs
+++ b/rust/src/tools/registered/ctx_expand.rs
@@ -33,7 +33,21 @@ impl McpTool for CtxExpandTool {
                     "json_path": { "type": "string", "description": "e.g. data.items.0" },
                     "query": { "type": "string" },
                     "session_id": { "type": "string" }
-                }
+                },
+                "oneOf": [
+                    {
+                        "properties": { "action": { "enum": ["retrieve"] } },
+                        "required": ["id"]
+                    },
+                    {
+                        "properties": { "action": { "const": "list" } },
+                        "required": ["action"]
+                    },
+                    {
+                        "properties": { "action": { "const": "search_all" } },
+                        "required": ["action", "query"]
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_expand.rs
+++ b/rust/src/tools/registered/ctx_expand.rs
@@ -34,19 +34,9 @@ impl McpTool for CtxExpandTool {
                     "query": { "type": "string" },
                     "session_id": { "type": "string" }
                 },
-                "oneOf": [
-                    {
-                        "properties": { "action": { "enum": ["retrieve"] } },
-                        "required": ["id"]
-                    },
-                    {
-                        "properties": { "action": { "const": "list" } },
-                        "required": ["action"]
-                    },
-                    {
-                        "properties": { "action": { "const": "search_all" } },
-                        "required": ["action", "query"]
-                    }
+                "allOf": [
+                    { "if": { "properties": { "action": { "const": "search_all" } }, "required": ["action"] }, "then": { "required": ["query"] } },
+                    { "if": { "not": { "properties": { "action": { "enum": ["list", "search_all"] } }, "required": ["action"] } }, "then": { "required": ["id"] } }
                 ]
             }),
         )

--- a/rust/src/tools/registered/ctx_graph.rs
+++ b/rust/src/tools/registered/ctx_graph.rs
@@ -39,7 +39,20 @@ impl McpTool for CtxGraphTool {
                     "since": { "type": "string", "description": "Git ref (default HEAD~1)" },
                     "project_root": { "type": "string" }
                 },
-                "required": ["action"]
+                "oneOf": [
+                    {
+                        "properties": { "action": { "enum": ["symbol", "impact", "neighbors"] } },
+                        "required": ["action", "path"]
+                    },
+                    {
+                        "properties": { "action": { "const": "path" } },
+                        "required": ["action", "path", "to"]
+                    },
+                    {
+                        "properties": { "action": { "enum": ["build", "related", "status", "enrich", "context", "diagram", "explain", "diff"] } },
+                        "required": ["action"]
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_graph.rs
+++ b/rust/src/tools/registered/ctx_graph.rs
@@ -39,19 +39,10 @@ impl McpTool for CtxGraphTool {
                     "since": { "type": "string", "description": "Git ref (default HEAD~1)" },
                     "project_root": { "type": "string" }
                 },
-                "oneOf": [
-                    {
-                        "properties": { "action": { "enum": ["symbol", "impact", "neighbors"] } },
-                        "required": ["action", "path"]
-                    },
-                    {
-                        "properties": { "action": { "const": "path" } },
-                        "required": ["action", "path", "to"]
-                    },
-                    {
-                        "properties": { "action": { "enum": ["build", "related", "status", "enrich", "context", "diagram", "explain", "diff"] } },
-                        "required": ["action"]
-                    }
+                "required": ["action"],
+                "allOf": [
+                    { "if": { "properties": { "action": { "enum": ["related", "symbol", "impact", "neighbors", "explain", "path"] } }, "required": ["action"] }, "then": { "required": ["path"] } },
+                    { "if": { "properties": { "action": { "const": "path" } }, "required": ["action"] }, "then": { "required": ["path", "to"] } }
                 ]
             }),
         )

--- a/rust/src/tools/registered/ctx_knowledge.rs
+++ b/rust/src/tools/registered/ctx_knowledge.rs
@@ -37,6 +37,7 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
                     "category": { "type": "string", "description": "Fact category" },
                     "key": { "type": "string" },
                     "value": { "type": "string" },
+                    "content": { "type": "string", "description": "Alias for value (remember)" },
                     "query": { "type": "string", "description": "Query for recall/search/relate/restore" },
                     "mode": { "type": "string", "description": "auto|exact|semantic|hybrid" },
                     "as_of": { "type": "string", "description": "YYYY-MM-DD date filter" },
@@ -50,6 +51,20 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
                     "path": { "type": "string", "description": "export/import: bundle directory (OKF) or file path" },
                     "merge": { "type": "string", "description": "import: replace|append|skip-existing (default skip-existing)" }
                 },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "remember" } }, "required": ["action"] },
+                        "then": { "anyOf": [{ "required": ["value"] }, { "required": ["content"] }] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "search" } }, "required": ["action"] },
+                        "then": { "required": ["query"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "gotcha" } }, "required": ["action"] },
+                        "then": { "required": ["trigger", "resolution"] }
+                    }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_knowledge.rs
+++ b/rust/src/tools/registered/ctx_knowledge.rs
@@ -54,7 +54,11 @@ action=consolidate imports latest session if present, runs lifecycle, then frees
                 "allOf": [
                     {
                         "if": { "properties": { "action": { "const": "remember" } }, "required": ["action"] },
-                        "then": { "anyOf": [{ "required": ["value"] }, { "required": ["content"] }] }
+                        "then": { "required": ["category"], "anyOf": [{ "required": ["value"] }, { "required": ["content"] }] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "pattern" } }, "required": ["action"] },
+                        "then": { "required": ["value"] }
                     },
                     {
                         "if": { "properties": { "action": { "const": "search" } }, "required": ["action"] },

--- a/rust/src/tools/registered/ctx_patch.rs
+++ b/rust/src/tools/registered/ctx_patch.rs
@@ -45,7 +45,7 @@ impl McpTool for CtxPatchTool {
                     "find": { "type": "string", "description": "Literal text to find (replace_all)" },
                     "replace": { "type": "string", "description": "Replacement text (replace_all)" },
                     "dry_run": { "type": "boolean", "description": "Preview only, do not write (replace_all)" },
-                    "ops": { "type": "array", "items": { "type": "object" }, "description": "Batch: each item is an op object that may carry its own 'path' (cross-file); it falls back to the top-level 'path'. When 'ops' is present the top-level 'path' is optional." }
+                    "ops": { "type": "array", "items": { "type": "object" }, "description": "Batch ops; per-op path overrides optional top-level path." }
                 }
             }),
         )
@@ -82,9 +82,10 @@ impl McpTool for CtxPatchTool {
         // batch may span files and needs no top-level `path`. A single op still
         // requires the top-level `path`.
         let groups = plan_groups(args, ctx)?;
+        validate_cross_file_options(args, groups.len())?;
+        let output_path = (groups.len() == 1).then(|| groups[0].0.clone());
 
         let mut texts = Vec::with_capacity(groups.len());
-        let mut last_path = String::new();
         for (path, ops) in groups {
             let patch_params = crate::tools::ctx_patch::PatchParams {
                 path: path.clone(),
@@ -97,8 +98,8 @@ impl McpTool for CtxPatchTool {
                 allow_lossy_utf8,
                 validate_syntax,
             };
-            texts.push(apply_one(ctx, &patch_params)?);
-            last_path = path;
+            let output = apply_one(ctx, &patch_params)?;
+            texts.push(format!("[{path}]\n{output}"));
         }
 
         Ok(ToolOutput {
@@ -106,12 +107,33 @@ impl McpTool for CtxPatchTool {
             original_tokens: 0,
             saved_tokens: 0,
             mode: None,
-            path: Some(last_path),
+            path: output_path,
             changed: false,
             shell_outcome: None,
             content_blocks: None,
         })
     }
+}
+
+/// Options with one top-level value cannot be applied safely to multiple files:
+/// one digest cannot describe several preimages, and one explicit backup path
+/// would be overwritten by the second file. Reject before any write occurs.
+fn validate_cross_file_options(
+    args: &Map<String, Value>,
+    file_count: usize,
+) -> Result<(), ErrorData> {
+    if file_count <= 1 {
+        return Ok(());
+    }
+    for key in ["expected_md5", "backup_path"] {
+        if args.contains_key(key) {
+            return Err(ErrorData::invalid_params(
+                format!("cross-file ctx_patch batches do not support top-level '{key}'"),
+                None,
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Build the per-file work list. A single op targets the top-level `path`
@@ -482,5 +504,14 @@ mod batch_grouping_tests {
     fn empty_ops_rejected() {
         let err = group_ops_by_path(&[], None).unwrap_err();
         assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn cross_file_rejects_single_value_preimage_and_backup_options() {
+        for key in ["expected_md5", "backup_path"] {
+            let args = Map::from_iter([(key.to_string(), json!("one-value"))]);
+            assert!(validate_cross_file_options(&args, 2).is_err());
+            assert!(validate_cross_file_options(&args, 1).is_ok());
+        }
     }
 }

--- a/rust/src/tools/registered/ctx_patch.rs
+++ b/rust/src/tools/registered/ctx_patch.rs
@@ -22,17 +22,14 @@ impl McpTool for CtxPatchTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_patch",
-            "Hash-anchored edit. ALWAYS ctx_read(mode=\"anchored\") first → lines like 42:a1b2|code (line=42, hash=a1b2).\n\
-             replace_lines(path, start_line, start_hash, end_line, end_hash, new_text) — ALL required.\n\
-             set_line(path, line, hash, new_text) | insert_after(path, line, hash, new_text) | delete(path, line, hash).\n\
-             replace_symbol(path, name, new_body) | create(path, new_text) | replace_all(path, find, replace, dry_run?).\n\
-             Batch: ops:[{op, path, ...}] — not replace_symbol/replace_all.\n\
-             CONFLICT = stale anchors, re-read. Line-only patch (no hash) → error.",
+            "Safe file edit. Anchored ops use line+hash from ctx_read(mode=\"anchored\"); \
+             CONFLICT means re-read. replace_unique(path,old_text,new_text) is a no-read, \
+             exact unique replacement. replace_symbol/create/replace_all and cross-file ops[] supported.",
             json!({
                 "type": "object",
                 "properties": {
                     "path": { "type": "string" },
-                    "op": { "type": "string", "enum": ["set_line", "replace_lines", "insert_after", "delete", "replace_symbol", "create", "replace_all"] },
+                    "op": { "type": "string", "enum": ["set_line", "replace_lines", "insert_after", "delete", "replace_unique", "replace_symbol", "create", "replace_all"] },
                     "line": { "type": "integer" },
                     "hash": { "type": "string" },
                     "start_line": { "type": "integer" },
@@ -40,12 +37,13 @@ impl McpTool for CtxPatchTool {
                     "end_line": { "type": "integer" },
                     "end_hash": { "type": "string" },
                     "new_text": { "type": "string" },
+                    "old_text": { "type": "string" },
                     "name": { "type": "string" },
                     "new_body": { "type": "string" },
-                    "find": { "type": "string", "description": "Literal text to find (replace_all)" },
-                    "replace": { "type": "string", "description": "Replacement text (replace_all)" },
-                    "dry_run": { "type": "boolean", "description": "Preview only, do not write (replace_all)" },
-                    "ops": { "type": "array", "items": { "type": "object" }, "description": "Batch ops; per-op path overrides optional top-level path." }
+                    "find": { "type": "string" },
+                    "replace": { "type": "string" },
+                    "dry_run": { "type": "boolean" },
+                    "ops": { "type": "array", "items": { "type": "object" } }
                 }
             }),
         )
@@ -60,6 +58,10 @@ impl McpTool for CtxPatchTool {
         // ctx_refactor so there is one symbol-edit implementation (epic #1008).
         if crate::tools::ctx_patch::is_replace_symbol(args) {
             return delegate_replace_symbol(args, ctx);
+        }
+
+        if get_str(args, "op").as_deref() == Some("replace_unique") {
+            return delegate_replace_unique(args, ctx);
         }
 
         // #825: replace_all short-circuits before anchor parsing.
@@ -113,6 +115,34 @@ impl McpTool for CtxPatchTool {
             content_blocks: None,
         })
     }
+}
+
+/// One-shot content-anchored edit (#1010). Delegate to ctx_edit's audited
+/// unique-replacement path so ambiguity checks, TOCTOU guards, atomic writes,
+/// cache invalidation, evidence and session tracking remain single-sourced.
+fn delegate_replace_unique(
+    args: &Map<String, Value>,
+    ctx: &ToolContext,
+) -> Result<ToolOutput, ErrorData> {
+    let edit_args =
+        build_unique_edit_args(args).map_err(|message| ErrorData::invalid_params(message, None))?;
+    crate::tools::registered::ctx_edit::CtxEditTool.handle(&edit_args, ctx)
+}
+
+fn build_unique_edit_args(args: &Map<String, Value>) -> Result<Map<String, Value>, String> {
+    let old_text = get_str(args, "old_text")
+        .filter(|text| !text.is_empty())
+        .ok_or_else(|| "replace_unique requires non-empty old_text".to_string())?;
+    let new_text =
+        get_str(args, "new_text").ok_or_else(|| "replace_unique requires new_text".to_string())?;
+
+    let mut edit_args = args.clone();
+    edit_args.insert("old_string".into(), Value::String(old_text));
+    edit_args.insert("new_string".into(), Value::String(new_text));
+    edit_args.insert("replace_all".into(), Value::Bool(false));
+    edit_args.remove("old_text");
+    edit_args.remove("op");
+    Ok(edit_args)
 }
 
 /// Options with one top-level value cannot be applied safely to multiple files:
@@ -513,5 +543,28 @@ mod batch_grouping_tests {
             assert!(validate_cross_file_options(&args, 2).is_err());
             assert!(validate_cross_file_options(&args, 1).is_ok());
         }
+    }
+
+    #[test]
+    fn replace_unique_maps_to_a_single_safe_ctx_edit_replacement() {
+        let args = Map::from_iter([
+            ("path".into(), json!("a.rs")),
+            ("op".into(), json!("replace_unique")),
+            ("old_text".into(), json!("old")),
+            ("new_text".into(), json!("new")),
+        ]);
+        let mapped = build_unique_edit_args(&args).expect("valid mapping");
+        assert_eq!(mapped.get("old_string"), Some(&json!("old")));
+        assert_eq!(mapped.get("new_string"), Some(&json!("new")));
+        assert_eq!(mapped.get("replace_all"), Some(&json!(false)));
+        assert!(!mapped.contains_key("op"));
+        assert!(!mapped.contains_key("old_text"));
+    }
+
+    #[test]
+    fn replace_unique_requires_explicit_old_and_new_text() {
+        assert!(build_unique_edit_args(&Map::new()).is_err());
+        let only_old = Map::from_iter([("old_text".into(), json!("old"))]);
+        assert!(build_unique_edit_args(&only_old).is_err());
     }
 }

--- a/rust/src/tools/registered/ctx_patch.rs
+++ b/rust/src/tools/registered/ctx_patch.rs
@@ -45,9 +45,8 @@ impl McpTool for CtxPatchTool {
                     "find": { "type": "string", "description": "Literal text to find (replace_all)" },
                     "replace": { "type": "string", "description": "Replacement text (replace_all)" },
                     "dry_run": { "type": "boolean", "description": "Preview only, do not write (replace_all)" },
-                    "ops": { "type": "array", "items": { "type": "object" } }
-                },
-                "required": ["path"]
+                    "ops": { "type": "array", "items": { "type": "object" }, "description": "Batch: each item is an op object that may carry its own 'path' (cross-file); it falls back to the top-level 'path'. When 'ops' is present the top-level 'path' is optional." }
+                }
             }),
         )
     }
@@ -68,11 +67,6 @@ impl McpTool for CtxPatchTool {
             return handle_replace_all(args, ctx);
         }
 
-        let path = require_resolved_path(ctx, args, "path")?;
-
-        let ops = crate::tools::ctx_patch::parse_ops(args)
-            .map_err(|e| ErrorData::invalid_params(e, None))?;
-
         let expected_md5 = get_str(args, "expected_md5");
         let backup = get_bool(args, "backup").unwrap_or(false);
         let backup_path = get_str(args, "backup_path")
@@ -84,102 +78,200 @@ impl McpTool for CtxPatchTool {
         let allow_lossy_utf8 = get_bool(args, "allow_lossy_utf8").unwrap_or(false);
         let validate_syntax = get_bool(args, "validate_syntax").unwrap_or(true);
 
-        let patch_params = crate::tools::ctx_patch::PatchParams {
-            path: path.clone(),
-            ops,
-            expected_md5,
-            backup,
-            backup_path,
-            evidence,
-            diff_max_lines,
-            allow_lossy_utf8,
-            validate_syntax,
-        };
+        // #1005: a batch (`ops[]`) groups its ops by each op's own `path`, so a
+        // batch may span files and needs no top-level `path`. A single op still
+        // requires the top-level `path`.
+        let groups = plan_groups(args, ctx)?;
 
-        tokio::task::block_in_place(|| {
-            let cache_lock = ctx
-                .cache
-                .as_ref()
-                .ok_or_else(|| ErrorData::internal_error("cache not available", None))?;
-            let rt = tokio::runtime::Handle::current();
-
-            // Serialize edits to the SAME file via the shared per-file lock (the
-            // same registry ctx_edit/ctx_read use), so anchored and str_replace
-            // edits of one file never interleave (issue #320). Correctness across
-            // processes still rests on the TOCTOU preimage guard + atomic rename.
-            let file_lock = crate::core::path_locks::per_file_lock(&path);
-            let _file_guard = {
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-                loop {
-                    if let Ok(guard) = file_lock.try_lock() {
-                        break guard;
-                    }
-                    if std::time::Instant::now() >= deadline {
-                        return Err(ErrorData::internal_error(
-                            format!(
-                                "per-file edit lock contention for {path} — another edit to the same file is in progress, retry in a moment"
-                            ),
-                            None,
-                        ));
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(20));
-                }
+        let mut texts = Vec::with_capacity(groups.len());
+        let mut last_path = String::new();
+        for (path, ops) in groups {
+            let patch_params = crate::tools::ctx_patch::PatchParams {
+                path: path.clone(),
+                ops,
+                expected_md5: expected_md5.clone(),
+                backup,
+                backup_path: backup_path.clone(),
+                evidence,
+                diff_max_lines,
+                allow_lossy_utf8,
+                validate_syntax,
             };
+            texts.push(apply_one(ctx, &patch_params)?);
+            last_path = path;
+        }
 
-            let last_mode = match rt.block_on(tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                cache_lock.read(),
-            )) {
-                Ok(cache) => cache
-                    .get(&path)
-                    .map(|e| e.last_mode.clone())
-                    .unwrap_or_default(),
-                Err(_) => String::new(),
-            };
-
-            // Heavy disk I/O — no global cache lock held here.
-            let (output, effect) = crate::tools::ctx_patch::run_io(&patch_params, &last_mode);
-
-            crate::tools::ctx_patch::record_outcome(&patch_params, &last_mode, &output, &effect);
-
-            if !matches!(effect, crate::tools::ctx_edit::CacheEffect::None) {
-                match rt.block_on(tokio::time::timeout(
-                    std::time::Duration::from_secs(5),
-                    cache_lock.write(),
-                )) {
-                    Ok(mut cache) => {
-                        crate::tools::ctx_edit::apply_cache_effect(&mut cache, &path, effect);
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            "ctx_patch: cache write-lock timeout (5s) applying post-edit cache effect for {path}"
-                        );
-                    }
-                }
-            }
-
-            if let Some(session_lock) = ctx.session.as_ref() {
-                let guard = rt.block_on(tokio::time::timeout(
-                    std::time::Duration::from_secs(5),
-                    session_lock.write(),
-                ));
-                if let Ok(mut session) = guard {
-                    session.mark_modified(&path);
-                }
-            }
-
-            Ok(ToolOutput {
-                text: output,
-                original_tokens: 0,
-                saved_tokens: 0,
-                mode: None,
-                path: Some(path),
-                changed: false,
-                shell_outcome: None,
-                content_blocks: None,
-            })
+        Ok(ToolOutput {
+            text: texts.join("\n\n"),
+            original_tokens: 0,
+            saved_tokens: 0,
+            mode: None,
+            path: Some(last_path),
+            changed: false,
+            shell_outcome: None,
+            content_blocks: None,
         })
     }
+}
+
+/// Build the per-file work list. A single op targets the top-level `path`
+/// (still required). A batch (`ops[]`) groups its ops by each op's own `path`,
+/// falling back to the top-level `path`, so a batch may span files without a
+/// top-level `path` (#1005).
+fn plan_groups(
+    args: &Map<String, Value>,
+    ctx: &ToolContext,
+) -> Result<Vec<(String, Vec<crate::tools::ctx_patch::AnchorOp>)>, ErrorData> {
+    let Some(ops_val) = args.get("ops") else {
+        let path = require_resolved_path(ctx, args, "path")?;
+        let ops = crate::tools::ctx_patch::parse_ops(args)
+            .map_err(|e| ErrorData::invalid_params(e, None))?;
+        return Ok(vec![(path, ops)]);
+    };
+
+    let arr = ops_val
+        .as_array()
+        .ok_or_else(|| ErrorData::invalid_params("ops must be an array of edit objects", None))?;
+    let grouped = group_ops_by_path(arr, get_str(args, "path").as_deref())
+        .map_err(|e| ErrorData::invalid_params(e, None))?;
+
+    let mut groups = Vec::with_capacity(grouped.len());
+    for (raw_path, op_objs) in grouped {
+        let resolved = ctx
+            .resolve_path_sync(&raw_path)
+            .map_err(|e| ErrorData::invalid_params(format!("path: {e}"), None))?;
+        ctx.ensure_writable(&resolved)
+            .map_err(|e| ErrorData::invalid_params(e, None))?;
+        let sub = Map::from_iter([("ops".to_string(), Value::Array(op_objs))]);
+        let ops = crate::tools::ctx_patch::parse_ops(&sub)
+            .map_err(|e| ErrorData::invalid_params(e, None))?;
+        groups.push((resolved, ops));
+    }
+    Ok(groups)
+}
+
+/// Pure grouping: bucket batch op objects by their own `path` (or the batch's
+/// top-level `path` fallback), preserving first-seen file order. Errors if an op
+/// names no path and there is no top-level fallback.
+fn group_ops_by_path(
+    ops: &[Value],
+    top_path: Option<&str>,
+) -> Result<Vec<(String, Vec<Value>)>, String> {
+    if ops.is_empty() {
+        return Err("ops[] is empty — provide at least one edit".to_string());
+    }
+    let mut order: Vec<String> = Vec::new();
+    let mut by_path: std::collections::HashMap<String, Vec<Value>> =
+        std::collections::HashMap::new();
+    for (i, op) in ops.iter().enumerate() {
+        let obj = op
+            .as_object()
+            .ok_or_else(|| format!("ops[{i}] must be an object"))?;
+        let raw = obj
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| top_path.map(str::to_string))
+            .ok_or_else(|| {
+                format!("ops[{i}] needs its own 'path' (no top-level 'path' to fall back to)")
+            })?;
+        if !by_path.contains_key(&raw) {
+            order.push(raw.clone());
+        }
+        by_path.entry(raw).or_default().push(op.clone());
+    }
+    Ok(order
+        .into_iter()
+        .map(|p| {
+            let ops = by_path.remove(&p).unwrap_or_default();
+            (p, ops)
+        })
+        .collect())
+}
+
+/// Apply one file's anchored patch: acquire the per-file lock, run the I/O off
+/// the global cache lock, then fold the resulting cache effect and session mark.
+/// Returns the rendered patch/CONFLICT text. Shared by the single-op and the
+/// per-file batch paths (#1005).
+fn apply_one(
+    ctx: &ToolContext,
+    params: &crate::tools::ctx_patch::PatchParams,
+) -> Result<String, ErrorData> {
+    let path = params.path.clone();
+    tokio::task::block_in_place(|| {
+        let cache_lock = ctx
+            .cache
+            .as_ref()
+            .ok_or_else(|| ErrorData::internal_error("cache not available", None))?;
+        let rt = tokio::runtime::Handle::current();
+
+        // Serialize edits to the SAME file via the shared per-file lock (the same
+        // registry ctx_edit/ctx_read use), so anchored and str_replace edits of
+        // one file never interleave (issue #320). Correctness across processes
+        // still rests on the TOCTOU preimage guard + atomic rename.
+        let file_lock = crate::core::path_locks::per_file_lock(&path);
+        let _file_guard = {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            loop {
+                if let Ok(guard) = file_lock.try_lock() {
+                    break guard;
+                }
+                if std::time::Instant::now() >= deadline {
+                    return Err(ErrorData::internal_error(
+                        format!(
+                            "per-file edit lock contention for {path} — another edit to the same file is in progress, retry in a moment"
+                        ),
+                        None,
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        };
+
+        let last_mode = match rt.block_on(tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            cache_lock.read(),
+        )) {
+            Ok(cache) => cache
+                .get(&path)
+                .map(|e| e.last_mode.clone())
+                .unwrap_or_default(),
+            Err(_) => String::new(),
+        };
+
+        // Heavy disk I/O — no global cache lock held here.
+        let (output, effect) = crate::tools::ctx_patch::run_io(params, &last_mode);
+
+        crate::tools::ctx_patch::record_outcome(params, &last_mode, &output, &effect);
+
+        if !matches!(effect, crate::tools::ctx_edit::CacheEffect::None) {
+            match rt.block_on(tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                cache_lock.write(),
+            )) {
+                Ok(mut cache) => {
+                    crate::tools::ctx_edit::apply_cache_effect(&mut cache, &path, effect);
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "ctx_patch: cache write-lock timeout (5s) applying post-edit cache effect for {path}"
+                    );
+                }
+            }
+        }
+
+        if let Some(session_lock) = ctx.session.as_ref() {
+            let guard = rt.block_on(tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                session_lock.write(),
+            ));
+            if let Ok(mut session) = guard {
+                session.mark_modified(&path);
+            }
+        }
+
+        Ok(output)
+    })
 }
 
 /// Handle `op="replace_symbol"` by translating to `ctx_refactor`'s
@@ -346,5 +438,49 @@ mod replace_all_tests {
     fn empty_find_is_rejected() {
         let err = resolve_find_replace(&obj(json!({"find": "", "replace": "b"}))).unwrap_err();
         assert!(err.contains("find"), "got: {err}");
+    }
+}
+
+#[cfg(test)]
+mod batch_grouping_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// #1005: a batch spanning two files groups ops per file, preserving the
+    /// first-seen file order — no top-level `path` needed.
+    #[test]
+    fn groups_ops_across_files_preserving_order() {
+        let ops = vec![
+            json!({"op":"insert_after","path":"a.go","line":1,"hash":"aa","new_text":"x"}),
+            json!({"op":"insert_after","path":"b.go","line":2,"hash":"bb","new_text":"y"}),
+            json!({"op":"set_line","path":"a.go","line":3,"hash":"cc","new_text":"z"}),
+        ];
+        let g = group_ops_by_path(&ops, None).unwrap();
+        assert_eq!(g.len(), 2);
+        assert_eq!(g[0].0, "a.go");
+        assert_eq!(g[0].1.len(), 2);
+        assert_eq!(g[1].0, "b.go");
+        assert_eq!(g[1].1.len(), 1);
+    }
+
+    #[test]
+    fn ops_without_path_fall_back_to_top_level() {
+        let ops = vec![json!({"op":"set_line","line":1,"hash":"aa","new_text":"x"})];
+        let g = group_ops_by_path(&ops, Some("top.go")).unwrap();
+        assert_eq!(g.len(), 1);
+        assert_eq!(g[0].0, "top.go");
+    }
+
+    #[test]
+    fn op_without_path_and_no_top_level_is_rejected() {
+        let ops = vec![json!({"op":"set_line","line":1,"hash":"aa","new_text":"x"})];
+        let err = group_ops_by_path(&ops, None).unwrap_err();
+        assert!(err.contains("path"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_ops_rejected() {
+        let err = group_ops_by_path(&[], None).unwrap_err();
+        assert!(err.contains("empty"), "got: {err}");
     }
 }

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -35,7 +35,7 @@ impl McpTool for CtxReadTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_read",
-            "Read source files. mode REQUIRED — choose by intent (see `mode` below).\n\
+            "Read source files. mode recommended — choose by intent (see `mode` below); defaults to auto when omitted.\n\
              To UNDERSTAND code run ctx_compose FIRST; ctx_read after it identified files.\n\
              anchored → edit by reference via ctx_patch (no exact-recall).",
             json!({
@@ -45,7 +45,7 @@ impl McpTool for CtxReadTool {
                     "paths": { "type": "array", "items": { "type": "string" }, "description": "Batch read" },
                     "mode": {
                         "type": "string",
-                        "description": "REQUIRED. full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window (comma multi-selects: lines:5,10-20) reference=quotes task=focus"
+                        "description": "Recommended (defaults to auto). full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window (comma multi-selects: lines:5,10-20) reference=quotes task=focus"
                     },
                     "raw": { "type": "boolean", "description": "Verbatim (= mode=raw + fresh)" },
                     "start_line": { "type": "integer", "description": "1-based" },

--- a/rust/src/tools/registered/ctx_search.rs
+++ b/rust/src/tools/registered/ctx_search.rs
@@ -60,10 +60,9 @@ impl McpTool for CtxSearchTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_search",
-            "Search code; `action` picks the engine (default regex). \
-             regex(pattern) | semantic(query, by meaning) | symbol(name, AST-exact; \
-             or handle=path#name@Lline) | reindex | find_related(file_path,line). \
-             anchored=true tags hits for ctx_patch. queries:[{pattern}] for batch. Run ctx_compose FIRST.",
+            "Search code: regex(pattern, default) | semantic(query) | symbol(name|handle) | \
+             reindex | find_related(file_path,line). anchored=true enables ctx_patch refs; \
+             queries batches regex searches. Run ctx_compose FIRST.",
             json!({
                 "type": "object",
                 "properties": {
@@ -74,26 +73,48 @@ impl McpTool for CtxSearchTool {
                     "pattern": { "type": "string" },
                     "query": { "type": "string" },
                     "name": { "type": "string" },
-                    "handle": { "type": "string", "description": "path#name@Lline (exact, stable)" },
-                    "path": { "type": "string", "description": "Scope dir/root" },
+                    "handle": { "type": "string" },
+                    "path": { "type": "string" },
                     "paths": { "type": "array", "items": { "type": "string" } },
                     "include": { "type": "string", "description": "Glob, e.g. *.rs" },
                     "exclude": { "type": "string" },
-                    "exclude_pattern": { "type": "string", "description": "drop lines matching (grep -v)" },
+                    "exclude_pattern": { "type": "string" },
                     "anchored": { "type": "boolean" },
                     "max_results": { "type": "integer" },
                     "top_k": { "type": "integer" },
                     "mode": { "type": "string", "enum": ["bm25", "dense", "hybrid"] },
                     "file": { "type": "string" },
-                    "kind": { "type": "string", "description": "fn|struct|class|trait|enum" },
+                    "kind": { "type": "string" },
                     "file_path": { "type": "string" },
                     "line": { "type": "integer" },
                     "queries": {
                         "type": "array",
-                        "items": { "type": "object" },
-                        "description": "[{pattern,include?,exclude?}] batch"
+                        "items": { "type": "object" }
                     }
-                }
+                },
+                "oneOf": [
+                    {
+                        "properties": { "action": { "enum": ["regex"] } },
+                        "anyOf": [{ "required": ["pattern"] }, { "required": ["queries"] }]
+                    },
+                    {
+                        "properties": { "action": { "const": "semantic" } },
+                        "required": ["action", "query"]
+                    },
+                    {
+                        "properties": { "action": { "const": "symbol" } },
+                        "required": ["action"],
+                        "anyOf": [{ "required": ["name"] }, { "required": ["handle"] }]
+                    },
+                    {
+                        "properties": { "action": { "const": "reindex" } },
+                        "required": ["action"]
+                    },
+                    {
+                        "properties": { "action": { "const": "find_related" } },
+                        "required": ["action", "file_path", "line"]
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/schema_qa_tests.rs
+++ b/rust/src/tools/registered/schema_qa_tests.rs
@@ -1,0 +1,58 @@
+//! Runtime validation of published action-conditional tool schemas (#1008).
+
+use serde_json::{Value, json};
+
+use super::ctx_callgraph::CtxCallgraphTool;
+use super::ctx_execute::CtxExecuteTool;
+use super::ctx_expand::CtxExpandTool;
+use super::ctx_graph::CtxGraphTool;
+use super::ctx_knowledge::CtxKnowledgeTool;
+use super::ctx_search::CtxSearchTool;
+use crate::server::tool_trait::McpTool;
+
+fn validator(tool: &dyn McpTool) -> jsonschema::Validator {
+    let schema = Value::Object((*tool.tool_def().input_schema).clone());
+    jsonschema::validator_for(&schema).expect("published tool schema must compile")
+}
+
+#[test]
+fn callgraph_expand_and_graph_require_action_inputs() {
+    let callgraph = validator(&CtxCallgraphTool);
+    assert!(callgraph.is_valid(&json!({"action":"callers","symbol":"f"})));
+    assert!(callgraph.is_valid(&json!({"action":"trace","from":"a","to":"b"})));
+    assert!(!callgraph.is_valid(&json!({})));
+    assert!(!callgraph.is_valid(&json!({"action":"trace","from":"a"})));
+
+    let expand = validator(&CtxExpandTool);
+    assert!(expand.is_valid(&json!({"id":"F1"})));
+    assert!(expand.is_valid(&json!({"action":"list"})));
+    assert!(!expand.is_valid(&json!({})));
+    assert!(!expand.is_valid(&json!({"action":"search_all"})));
+
+    let graph = validator(&CtxGraphTool);
+    assert!(graph.is_valid(&json!({"action":"status"})));
+    assert!(graph.is_valid(&json!({"action":"path","path":"a","to":"b"})));
+    assert!(!graph.is_valid(&json!({"action":"symbol"})));
+    assert!(!graph.is_valid(&json!({"action":"path","path":"a"})));
+}
+
+#[test]
+fn knowledge_search_and_execute_require_mode_specific_inputs() {
+    let knowledge = validator(&CtxKnowledgeTool);
+    assert!(knowledge.is_valid(&json!({"action":"remember","category":"decision","value":"v"})));
+    assert!(knowledge.is_valid(&json!({"action":"recall"})));
+    assert!(!knowledge.is_valid(&json!({"action":"remember","value":"v"})));
+    assert!(!knowledge.is_valid(&json!({"action":"gotcha","trigger":"t"})));
+
+    let search = validator(&CtxSearchTool);
+    assert!(search.is_valid(&json!({"pattern":"needle"})));
+    assert!(search.is_valid(&json!({"action":"symbol","handle":"f.rs#f@L1"})));
+    assert!(!search.is_valid(&json!({})));
+    assert!(!search.is_valid(&json!({"action":"semantic"})));
+
+    let execute = validator(&CtxExecuteTool);
+    assert!(execute.is_valid(&json!({"language":"python","code":"print(1)"})));
+    assert!(execute.is_valid(&json!({"action":"file","path":"a.py"})));
+    assert!(!execute.is_valid(&json!({})));
+    assert!(!execute.is_valid(&json!({"action":"batch"})));
+}

--- a/rust/tests/intensive_benchmarks.rs
+++ b/rust/tests/intensive_benchmarks.rs
@@ -1051,8 +1051,8 @@ fn guard_shell_execute_policy_is_discoverable() {
 
     let execute = desc_of("ctx_execute");
     assert!(
-        execute.contains("allowlist"),
-        "ctx_execute must state its no-allowlist policy (#905), got: '{execute}'"
+        execute.contains("shares ctx_shell's security policy"),
+        "ctx_execute must state that shell execution shares ctx_shell's policy (#1011), got: '{execute}'"
     );
     assert!(
         execute.contains("ctx_shell"),
@@ -1060,7 +1060,7 @@ fn guard_shell_execute_policy_is_discoverable() {
     );
 
     eprintln!(
-        "\n  [guard] ctx_shell/ctx_execute policy split is documented in both descriptions ✓"
+        "\n  [guard] ctx_shell/ctx_execute shared shell policy is documented in both descriptions ✓"
     );
 }
 


### PR DESCRIPTION
## Summary

- integrate and harden the fixes for #1003, #1004, #1005 and #1008
- add `ctx_patch(op="replace_unique")` for safe one-shot unique edits (#1010)
- enforce the same shell policy in `ctx_execute(language="shell")` and batches as in `ctx_shell` (#1011)
- add executable JSON Schema QA for all action-dispatched core tools
- preserve cross-file patch safety, cache/session correctness and Windows PathJail boundaries

## Root causes

The open issues came from four independent gaps: conversation identity was not propagated on every host, batch patch paths were validated at the wrong level, action-dispatched schemas described only unconditional required fields, and shell execution had two policy paths with different enforcement.

## Validation

- `cargo test --lib`: 7,905 tests exercised; the only transient unrelated timing test was rerun successfully
- `cargo clippy --all-targets -- -D warnings`
- generated MCP documentation check
- core tool token-budget regression test
- push preflight CI-parity gate

Closes #1003
Closes #1004
Closes #1005
Closes #1008
Closes #1010
Closes #1011
