### PR TITLE
fix(stats): persist tool events immediately to close ROI/Home divergence

### DIFF
--- a/rust/src/core/ocla/builtin/compression_provider.rs
+++ b/rust/src/core/ocla/builtin/compression_provider.rs
@@ -10,13 +10,13 @@ use std::sync::OnceLock;
 
 use crate::core::compressor;
 use crate::core::config::Config;
+use crate::core::ocla::OclaError;
 use crate::core::ocla::content_port::CompressionContentPort;
 use crate::core::ocla::traits::{CompressionProvider, OclaService};
 use crate::core::ocla::types::{
-    CompressionRequest, CompressionResult, OclaCapability, OclaCapabilityKind,
-    OclaCapabilityStatus, OclaResult, OCLA_API_VERSION,
+    CompressionRequest, CompressionResult, OCLA_API_VERSION, OclaCapability, OclaCapabilityKind,
+    OclaCapabilityStatus, OclaResult,
 };
-use crate::core::ocla::OclaError;
 use crate::core::ocla_bus::{self, OclaEvent};
 use crate::core::tokens;
 

--- a/rust/src/core/ocla/content_port.rs
+++ b/rust/src/core/ocla/content_port.rs
@@ -9,7 +9,7 @@
 
 use std::fs;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 use crate::core::ocla::OclaError;
@@ -56,8 +56,17 @@ impl CompressionContentPort {
             .strip_prefix("file:")
             .ok_or_else(|| OclaError::InvalidRequest("content_ref must use file: scheme".into()))?;
 
+        if Path::new(rel_path)
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(OclaError::InvalidRequest(
+                "path jail: parent directory traversal is not allowed".into(),
+            ));
+        }
+
         // Validate containment via PathJail (traversal safety)
-        let _jailed = pathjail::jail_path(Path::new(rel_path), &self.project_root)
+        pathjail::jail_path(Path::new(rel_path), &self.project_root)
             .map_err(|e| OclaError::InvalidRequest(format!("path jail: {e}")))?;
 
         // Canonicalize root to handle /tmp → /private/tmp on macOS

--- a/rust/src/core/stats/io.rs
+++ b/rust/src/core/stats/io.rs
@@ -85,20 +85,18 @@ pub(super) fn load_from_dir(dir: &std::path::Path) -> StatsStore {
     }
 }
 
-fn write_to_disk(store: &StatsStore) {
-    let Some(dir) = stats_dir() else { return };
+fn write_to_disk(store: &StatsStore) -> bool {
+    let Some(dir) = stats_dir() else { return false };
 
-    if !dir.exists() {
-        let _ = std::fs::create_dir_all(&dir);
+    if !dir.exists() && std::fs::create_dir_all(&dir).is_err() {
+        return false;
     }
 
     let path = dir.join("stats.json");
-    if let Ok(json) = serde_json::to_string(store) {
-        let tmp = dir.join(".stats.json.tmp");
-        if std::fs::write(&tmp, &json).is_ok() {
-            let _ = std::fs::rename(&tmp, &path);
-        }
-    }
+    let tmp = dir.join(".stats.json.tmp");
+    serde_json::to_string(store).is_ok_and(|json| {
+        std::fs::write(&tmp, json).is_ok() && std::fs::rename(&tmp, &path).is_ok()
+    })
 }
 
 pub(super) fn locked_write(store: &StatsStore) {
@@ -108,26 +106,17 @@ pub(super) fn locked_write(store: &StatsStore) {
     if _lock.is_none() {
         return;
     }
-    write_to_disk(store);
+    let _ = write_to_disk(store);
 }
 
-pub(super) fn merge_and_save(current: &StatsStore, baseline: &StatsStore) -> StatsStore {
-    let Some(dir) = stats_dir() else {
-        let disk = load_from_disk();
-        return apply_deltas(&disk, current, baseline);
-    };
-
+pub(super) fn merge_and_save(current: &StatsStore, baseline: &StatsStore) -> Option<StatsStore> {
+    let dir = stats_dir()?;
     let lock_path = dir.join(".stats.lock");
-    let _lock = acquire_file_lock(&lock_path);
+    let _lock = acquire_file_lock(&lock_path)?;
 
     let disk = load_from_disk();
     let merged = apply_deltas(&disk, current, baseline);
-
-    if _lock.is_some() {
-        write_to_disk(&merged);
-    }
-
-    merged
+    write_to_disk(&merged).then_some(merged)
 }
 
 struct FileLockGuard(PathBuf);

--- a/rust/src/core/stats/mod.rs
+++ b/rust/src/core/stats/mod.rs
@@ -80,8 +80,9 @@ pub fn save(store: &StatsStore) {
 }
 
 fn maybe_flush(store: &mut StatsStore, baseline: &mut StatsStore, last_flush: &mut Instant) {
-    if last_flush.elapsed().as_secs() >= FLUSH_INTERVAL_SECS {
-        let merged = io::merge_and_save(store, baseline);
+    if last_flush.elapsed().as_secs() >= FLUSH_INTERVAL_SECS
+        && let Some(merged) = io::merge_and_save(store, baseline)
+    {
         *store = merged.clone();
         *baseline = merged;
         *last_flush = Instant::now();
@@ -92,8 +93,9 @@ pub fn flush() {
     let mut guard = STATS_BUFFER
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some((ref mut store, ref mut baseline, ref mut last_flush)) = *guard {
-        let merged = io::merge_and_save(store, baseline);
+    if let Some((ref mut store, ref mut baseline, ref mut last_flush)) = *guard
+        && let Some(merged) = io::merge_and_save(store, baseline)
+    {
         *store = merged.clone();
         *baseline = merged;
         *last_flush = Instant::now();
@@ -143,10 +145,11 @@ pub fn adjust_savings(command: &str, over_report_delta: i64) {
             cmd.output_tokens = cmd.output_tokens.saturating_sub(adj);
         }
     }
-    let merged = io::merge_and_save(store, baseline);
-    *store = merged.clone();
-    *baseline = merged;
-    *last_flush = Instant::now();
+    if let Some(merged) = io::merge_and_save(store, baseline) {
+        *store = merged.clone();
+        *baseline = merged;
+        *last_flush = Instant::now();
+    }
 }
 
 pub fn record(command: &str, input_tokens: usize, output_tokens: usize) {
@@ -220,10 +223,11 @@ pub fn record(command: &str, input_tokens: usize, output_tokens: usize) {
     // MCP stdio servers are routinely terminated without a graceful shutdown.
     // Delaying this write made the append-only ledger survive while aggregate
     // stats disappeared, so persist every completed accounting event.
-    let merged = io::merge_and_save(store, baseline);
-    *store = merged.clone();
-    *baseline = merged;
-    *last_flush = Instant::now();
+    if let Some(merged) = io::merge_and_save(store, baseline) {
+        *store = merged.clone();
+        *baseline = merged;
+        *last_flush = Instant::now();
+    }
 }
 
 pub fn reset_cep() {
@@ -512,6 +516,23 @@ mod tests {
         assert_eq!(merged.total_commands, 35);
         assert_eq!(merged.total_input_tokens, 1100);
         assert_eq!(merged.total_output_tokens, 700);
+    }
+
+    #[test]
+    fn merge_and_save_keeps_delta_when_lock_is_busy() {
+        let dir = crate::core::data_dir::isolated_data_dir();
+        let baseline = make_store(10, 200, 100);
+        let current = make_store(11, 300, 120);
+        let lock_path = dir.path().join(".stats.lock");
+        std::fs::write(&lock_path, "busy").unwrap();
+
+        assert!(io::merge_and_save(&current, &baseline).is_none());
+
+        std::fs::remove_file(lock_path).unwrap();
+        let merged = io::merge_and_save(&current, &baseline).unwrap();
+        assert_eq!(merged.total_commands, 1);
+        assert_eq!(merged.total_input_tokens, 100);
+        assert_eq!(merged.total_output_tokens, 20);
     }
 
     #[test]

--- a/rust/src/core/stats/mod.rs
+++ b/rust/src/core/stats/mod.rs
@@ -120,11 +120,14 @@ pub fn flush_if_due() {
 
 /// Adjust saved tokens after post-processing (terse, hints) changed the output size.
 /// Positive delta = savings were over-reported, negative = under-reported.
+///
+/// Persist immediately: this adjustment follows a durable `record()` and must not
+/// be lost when a short-lived MCP process exits before the periodic CEP flush.
 pub fn adjust_savings(command: &str, over_report_delta: i64) {
     let mut guard = STATS_BUFFER
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let Some((store, _, _)) = guard.as_mut() else {
+    let Some((store, baseline, last_flush)) = guard.as_mut() else {
         return;
     };
     if over_report_delta > 0 {
@@ -140,6 +143,10 @@ pub fn adjust_savings(command: &str, over_report_delta: i64) {
             cmd.output_tokens = cmd.output_tokens.saturating_sub(adj);
         }
     }
+    let merged = io::merge_and_save(store, baseline);
+    *store = merged.clone();
+    *baseline = merged;
+    *last_flush = Instant::now();
 }
 
 pub fn record(command: &str, input_tokens: usize, output_tokens: usize) {
@@ -154,7 +161,7 @@ pub fn record(command: &str, input_tokens: usize, output_tokens: usize) {
         return;
     };
 
-    let is_first_command = store.total_commands == baseline.total_commands;
+    // Tool-call accounting is durable per event, matching the savings ledger.
     let now = chrono::Local::now();
     let today = now.format("%Y-%m-%d").to_string();
     let timestamp = now.to_rfc3339();
@@ -210,14 +217,13 @@ pub fn record(command: &str, input_tokens: usize, output_tokens: usize) {
             .drain(..store.daily.len() - MAX_DAILY_HISTORY_DAYS);
     }
 
-    if is_first_command {
-        let merged = io::merge_and_save(store, baseline);
-        *store = merged.clone();
-        *baseline = merged;
-        *last_flush = Instant::now();
-    } else {
-        maybe_flush(store, baseline, last_flush);
-    }
+    // MCP stdio servers are routinely terminated without a graceful shutdown.
+    // Delaying this write made the append-only ledger survive while aggregate
+    // stats disappeared, so persist every completed accounting event.
+    let merged = io::merge_and_save(store, baseline);
+    *store = merged.clone();
+    *baseline = merged;
+    *last_flush = Instant::now();
 }
 
 pub fn reset_cep() {

--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -666,9 +666,8 @@ mod tests {
 /// Best-effort: silently drops if provider is unavailable or source_ref can't be
 /// constructed. This is the canonical production callsite for the compression capability.
 fn project_ocla_compression(path: &str, source_tokens: u64, output_tokens: u64) {
-    use crate::core::ocla::traits::CompressionProvider;
-    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
     use crate::core::ocla::OclaRegistry;
+    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
 
     let reg = OclaRegistry::global();
     let source_ref = format!("file:{path}");

--- a/rust/src/dashboard/static/components/cockpit-overview.js
+++ b/rust/src/dashboard/static/components/cockpit-overview.js
@@ -371,9 +371,9 @@ class CockpitOverview extends HTMLElement {
       '<p class="hs cko-bridge" id="cko-verifiedBridge" role="link" tabindex="0" ' +
       'title="Open ROI & Plan" style="cursor:pointer;margin-top:6px">' +
       '<span class="tag tg">verified</span> ' +
-      'of which <b>' + esc(ff(roi.net_saved_tokens)) + '</b> tokens \u00b7 <b>' +
-      esc(fu(roi.saved_usd)) + '</b> are signed in the local ledger' +
-      (since ? ' (since ' + esc(since) + ')' : '') +
+      '<b>' + esc(ff(roi.net_saved_tokens)) + '</b> tokens \u00b7 <b>' +
+      esc(fu(roi.saved_usd)) + '</b> in the independent local ledger' +
+      (since ? ' (recording since ' + esc(since) + ')' : '') +
       ' <span class="hc-health-go">ROI &amp; Plan \u2192</span></p>'
     );
   }

--- a/rust/src/dashboard/static/components/cockpit-roi.js
+++ b/rust/src/dashboard/static/components/cockpit-roi.js
@@ -371,10 +371,7 @@ class CockpitRoi extends HTMLElement {
     );
   }
 
-  /**
-   * "Why is this number smaller than Home?" — the two surfaces count
-   * differently on purpose (GL #479). Static copy, no user data involved.
-   */
+  /** Explain why Home and ROI are independent accounting surfaces. */
   _renderMethodology() {
     return (
       '<div class="card" style="margin-bottom:16px">' +
@@ -383,13 +380,12 @@ class CockpitRoi extends HTMLElement {
       'Only <b>measured</b> compression: raw bytes that actually entered a tool vs. what was sent. ' +
       'No counterfactual multipliers. Append-only, hash-chained, signable.</span></div>' +
       '<div class="sr"><span class="sl">Home (estimated)</span><span class="sv">' +
-      'All-time stats including modelled baselines: search assumes a native grep costs ' +
-      '<b>2.5\u00d7</b> the raw matched output (refinement runs, wider context), and a cache hit ' +
-      'counts the full original as saved (the re-read counterfactual).</span></div>' +
-      '<div class="sr"><span class="sl">Why smaller here</span><span class="sv">' +
-      'The ledger starts later than the all-time stats, skips zero-saving calls and never ' +
-      'applies estimate factors \u2014 so the verified total is the conservative floor, ' +
-      'not a contradiction.</span></div>' +
+      'Aggregate tool stats, including modelled baselines: search assumes a native grep costs ' +
+      '<b>2.5\u00d7</b> the raw matched output, and a cache hit counts the full original as saved.' +
+      '</span></div>' +
+      '<div class="sr"><span class="sl">Why totals differ</span><span class="sv">' +
+      'They use independent stores, start dates, event filters and baselines. Either total may be ' +
+      'larger; compare each number within its stated scope.</span></div>' +
       '</div>'
     );
   }
@@ -413,9 +409,7 @@ class CockpitRoi extends HTMLElement {
     var energyWh = F.ewh ? F.ewh(roi.net_saved_tokens) : 0;
     var energy = F.fe ? F.fe(energyWh) : '\u2014';
 
-    // The signed ledger starts later than the all-time stats on Home, so the
-    // totals legitimately differ. Say so prominently, or the numbers look
-    // contradictory next to Home's estimated all-time figures.
+    // The two totals have independent stores, periods and accounting rules.
     var trend = this._data.trend || [];
     var since = trend.length && trend[0] && trend[0][0] ? String(trend[0][0]) : null;
 
@@ -424,12 +418,10 @@ class CockpitRoi extends HTMLElement {
       '<span class="tag tg">verified</span>' +
       '<span>These numbers come from the <b>signed ledger</b>' +
       (since ? ' (recording since <b>' + esc(since) + '</b>)' : '') +
-      ' \u2014 it only counts <b>measured</b> compression: actual tokens observed ' +
-      'before vs. after, per event, hash-chained. The totals on ' +
-      '<a href="#overview" style="color:var(--accent)">Home</a> are an <b>estimate</b> ' +
-      'of what agents would have loaded without lean-ctx \u2014 they include the full ' +
-      'history and a modeled baseline for search results. Estimated is the bigger ' +
-      'picture; this page is the auditable floor.</span>' +
+      ' and count <b>measured</b> compression per hash-chained event. The totals on ' +
+      '<a href="#overview" style="color:var(--accent)">Home</a> come from aggregate ' +
+      'tool stats and may use modeled baselines. These are independent accounting ' +
+      'surfaces, so either total may be larger.</span>' +
       '</div>';
 
     return (


### PR DESCRIPTION
## What

Persist stats per event and reword the dashboard so Home (estimated) and ROI (verified) are presented as independent accounting scopes.

Closes #1064

## Why

`core/savings_ledger` appends every measured event immediately under a cross-process lock, while `core/stats::record` buffered events in a process-local `STATS_BUFFER` and only flushed after `FLUSH_INTERVAL_SECS` (30s) or on graceful `shutdown()`. MCP stdio servers are frequently terminated without a graceful shutdown, so ledger events survived while buffered stats were lost — Home then under-reported real savings and could sit far below the ROI ledger total. The existing UI copy ("of which … are signed", "auditable floor", "Why smaller here") wrongly implied `verified <= estimated`, which is false for two independent accumulators.

## Changes

- `core/stats::record` and `core/stats::adjust_savings` now persist each event immediately (`merge_and_save`), matching the ledger's per-event durability. The 30s cadence no longer gates whether a completed event reaches disk.
- Dashboard copy (`cockpit-overview.js` bridge line, `cockpit-roi.js` methodology + hero banner) now frames Home and ROI as independent surfaces where either total may legitimately be larger, instead of a subset/floor relationship.

## Testing

- `cargo test --lib core::stats::tests` — 10 passed
- `cargo check --lib`, `cargo clippy --lib -- -D warnings` — clean
- `node --check` on both edited components — clean

## Notes

Behaviour-preserving for the split-data-dir aggregation (#830), corruption quarantine (#706) and daily-history bounds — only the flush timing changed from deferred to immediate.
