### PR TITLE
fix(hooks): Windows trio — deny suppress, backslash, harden --help (#1037 #1038 #1039)

### DIFF
--- a/packages/lean-ctx-bin/postinstall.js
+++ b/packages/lean-ctx-bin/postinstall.js
@@ -188,7 +188,13 @@ async function main() {
     fs.mkdirSync(BIN_DIR, { recursive: true });
 
     if (IS_WIN) {
+      // Windows locks running executables — rename-before-extract (#1039).
+      // Renaming a running .exe IS allowed on Windows; overwriting is not.
+      const oldBin = BINARY_PATH + ".old";
+      try { fs.unlinkSync(oldBin); } catch {}
+      try { fs.renameSync(BINARY_PATH, oldBin); } catch {}
       execSync(`tar -xf "${archivePath}" -C "${BIN_DIR}"`, { stdio: "ignore" });
+      try { fs.unlinkSync(oldBin); } catch {}
     } else {
       await extractTarGz(archivePath, BIN_DIR, "lean-ctx");
     }

--- a/rust/src/cli/harden.rs
+++ b/rust/src/cli/harden.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
 
 pub fn run(args: &[String]) {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return;
+    }
+
     let undo = args.iter().any(|a| a == "--undo");
     let level = if args.iter().any(|a| a == "--hard") {
         "hard"
@@ -13,6 +18,18 @@ pub fn run(args: &[String]) {
     } else {
         apply_harden(level);
     }
+}
+
+fn print_help() {
+    println!("lean-ctx harden — tighten IDE security by denying native Read/Grep/Glob");
+    println!();
+    println!("USAGE:");
+    println!("    lean-ctx harden [OPTIONS]");
+    println!();
+    println!("OPTIONS:");
+    println!("    --hard     Replace mode: deny native tools across all IDEs");
+    println!("    --undo     Revert all harden changes");
+    println!("    --help     Show this help message");
 }
 
 fn apply_harden(level: &str) {

--- a/rust/src/hook_handlers/search_rewrite.rs
+++ b/rust/src/hook_handlers/search_rewrite.rs
@@ -341,8 +341,21 @@ pub fn shell_tokenize(input: &str) -> Vec<String> {
             '\'' if !in_double => in_single = !in_single,
             '"' if !in_single => in_double = !in_double,
             '\\' if !in_single => {
-                if let Some(next) = chars.next() {
-                    current.push(next);
+                if let Some(&next) = chars.peek() {
+                    if in_double {
+                        // POSIX: inside double quotes only \\ \" \$ \` \newline
+                        // are special. Everything else (including Windows path
+                        // separators like \U \f) keeps the backslash (#1038).
+                        if matches!(next, '\\' | '"' | '$' | '`' | '\n') {
+                            chars.next();
+                            current.push(next);
+                        } else {
+                            current.push('\\');
+                        }
+                    } else {
+                        chars.next();
+                        current.push(next);
+                    }
                 }
             }
             c if c.is_whitespace() && !in_single && !in_double => {

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -1438,3 +1438,24 @@ fn warm_daemon_cache_tolerates_missing_socket() {
     // disk it returns immediately.
     warm_daemon_cache("/nonexistent/file.rs");
 }
+
+#[test]
+fn shell_tokenize_preserves_backslashes_in_double_quotes() {
+    let result = shell_tokenize(r#"cat "C:\Users\me\file.txt""#);
+    assert_eq!(result, vec!["cat", r"C:\Users\me\file.txt"]);
+}
+
+#[test]
+fn shell_tokenize_escapes_posix_specials_in_double_quotes() {
+    let result = shell_tokenize(r#"echo "hello\"world""#);
+    assert_eq!(result, vec!["echo", r#"hello"world"#]);
+
+    let result = shell_tokenize(r#"echo "a\\b""#);
+    assert_eq!(result, vec!["echo", r"a\b"]);
+}
+
+#[test]
+fn shell_tokenize_unquoted_backslash_still_escapes() {
+    let result = shell_tokenize(r"echo hello\ world");
+    assert_eq!(result, vec!["echo", "hello world"]);
+}

--- a/rust/src/hooks/agents/claude.rs
+++ b/rust/src/hooks/agents/claude.rs
@@ -491,7 +491,7 @@ fn ensure_command_hook(pre_arr: &mut Vec<serde_json::Value>, matcher: &str, comm
                 .or_insert_with(|| serde_json::json!([]))
                 .as_array_mut()
             {
-                Some(hooks) => hooks.push(desired),
+                Some(hooks) => hooks.insert(0, desired),
                 None => {
                     obj.insert("hooks".to_string(), serde_json::json!([desired]));
                 }


### PR DESCRIPTION
Integrates 3 hook bugfixes from feature branches:

1. **#1037** — `recommend_hook_mode` caps at Hybrid when disable switches active (LEAN_CTX_DISABLED, shadow_mode=false, LEAN_CTX_HEAL=off). Prevents deny-list re-injection.
2. **#1038** — `shell_tokenize` preserves backslashes in double-quoted Windows paths (only POSIX escape sequences consume backslash). 
3. **#1039** — Three micro-fixes: harden --help short-circuit, npm postinstall rename-before-extract on Windows, hook exit code ordering.

Closes #1037, closes #1038, closes #1039

Made with [Cursor](https://cursor.com)