### PR TITLE
feat(shell): expand heavy-command detection for scripts and timeout

### DIFF
--- a/rust/src/core/config/mod.rs
+++ b/rust/src/core/config/mod.rs
@@ -686,6 +686,11 @@ pub struct Config {
     #[serde(default)]
     pub shell_heavy_timeout_secs: Option<u64>,
 
+    /// Extra command prefixes that get the heavy timeout ceiling. Merged with
+    /// the built-in list. Useful for project-specific long-running scripts.
+    /// Example: `shell_heavy_prefixes = ["python3 ", "./scripts/"]`
+    #[serde(default)]
+    pub shell_heavy_prefixes: Vec<String>,
     /// When true, `ctx_shell` accepts shell file-write redirects (`>`, `>>`,
     /// `tee`, heredoc-to-file, `curl -o`, `wget` default mode). Default false —
     /// the native Write/Edit tool is preferred. Opt-in for power users who want
@@ -827,6 +832,7 @@ impl Default for Config {
             shell_security: None,
             shell_timeout_secs: None,
             shell_heavy_timeout_secs: None,
+            shell_heavy_prefixes: Vec::new(),
             shell_allow_writes: false,
             shell_allow_inline_scripts: false,
             setup: SetupConfig::default(),

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -355,6 +355,17 @@ fn is_heavy_command(command: &str) -> bool {
         // because the prefix is the full `git <verb>`.
         "git commit",
         "git push",
+        // Scripts and test runners that scan repos, run audits, or invoke
+        // subprocesses with their own timeouts. Killing them mid-run wastes
+        // agent tokens on retries.
+        "python3 ",
+        "python ",
+        "pytest",
+        "bash scripts/",
+        "sh scripts/",
+        "./scripts/",
+        // `timeout N cmd` wraps an intentionally long command — respect it.
+        "timeout ",
         // Task runners wrap builds/test gates; the underlying job is what's
         // heavy, so the wrapper gets the same ceiling. A fast subcommand
         // (`mise ls`) merely inherits a longer kill deadline — harmless.
@@ -362,7 +373,11 @@ fn is_heavy_command(command: &str) -> bool {
         "just ",
     ];
 
-    let matches_heavy = |s: &str| HEAVY_PREFIXES.iter().any(|p| s.starts_with(p));
+    let cfg_prefixes = config::Config::load().shell_heavy_prefixes;
+    let matches_heavy = |s: &str| {
+        HEAVY_PREFIXES.iter().any(|p| s.starts_with(p))
+            || cfg_prefixes.iter().any(|p| s.starts_with(p.as_str()))
+    };
 
     if matches_heavy(&lower) {
         return true;
@@ -1468,6 +1483,57 @@ mod exec_tests {
         assert_eq!(super::shell_timeout("mise gate"), super::HEAVY_TIMEOUT);
         assert_eq!(super::shell_timeout("mise run gate"), super::HEAVY_TIMEOUT);
         assert_eq!(super::shell_timeout("just build"), super::HEAVY_TIMEOUT);
+
+        if let Some(v) = saved_ms {
+            crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);
+        }
+        if let Some(v) = saved_heavy {
+            crate::test_env::set_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS", v);
+        }
+    }
+
+    #[test]
+    fn scripts_and_timeout_get_heavy_ceiling() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let saved_ms = std::env::var("LEAN_CTX_SHELL_TIMEOUT_MS").ok();
+        let saved_heavy = std::env::var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS").ok();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        crate::test_env::remove_var("LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS");
+
+        assert_eq!(
+            super::shell_timeout("python3 scripts/audit.py"),
+            super::HEAVY_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout("python scripts/gate.py --root ."),
+            super::HEAVY_TIMEOUT
+        );
+        assert_eq!(super::shell_timeout("pytest tests/"), super::HEAVY_TIMEOUT);
+        assert_eq!(
+            super::shell_timeout("bash scripts/loc-gate.sh"),
+            super::HEAVY_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout("sh scripts/run.sh"),
+            super::HEAVY_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout("./scripts/deploy.sh"),
+            super::HEAVY_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout("timeout 300 python3 audit.py"),
+            super::HEAVY_TIMEOUT
+        );
+
+        assert_eq!(
+            super::shell_timeout("cd /repo && python3 gate.py"),
+            super::HEAVY_TIMEOUT
+        );
+        assert_eq!(
+            super::shell_timeout("cd /repo && timeout 600 make"),
+            super::HEAVY_TIMEOUT
+        );
 
         if let Some(v) = saved_ms {
             crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);

--- a/scripts/history-policy-gate.py
+++ b/scripts/history-policy-gate.py
@@ -47,7 +47,9 @@ def load_policy(path):
     if not isinstance(policy, dict) or set(policy) != expected or policy["schema_version"] != "leanctx.history-policy/v1":
         raise GateError("invalid policy contract")
     limits = policy["limits"]
-    if set(limits) != {"max_commits", "max_objects", "max_findings", "command_timeout_seconds"} or not all(isinstance(v, int) and v > 0 for v in limits.values()):
+    required_keys = {"max_commits", "max_objects", "max_findings", "command_timeout_seconds"}
+    optional_keys = {"full_audit_timeout_seconds"}
+    if not required_keys <= set(limits) or not set(limits) <= required_keys | optional_keys or not all(isinstance(v, int) and v > 0 for v in limits.values()):
         raise GateError("invalid policy limits")
     baseline = policy["baseline"]
     if set(baseline) != {"commit", "report", "report_sha256"} or not re.fullmatch(r"[0-9a-f]{40}", baseline["commit"]) or not re.fullmatch(r"[0-9a-f]{64}", baseline["report_sha256"]):
@@ -218,7 +220,7 @@ def gate(root, policy):
 
 
 def full_audit(root, policy):
-    timeout = policy["limits"]["command_timeout_seconds"]
+    timeout = policy["limits"].get("full_audit_timeout_seconds", policy["limits"]["command_timeout_seconds"] * 5)
     commits = git(root, timeout, "rev-list", "--all").decode().splitlines()
     objects = git(root, timeout, "rev-list", "--objects", "--all").splitlines()
     if not commits or len(commits) > policy["limits"]["max_commits"] or len(objects) > policy["limits"]["max_objects"]:

--- a/security/history-policy-v1.json
+++ b/security/history-policy-v1.json
@@ -45,7 +45,7 @@
   ],
   "scanner_source_sha256": {
     ".github/workflows/security-check.yml": "c1ee715b5609e0861ae5b8e4517ef4961a7ede9ffcf19d0c304f66da2fc9c421",
-    "scripts/history-policy-gate.py": "ffdce6066e2831cc0a1cb03eaa165c308dff5c8a2ed4038cfd273a3b87f7019a",
+    "scripts/history-policy-gate.py": "e554c071cd785dc82fa73e5f0144d080a516550a17732fe103b4a4788db43182",
     "tests/security/test_history_policy_gate.py": "f3921aaecc395691d1c113bcec3955a2a70ca4362cb521246fd3355d880870fc"
   },
   "baseline": {


### PR DESCRIPTION
## Problem

Agents repeatedly hit the 2-minute default timeout when running:
- `python3 scripts/history-policy-gate.py full-audit ...`
- `timeout 300 python3 ...`
- `bash scripts/loc-gate.sh`

This wastes tokens on retries and workarounds.

## Solution (3 layers)

### Layer 1: Expanded HEAVY_PREFIXES
Added to the 10-minute ceiling tier:
- `python3 `, `python `, `pytest`
- `bash scripts/`, `sh scripts/`, `./scripts/`
- `timeout `

### Layer 2: Config-driven prefixes
New `shell_heavy_prefixes` field in config.toml:
```toml
shell_heavy_prefixes = ["my-custom-script "]
```
Merged with built-in list at runtime.

### Layer 3: full-audit timeout
`history-policy-gate.py` now uses `full_audit_timeout_seconds` (defaults to 5x `command_timeout_seconds`) for the inherently slow full-audit mode.

## Tests
- `scripts_and_timeout_get_heavy_ceiling` — 9 assertions covering all new patterns
- 13/13 Python gate tests pass

Made with [Cursor](https://cursor.com)