### PR TITLE
Add Mistral Vibe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ LeanCTX is a standard **MCP server**, so it works with any MCP-compatible client
 | Trae | ● | | `lean-ctx init --agent trae` |
 | Verdent | ● | | `lean-ctx init --agent verdent` |
 | Aider | | ● | `lean-ctx init --agent aider` |
+| Mistral Vibe | | ● | `lean-ctx init --agent vibe` |
 | Continue | | ● | `lean-ctx init --agent continue` |
 | JetBrains IDEs | | ● | `lean-ctx init --agent jetbrains` |
 | QoderWork | | ● | `lean-ctx init --agent qoderwork` |

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -2,8 +2,9 @@ use std::path::{Path, PathBuf};
 
 use super::paths::{
     augment_cli_settings_path, augment_vscode_mcp_path, claude_mcp_json_path, cline_mcp_path,
-    codebuddy_mcp_json_path, qoder_all_mcp_paths, qoderwork_mcp_path, roo_mcp_path,
-    vscode_insiders_mcp_path, vscode_mcp_path, zed_config_dir, zed_settings_path,
+    codebuddy_mcp_json_path, detect_vibe_path, qoder_all_mcp_paths, qoderwork_mcp_path,
+    roo_mcp_path, vibe_config_path, vscode_insiders_mcp_path, vscode_mcp_path, zed_config_dir,
+    zed_settings_path,
 };
 use super::types::{ConfigType, EditorTarget};
 
@@ -277,6 +278,13 @@ pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
             // a top-level `mcpServers` key ("Unrecognized key") — it requires
             // the nested `mcp.servers` schema (GitHub #390).
             config_type: ConfigType::OpenClaw,
+        },
+        EditorTarget {
+            name: "Mistral Vibe",
+            agent_key: "vibe".to_string(),
+            config_path: vibe_config_path(home),
+            detect_path: detect_vibe_path(home),
+            config_type: ConfigType::VibeToml,
         },
     ];
 

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -295,7 +295,7 @@ pub fn vibe_config_path(home: &Path) -> PathBuf {
     home.join(".vibe/config.toml")
 }
 
-fn detect_vibe_path(home: &Path) -> PathBuf {
+pub fn detect_vibe_path(home: &Path) -> PathBuf {
     let vibe_dir = home.join(".vibe");
     if vibe_dir.exists() {
         return vibe_dir;

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -291,6 +291,18 @@ pub fn augment_vscode_mcp_path(home: &Path) -> PathBuf {
     home.join(".config/Code/User").join(TAIL)
 }
 
+pub fn vibe_config_path(home: &Path) -> PathBuf {
+    home.join(".vibe/config.toml")
+}
+
+fn detect_vibe_path(home: &Path) -> PathBuf {
+    let vibe_dir = home.join(".vibe");
+    if vibe_dir.exists() {
+        return vibe_dir;
+    }
+    PathBuf::from("/nonexistent")
+}
+
 #[cfg(test)]
 mod augment_tests {
     use super::*;

--- a/rust/src/core/editor_registry/types.rs
+++ b/rust/src/core/editor_registry/types.rs
@@ -32,4 +32,6 @@ pub enum ConfigType {
     /// Older versions use the legacy camelCase key — the writer detects the
     /// version via `meta.lastTouchedVersion` and migrates (GitHub #390).
     OpenClaw,
+    /// Mistral Vibe (`~/.vibe/config.toml`): TOML-based config with `[[mcp_servers]]` array
+    VibeToml,
 }

--- a/rust/src/core/editor_registry/writers/install.rs
+++ b/rust/src/core/editor_registry/writers/install.rs
@@ -1334,41 +1334,53 @@ pub(super) fn write_vibe_toml(
     lean_ctx_server.insert("name", toml_edit::value("lean-ctx"));
     lean_ctx_server.insert("transport", toml_edit::value("stdio"));
     lean_ctx_server.insert("command", toml_edit::value(binary));
-    
+
     // Create args array
     let mut args_array = toml_edit::Array::new();
-    args_array.push(toml_edit::Value::String(toml_edit::Formatted::new("serve".to_string())));
-    lean_ctx_server.insert("args", toml_edit::Item::Value(toml_edit::Value::Array(args_array)));
+    args_array.push(toml_edit::Value::String(toml_edit::Formatted::new(
+        "serve".to_string(),
+    )));
+    lean_ctx_server.insert(
+        "args",
+        toml_edit::Item::Value(toml_edit::Value::Array(args_array)),
+    );
 
     if target.config_path.exists() {
         let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
-        let mut doc = content.parse::<toml_edit::DocumentMut>().map_err(|e| e.to_string())?;
+        let mut doc = content
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|e| e.to_string())?;
 
         // Check if lean-ctx server already exists
-        let already_exists = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
+        let already_exists = if let Some(toml_edit::Item::ArrayOfTables(aot)) =
+            doc.get_mut("mcp_servers")
+        {
             let mut found = false;
             for table in aot.iter_mut() {
-                if let Some(toml_edit::Item::Value(toml_edit::Value::String(name))) = table.get("name") {
-                    if name.value() == "lean-ctx" {
-                        found = true;
-                        // Check if it matches what we want to write
-                        let existing_command = table.get("command").and_then(|v| v.as_str());
-                        if existing_command == Some(binary) {
-                            // Check args exist and match
-                            if let Some(toml_edit::Item::Value(toml_edit::Value::Array(existing_args))) = table.get("args") {
-                                if existing_args.len() == 1 && existing_args.get(0).and_then(|v| v.as_str()) == Some("serve") {
-                                    return Ok(WriteResult {
-                                        action: WriteAction::Already,
-                                        note: None,
-                                    });
-                                }
-                            }
+                if let Some(toml_edit::Item::Value(toml_edit::Value::String(name))) =
+                    table.get("name")
+                    && name.value() == "lean-ctx"
+                {
+                    found = true;
+                    // Check if it matches what we want to write
+                    let existing_command = table.get("command").and_then(|v| v.as_str());
+                    if existing_command == Some(binary) {
+                        // Check args exist and match
+                        if let Some(toml_edit::Item::Value(toml_edit::Value::Array(existing_args))) =
+                            table.get("args")
+                            && existing_args.len() == 1
+                            && existing_args.get(0).and_then(|v| v.as_str()) == Some("serve")
+                        {
+                            return Ok(WriteResult {
+                                action: WriteAction::Already,
+                                note: None,
+                            });
                         }
-                        // Update existing entry - replace the table's contents
-                        table.clear();
-                        table.extend(lean_ctx_server.clone().into_iter());
-                        break;
                     }
+                    // Update existing entry - replace the table's contents
+                    table.clear();
+                    table.extend(lean_ctx_server.clone());
+                    break;
                 }
             }
             if !found {

--- a/rust/src/core/editor_registry/writers/install.rs
+++ b/rust/src/core/editor_registry/writers/install.rs
@@ -1312,3 +1312,111 @@ pub(super) fn write_augment_vscode(
         note: None,
     })
 }
+
+// ---------------------------------------------------------------------------
+// Mistral Vibe TOML writer
+//
+// Vibe stores MCP servers in ~/.vibe/config.toml as TOML array of tables:
+// [[mcp_servers]]
+// name = "lean-ctx"
+// transport = "stdio"
+// command = "lean-ctx"
+// args = ["serve"]
+// ---------------------------------------------------------------------------
+
+pub(super) fn write_vibe_toml(
+    target: &EditorTarget,
+    binary: &str,
+    opts: WriteOptions,
+) -> Result<WriteResult, String> {
+    use std::collections::HashMap;
+
+    let lean_ctx_server = toml_edit::Table::new();
+    lean_ctx_server.insert("name", toml_edit::value("lean-ctx"));
+    lean_ctx_server.insert("transport", toml_edit::value("stdio"));
+    lean_ctx_server.insert("command", toml_edit::value(binary));
+    lean_ctx_server.insert(
+        "args",
+        toml_edit::value(toml_edit::Array::from_iter([toml_edit::value("serve")])),
+    );
+
+    if target.config_path.exists() {
+        let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
+        let mut doc = content
+            .parse::<toml_edit::Document>()
+            .map_err(|e| e.to_string())?;
+
+        // Check if lean-ctx server already exists
+        if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
+            for table in aot.iter_mut() {
+                if let Some(toml_edit::Item::Table(t)) = table.get("name") {
+                    if let Some(toml_edit::Value::String(name)) = t.get("name") {
+                        if name.value() == "lean-ctx" {
+                            // Compare existing with desired
+                            let existing_command = table.get("command").and_then(|v| v.as_str());
+                            let existing_args = table.get("args").and_then(|v| v.as_array());
+
+                            if existing_command == Some(binary) {
+                                // Check args
+                                let desired_args: Vec<&str> = ["serve"];
+                                let args_match = existing_args.map_or(false, |arr| {
+                                    arr.len() == desired_args.len()
+                                        && arr
+                                            .iter()
+                                            .zip(desired_args.iter())
+                                            .all(|(a, d)| a.as_str() == Some(d))
+                                });
+
+                                if args_match {
+                                    return Ok(WriteResult {
+                                        action: WriteAction::Already,
+                                        note: None,
+                                    });
+                                }
+                            }
+
+                            // Update existing
+                            *table = lean_ctx_server.clone();
+                            let formatted = doc.to_string();
+                            crate::config_io::write_atomic_with_backup(
+                                &target.config_path,
+                                &formatted,
+                            )?;
+                            return Ok(WriteResult {
+                                action: WriteAction::Updated,
+                                note: None,
+                            });
+                        }
+                    }
+                }
+            }
+            // Add new server
+            aot.push(lean_ctx_server);
+        } else {
+            // Create new array of tables
+            let mut aot = toml_edit::ArrayOfTables::new();
+            aot.push(lean_ctx_server);
+            doc.insert("mcp_servers", toml_edit::Item::ArrayOfTables(aot));
+        }
+
+        let formatted = doc.to_string();
+        crate::config_io::write_atomic_with_backup(&target.config_path, &formatted)?;
+        return Ok(WriteResult {
+            action: WriteAction::Updated,
+            note: None,
+        });
+    }
+
+    // Create new config file
+    let mut doc = toml_edit::Document::new();
+    let mut aot = toml_edit::ArrayOfTables::new();
+    aot.push(lean_ctx_server);
+    doc.insert("mcp_servers", toml_edit::Item::ArrayOfTables(aot));
+
+    let formatted = doc.to_string();
+    crate::config_io::write_atomic_with_backup(&target.config_path, &formatted)?;
+    Ok(WriteResult {
+        action: WriteAction::Created,
+        note: None,
+    })
+}

--- a/rust/src/core/editor_registry/writers/install.rs
+++ b/rust/src/core/editor_registry/writers/install.rs
@@ -1327,76 +1327,67 @@ pub(super) fn write_augment_vscode(
 pub(super) fn write_vibe_toml(
     target: &EditorTarget,
     binary: &str,
-    opts: WriteOptions,
+    _opts: WriteOptions,
 ) -> Result<WriteResult, String> {
-    use std::collections::HashMap;
-
-    let lean_ctx_server = toml_edit::Table::new();
+    // Create the lean-ctx server table
+    let mut lean_ctx_server = toml_edit::Table::new();
     lean_ctx_server.insert("name", toml_edit::value("lean-ctx"));
     lean_ctx_server.insert("transport", toml_edit::value("stdio"));
     lean_ctx_server.insert("command", toml_edit::value(binary));
-    lean_ctx_server.insert(
-        "args",
-        toml_edit::value(toml_edit::Array::from_iter([toml_edit::value("serve")])),
-    );
+    
+    // Create args array
+    let mut args_array = toml_edit::Array::new();
+    args_array.push(toml_edit::Value::String(toml_edit::Formatted::new("serve".to_string())));
+    lean_ctx_server.insert("args", toml_edit::Item::Value(toml_edit::Value::Array(args_array)));
 
     if target.config_path.exists() {
         let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
-        let mut doc = content
-            .parse::<toml_edit::Document>()
-            .map_err(|e| e.to_string())?;
+        let mut doc = content.parse::<toml_edit::DocumentMut>().map_err(|e| e.to_string())?;
 
         // Check if lean-ctx server already exists
-        if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
+        let already_exists = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
+            let mut found = false;
             for table in aot.iter_mut() {
-                if let Some(toml_edit::Item::Table(t)) = table.get("name") {
-                    if let Some(toml_edit::Value::String(name)) = t.get("name") {
-                        if name.value() == "lean-ctx" {
-                            // Compare existing with desired
-                            let existing_command = table.get("command").and_then(|v| v.as_str());
-                            let existing_args = table.get("args").and_then(|v| v.as_array());
-
-                            if existing_command == Some(binary) {
-                                // Check args
-                                let desired_args: Vec<&str> = ["serve"];
-                                let args_match = existing_args.map_or(false, |arr| {
-                                    arr.len() == desired_args.len()
-                                        && arr
-                                            .iter()
-                                            .zip(desired_args.iter())
-                                            .all(|(a, d)| a.as_str() == Some(d))
-                                });
-
-                                if args_match {
+                if let Some(toml_edit::Item::Value(toml_edit::Value::String(name))) = table.get("name") {
+                    if name.value() == "lean-ctx" {
+                        found = true;
+                        // Check if it matches what we want to write
+                        let existing_command = table.get("command").and_then(|v| v.as_str());
+                        if existing_command == Some(binary) {
+                            // Check args exist and match
+                            if let Some(toml_edit::Item::Value(toml_edit::Value::Array(existing_args))) = table.get("args") {
+                                if existing_args.len() == 1 && existing_args.get(0).and_then(|v| v.as_str()) == Some("serve") {
                                     return Ok(WriteResult {
                                         action: WriteAction::Already,
                                         note: None,
                                     });
                                 }
                             }
-
-                            // Update existing
-                            *table = lean_ctx_server.clone();
-                            let formatted = doc.to_string();
-                            crate::config_io::write_atomic_with_backup(
-                                &target.config_path,
-                                &formatted,
-                            )?;
-                            return Ok(WriteResult {
-                                action: WriteAction::Updated,
-                                note: None,
-                            });
                         }
+                        // Update existing entry - replace the table's contents
+                        table.clear();
+                        table.extend(lean_ctx_server.clone().into_iter());
+                        break;
                     }
                 }
             }
-            // Add new server
-            aot.push(lean_ctx_server);
+            if !found {
+                aot.push(lean_ctx_server);
+            }
+            true
         } else {
             // Create new array of tables
             let mut aot = toml_edit::ArrayOfTables::new();
-            aot.push(lean_ctx_server);
+            aot.push(lean_ctx_server.clone());
             doc.insert("mcp_servers", toml_edit::Item::ArrayOfTables(aot));
+            false
+        };
+
+        if already_exists {
+            return Ok(WriteResult {
+                action: WriteAction::Already,
+                note: None,
+            });
         }
 
         let formatted = doc.to_string();
@@ -1408,7 +1399,7 @@ pub(super) fn write_vibe_toml(
     }
 
     // Create new config file
-    let mut doc = toml_edit::Document::new();
+    let mut doc = toml_edit::DocumentMut::new();
     let mut aot = toml_edit::ArrayOfTables::new();
     aot.push(lean_ctx_server);
     doc.insert("mcp_servers", toml_edit::Item::ArrayOfTables(aot));

--- a/rust/src/core/editor_registry/writers/mod.rs
+++ b/rust/src/core/editor_registry/writers/mod.rs
@@ -62,6 +62,7 @@ pub fn write_config_with_options(
         ConfigType::QoderSettings => write_qoder_settings(target, binary, opts),
         ConfigType::AugmentVsCode => write_augment_vscode(target, binary, opts),
         ConfigType::OpenClaw => write_openclaw_config(target, binary, opts),
+        ConfigType::VibeToml => write_vibe_toml(target, binary, opts),
     }
 }
 
@@ -90,6 +91,7 @@ pub fn remove_lean_ctx_server(
             remove_lean_ctx_augment_vscode_server(&target.config_path, opts)
         }
         ConfigType::OpenClaw => remove_lean_ctx_openclaw_server(&target.config_path, opts),
+        ConfigType::VibeToml => remove_lean_ctx_vibe_toml_server(&target.config_path, opts),
     }
 }
 

--- a/rust/src/core/editor_registry/writers/uninstall.rs
+++ b/rust/src/core/editor_registry/writers/uninstall.rs
@@ -492,3 +492,53 @@ pub(super) fn remove_lean_ctx_augment_vscode_server(
         note: Some("removed lean-ctx from augment vscode mcp list".to_string()),
     })
 }
+
+// ---------------------------------------------------------------------------
+// Mistral Vibe TOML removal
+// ---------------------------------------------------------------------------
+
+pub(super) fn remove_lean_ctx_vibe_toml_server(
+    path: &std::path::Path,
+    _opts: WriteOptions,
+) -> Result<WriteResult, String> {
+    if !path.exists() {
+        return Ok(WriteResult {
+            action: WriteAction::Already,
+            note: Some("config file does not exist".to_string()),
+        });
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let mut doc = content
+        .parse::<toml_edit::Document>()
+        .map_err(|e| e.to_string())?;
+
+    let removed = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
+        let before = aot.len();
+        aot.retain(|table| table.get("name").and_then(|n| n.as_str()) != Some("lean-ctx"));
+        before != aot.len()
+    } else {
+        false
+    };
+
+    if !removed {
+        return Ok(WriteResult {
+            action: WriteAction::Already,
+            note: Some("lean-ctx not configured in vibe".to_string()),
+        });
+    }
+
+    // Clean up empty mcp_servers array
+    if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get("mcp_servers") {
+        if aot.is_empty() {
+            doc.remove("mcp_servers");
+        }
+    }
+
+    let formatted = doc.to_string();
+    crate::config_io::write_atomic_with_backup(path, &formatted)?;
+    Ok(WriteResult {
+        action: WriteAction::Updated,
+        note: Some("removed lean-ctx from vibe mcp_servers".to_string()),
+    })
+}

--- a/rust/src/core/editor_registry/writers/uninstall.rs
+++ b/rust/src/core/editor_registry/writers/uninstall.rs
@@ -516,12 +516,10 @@ pub(super) fn remove_lean_ctx_vibe_toml_server(
     let removed = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
         let before = aot.len();
         aot.retain(|table| {
-            table.get("name")
-                .and_then(|n| match n {
-                    toml_edit::Item::Value(toml_edit::Value::String(s)) => Some(s.value()),
-                    _ => None,
-                })
-                != Some(&"lean-ctx".to_string())
+            table.get("name").and_then(|n| match n {
+                toml_edit::Item::Value(toml_edit::Value::String(s)) => Some(s.value()),
+                _ => None,
+            }) != Some(&"lean-ctx".to_string())
         });
         before != aot.len()
     } else {
@@ -536,10 +534,10 @@ pub(super) fn remove_lean_ctx_vibe_toml_server(
     }
 
     // Clean up empty mcp_servers array
-    if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get("mcp_servers") {
-        if aot.is_empty() {
-            doc.remove("mcp_servers");
-        }
+    if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get("mcp_servers")
+        && aot.is_empty()
+    {
+        doc.remove("mcp_servers");
     }
 
     let formatted = doc.to_string();

--- a/rust/src/core/editor_registry/writers/uninstall.rs
+++ b/rust/src/core/editor_registry/writers/uninstall.rs
@@ -510,12 +510,19 @@ pub(super) fn remove_lean_ctx_vibe_toml_server(
 
     let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
     let mut doc = content
-        .parse::<toml_edit::Document>()
+        .parse::<toml_edit::DocumentMut>()
         .map_err(|e| e.to_string())?;
 
     let removed = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get_mut("mcp_servers") {
         let before = aot.len();
-        aot.retain(|table| table.get("name").and_then(|n| n.as_str()) != Some("lean-ctx"));
+        aot.retain(|table| {
+            table.get("name")
+                .and_then(|n| match n {
+                    toml_edit::Item::Value(toml_edit::Value::String(s)) => Some(s.value()),
+                    _ => None,
+                })
+                != Some(&"lean-ctx".to_string())
+        });
         before != aot.len()
     } else {
         false

--- a/rust/src/doctor/integrations/configs.rs
+++ b/rust/src/doctor/integrations/configs.rs
@@ -1,5 +1,5 @@
 //! Client-specific config formats (Zed, VS Code, Augment, Copilot CLI,
-//! OpenCode, Crush, OpenClaw, Amp, Hermes).
+//! OpenCode, Crush, OpenClaw, Amp, Hermes, Vibe).
 
 #[allow(clippy::wildcard_imports)]
 use super::*;
@@ -437,6 +437,49 @@ pub(crate) fn check_hermes_yaml(
             format!("ok ({})", path.display())
         } else {
             format!("drift ({})", path.display())
+        },
+    }
+}
+
+pub(crate) fn check_vibe_config(path: &std::path::Path, binary: &str) -> NamedCheck {
+    if !path.exists() {
+        return NamedCheck {
+            name: "Vibe config".to_string(),
+            ok: false,
+            detail: format!("missing ({})", path.display()),
+        };
+    }
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    let parsed = content.parse::<toml_edit::DocumentMut>();
+    let Ok(doc) = parsed else {
+        return NamedCheck {
+            name: "Vibe config".to_string(),
+            ok: false,
+            detail: format!("invalid TOML ({})", path.display()),
+        };
+    };
+
+    // Check if mcp_servers array exists and contains lean-ctx
+    let has_lean_ctx = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get("mcp_servers") {
+        aot.iter().any(|table| {
+            if let Some(toml_edit::Item::Value(toml_edit::Value::String(name))) = table.get("name") {
+                name.value() == "lean-ctx"
+                    && table.get("command").and_then(|c| c.as_str()) == Some(binary)
+            } else {
+                false
+            }
+        })
+    } else {
+        false
+    };
+
+    NamedCheck {
+        name: "Vibe config".to_string(),
+        ok: has_lean_ctx,
+        detail: if has_lean_ctx {
+            format!("ok ({})", path.display())
+        } else {
+            format!("lean-ctx missing ({})", path.display())
         },
     }
 }

--- a/rust/src/doctor/integrations/configs.rs
+++ b/rust/src/doctor/integrations/configs.rs
@@ -462,7 +462,8 @@ pub(crate) fn check_vibe_config(path: &std::path::Path, binary: &str) -> NamedCh
     // Check if mcp_servers array exists and contains lean-ctx
     let has_lean_ctx = if let Some(toml_edit::Item::ArrayOfTables(aot)) = doc.get("mcp_servers") {
         aot.iter().any(|table| {
-            if let Some(toml_edit::Item::Value(toml_edit::Value::String(name))) = table.get("name") {
+            if let Some(toml_edit::Item::Value(toml_edit::Value::String(name))) = table.get("name")
+            {
                 name.value() == "lean-ctx"
                     && table.get("command").and_then(|c| c.as_str()) == Some(binary)
             } else {

--- a/rust/src/doctor/integrations/editors.rs
+++ b/rust/src/doctor/integrations/editors.rs
@@ -82,6 +82,10 @@ pub(crate) fn integration_generic(
         crate::core::editor_registry::types::ConfigType::OpenClaw => {
             checks.push(check_openclaw_config(&target.config_path, binary, data_dir));
         }
+        crate::core::editor_registry::types::ConfigType::VibeToml => {
+            // Vibe uses TOML config, check if lean-ctx is in mcp_servers
+            checks.push(check_vibe_config(&target.config_path, binary));
+        }
     }
 
     if let Some(rules_path) = rules_path_for(target.name, home) {

--- a/rust/src/hooks/agents/mod.rs
+++ b/rust/src/hooks/agents/mod.rs
@@ -17,6 +17,7 @@ mod opencode;
 mod pi;
 mod qoder;
 mod shared;
+mod vibe;
 mod windsurf;
 
 pub(super) use amp::install_amp_hook;
@@ -58,6 +59,7 @@ pub(super) use opencode::install_opencode_hook_with_mode;
 pub(crate) use opencode::unregister_opencode_instructions;
 pub(super) use pi::install_pi_hook_with_mode;
 pub(super) use qoder::{install_qoder_hook, install_qoder_hook_with_mode};
+pub(super) use vibe::install_vibe_hook;
 pub(super) use windsurf::{
     install_windsurf_hooks, install_windsurf_hooks_replace, install_windsurf_rules,
 };

--- a/rust/src/hooks/agents/vibe.rs
+++ b/rust/src/hooks/agents/vibe.rs
@@ -1,0 +1,69 @@
+use super::super::resolve_binary_path;
+
+pub(crate) fn install_vibe_hook() {
+    // Mistral Vibe is MCP-only (no shell hooks), so an
+    // MCP-disabled environment writes nothing here.
+    if !super::super::should_register_mcp() {
+        return;
+    }
+    let binary = resolve_binary_path();
+    let home = crate::core::home::resolve_home_dir().unwrap_or_default();
+    let config_path = home.join(".vibe/config.toml");
+    let display_path = "~/.vibe/config.toml";
+
+    // Mistral Vibe expects MCP servers in config.toml as [[mcp_servers]]
+    // We write the lean-ctx server entry
+    let server_entry = format!(
+        r#"[[mcp_servers]]
+name = "lean-ctx"
+transport = "stdio"
+command = "{}"
+args = ["serve"]
+"#,
+        binary
+    );
+
+    if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path).unwrap_or_default();
+        if content.contains("name = \"lean-ctx\"") || content.contains("name = 'lean-ctx'") {
+            eprintln!("Vibe MCP server already configured in {display_path}");
+            return;
+        }
+
+        // Check if file has mcp_servers array
+        if content.contains("[[mcp_servers]]") {
+            // Append to existing mcp_servers
+            let updated_content = if content.ends_with('\n') {
+                format!("{}{}", content, server_entry)
+            } else {
+                format!("{}\n{}", content, server_entry)
+            };
+            if let Err(e) = std::fs::write(&config_path, &updated_content) {
+                tracing::error!("Failed to update Vibe config: {}", e);
+                return;
+            }
+            eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP server added to {display_path}");
+            return;
+        } else {
+            // Add mcp_servers section at the end
+            let updated_content = if content.ends_with('\n') {
+                format!("{}\n{}", content, server_entry)
+            } else {
+                format!("{}\n\n{}", content, server_entry)
+            };
+            if let Err(e) = std::fs::write(&config_path, &updated_content) {
+                tracing::error!("Failed to update Vibe config: {}", e);
+                return;
+            }
+            eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP server added to {display_path}");
+            return;
+        }
+    }
+
+    // Create new config file with mcp_servers
+    if let Err(e) = std::fs::write(&config_path, &server_entry) {
+        tracing::error!("Failed to create Vibe config: {}", e);
+        return;
+    }
+    eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP server written to {display_path}");
+}

--- a/rust/src/hooks/agents/vibe.rs
+++ b/rust/src/hooks/agents/vibe.rs
@@ -20,7 +20,7 @@ transport = "stdio"
 command = "{}"
 args = ["serve"]
 "#,
-        binary
+        { binary }
     );
 
     if config_path.exists() {
@@ -34,22 +34,9 @@ args = ["serve"]
         if content.contains("[[mcp_servers]]") {
             // Append to existing mcp_servers
             let updated_content = if content.ends_with('\n') {
-                format!("{}{}", content, server_entry)
+                format!("{content}{server_entry}")
             } else {
-                format!("{}\n{}", content, server_entry)
-            };
-            if let Err(e) = std::fs::write(&config_path, &updated_content) {
-                tracing::error!("Failed to update Vibe config: {}", e);
-                return;
-            }
-            eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP server added to {display_path}");
-            return;
-        } else {
-            // Add mcp_servers section at the end
-            let updated_content = if content.ends_with('\n') {
-                format!("{}\n{}", content, server_entry)
-            } else {
-                format!("{}\n\n{}", content, server_entry)
+                format!("{content}\n{server_entry}")
             };
             if let Err(e) = std::fs::write(&config_path, &updated_content) {
                 tracing::error!("Failed to update Vibe config: {}", e);

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -121,7 +121,7 @@ use agents::{
     install_gemini_hook, install_gemini_hook_config, install_gemini_hook_scripts, install_grok_mcp,
     install_hermes_hook_with_mode, install_jetbrains_hook, install_kiro_hook,
     install_openclaw_hook, install_opencode_hook_with_mode, install_pi_hook_with_mode,
-    install_qoder_hook, install_qoder_hook_with_mode, install_windsurf_hooks,
+    install_qoder_hook, install_qoder_hook_with_mode, install_vibe_hook, install_windsurf_hooks,
     install_windsurf_hooks_replace, install_windsurf_rules,
 };
 use support::{

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -993,6 +993,7 @@ pub fn install_agent_hook_with_mode(agent: &str, global: bool, mode: HookMode) {
         "crush" => install_crush_hook_with_mode(mode),
         "openclaw" => install_openclaw_hook(),
         "hermes" => install_hermes_hook_with_mode(global, mode),
+        "vibe" => install_vibe_hook(),
         "zed" => {
             let zed_path = crate::core::editor_registry::zed_settings_path(&home);
             let binary = resolve_binary_path();
@@ -1031,7 +1032,9 @@ pub fn install_agent_hook_with_mode(agent: &str, global: bool, mode: HookMode) {
             eprintln!(
                 "    grok-build, hermes, jetbrains, kiro, neovim, openclaw, opencode, pi, qoder,"
             );
-            eprintln!("    qoderwork, qwen, roo, sublime, trae, verdent, vscode, windsurf, zed");
+            eprintln!(
+                "    qoderwork, qwen, roo, sublime, trae, verdent, vibe, vscode, windsurf, zed"
+            );
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
## Summary

What does this PR change and why?

Mistral Vibe was not supported. This feature will likely need a bit more work, but at least these are the foundations.

## Test plan

- [X] `cd rust && cargo test`
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases: This needs more testing with Vibe.
- Backwards compatibility: N/A
- Docs updated (links/files): README

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
