### PR TITLE
fix(core): reduce stats flush interval 30s→2s to prevent data loss on abrupt MCP termination

### DIFF
--- a/rust/src/core/stats/mod.rs
+++ b/rust/src/core/stats/mod.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 /// (current_state, baseline_from_disk, last_flush_time)
 static STATS_BUFFER: Mutex<Option<(StatsStore, StatsStore, Instant)>> = Mutex::new(None);
 
-const FLUSH_INTERVAL_SECS: u64 = 30;
+const FLUSH_INTERVAL_SECS: u64 = 2;
 
 /// Daily savings history retained on disk (~10 years of active days). This is a
 /// storage/sync safety bound, NOT a display limit: all-time token totals are
@@ -97,6 +97,26 @@ pub fn flush() {
         *store = merged.clone();
         *baseline = merged;
         *last_flush = Instant::now();
+    }
+}
+
+/// Debounced flush: persists at most once per FLUSH_INTERVAL_SECS.
+/// Call from post_dispatch on every tool call to bound data loss
+/// on abrupt MCP termination to at most 2 seconds of events.
+pub fn flush_if_due() {
+    let due = {
+        let guard = STATS_BUFFER
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match guard.as_ref() {
+            Some((_, _, last_flush)) => {
+                last_flush.elapsed().as_secs() >= FLUSH_INTERVAL_SECS
+            }
+            None => false,
+        }
+    };
+    if due {
+        flush();
     }
 }
 


### PR DESCRIPTION
Fixes #1064

## Problem
Stats buffer flushed to disk only every 30 seconds. MCP stdio servers are routinely SIGKILL'd by Cursor without graceful shutdown, losing all buffered events since last flush. This caused growing divergence between the append-only savings ledger (immediate persistence) and stats.json (30s-buffered).

## Fix
- `FLUSH_INTERVAL_SECS`: 30 → 2 seconds
- Adds `flush_if_due()` public API for external debounced callers

Worst-case data loss reduced from 30s to 2s of events.

Made with [Cursor](https://cursor.com)