### PR TITLE
feat(schema): sharp per-action required params + generic guard, all action-conditional tools (#1020)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,12 +526,14 @@ jobs:
       # must stay under budget. Runs in a scratch HOME + empty cwd so only OUR
       # footprint is measured — no repo rules files, no developer state.
       # Baseline: ~2790 tok (schemas ~2320, instructions ~470).
-      # Raised 2700→2800 after #1017 added background-shell controls; keep a
-      # small headroom while preserving the gate against further creep.
+      # Raised 2700→2800 after #1017 added background-shell controls.
+      # Raised 2800→3000 after #1020 encoded per-op required params in the
+      # ctx_patch schema as if/then conditionals (~183 tok of discoverability on
+      # the advertised surface); keep small headroom against further creep.
       - name: Self-footprint gate (doctor overhead)
         shell: bash
         env:
-          LEAN_CTX_CONTEXT_BUDGET_TOKENS: "2800"
+          LEAN_CTX_CONTEXT_BUDGET_TOKENS: "3000"
         run: |
           set -euo pipefail
           BIN="$GITHUB_WORKSPACE/rust/target/debug/lean-ctx"

--- a/rust/src/server/tool_visibility.rs
+++ b/rust/src/server/tool_visibility.rs
@@ -545,10 +545,13 @@ mod tests {
     /// Bumped to 370/2500 for #871: `ctx_search` gained `queries` batch mode
     /// and restored full action descriptions. Tool correctness > token savings —
     /// incomplete descriptions cause agents to misuse parameters.
+    ///
+    /// Bumped to 410/3000 for #1020: `ctx_patch` gained per-op JSON Schema
+    /// if/then conditionals so required params are discoverable pre-call.
     #[test]
     fn core_tool_surface_stays_within_budget() {
-        const PER_TOOL_BUDGET: usize = 370;
-        const TOTAL_BUDGET: usize = 2500;
+        const PER_TOOL_BUDGET: usize = 410;
+        const TOTAL_BUDGET: usize = 3000;
 
         let _guard = crate::core::data_dir::isolated_data_dir();
         let core = crate::tool_defs::core_tool_names();

--- a/rust/src/tools/registered/ctx_agent.rs
+++ b/rust/src/tools/registered/ctx_agent.rs
@@ -57,6 +57,17 @@ impl McpTool for CtxAgentTool {
                         "description": "active|idle|finished"
                     }
                 },
+                "allOf": [
+                    { "if": { "properties": { "action": { "const": "post" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } },
+                    { "if": { "properties": { "action": { "const": "status" } }, "required": ["action"] }, "then": { "required": ["action", "status"] } },
+                    { "if": { "properties": { "action": { "const": "handoff" } }, "required": ["action"] }, "then": { "required": ["action", "to_agent"] } },
+                    { "if": { "properties": { "action": { "const": "claim" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } },
+                    { "if": { "properties": { "action": { "const": "release" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } },
+                    { "if": { "properties": { "action": { "const": "brief" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } },
+                    { "if": { "properties": { "action": { "const": "return" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } },
+                    { "if": { "properties": { "action": { "const": "diary" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } },
+                    { "if": { "properties": { "action": { "const": "share_knowledge" } }, "required": ["action"] }, "then": { "required": ["action", "message"] } }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_architecture.rs
+++ b/rust/src/tools/registered/ctx_architecture.rs
@@ -41,7 +41,13 @@ impl McpTool for CtxArchitectureTool {
                         "type": "string",
                         "description": "Output format: text|json (default text)"
                     }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "module" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_cache.rs
+++ b/rust/src/tools/registered/ctx_cache.rs
@@ -33,6 +33,15 @@ impl McpTool for CtxCacheTool {
                         "description": "File path for invalidate action (only used with action=invalidate)"
                     }
                 },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "invalidate" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "path"] }
+                    }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_checkpoint.rs
+++ b/rust/src/tools/registered/ctx_checkpoint.rs
@@ -43,7 +43,13 @@ ANTIPATTERN: Never touches the user's repository — completely isolated shadow 
                     "ref": { "type": "string", "description": "Checkpoint SHA to restore (required for action=restore)" },
                     "path": { "type": "string", "description": "File/dir to restore (omit for full restore, action=restore only)" },
                     "limit": { "type": "integer", "description": "Max checkpoints in log (default: 20, max: 200)" }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "restore" } }, "required": ["action"] },
+                        "then": { "required": ["action", "ref"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_feedback.rs
+++ b/rust/src/tools/registered/ctx_feedback.rs
@@ -37,7 +37,13 @@ impl McpTool for CtxFeedbackTool {
                     "latency_ms": { "type": "integer", "description": "Latency in ms (for record)" },
                     "note": { "type": "string", "description": "Note (no prompts/PII)" },
                     "limit": { "type": "integer", "description": "Max recent events (default: 500)" }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "record" } }, "required": ["action"] },
+                        "then": { "required": ["action", "llm_input_tokens", "llm_output_tokens"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_git_read.rs
+++ b/rust/src/tools/registered/ctx_git_read.rs
@@ -46,6 +46,12 @@ impl McpTool for CtxGitReadTool {
                     "max_tokens": { "type": "integer", "description": "Token budget (default: 6000)" },
                     "timeout_secs": { "type": "integer", "description": "Timeout seconds (default: 90, max: 300)" }
                 },
+                "allOf": [
+                    {
+                        "if": { "properties": { "mode": { "const": "grep" } }, "required": ["mode"] },
+                        "then": { "required": ["mode", "query"] }
+                    }
+                ],
                 "required": ["url"]
             }),
         )

--- a/rust/src/tools/registered/ctx_handoff.rs
+++ b/rust/src/tools/registered/ctx_handoff.rs
@@ -37,7 +37,21 @@ impl McpTool for CtxHandoffTool {
                     "apply_workflow": { "type": "boolean", "description": "Apply workflow state" },
                     "apply_session": { "type": "boolean", "description": "Apply session snapshot" },
                     "apply_knowledge": { "type": "boolean", "description": "Import knowledge facts" }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "show" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "pull" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "import" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_impact.rs
+++ b/rust/src/tools/registered/ctx_impact.rs
@@ -42,7 +42,27 @@ impl McpTool for CtxImpactTool {
                         "type": "string",
                         "description": "Output format"
                     }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "analyze" } },
+                            "required": ["action"]
+                        },
+                        "then": {
+                            "required": ["action", "path"]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "chain" } },
+                            "required": ["action"]
+                        },
+                        "then": {
+                            "required": ["action", "path"]
+                        }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_ledger.rs
+++ b/rust/src/tools/registered/ctx_ledger.rs
@@ -36,7 +36,16 @@ impl McpTool for CtxLedgerTool {
                         "description": "Paths to evict (comma-separated)"
                     }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "evict" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "targets"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_load_tools.rs
+++ b/rust/src/tools/registered/ctx_load_tools.rs
@@ -34,6 +34,22 @@ impl McpTool for CtxLoadToolsTool {
                         "description": "arch|debug|memory|metrics|session"
                     }
                 },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "load" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "category"] }
+                    },
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "unload" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "category"] }
+                    }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_multi_repo.rs
+++ b/rust/src/tools/registered/ctx_multi_repo.rs
@@ -61,7 +61,21 @@ impl McpTool for CtxMultiRepoTool {
                         "description": "Per-root ranking signal (default: hybrid; bm25 = lexical only)"
                     }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "add_root" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "remove_root" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "search" } }, "required": ["action"] },
+                        "then": { "required": ["action", "query"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_pack.rs
+++ b/rust/src/tools/registered/ctx_pack.rs
@@ -99,7 +99,33 @@ impl McpTool for CtxPackTool {
                         "description": "Enable auto-load (default: true)"
                     }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "create" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "info" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "remove" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "install" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "export" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "import" } }, "required": ["action"] },
+                        "then": { "required": ["action", "file"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_package.rs
+++ b/rust/src/tools/registered/ctx_package.rs
@@ -37,6 +37,16 @@ impl McpTool for CtxPackageTool {
                         "description": "Package description (for save action)"
                     }
                 },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "resume" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "info" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    }
+                ],
                 "required": []
             }),
         )

--- a/rust/src/tools/registered/ctx_patch.rs
+++ b/rust/src/tools/registered/ctx_patch.rs
@@ -43,7 +43,28 @@ impl McpTool for CtxPatchTool {
                     "replace": { "type": "string" },
                     "dry_run": { "type": "boolean" },
                     "ops": { "type": "array", "items": { "type": "object" } }
-                }
+                },
+                // Per-op required params encoded as the source of truth (#1020):
+                // a client reading the schema knows which fields an op needs
+                // BEFORE calling. Each `if` requires `op` so it stays dormant for
+                // batch calls (which carry `op` inside ops[], not at top level).
+                // Only ops with UNCONDITIONAL requirements are listed — insert_after
+                // (hash optional when line=0) and delete (single vs range) keep their
+                // requirements in the parser to avoid rejecting valid calls.
+                "allOf": [
+                    { "if": { "properties": { "op": { "const": "set_line" } }, "required": ["op"] },
+                      "then": { "required": ["op", "line", "hash", "new_text"] } },
+                    { "if": { "properties": { "op": { "const": "replace_lines" } }, "required": ["op"] },
+                      "then": { "required": ["op", "start_line", "start_hash", "end_line", "end_hash", "new_text"] } },
+                    { "if": { "properties": { "op": { "const": "replace_unique" } }, "required": ["op"] },
+                      "then": { "required": ["op", "old_text", "new_text"] } },
+                    { "if": { "properties": { "op": { "const": "replace_symbol" } }, "required": ["op"] },
+                      "then": { "required": ["op", "new_text"] } },
+                    { "if": { "properties": { "op": { "const": "create" } }, "required": ["op"] },
+                      "then": { "required": ["op", "new_text"] } },
+                    { "if": { "properties": { "op": { "const": "replace_all" } }, "required": ["op"] },
+                      "then": { "required": ["op", "find", "replace"] } }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_plugins.rs
+++ b/rust/src/tools/registered/ctx_plugins.rs
@@ -33,6 +33,20 @@ impl McpTool for CtxPluginsTool {
                         "description": "Plugin name (required for enable, disable, info)"
                     }
                 },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "enable" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "disable" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "info" } }, "required": ["action"] },
+                        "then": { "required": ["action", "name"] }
+                    }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_quality.rs
+++ b/rust/src/tools/registered/ctx_quality.rs
@@ -39,7 +39,23 @@ impl McpTool for CtxQualityTool {
                         "type": "string",
                         "description": "Output format (text|json)"
                     }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "file" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "delta" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "path"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_refactor.rs
+++ b/rust/src/tools/registered/ctx_refactor.rs
@@ -63,6 +63,72 @@ impl McpTool for CtxRefactorTool {
                     "keep_definition": { "type": "boolean", "description": "Keep declaration after inline" },
                     "optimize_imports": { "type": "boolean", "description": "Remove unused imports" }
                 },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "rename" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path", "new_name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "references" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "definition" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "implementations" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "declaration" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "type_hierarchy" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "symbols_overview" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "inspections" } }, "required": ["action"] },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "replace_symbol_body" } }, "required": ["action"] },
+                        "then": { "required": ["action", "new_text"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "insert_before_symbol" } }, "required": ["action"] },
+                        "then": { "required": ["action", "text"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "insert_after_symbol" } }, "required": ["action"] },
+                        "then": { "required": ["action", "text"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "rename_preview" } }, "required": ["action"] },
+                        "then": { "required": ["action", "new_name"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "rename_apply" } }, "required": ["action"] },
+                        "then": { "required": ["action", "new_name", "plan_hash"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "safe_delete_apply" } }, "required": ["action"] },
+                        "then": { "required": ["action", "plan_hash"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "move_apply" } }, "required": ["action"] },
+                        "then": { "required": ["action", "plan_hash"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "inline_apply" } }, "required": ["action"] },
+                        "then": { "required": ["action", "plan_hash"] }
+                    }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_review.rs
+++ b/rust/src/tools/registered/ctx_review.rs
@@ -36,7 +36,30 @@ impl McpTool for CtxReviewTool {
                         "description": "Analysis breadth (default 3)"
                     }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "review" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "diff-review" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "path"] }
+                    },
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "checklist" } },
+                            "required": ["action"]
+                        },
+                        "then": { "required": ["action", "path"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_semantic_search.rs
+++ b/rust/src/tools/registered/ctx_semantic_search.rs
@@ -43,6 +43,12 @@ impl McpTool for CtxSemanticSearchTool {
                     },
                     "path_glob": { "type": "string", "description": "Glob over relative file paths" }
                 },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "find_related" } }, "required": ["action"] },
+                        "then": { "required": ["action", "file_path"] }
+                    }
+                ],
                 "required": ["query"]
             }),
         )

--- a/rust/src/tools/registered/ctx_share.rs
+++ b/rust/src/tools/registered/ctx_share.rs
@@ -39,6 +39,17 @@ impl McpTool for CtxShareTool {
                         "description": "Context message about what was shared"
                     }
                 },
+                "allOf": [
+                    {
+                        "if": {
+                            "properties": { "action": { "const": "push" } },
+                            "required": ["action"]
+                        },
+                        "then": {
+                            "required": ["action", "paths"]
+                        }
+                    }
+                ],
                 "required": ["action"]
             }),
         )

--- a/rust/src/tools/registered/ctx_skillify.rs
+++ b/rust/src/tools/registered/ctx_skillify.rs
@@ -31,7 +31,13 @@ impl McpTool for CtxSkillifyTool {
                         "type": "string",
                         "description": "Rule slug (for promote)"
                     }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "promote" } }, "required": ["action"] },
+                        "then": { "required": ["action", "slug"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_task.rs
+++ b/rust/src/tools/registered/ctx_task.rs
@@ -34,7 +34,29 @@ impl McpTool for CtxTaskTool {
                     "state": { "type": "string", "description": "New state (working|input-required|completed|failed|canceled)" },
                     "message": { "type": "string", "description": "Message or reason" }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "create" } }, "required": ["action"] },
+                        "then": { "required": ["action", "to_agent"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "update" } }, "required": ["action"] },
+                        "then": { "required": ["action", "task_id", "state"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "get" } }, "required": ["action"] },
+                        "then": { "required": ["action", "task_id"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "cancel" } }, "required": ["action"] },
+                        "then": { "required": ["action", "task_id"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "message" } }, "required": ["action"] },
+                        "then": { "required": ["action", "task_id", "message"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_tools.rs
+++ b/rust/src/tools/registered/ctx_tools.rs
@@ -34,7 +34,13 @@ impl McpTool for CtxToolsTool {
                     "query": { "type": "string", "description": "What you want to do (for find)" },
                     "tool": { "type": "string", "description": "`server::tool` handle (for call)" },
                     "arguments": { "type": "object", "description": "Arguments for downstream tool (call)" }
-                }
+                },
+                "allOf": [
+                    {
+                        "if": { "properties": { "action": { "const": "call" } }, "required": ["action"] },
+                        "then": { "required": ["action", "tool"] }
+                    }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/ctx_workflow.rs
+++ b/rust/src/tools/registered/ctx_workflow.rs
@@ -34,7 +34,13 @@ impl McpTool for CtxWorkflowTool {
                     "to": { "type": "string", "description": "Target state (for transition)" },
                     "key": { "type": "string", "description": "Evidence key (for evidence_add)" },
                     "value": { "type": "string", "description": "Evidence value or transition note" }
-                }
+                },
+                "allOf": [
+                    { "if": { "properties": { "action": { "const": "transition" } }, "required": ["action"] },
+                      "then": { "required": ["action", "to"] } },
+                    { "if": { "properties": { "action": { "const": "evidence_add" } }, "required": ["action"] },
+                      "then": { "required": ["action", "key"] } }
+                ]
             }),
         )
     }

--- a/rust/src/tools/registered/schema_qa_tests.rs
+++ b/rust/src/tools/registered/schema_qa_tests.rs
@@ -1,5 +1,7 @@
 //! Runtime validation of published action-conditional tool schemas (#1008).
 
+use std::collections::HashSet;
+
 use serde_json::{Value, json};
 
 use super::ctx_callgraph::CtxCallgraphTool;
@@ -58,35 +60,109 @@ fn knowledge_search_and_execute_require_mode_specific_inputs() {
     assert!(!execute.is_valid(&json!({"action":"batch"})));
 }
 
-/// Prose regression guard (#1020): the published ctx_patch description teaches
-/// callers which param each op needs. A rename that updates the code but not the
-/// prose (e.g. new_body→new_text) leaves the schema description silently stale.
-/// Assert every op's required param is still named, and the retired alias is not.
-#[test]
-fn patch_description_names_each_ops_required_param() {
-    let def = CtxPatchTool.tool_def();
-    let desc = def.description.as_deref().unwrap_or("");
+/// Collect every declared `properties` key anywhere in a schema (top level and
+/// nested — object params, `if`/`then` applicators, array `items`).
+fn collect_property_names(node: &Value, out: &mut HashSet<String>) {
+    match node {
+        Value::Object(map) => {
+            if let Some(Value::Object(props)) = map.get("properties") {
+                out.extend(props.keys().cloned());
+            }
+            for v in map.values() {
+                collect_property_names(v, out);
+            }
+        }
+        Value::Array(arr) => arr.iter().for_each(|v| collect_property_names(v, out)),
+        _ => {}
+    }
+}
 
-    for token in [
-        "line",
-        "hash", // anchored ops: set_line/replace_lines/insert_after/delete
-        "old_text",
-        "new_text", // replace_unique(path,old_text,new_text)
-        "replace_symbol",
-        "create",
-        "replace_all",
-        "ops[]", // op routing
-    ] {
-        assert!(
-            desc.contains(token),
-            "ctx_patch description must name `{token}`; got: {desc}"
-        );
+/// Collect every string listed in any `required` array anywhere in a schema —
+/// including the `then.required` of conditional (`if`/`then`) subschemas.
+fn collect_required(node: &Value, out: &mut Vec<String>) {
+    match node {
+        Value::Object(map) => {
+            if let Some(Value::Array(req)) = map.get("required") {
+                out.extend(req.iter().filter_map(|r| r.as_str().map(str::to_string)));
+            }
+            for v in map.values() {
+                collect_required(v, out);
+            }
+        }
+        Value::Array(arr) => arr.iter().for_each(|v| collect_required(v, out)),
+        _ => {}
+    }
+}
+
+/// Generic schema-integrity guard (#1020): once per-op requirements live in the
+/// schema (as `if`/`then` conditionals) rather than only in imperative parser
+/// code, the schema IS the source of truth — and requiring a param the schema
+/// never declares is a self-contradiction a client hits before the handler runs.
+/// Assert, for every registered tool, that every `required` token is a declared
+/// property. A `then: {required:["new_body"]}` left after `new_body` was renamed
+/// to `new_text` fails here, for all tools, with no per-tool hardcoding.
+#[test]
+fn every_required_param_is_a_declared_property() {
+    let registry = crate::server::registry::build_registry();
+    let mut violations = Vec::new();
+
+    for def in registry.tool_defs() {
+        let schema = Value::Object((*def.input_schema).clone());
+        let mut props = HashSet::new();
+        collect_property_names(&schema, &mut props);
+        let mut required = Vec::new();
+        collect_required(&schema, &mut required);
+        for r in required {
+            if !props.contains(&r) {
+                violations.push(format!(
+                    "{}: schema requires `{r}` but declares no such property",
+                    def.name
+                ));
+            }
+        }
     }
 
-    // new_text is the single write-param name across every op (#1020); new_body
-    // was fully retired (no alias) — it must never reappear in the published prose.
     assert!(
-        !desc.contains("new_body"),
-        "new_body is retired; published prose must say new_text"
+        violations.is_empty(),
+        "tool schemas require undeclared params (retired/typo'd field?):\n  {}",
+        violations.join("\n  ")
     );
+}
+
+/// The sharp ctx_patch schema (#1020) encodes per-op required params, so a
+/// client knows before calling that `replace_lines` needs `new_text` — not the
+/// retired `new_body`. Exercise the conditionals directly.
+#[test]
+fn patch_schema_encodes_per_op_required_params() {
+    let patch = validator(&CtxPatchTool);
+
+    // set_line requires new_text; the retired new_body does not satisfy it.
+    assert!(
+        patch.is_valid(&json!({"op":"set_line","path":"a","line":1,"hash":"aa","new_text":"x"}))
+    );
+    assert!(
+        !patch.is_valid(&json!({"op":"set_line","path":"a","line":1,"hash":"aa","new_body":"x"}))
+    );
+
+    // replace_lines requires all four anchors + new_text.
+    assert!(patch.is_valid(&json!({
+        "op":"replace_lines","path":"a",
+        "start_line":1,"start_hash":"aa","end_line":2,"end_hash":"bb","new_text":"y"
+    })));
+    assert!(!patch.is_valid(&json!({
+        "op":"replace_lines","path":"a",
+        "start_line":1,"start_hash":"aa","end_line":2,"end_hash":"bb"
+    })));
+
+    // create/replace_all bodies.
+    assert!(!patch.is_valid(&json!({"op":"create","path":"a"})));
+    assert!(patch.is_valid(&json!({"op":"create","path":"a","new_text":""})));
+    assert!(!patch.is_valid(&json!({"op":"replace_all","path":"a","find":"x"})));
+    assert!(patch.is_valid(&json!({"op":"replace_all","path":"a","find":"x","replace":"y"})));
+
+    // Conditionals stay dormant for batch calls: `op` lives inside ops[], so no
+    // top-level `if op==…` fires and the batch validates without body params.
+    assert!(patch.is_valid(&json!({
+        "ops":[{"op":"set_line","path":"a","line":1,"hash":"aa","new_text":"x"}]
+    })));
 }

--- a/rust/tests/intensive_benchmarks.rs
+++ b/rust/tests/intensive_benchmarks.rs
@@ -224,11 +224,15 @@ fn bench_total_input_overhead() {
     // lifted the actual to ~15116 (instr ~502 + desc ~5905 + schemas ~8709), over
     // the previous 15000 ceiling. Per #290 the ceiling must carry "a tool or two"
     // of slack over the actual, so 16000 (actual ~15116, ~2 tools headroom)
-    // restores that buffer. The lazy default surface users actually pay is
-    // unaffected (bench_lazy_default_vs_full_overhead).
+    // restores that buffer.
+    // Raised 16000 -> 18000 for #1020: per-action schema conditionals across 23
+    // tools added ~1300 tok to the full profile (actual ~17293). Default profile
+    // is unaffected (conditionals only on non-default-advertised tools).
+    // The lazy default surface users actually pay is unaffected
+    // (bench_lazy_default_vs_full_overhead).
     assert!(
-        total < 16000,
-        "Total input overhead should be <16000 tokens, got {total}"
+        total < 18000,
+        "Total input overhead should be <18000 tokens, got {total}"
     );
 }
 


### PR DESCRIPTION
Supersedes #1025 (rebased on current main which includes #1023, and fixes the CI-failing per-tool budget).

## Changes from #1025
- Rebased on main (includes the merged #1023 new_text unification)
- **Fixed CI**: bumped per-tool budget 370→410 and total 2500→3000 in `tool_visibility.rs` (the test that was failing)

## Original scope (from @andig)
1. **ctx_patch** — per-op required params as `allOf` if/then conditionals
2. **Generic guard** — `every_required_param_is_a_declared_property` across all ~86 tools
3. **23 action-conditional tools swept** with per-action required params
4. Removed superseded prose guard

Credit: @andig + Claude Opus 4.8 (original implementation)
Budget justification: +31 tok for ctx_patch buys pre-call discoverability, net positive under prompt caching (10% rebill).

Made with [Cursor](https://cursor.com)