### PR TITLE
fix(ci): add 7 missing contract docs + update frozen hashes

### DIFF
--- a/docs/contracts/context-candidate-admission-v1.md
+++ b/docs/contracts/context-candidate-admission-v1.md
@@ -1,0 +1,24 @@
+# Context Candidate Admission V1
+
+`core::candidate_admission` is the shared, payload-free decision contract for
+checking candidate provenance, freshness, sensitivity, policy, and target
+eligibility before materialization.
+
+The evaluator accepts at most 256 candidates and bindings, covers all eight
+`CandidateDomainV1` values, validates every `ContextObjectV1`, and requires exact
+content-, freshness-, and policy-reference agreement. Missing, unknown, or
+duplicate bindings; duplicate objects; schema/reference drift; denied
+sensitivity or targets; and every `StalenessReasonV1` produce explicit
+fail-closed decisions. Structurally invalid input exposes no per-candidate
+partial result. Canonical reports are sorted, permutation-stable, and contain no
+source path or object payload.
+
+The accompanying store primitives provide exact, bounded, idempotent
+invalidation for semantic-cache paths, search roots, and workspace files.
+Search invalidation advances a generation so an in-flight stale build cannot
+reinstall invalidated state.
+
+This contract and its hermetic gate prove local decision and invalidation
+semantics only. They do not yet prove enforcement by every read, search, graph,
+knowledge, provider, or materialization hotpath; live adoption, cross-process
+durability, customer policy, and production SLO claims remain open.

--- a/docs/contracts/delivery-manifest-v1.md
+++ b/docs/contracts/delivery-manifest-v1.md
@@ -1,0 +1,49 @@
+# Delivery Manifest v1
+
+`leanctx.delivery/v1` is the promotion boundary between a CI build and a
+deployment. It binds one component version and source commit to an immutable
+OCI digest, configuration/migration state, the public OCLA contract pack, and
+content-addressed supply-chain evidence.
+
+The verifier is deliberately fail-closed: unknown or missing fields, mutable
+image references, non-canonical JSON, path traversal, missing evidence,
+digest mismatch, wrong SLSA subject, or an SBOM without the delivered component
+all reject promotion. The release receipt is an Ed25519 signature over the
+canonical promotion payload (component, commit, image digest, config, contract
+pack, SBOM, provenance, and vulnerability report). Verification is offline
+against an explicit content-identified public trust root; the private seed is
+never part of the repository or deployment evidence.
+
+Run the repository gate with:
+
+```bash
+python3 scripts/verify-delivery-manifest.py \
+  tests/delivery/valid/delivery-manifest.json --root . \
+  --trust-root tests/delivery/valid/release-trust-root.json
+```
+
+Release automation creates a receipt with `scripts/delivery-trust.py sign` and
+a KMS-/HSM-provided 32-byte Ed25519 seed file, then destroys that ephemeral file.
+Promotion uses only `verify`; changing any bound field invalidates the receipt.
+
+An offline key transition may instead pass `--rotation-plan` with the bounded
+canonical `leanctx.release-key-rotation/v1` contract. The plan binds distinct
+old and new public trust roots by both canonical-file SHA-256 and public-key
+SHA-256. Its closed state allowlist accepts only the old key before activation,
+both keys during overlap, and only the new key after explicit old-key
+revocation. Receipt `key_id` selects an allowed role before the existing strict
+Ed25519 verification runs. This compatibility evidence does not claim a
+production key ceremony, deployment, activation, or completed rotation.
+
+Contract-pack compatibility follows `N and N-1`. A breaking schema or wire
+change requires a new major pack version; additive compatible changes require
+a minor version; evidence-only corrections require a patch version. The
+explicit `compatibility.supported` array is authoritative: `N-1` is listed only
+while its immutable artifacts and conformance evidence remain supported. The
+current `2.0.0` pack intentionally lists only `2.0.0`; it makes no compatibility
+claim for the tightened `1.0.0` wire schemas.
+
+The committed valid-delivery fixture is reproducible with the public RFC 8032
+test vector used by `tests/delivery/test_verify_delivery_manifest.py`. That
+known seed is test-only and must never be used by production release signing;
+production continues to require an ephemeral KMS-/HSM-provided seed.

--- a/docs/contracts/deployment-rehearsal-v1.md
+++ b/docs/contracts/deployment-rehearsal-v1.md
@@ -1,0 +1,35 @@
+# Hermetic Deployment Rehearsal v1
+
+`leanctx.deployment-rehearsal/v1` is a local pre-deployment gate over two
+`leanctx.delivery/v1` manifests. It proves that a candidate and an explicit
+rollback target can both be verified offline and that their OCI bytes,
+configuration schema, migration bytes, provenance, and release receipts match
+the supplied content digests.
+
+The rehearsal performs no deployment, health check, migration, or rollback. It
+models only the in-memory sequence `previous → candidate → previous` and emits
+deterministic `leanctx.deployment-rehearsal-evidence/v1` JSON. Its
+`rehearsal_kind` is always `hermetic-local-no-deployment`, and every transition
+is scoped to `in-memory-simulation`. The evidence binds the canonical plan and
+the explicit trust root by SHA-256.
+
+The gate rejects non-canonical or oversized plans, unknown fields, missing or
+oversized artifacts, path traversal, any symlink component, digest drift,
+untrusted delivery manifests, image/config/migration mismatches, an incorrect
+rollback target, identical releases, or a component/repository discontinuity.
+Candidate and previous releases must use distinct manifest digests, OCI
+digests, versions, and source commits under the same explicit trust root.
+
+Run with repository-relative paths:
+
+```bash
+python3 scripts/rehearse-delivery.py "$PLAN" \
+  --root . \
+  --trust-root "$TRUST_ROOT" \
+  --output delivery-rehearsal-evidence.json
+```
+
+The output file must be new and remain beneath the root. Passing this rehearsal
+does not establish runtime health, successful production migration, deployment
+authorization, key ceremony, or a completed rollback exercise against a real
+environment; those require separately retained operational evidence.

--- a/docs/contracts/frozen-hashes.json
+++ b/docs/contracts/frozen-hashes.json
@@ -1,9 +1,12 @@
 {
   "billing-plane-v1.md": "6cf3ac0ed5b7e9ad753ed5d23482772013a41478d9fa4d38f2f8f959f9cece2d",
   "context-ir-v1.md": "f551d5d48daeda34d7f7bee57582984e58d7f65659ec52a55b23946fc942a81c",
+  "delivery-manifest-v1.md": "2aed9735fc42baa10ca96a7edd786f8c2e26b568b6a6325ce2e4bcded33fe5b1",
+  "deployment-rehearsal-v1.md": "db76d9779887e3e5493a99b4356a1629df34607b54f52815e4da0e29ecfc832d",
   "http-mcp-contract-v1.md": "523eed99932abfdb27f120eb5faa0910536fbe5f638570109b396c531bc765c3",
   "local-free-invariant-v1.md": "a7ca430fa961e1b0bdd700d39deae74e003133789d9e65e84502fd5c8abe6a51",
   "oss-plane-separation-v1.md": "dbf432ae3804a54d7869663893fbc5d623dc2e3d9f9c515cfcc0859edeb8cab9",
+  "release-key-rotation-v1.md": "814b6adb8e6c496b0554cf821738b41fe1472e4565449d1924f9324a491b19ea",
   "team-server-contract-v1.md": "bc0131ca39a181918a8b254f095f358076115bd355a649c7409bd35c310e330c",
   "wasm-abi-v1.md": "9f126d3d3cdc106b9fef30d2a8d3000e279980a7cc6f2ec0197b40c6aad2a707"
 }

--- a/docs/contracts/multi-agent-efficiency-benchmark-v1.md
+++ b/docs/contracts/multi-agent-efficiency-benchmark-v1.md
@@ -1,0 +1,45 @@
+# Multi-Agent Efficiency Benchmark V1
+
+`core::multi_agent_efficiency_benchmark` is the canonical OSS contract for a
+hermetic single-agent control versus multi-agent treatment replay.
+
+## Evidence contract
+
+- 30–256 paired workloads; every pair carries identical opaque workload, task,
+  expected-outcome, acceptance-criteria, policy, and coverage references.
+- Both arms carry a canonical `ContextReceiptV1`, a uniquely correlated
+  `OutcomeRecorded` event, an explicit experiment assignment, and all ten
+  `EffectiveTokenCostV1` components.
+- Control is a single-agent arm with no handoff. Treatment has at least one
+  `SignedContextCapsuleV1` handoff whose pinned Ed25519 key, allowed recipient,
+  relay ID, a process-bound `AgentRelayDeliveryEvidenceV2` shape, receipt entry,
+  and canonical bounded A2A byte/token recount reconcile exactly. Unsigned V1
+  `delivered_tokens` are never accepted as efficiency evidence.
+- Every per-workload capsule graph has one chain identity, exactly one root,
+  and unique capsules, relays, edges, and recipients; the root starts at the
+  receipt owner with hop 1,
+  while descendants bind parent and delta to the same prior capsule, increment
+  hop exactly, and transfer ownership to the prior recipient.
+- ETPAO and quality/outcome parity are computed by the production
+  `reconcile_accepted_outcome_etpao` and
+  `evaluate_experiment_outcome_parity` APIs. Duplicate context and configured
+  local fan-out are reported from explicit receipts plus signed-capsule/delivery
+  evidence.
+
+## Fail-closed semantics
+
+`missing_evidence`, `incomplete_evidence`, `ambiguous_evidence`,
+`reference_drift`, `quality_outcome_regression`, and `overflow` never expose arm
+metrics or an efficiency delta. Corpus bytes are counted through a non-allocating
+bounded writer; top-level and nested cardinalities fail before sorting,
+reconciliation, or cryptographic work. Pairs, signers, handoffs, token
+components, arithmetic, identities, and evidence cardinality remain bounded.
+Equivalent input in the same process produces byte-identical report JSON and
+integrity references.
+
+The report is local reconciled evidence only. `live_traffic_observed`,
+`provider_billing_observed`, and `commercial_savings_eligible` are always
+`false`; the contract cannot authorize billing, settlement, causal savings, or
+production-performance claims. Process-bound V2 evidence is a local integrity
+binding, not a durable attestation, transport-commit proof, observation of
+actual fan-out execution, or proof of external delivery.

--- a/docs/contracts/ocla-config-tuning-v2.md
+++ b/docs/contracts/ocla-config-tuning-v2.md
@@ -1,0 +1,112 @@
+# OCLA Config Tuning v2
+
+Status: local OSS contract. OCLA v1 remains source- and wire-compatible:
+`OCLA_API_VERSION`, `ConfigTuningRequest`, and `ConfigProposal` are unchanged.
+The built-in v1 method is unavailable; mutation authority exists only through
+the explicitly versioned v2 request, proposal, approval, apply, receipt, and
+rollback types and opt-in trait methods.
+
+## Boundary
+
+`BuiltinConfigTuner` mutates only the canonical global `Config` through four
+allowlisted root scalars:
+
+- `compression_level`
+- `max_disk_mb`
+- `max_ram_percent`
+- `max_staleness_days`
+
+Security, policy, egress, network, secret, token, path, symlink, license, and
+identity keys are outside ACT. Values are schema-validated and bounded.
+
+The approval store is an unsigned, operator-owned filesystem input. Content
+addressing detects accidental or adversarial content changes after issuance;
+it does not authenticate an operator, prove a human decision, enforce RBAC,
+verify a signature, or consume/revoke a nonce. A production operator boundary
+must provide those controls before writing the store. The tuner never writes
+its own approval and binds each receipt to the exact proposal, requester,
+tenant, config target path identity, base target instance, and base bytes.
+
+## Transaction and CAS
+
+```text
+proposal (read-only, under global target lock)
+  -> unsigned operator-owned approval
+  -> prepared -> applying -> applied
+  -> rolling_back -> rolled_back
+```
+
+One same-directory cooperative config-target lock serializes every ACT propose,
+apply, and rollback plus normal LeanCTX `config_io`, `Config::save`,
+`Config::update_global`, and `config set` writes. The lock is thread-reentrant
+so those layered write paths cannot self-deadlock. While holding it, the proposal
+snapshots and content-addresses:
+
+- Exists versus Missing state
+- normalized absolute target path
+- parent device/inode/owner/mode identity
+- exact config bytes and digest
+- target device/inode/mtime/length identity on Unix
+
+Apply and rollback compare the entire snapshot immediately under the same lock.
+Any byte, existence, path-parent, inode, device, mtime, or length drift from a
+cooperating LeanCTX writer rejects the operation. Apply replay succeeds only for
+an exact `applied` record and current post-write identity. Rollback requires the
+exact applied receipt and restores exact base bytes, or removes the target when
+the base was Missing.
+
+This is a cooperative CAS guarantee. An uncooperative external/manual writer
+does not take the lock, and common portable filesystem APIs do not provide an
+atomic conditional rename over exact bytes plus inode/mtime identity. The
+pre-rename recheck narrows that race but cannot eliminate it; this remains an
+explicit local residual risk.
+
+## Strict persistence
+
+On Unix, ACT config writes use only a same-directory `create_new` temporary
+file, file `fsync`, atomic rename, and parent-directory `fsync`, with strong
+device/inode/mtime identity. Rollback-to-Missing uses a same-directory rename
+tombstone and directory `fsync`. There is no
+`atomic_fs`/`config_io` fallback: if strict atomic replacement is unavailable,
+the operation fails closed without an alternate Config mutation path. On
+non-Unix platforms the local adapter remains present but strict mutation fails
+closed; discovery reports strict writer, strong identity, and parent fsync as 0.
+
+Approval, state, lock, and config paths are checked component by component.
+Symlink components, unexpected owners, unsafe file types, and group/other
+writable non-sticky components are rejected. Files are opened no-follow on
+Unix. Tuner-created lock/state files use mode `0600`; change directories use
+mode `0700`. Approval and durable state are bounded to 256 KiB; config input is
+bounded to 1 MiB.
+
+Durable state is written and synced before Config mutation. `prepared`,
+`applying`, and `rolling_back` are honest blocked crash states. Reopen rejects
+them and requires a separately specified explicit recovery procedure; ACT v2
+does not claim or attempt automatic recovery.
+
+## Discovery and evidence
+
+Discovery constructs the real global adapter but does not advertise an external
+service: MCP, HTTP, wire, SDK, v1, and v2 external-callable flags are 0 because
+no public invocation/approval workflow exists. `local_rust_adapter_present` is
+1 and `approval_store_present` reports a structurally valid, non-empty operator
+store. Generic discovery cannot prove expiry or the receipt's proposal-specific
+binding, so `approval_apply_ready` remains 0. Status remains `degraded` while the
+adapter is local-only, or `unavailable` when its target boundary cannot be
+constructed. Platform durability/identity limits are reported independently.
+
+Lifecycle evidence reuses the existing `AgentAction` control event with a
+non-secret `config_tuning_v2` action and proposal reference. No public
+`EventKind` variant or config values are added. These events contribute zero
+payload, cache, ledger, or token-accounting values; durable state remains the
+transaction source of truth.
+
+## Claim ceiling
+
+The OSS adapter establishes bounded local mutation, cooperative content/instance
+CAS, and deterministic unsigned approval binding. It does not establish human
+identity, organizational authorization, RBAC, signatures, nonce consumption or
+revocation, key management, remote approval transport, distributed consensus,
+or automated crash recovery. It also cannot exclude an uncooperative manual
+writer in the final portable check-to-rename window. Those controls and risks
+remain external requirements.

--- a/docs/contracts/release-key-rotation-v1.md
+++ b/docs/contracts/release-key-rotation-v1.md
@@ -1,0 +1,25 @@
+# Release Key Rotation v1
+
+`leanctx.release-key-rotation/v1` is a deterministic offline compatibility
+contract. It is canonical JSON, limited to 16 KiB, and contains exactly:
+
+- `old_trust_root` and `new_trust_root`: distinct confined regular files bound
+  by `path`, canonical-file `sha256`, and Ed25519 public-key `key_id`.
+- `transition`: exactly `activation`, `overlap`, and `revocation`.
+
+Only these state tuples are valid:
+
+| activation | overlap | revocation | Accepted receipt key |
+|---|---|---|---|
+| `pending` | `inactive` | `not-started` | old |
+| `complete` | `active` | `pending` | old or new |
+| `complete` | `complete` | `old-key-revoked` | new |
+
+Unknown fields, mixed states, identical roots or keys, digest drift, unsafe or
+symlinked paths, non-canonical JSON, oversized input, and a receipt signed by a
+key outside the selected state fail closed. After role selection, the existing
+canonical Base64, main-subgroup, payload-binding, and Ed25519 checks still run.
+
+Verification returns only content identifiers and the accepted key role. The
+plan stores no private material and proves no production ceremony, wall-clock
+activation, secret destruction, deployment, or completed operational rotation.

--- a/docs/contracts/settlement-evidence-v2.md
+++ b/docs/contracts/settlement-evidence-v2.md
@@ -1,0 +1,228 @@
+# Settlement Evidence v2 (`settlement-evidence-v2`)
+
+Status: **stable** · Plane: OSS contract / private policy input · Schema version: 2
+
+Settlement Evidence v2 defines a bounded, payload-free handoff from the open
+LeanCTX data plane to a private approval, dispute, settlement, or invoicing
+plane. The OSS implementation can canonicalize, reconcile, verify, and export
+evidence. It cannot approve a customer, decide a dispute, validate a contract,
+calculate a commercial formula, issue an invoice, or mutate private state.
+
+Requirement coverage: CO-09, EV-03, EV-05, EV-06, EV-07, EV-09, EV-10, BC-06.
+HC-03/12/13/17, RG-05, and BC-03 remain dependencies or explicit non-claims.
+
+## Compatibility boundary
+
+`billing-plane-v1` is frozen. Its `Usage` JSON shape and
+`Usage::is_billable() == signed && chain_valid` behavior remain unchanged.
+Settlement Evidence v2 names that predicate
+`Usage::source_integrity_verified()`.
+
+A true v1 predicate proves only that the source aggregate reports a valid
+signature and chain. It is never sufficient for v2 eligibility. In particular,
+it does not prove quality, causality, exclusive attribution, a complete period,
+contract validity, customer approval, a settlement amount, or invoice
+authority.
+
+The committed `legacy-usage-v1.json` fixture pins the original ten-field wire
+shape and both methods to the exact same boolean.
+
+## OSS/private boundary
+
+Open and Apache-2.0:
+
+- versioned Rust types and deterministic reconciliation;
+- canonical BLAKE3 content addresses;
+- bounded offline load, verify, and export;
+- payload-free positive and adversarial fixtures;
+- typed ineligibility reasons.
+
+Private and absent from this repository:
+
+- customer approval or dispute state mutation;
+- approval authority and trust-anchor administration;
+- schedules, caps, price formulas, deal economics, and contract interpretation;
+- invoice creation, payment processing, or settlement execution.
+
+Private services consume this contract over the published service/SDK boundary;
+they do not import internal runtime modules.
+
+## Inputs
+
+Verification takes two independent files:
+
+1. a `SettlementEvidenceManifestV2`; and
+2. an out-of-band `SettlementEvidenceTrustStoreV2` pinned by the verifier.
+
+A manifest cannot make itself trusted. Each active item must name a
+`trust_decision_id` and `trust_anchor_id`, and the exact
+`(evidence_id, trust_decision_id, trust_anchor_id)` tuple must appear in the
+separate trust store. Trust-store provenance remains caller-owned; the OSS
+verifier checks content-addressed consistency, not legal authority.
+
+Both top-level types and every nested type deny unknown fields.
+
+## Manifest
+
+Normative top-level fields:
+
+| Field | Rule |
+|---|---|
+| `schema_version` | exactly `2` |
+| `kind` | exactly `lean-ctx.settlement-evidence` |
+| `manifest_id` | `manifest:blake3:<64 lowercase hex>` over canonical manifest with a pending ID |
+| `subject_id` | opaque `subject:blake3:<64 lowercase hex>`; never a person, account name, or path |
+| `period` | non-negative epoch-second start and strictly later end |
+| `currency` | exactly three uppercase ASCII letters representing the caller's ISO 4217 alpha code |
+| `claimed_amount_minor_units` | unsigned integer minor units; no float |
+| `evidence[]` | at most 1,000 payload-free items |
+
+Each item is independently content-addressed as
+`artifact:blake3:<64 lowercase hex>`. Its ID commits to subject, state, trust
+references, typed measurement method/class, typed claim, correction references,
+and correction-reason ID.
+
+## Required evidence roles
+
+Eligibility requires active, externally trusted evidence for every role:
+
+| Role | Required claim |
+|---|---|
+| `baseline` | content-addressed baseline version and integer baseline tokens |
+| `price` | content-addressed price version, matching currency, integer micro-unit price |
+| `contract` | content-addressed contract version |
+| `quality` | content-addressed quality gate with `passed=true` |
+| `attribution` | one or more exclusive mechanism claims with integer tokens/minor units and source evidence IDs |
+| `period_completion` | exact manifest bounds with `complete=true` |
+| `customer_approval` | content-addressed approval artifact with `approved=true` |
+
+All non-attribution roles require exactly one active item. Missing roles fail
+closed; multiple active items are ambiguous. Multiple attribution items are
+allowed only for distinct mechanism IDs.
+
+Every item also carries a content-addressed `measurement.method_artifact_id`
+and an explicit closed evidence class. Baseline and period are `measured`;
+quality and attribution are `reconciled`; price, contract, and customer
+approval are `declared`. A mismatched, `derived`, or `unknown` class fails
+closed. A signature never upgrades the class.
+
+The verifier sums attributed tokens and minor units using checked `u64`
+arithmetic. The minor-unit sum must equal `claimed_amount_minor_units`, and
+attributed tokens cannot exceed baseline tokens. It does not derive the amount
+from price evidence; formulas and contract interpretation remain private.
+
+## Exclusive attribution
+
+Every attribution item must set `exclusive=true`. Each source evidence ID can
+appear only once across all active mechanisms. Reuse by another mechanism is
+`duplicate_attribution` and makes the manifest ineligible. Total source
+references are bounded to 1,000.
+
+This prevents compression, cache, routing, or any later mechanism from claiming
+the same source observation twice.
+
+## Correction and supersession lineage
+
+An active correction carries:
+
+- one to 32 sorted `supersedes[]` content addresses; and
+- one content-addressed `correction_reason_id`.
+
+Both fields must be present together. Self-reference, duplicate targets,
+unbounded targets, invalid IDs, correction fields on non-active evidence, or the
+same superseded target claimed by two corrections are invalid lineage.
+
+A manifest item whose own state is `superseded` or `disputed` cannot satisfy
+a role and produces a typed reason. A corrected active item can qualify only
+when its external trust tuple is independently pinned.
+
+## Determinism and limits
+
+Canonicalization:
+
+1. sort attribution source IDs;
+2. sort supersession IDs;
+3. sort evidence by its stable evidence ID only;
+4. sort trust decisions;
+5. serialize compact JSON in struct field order;
+6. hash the representation with the corresponding ID set to its pending value.
+
+Input permutations therefore produce identical IDs and canonical exports.
+Limits are fail-closed:
+
+- manifest file: 4 MiB;
+- evidence items: 1,000;
+- trust decisions: 1,000;
+- UTF-8 bytes per string: 256;
+- attribution source IDs per item: 1,000;
+- total attribution source IDs: 1,000;
+- supersession references per item: 32.
+
+The same structural and serialized-size preflight applies to constructors,
+direct reconciliation, hashing, canonicalization, file loading, and export.
+Oversized evidence or trust input therefore returns before cloning, sorting,
+hashing, serialization, or unbounded reconciliation traversal.
+
+Offline reads reject symbolic links and non-regular files, open with no-follow
+semantics where supported, verify the opened-file metadata, and read at most
+the limit plus one byte. Export rejects symbolic-link targets or parents,
+writes a same-directory create-new/no-follow temporary file, syncs it, renames
+atomically, syncs the parent directory, and removes temporary files on error.
+
+## Eligibility output and non-claims
+
+`SettlementEligibilityV2` binds both `manifest_id` and `trust_store_id`, and
+contains deterministic totals plus sorted, deduplicated typed reasons. It also
+always emits:
+
+```json
+{
+  "invoice_authority": false,
+  "contract_validity_verified": false,
+  "customer_approval_authority_verified": false
+}
+```
+
+`eligible=true` means only structural completeness and internal consistency
+under this contract and the supplied trust store. It is not an approval,
+settlement, invoice, contract-validity, or payment claim.
+
+Typed reasons cover unsupported schema/kind, invalid content addresses, invalid
+subject/period/currency, limits, trust-store failures, missing or ambiguous
+roles, duplicate IDs, untrusted/disputed/superseded evidence, incomplete
+period, failed quality, absent approval, currency mismatch, non-exclusive or
+duplicate attribution, invalid correction lineage, amount mismatch, baseline
+overrun, and arithmetic overflow.
+
+Signature-valid or chain-valid input alone remains ineligible.
+
+## CLI
+
+Read-only offline verification:
+
+```text
+lean-ctx billing settlement verify \
+  <manifest.json> <trust-store.json> [--json]
+```
+
+Canonical export after content-address verification:
+
+```text
+lean-ctx billing settlement export \
+  <manifest.json> <trust-store.json> <canonical.json> [--json]
+```
+
+Export does not change approval, dispute, settlement, ledger, or local runtime
+state.
+
+## Fixtures and gates
+
+- `rust/tests/fixtures/settlement-evidence-v2/eligible.json`
+- `rust/tests/fixtures/settlement-evidence-v2/trusted-decisions.json`
+- `rust/tests/fixtures/settlement-evidence-v2/legacy-usage-v1.json`
+- `rust/tests/settlement_evidence_v2_gate.rs`
+
+The gate covers canonical/permutation stability, v1 compatibility, out-of-band
+trust, all fail-closed evidence states, signed-chain insufficiency, exclusive
+attribution, checked overflow, limits, unknown fields, correction lineage,
+offline export, and payload/PII/path/secret-free fixtures.

--- a/rust/src/proxy/response_optimizer.rs
+++ b/rust/src/proxy/response_optimizer.rs
@@ -79,6 +79,7 @@ impl Default for ResponseOptimizerConfig {
 struct CacheEntry {
     response_body: String,
     created_at: Instant,
+    #[allow(dead_code)] // read in future stats aggregation
     output_tokens_saved: u64,
 }
 


### PR DESCRIPTION
Fixes the `contracts_frozen` integration test that has been failing since P7.

**Root cause:** The P7 commit (`f5c447a63`) registered 7 contract docs in `core::contracts::contract_docs()` but did not include the actual `.md` files (they existed on the W0/codex branch, not main).

**Test failure:**
```
contract_docs() lists files that do not exist in docs/contracts/:
["context-candidate-admission-v1.md", "delivery-manifest-v1.md",
 "deployment-rehearsal-v1.md", "multi-agent-efficiency-benchmark-v1.md",
 "ocla-config-tuning-v2.md", "release-key-rotation-v1.md",
 "settlement-evidence-v2.md"]
```

**Fix:** Extracted all 7 files from their originating commits and updated `frozen-hashes.json`.

| File | Status |
|---|---|
| delivery-manifest-v1.md | Frozen |
| deployment-rehearsal-v1.md | Frozen |
| release-key-rotation-v1.md | Frozen |
| settlement-evidence-v2.md | Stable |
| context-candidate-admission-v1.md | Experimental |
| multi-agent-efficiency-benchmark-v1.md | Experimental |
| ocla-config-tuning-v2.md | Experimental |

Also suppresses a dead_code warning on `CacheEntry::output_tokens_saved`.

Made with [Cursor](https://cursor.com)