### PR TITLE
fix(gain): align columns in `gain --deep` dashboard sections

### DIFF
--- a/rust/src/core/stats/format/dashboard.rs
+++ b/rust/src/core/stats/format/dashboard.rs
@@ -455,7 +455,7 @@ fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
     };
 
     out.push(sec_line(&format!(
-        "  {m}Without lean-ctx{rst}  {:>10}  {without_bar}",
+        "  {m}Without lean-ctx{rst}   {:>10}  {without_bar}",
         format_usd(cost.total_cost_without),
         m = t.muted.fg(),
     )));
@@ -476,11 +476,17 @@ fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
     // -- TOP COMMANDS section --
     if !store.commands.is_empty() {
         out.push(format!("  {}", t.box_top_labeled(w, "TOP COMMANDS")));
-        out.push(sec_line(&format!(
-            "  {dim}{}{rst}",
-            "Command          Runs  Compression               Saved  Rate",
-            dim = t.muted.fg()
-        )));
+        // Build the header from the same column widths as the data rows below,
+        // so labels sit over their columns (1-space lead, runs 6-wide, etc.).
+        let hdr = format!(
+            " {} {:>6}  {} {}{:>4}",
+            theme::pad_right("Command", 16),
+            "Runs",
+            theme::pad_right("Compression", 20),
+            theme::pad_right("Saved", 7),
+            "Rate",
+        );
+        out.push(sec_line(&format!("{dim}{hdr}{rst}", dim = t.muted.fg())));
 
         let mut sorted: Vec<_> = store
             .commands
@@ -516,7 +522,7 @@ fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
             let saved_col =
                 theme::pad_right(&format!("{bold}{pc}{}{rst}", format_big(cmd_saved)), 7);
             let row = format!(
-                " {cmd_col} {:>4}x {bar} {saved_col}{dim}{cmd_pct:>3.0}%{rst}",
+                " {cmd_col} {:>6}x {bar} {saved_col}{dim}{cmd_pct:>3.0}%{rst}",
                 stats.count,
             );
             out.push(sec_line(&row));

--- a/rust/src/tools/ctx_gain.rs
+++ b/rust/src/tools/ctx_gain.rs
@@ -391,7 +391,7 @@ fn format_cost_themed(
                 .map(|mk| format!(" {dim}[{mk}]{rst}"))
                 .unwrap_or_default();
             out.push(sec_line(&format!(
-                " {dim}{}. {rst}{name} {bar} {cost_s} {dim}{}c{rst}{model_tag}",
+                " {dim}{:>2}. {rst}{name} {bar} {cost_s} {dim}{}c{rst}{model_tag}",
                 i + 1,
                 agent.total_calls
             )));
@@ -414,7 +414,7 @@ fn format_cost_themed(
             );
             let cost_s = format!("{s}${:.4}{rst}", tool.cost_usd);
             out.push(sec_line(&format!(
-                " {dim}{}. {rst}{name} {bar} {cost_s} {dim}{}c avg {:.0}in+{:.0}out{rst}",
+                " {dim}{:>2}. {rst}{name} {bar} {cost_s} {dim}{}c avg {:.0}in+{:.0}out{rst}",
                 i + 1,
                 tool.total_calls,
                 tool.avg_input_tokens,
@@ -476,7 +476,7 @@ fn format_agents_themed(
             format_tokens(agent.total_output_tokens)
         );
         out.push(sec_line(&format!(
-            " {dim}{}.{rst} {name} {bar} {calls} {toks}",
+            " {dim}{:>2}.{rst} {name} {bar} {calls} {toks}",
             i + 1
         )));
     }


### PR DESCRIPTION
## Problem

`lean-ctx gain --deep` rendered several sections with columns pushed out of alignment. The box borders were fine (all 74 cols) — the **inner columns** drifted.

## Fixes

- **COST BREAKDOWN** — `Without lean-ctx` amount sat one column left of `With lean-ctx`/`You saved` (label pad 20 vs 21).
- **TOP COMMANDS** — runs field was `{:>4}`, so 5-digit counts (`18958x`) overflowed and shoved that row's bar/saved/rate right. The static header string also didn't sit over the data columns. Header is now built from the same widths as the data rows; runs widened to `{:>6}`.
- **COST ATTRIBUTION** (Top Agents / Top Tools) and **AGENTS** — the `{i}.` index prefix was unpadded, so the 10th row (two digits) was one column wider than rows 1-9, shifting its name/bar/cost right. Index is now `{:>2}` (HEATMAP already did this).

## Before / after (10th row)

```
 10. mcp-83683-087c5f34   BB   ...   ← name/bar shifted +1 col
  9. mcp-44463-968a0735   BBB  ...
```
```
 10. mcp-83683-087c5f34   BB   ...   ← aligned
  9. mcp-44463-968a0735   BBB  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)