### PR TITLE
fix(ci): resolve clippy lints for newer toolchain

### DIFF
--- a/rust/src/core/chain_compression.rs
+++ b/rust/src/core/chain_compression.rs
@@ -74,7 +74,7 @@ impl ChainCompressionTracker {
                 .entry(content_ref.clone())
                 .and_modify(|item| {
                     item.last_referenced_hop = hop;
-                    item.freshness_ref = freshness_ref.clone();
+                    item.freshness_ref.clone_from(&freshness_ref);
                 })
                 .or_insert(ChainContextItem {
                     content_ref,

--- a/rust/src/core/context_capsule.rs
+++ b/rust/src/core/context_capsule.rs
@@ -447,11 +447,17 @@ fn validate_agent_ids(ids: &[String]) -> Result<(), ContextCapsuleError> {
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{b:02x}")).collect()
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err("odd length".into());
     }
     (0..s.len())

--- a/rust/src/core/ocla/builtin/analyzer.rs
+++ b/rust/src/core/ocla/builtin/analyzer.rs
@@ -60,10 +60,7 @@ impl EfficiencyAnalyzer for BuiltinAnalyzer {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let sig = FileSignature::from_path(path, 0);
-        predictor
-            .predict_best_mode(&sig)
-            .map(|_| 0.8)
-            .unwrap_or(0.5)
+        predictor.predict_best_mode(&sig).map_or(0.5, |_| 0.8)
     }
 
     fn summary(&self) -> Vec<EfficiencyEntry> {

--- a/rust/src/core/ocla_bus.rs
+++ b/rust/src/core/ocla_bus.rs
@@ -261,9 +261,10 @@ impl OclaBus {
 
 impl std::fmt::Debug for OclaBus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ring_len = self.ring.lock().map_or(0, |r| r.len());
         f.debug_struct("OclaBus")
             .field("enabled", &self.is_enabled())
-            .field("ring_len", &self.len())
+            .field("ring", &format_args!("[{ring_len} events]"))
             .field("capacity", &self.capacity)
             .field("next_id", &self.next_id.load(Ordering::Relaxed))
             .finish()

--- a/rust/src/core/work_graph.rs
+++ b/rust/src/core/work_graph.rs
@@ -93,8 +93,8 @@ impl BoundedWorkGraph {
         Self {
             nodes: BTreeMap::new(),
             children: BTreeMap::new(),
-            max_fan_out: max_fan_out.min(MAX_FAN_OUT).max(1),
-            max_depth: max_depth.min(MAX_DEPTH).max(1),
+            max_fan_out: max_fan_out.clamp(1, MAX_FAN_OUT),
+            max_depth: max_depth.clamp(1, MAX_DEPTH),
         }
     }
 
@@ -279,9 +279,10 @@ impl BoundedWorkGraph {
         self.nodes.len()
     }
 
+    #[allow(clippy::collapsible_if)]
     fn stop_recursive(&mut self, node_id: &str, reason: StopReason, stopped: &mut Vec<String>) {
         if let Some(node) = self.nodes.get_mut(node_id) {
-            if node.status == NodeStatus::Active || node.status == NodeStatus::Pending {
+            if matches!(node.status, NodeStatus::Active | NodeStatus::Pending) {
                 node.status = NodeStatus::Stopped;
                 node.stop_reason = Some(reason);
                 stopped.push(node_id.to_string());


### PR DESCRIPTION
Fixes 8 clippy errors on CI (newer Rust toolchain than local):
- `assigning_clones`: use `clone_from` instead of `= .clone()`
- `format_collect`: manual hex encoding without per-byte `format!`
- `manual_is_multiple_of`: use `.is_multiple_of(2)`
- `manual_clamp`: use `.clamp(min, max)`
- `collapsible_if`: allow on recursive stop function
- `map_unwrap_or`: use `map_or`
- `missing_fields_in_debug`: include `ring` field in OclaBus Debug

Made with [Cursor](https://cursor.com)