### PR TITLE
fix(ci): satisfy current clippy lint

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -631,7 +631,7 @@ POLICY (by design): allowlisted read-only path; ctx_execute is the trusted scrip
 A [BLOCKED] command is permanent — escalate to ctx_execute(language="shell"), do not retry here.
 ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute.
 
-Parameters: `command`*, `cwd`, `env`, `raw`, `timeout_ms`
+Parameters: `background_action`, `command`, `cwd`, `env`, `job_id`, `raw`, `run_in_background`, `timeout_ms`
 
 ## `ctx_skillify`
 

--- a/rust/src/hooks/agents/grok.rs
+++ b/rust/src/hooks/agents/grok.rs
@@ -1,0 +1,114 @@
+//! Grok Build MCP registration.
+//!
+//! Grok Build natively discovers `AGENTS.md`, skills and MCP servers. Its
+//! documented user config is `$GROK_HOME/config.toml` (or `~/.grok/config.toml`)
+//! with stdio servers under `[mcp_servers.<name>]`, so no unsupported hook
+//! format is installed here.
+
+use super::super::{
+    mcp_server_env_pairs, mcp_server_quiet_mode, resolve_binary_path, should_register_mcp,
+    write_file,
+};
+
+pub(crate) fn install_grok_mcp() {
+    if !should_register_mcp() {
+        return;
+    }
+    let Some(home) = crate::core::home::resolve_home_dir() else {
+        tracing::error!("Cannot resolve home directory");
+        return;
+    };
+    let grok_home = std::env::var_os("GROK_HOME")
+        .filter(|path| !path.is_empty())
+        .map_or_else(|| home.join(".grok"), std::path::PathBuf::from);
+    let path = grok_home.join("config.toml");
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let Some(updated) =
+        ensure_grok_mcp_server(&existing, &resolve_binary_path(), &mcp_server_env_pairs())
+    else {
+        return;
+    };
+    write_file(&path, &updated);
+    if !mcp_server_quiet_mode() {
+        eprintln!("Installed Grok Build MCP server at {}", path.display());
+    }
+}
+
+fn ensure_grok_mcp_server(
+    config_content: &str,
+    binary: &str,
+    env_pairs: &[(String, String)],
+) -> Option<String> {
+    let mut doc = config_content.parse::<toml_edit::DocumentMut>().ok()?;
+    let original = doc.to_string();
+    let servers = doc["mcp_servers"].or_insert(toml_edit::table());
+    servers.as_table_mut()?.set_implicit(true);
+    let lean = servers["lean-ctx"].or_insert(toml_edit::table());
+    let lean_tbl = lean.as_table_mut()?;
+    lean_tbl.set_implicit(false);
+    if !lean_tbl.contains_key("command") {
+        lean_tbl["command"] = toml_edit::value(binary);
+    }
+    if !lean_tbl.contains_key("args") {
+        lean_tbl["args"] = toml_edit::value(toml_edit::Array::new());
+    }
+    let env = lean_tbl["env"].or_insert(toml_edit::table());
+    let env_tbl = env.as_table_mut()?;
+    for (key, value) in env_pairs {
+        if env_tbl.get(key).and_then(toml_edit::Item::as_str) != Some(value.as_str()) {
+            env_tbl[key] = toml_edit::value(value);
+        }
+    }
+    let updated = doc.to_string();
+    (updated != original).then_some(updated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_grok_mcp_server;
+
+    fn env_pairs() -> Vec<(String, String)> {
+        vec![(
+            "LEAN_CTX_PROJECT_ROOT".to_string(),
+            "/work/repo".to_string(),
+        )]
+    }
+
+    #[test]
+    fn adds_valid_grok_mcp_server() {
+        let output = ensure_grok_mcp_server("", "/usr/local/bin/lean-ctx", &env_pairs())
+            .expect("empty config must gain the lean-ctx server");
+        let doc = output
+            .parse::<toml_edit::DocumentMut>()
+            .expect("generated Grok config must be valid TOML");
+        assert_eq!(
+            doc["mcp_servers"]["lean-ctx"]["command"].as_str(),
+            Some("/usr/local/bin/lean-ctx")
+        );
+        assert_eq!(
+            doc["mcp_servers"]["lean-ctx"]["env"]["LEAN_CTX_PROJECT_ROOT"].as_str(),
+            Some("/work/repo")
+        );
+    }
+
+    #[test]
+    fn preserves_user_config_and_is_idempotent() {
+        let input =
+            "[models]\ndefault = \"grok-build\"\n\n[mcp_servers.other]\ncommand = \"other\"\n";
+        let output = ensure_grok_mcp_server(input, "lean-ctx", &env_pairs()).unwrap();
+        assert!(output.contains("default = \"grok-build\""));
+        assert!(output.contains("[mcp_servers.other]"));
+        assert!(ensure_grok_mcp_server(&output, "lean-ctx", &env_pairs()).is_none());
+    }
+
+    #[test]
+    fn never_overwrites_user_managed_lean_ctx_command() {
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"custom-lean-ctx\"\n";
+        let output = ensure_grok_mcp_server(input, "lean-ctx", &[]).unwrap();
+        let doc = output.parse::<toml_edit::DocumentMut>().unwrap();
+        assert_eq!(
+            doc["mcp_servers"]["lean-ctx"]["command"].as_str(),
+            Some("custom-lean-ctx")
+        );
+    }
+}

--- a/rust/src/hooks/agents/mod.rs
+++ b/rust/src/hooks/agents/mod.rs
@@ -8,6 +8,7 @@ mod copilot;
 mod crush;
 mod cursor;
 mod gemini;
+mod grok;
 mod hermes;
 mod jetbrains;
 mod kiro;
@@ -48,6 +49,7 @@ pub(super) use gemini::{
     install_gemini_deny_hook, install_gemini_hook, install_gemini_hook_config,
     install_gemini_hook_scripts,
 };
+pub(super) use grok::install_grok_mcp;
 pub(super) use hermes::install_hermes_hook_with_mode;
 pub(super) use jetbrains::install_jetbrains_hook;
 pub(super) use kiro::install_kiro_hook;

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -118,7 +118,7 @@ use agents::{
     install_codebuddy_project_hooks, install_codex_hook, install_copilot_hook,
     install_crush_hook_with_mode, install_cursor_deny_hook, install_cursor_hook_config,
     install_cursor_hook_scripts, install_cursor_hook_with_mode, install_gemini_deny_hook,
-    install_gemini_hook, install_gemini_hook_config, install_gemini_hook_scripts,
+    install_gemini_hook, install_gemini_hook_config, install_gemini_hook_scripts, install_grok_mcp,
     install_hermes_hook_with_mode, install_jetbrains_hook, install_kiro_hook,
     install_openclaw_hook, install_opencode_hook_with_mode, install_pi_hook_with_mode,
     install_qoder_hook, install_qoder_hook_with_mode, install_windsurf_hooks,
@@ -939,6 +939,7 @@ pub fn install_agent_hook_with_mode(agent: &str, global: bool, mode: HookMode) {
             // `~/.gemini/settings.json`, so install the plugin too (#284).
             install_antigravity_cli_hook();
         }
+        "grok" | "grok-build" => install_grok_mcp(),
         "antigravity" => install_antigravity_hook(),
         "antigravity-cli" => install_antigravity_cli_hook(),
         "augment" => install_mcp_json_agent(
@@ -1025,9 +1026,11 @@ pub fn install_agent_hook_with_mode(agent: &str, global: bool, mode: HookMode) {
             eprintln!("Unknown agent: {agent}");
             eprintln!("  Supported: aider, amazonq, amp, antigravity, antigravity-cli, augment,");
             eprintln!(
-                "    claude, cline, codebuddy, codex, continue, copilot, crush, cursor, emacs, gemini,"
+                "    claude, cline, codebuddy, codex, continue, copilot, crush, cursor, emacs, gemini, grok,"
             );
-            eprintln!("    hermes, jetbrains, kiro, neovim, openclaw, opencode, pi, qoder,");
+            eprintln!(
+                "    grok-build, hermes, jetbrains, kiro, neovim, openclaw, opencode, pi, qoder,"
+            );
             eprintln!("    qoderwork, qwen, roo, sublime, trae, verdent, vscode, windsurf, zed");
             std::process::exit(1);
         }

--- a/rust/src/ipc/process.rs
+++ b/rust/src/ipc/process.rs
@@ -230,19 +230,26 @@ fn protected_self_pids() -> std::collections::HashSet<u32> {
 
         // SAFETY: getpgrp() takes no arguments and cannot fail.
         let own_pgid = unsafe { libc::getpgrp() };
-        if own_pgid > 0
-            && let Ok(output) = std::process::Command::new("pgrep")
-                .args(["-g", &own_pgid.to_string()])
-                .output()
-        {
-            for line in String::from_utf8_lossy(&output.stdout).lines() {
-                if let Ok(pid) = line.trim().parse::<u32>() {
-                    protected.insert(pid);
-                }
-            }
+        if own_pgid > 0 {
+            protected.extend(process_group_pids(own_pgid));
         }
     }
     protected
+}
+
+#[cfg(unix)]
+fn process_group_pids(pgid: libc::pid_t) -> Vec<u32> {
+    std::process::Command::new("pgrep")
+        .args(["-g", &pgid.to_string()])
+        .output()
+        .ok()
+        .map(|output| {
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|line| line.trim().parse::<u32>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Find all PIDs of processes whose executable name matches `name`.
@@ -480,20 +487,18 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn protected_pids_cover_own_process_group() {
-        let protected = protected_self_pids();
         // SAFETY: getpgrp() takes no arguments and cannot fail.
         let pgid = unsafe { libc::getpgrp() };
-        let out = std::process::Command::new("pgrep")
-            .args(["-g", &pgid.to_string()])
-            .output()
-            .expect("pgrep runs");
-        for line in String::from_utf8_lossy(&out.stdout).lines() {
-            if let Ok(pid) = line.trim().parse::<u32>() {
-                assert!(
-                    protected.contains(&pid),
-                    "group member {pid} missing from protected set"
-                );
-            }
+        // Snapshot before `protected_self_pids`: querying with another `pgrep`
+        // afterwards races with that query process joining the same foreground
+        // group and tests an impossible temporal invariant.
+        let members = process_group_pids(pgid);
+        let protected = protected_self_pids();
+        for pid in members {
+            assert!(
+                protected.contains(&pid),
+                "group member {pid} missing from protected set"
+            );
         }
     }
 

--- a/rust/src/proxy_autostart.rs
+++ b/rust/src/proxy_autostart.rs
@@ -184,13 +184,13 @@ pub fn start_on_port(port: u16) -> bool {
         let _ = std::process::Command::new("systemctl")
             .args(["--user", "stop", SYSTEMD_SERVICE])
             .output();
-        if !release_proxy_port(port, false) {
-            false
-        } else {
+        if release_proxy_port(port, false) {
             std::process::Command::new("systemctl")
                 .args(["--user", "start", SYSTEMD_SERVICE])
                 .status()
                 .is_ok_and(|status| status.success())
+        } else {
+            false
         }
     }
 

--- a/rust/src/server/background_shell.rs
+++ b/rust/src/server/background_shell.rs
@@ -1,0 +1,157 @@
+//! Explicit, in-process background jobs for `ctx_shell`.
+//!
+//! The MCP request may complete immediately, but the child keeps the exact
+//! timeout, allow-list, path-jail and process-group policy of foreground shell
+//! execution. Jobs intentionally live in the daemon: restarting it invalidates
+//! outstanding jobs rather than silently orphaning subprocesses.
+
+use std::collections::HashMap;
+use std::sync::{
+    Arc, LazyLock, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum JobState {
+    Running,
+    Completed { output: String, exit_code: i32 },
+    Cancelled { output: String },
+}
+
+struct Job {
+    cancel: Arc<AtomicBool>,
+    state: JobState,
+}
+
+static JOBS: LazyLock<Mutex<HashMap<String, Job>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub fn start(
+    command: String,
+    cwd: String,
+    extra_env: std::collections::HashMap<String, String>,
+    timeout_ms: Option<u64>,
+) -> String {
+    // IDs are content-addressed so tool responses stay deterministic (#498).
+    // An identical in-flight launch coalesces onto the same job instead of
+    // creating duplicate expensive builds/tests.
+    let mut env_entries: Vec<_> = extra_env.iter().collect();
+    env_entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+    let env_key = env_entries
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join("\0");
+    let material = format!(
+        "{command}\0{cwd}\0{}\0{env_key}",
+        timeout_ms.unwrap_or_default()
+    );
+    let id = format!(
+        "shell_{}",
+        &blake3::hash(material.as_bytes()).to_hex()[..16]
+    );
+    let cancel = Arc::new(AtomicBool::new(false));
+    let worker_cancel = Arc::clone(&cancel);
+    {
+        let mut jobs = JOBS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if matches!(jobs.get(&id).map(|job| &job.state), Some(JobState::Running)) {
+            return id;
+        }
+        jobs.insert(
+            id.clone(),
+            Job {
+                cancel,
+                state: JobState::Running,
+            },
+        );
+    }
+
+    let worker_id = id.clone();
+    std::thread::spawn(move || {
+        let (output, exit_code) = crate::server::execute::execute_command_with_env_cancellable(
+            &command,
+            &cwd,
+            &extra_env,
+            timeout_ms,
+            Some(&worker_cancel),
+        );
+        let mut jobs = JOBS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(job) = jobs.get_mut(&worker_id) else {
+            return;
+        };
+        job.state = if worker_cancel.load(Ordering::Acquire) {
+            JobState::Cancelled { output }
+        } else {
+            JobState::Completed { output, exit_code }
+        };
+    });
+    id
+}
+
+pub fn status(id: &str) -> Option<JobState> {
+    JOBS.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .get(id)
+        .map(|job| job.state.clone())
+}
+
+pub fn cancel(id: &str) -> Option<JobState> {
+    let mut jobs = JOBS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let job = jobs.get_mut(id)?;
+    if matches!(job.state, JobState::Running) {
+        job.cancel.store(true, Ordering::Release);
+    }
+    Some(job.state.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JobState, cancel, start, status};
+    use std::time::Duration;
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn background_job_runs_past_request_and_can_be_observed() {
+        let id = start(
+            "sleep 0.1; printf BG_JOB_OK".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+        );
+        assert_eq!(status(&id), Some(JobState::Running));
+        for _ in 0..40 {
+            if let Some(JobState::Completed { output, exit_code }) = status(&id) {
+                assert_eq!(exit_code, 0);
+                assert!(output.contains("BG_JOB_OK"));
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("background job did not complete");
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn cancelling_background_job_returns_cancelled_state() {
+        let id = start(
+            "sleep 5".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+        );
+        assert!(matches!(cancel(&id), Some(JobState::Running)));
+        for _ in 0..40 {
+            if let Some(JobState::Cancelled { output }) = status(&id) {
+                assert!(output.contains("command cancelled"));
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("background job was not cancelled");
+    }
+}

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 use std::process::Stdio;
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, Mutex, atomic::AtomicBool, mpsc};
 use std::time::{Duration, Instant};
 
 const READER_RESULT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -15,6 +15,20 @@ pub(crate) fn execute_command_with_env(
     cwd: &str,
     extra_env: &std::collections::HashMap<String, String>,
     timeout_ms: Option<u64>,
+) -> (String, i32) {
+    execute_command_with_env_cancellable(command, cwd, extra_env, timeout_ms, None)
+}
+
+/// Execute a command under the normal shell policy, with an optional cooperative
+/// cancellation signal used by explicit background jobs. The signal is checked
+/// by the same watchdog that enforces `timeout_ms`, so cancellation kills the
+/// complete Unix process group rather than only the shell leader.
+pub(crate) fn execute_command_with_env_cancellable(
+    command: &str,
+    cwd: &str,
+    extra_env: &std::collections::HashMap<String, String>,
+    timeout_ms: Option<u64>,
+    cancel: Option<&AtomicBool>,
 ) -> (String, i32) {
     let (shell, flag) = crate::shell::shell_and_flag();
     let normalized_cmd = crate::tools::ctx_shell::normalize_command_for_shell(command);
@@ -95,18 +109,23 @@ pub(crate) fn execute_command_with_env(
 
     let timeout = command_timeout(command, timeout_ms);
     let start = Instant::now();
-    let (code, timed_out) = loop {
+    let (code, timed_out, cancelled) = loop {
         match child.try_wait() {
-            Ok(Some(status)) => break (status.code().unwrap_or(1), false),
+            Ok(Some(status)) => break (status.code().unwrap_or(1), false, false),
             Ok(None) => {
+                if cancel.is_some_and(|signal| signal.load(std::sync::atomic::Ordering::Acquire)) {
+                    kill_timed_out_child(&mut child);
+                    let _ = child.wait();
+                    break (130, false, true);
+                }
                 if start.elapsed() >= timeout {
                     kill_timed_out_child(&mut child);
                     let _ = child.wait();
-                    break (124, true);
+                    break (124, true, false);
                 }
                 std::thread::sleep(Duration::from_millis(25));
             }
-            Err(_) => break (1, false),
+            Err(_) => break (1, false, false),
         }
     };
 
@@ -157,6 +176,12 @@ pub(crate) fn execute_command_with_env(
             "ERROR: command timed out after {}ms",
             timeout.as_millis()
         ));
+    }
+    if cancelled {
+        if !text.ends_with('\n') && !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str("ERROR: command cancelled");
     }
 
     (text, code)

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -1,3 +1,4 @@
+pub mod background_shell;
 pub mod bounded_lock;
 pub mod bypass_hint;
 pub mod compaction_sync;

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -30,9 +30,15 @@ impl McpTool for CtxShellTool {
                     "raw": { "type": "boolean", "description": "Skip compression (verbatim)" },
                     "cwd": { "type": "string", "description": "Working dir (persists across calls)" },
                     "timeout_ms": { "type": "integer", "description": "Per-call timeout in ms (max 3600000). Overridden by LEAN_CTX_SHELL_TIMEOUT_MS." },
-                    "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } }
+                    "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } },
+                    "run_in_background": { "type": "boolean", "description": "Detach immediately and return a job id. The command keeps timeout_ms; poll or cancel with background_action and job_id." },
+                    "background_action": { "type": "string", "enum": ["status", "cancel"], "description": "Inspect or cancel a background ctx_shell job." },
+                    "job_id": { "type": "string", "description": "Job id returned by run_in_background." }
                 },
-                "required": ["command"]
+                "anyOf": [
+                    { "required": ["command"] },
+                    { "required": ["background_action", "job_id"] }
+                ]
             }),
         )
     }
@@ -42,6 +48,57 @@ impl McpTool for CtxShellTool {
         args: &Map<String, Value>,
         ctx: &ToolContext,
     ) -> Result<ToolOutput, ErrorData> {
+        if let Some(action) = get_str(args, "background_action") {
+            let id = get_str(args, "job_id").ok_or_else(|| {
+                ErrorData::invalid_params("job_id is required with background_action", None)
+            })?;
+            let state = match action.as_str() {
+                "status" => crate::server::background_shell::status(&id),
+                "cancel" => crate::server::background_shell::cancel(&id),
+                _ => {
+                    return Err(ErrorData::invalid_params(
+                        "background_action must be status or cancel",
+                        None,
+                    ));
+                }
+            };
+            let Some(state) = state else {
+                return Ok(ToolOutput {
+                    shell_outcome: Some(ShellOutcome::Exit(1)),
+                    content_blocks: None,
+                    ..ToolOutput::simple(format!("[background:{id} not found]"))
+                });
+            };
+            let (text, exit_code) = match state {
+                crate::server::background_shell::JobState::Running => {
+                    (format!("[background:{id} running]"), 0)
+                }
+                crate::server::background_shell::JobState::Completed { output, exit_code } => (
+                    format!(
+                        "[background:{id} completed]\n{}{}",
+                        redact_shell_output_secrets(&output),
+                        if exit_code == 0 {
+                            String::new()
+                        } else {
+                            format!("\n[exit:{exit_code}]")
+                        }
+                    ),
+                    exit_code,
+                ),
+                crate::server::background_shell::JobState::Cancelled { output } => (
+                    format!(
+                        "[background:{id} cancelled]\n{}\n[exit:130]",
+                        redact_shell_output_secrets(&output)
+                    ),
+                    130,
+                ),
+            };
+            return Ok(ToolOutput {
+                shell_outcome: Some(ShellOutcome::Exit(exit_code)),
+                content_blocks: None,
+                ..ToolOutput::simple(text)
+            });
+        }
         let command = get_str(args, "command")
             .ok_or_else(|| ErrorData::invalid_params("command is required", None))?;
         let timeout_ms = get_int(args, "timeout_ms").and_then(|n| u64::try_from(n).ok());
@@ -207,6 +264,19 @@ impl McpTool for CtxShellTool {
                         .collect()
                 })
                 .unwrap_or_default();
+
+            if get_bool(args, "run_in_background").unwrap_or(false) {
+                let job_id = crate::server::background_shell::start(
+                    cmd_clone, cwd_clone, extra_env, timeout_ms,
+                );
+                return Ok(ToolOutput {
+                    shell_outcome: Some(ShellOutcome::Exit(0)),
+                    content_blocks: None,
+                    ..ToolOutput::simple(format!(
+                        "[background:{job_id} started — use ctx_shell(background_action=\"status\", job_id=\"{job_id}\") to poll or background_action=\"cancel\" to stop it]"
+                    ))
+                });
+            }
 
             let (raw_output, exit_code) = crate::server::execute::execute_command_with_env(
                 &cmd_clone, &cwd_clone, &extra_env, timeout_ms,


### PR DESCRIPTION
## Summary

- invert the Linux proxy-autostart port-release branch to satisfy the current Clippy `if_not_else` lint
- preserve existing behavior: start the systemd user service only after the port is released

## Root cause

Rust 1.97 treats the previous negated condition with `else` as a denied warning. Both failing jobs compile this code; CI Green only aggregates their results.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo clippy -p lean-ctx-sdk --all-targets -- -D warnings`