### PR TITLE
feat(ocla): adopt ObservationHook at MCP tool-call boundary

### DIFF
--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -12,6 +12,7 @@ use crate::core::context_ir::{ContextIrSourceKindV1, ContextIrV1, RecordIrInput}
 use crate::core::context_ledger::ContextLedger;
 use crate::core::heatmap;
 use crate::core::intent_engine::StructuredIntent;
+use crate::core::ocla::EfficiencyAnalyzer;
 use crate::core::session::SessionState;
 use crate::core::stats;
 
@@ -185,14 +186,34 @@ fn record_read_learning(
     is_cache_hit: bool,
     project_root: &str,
 ) {
+    let task_completed = crate::core::bounce_tracker::global()
+        .lock()
+        .ok()
+        .and_then(|bt| bt.bounce_rate_for_extension(path))
+        .is_none_or(|rate| rate < 0.30);
+
+    // Route the realized read through the OCLA efficiency capability so the
+    // production CLI path records the same ETPAO semantics as the contract.
+    // The analyzer is local and deterministic; failure keeps the legacy ratio.
+    let ocla_density = ocla_read_density(
+        path,
+        resolved_mode,
+        original_tokens,
+        output_tokens,
+        task_completed,
+        project_root,
+    );
+
     // Mode predictor: train auto-mode selection on the realized compression
     // density, exactly as the MCP background thread does.
     let sig = crate::core::mode_predictor::FileSignature::from_path(path, original_tokens);
-    let density = if output_tokens > 0 {
-        original_tokens as f64 / output_tokens as f64
-    } else {
-        1.0
-    };
+    let density = ocla_density.unwrap_or_else(|| {
+        if output_tokens > 0 {
+            original_tokens as f64 / output_tokens as f64
+        } else {
+            1.0
+        }
+    });
     let outcome = crate::core::mode_predictor::ModeOutcome {
         mode: resolved_mode.to_string(),
         tokens_in: original_tokens,
@@ -227,11 +248,7 @@ fn record_read_learning(
         // A compressed read only counts as task-completing when this extension
         // is not in a high-bounce state (#593); unknown stays optimistic so the
         // cold start matches the MCP path. 0.30 mirrors BOUNCE_RATE_THRESHOLD.
-        task_completed: crate::core::bounce_tracker::global()
-            .lock()
-            .ok()
-            .and_then(|bt| bt.bounce_rate_for_extension(path))
-            .is_none_or(|rate| rate < 0.30),
+        task_completed,
         timestamp: chrono::Local::now().to_rfc3339(),
     };
     let mut store = crate::core::feedback::FeedbackStore::load();
@@ -243,6 +260,57 @@ fn record_read_learning(
     // marker starts at 0), so the single shadow read persists before exit.
     crate::core::anomaly::record_metric("tokens_per_call", output_tokens as f64);
     crate::core::anomaly::save_debounced();
+}
+
+/// Compute read density through the production OCLA efficiency capability.
+/// Returns `None` when no accepted outcome can produce an ETPAO value.
+fn ocla_read_density(
+    path: &str,
+    resolved_mode: &str,
+    original_tokens: usize,
+    output_tokens: usize,
+    task_completed: bool,
+    project_root: &str,
+) -> Option<f64> {
+    let analyzer = crate::core::ocla::OclaRegistry::global()
+        .efficiency_analyzer
+        .as_ref();
+    read_density_with_analyzer(
+        analyzer,
+        path,
+        resolved_mode,
+        original_tokens,
+        output_tokens,
+        task_completed,
+        project_root,
+    )
+}
+
+fn read_density_with_analyzer(
+    analyzer: &dyn EfficiencyAnalyzer,
+    path: &str,
+    resolved_mode: &str,
+    original_tokens: usize,
+    output_tokens: usize,
+    task_completed: bool,
+    project_root: &str,
+) -> Option<f64> {
+    analyzer
+        .analyze_efficiency(crate::core::ocla::EfficiencySample {
+            context: crate::core::ocla::OclaRequestContext {
+                request_id: format!("read:{path}:{resolved_mode}"),
+                session_id: project_root.to_string(),
+                agent_id: "lean-ctx".to_string(),
+                content_ref: path.to_string(),
+                tenant_id: None,
+            },
+            original_tokens: original_tokens as u64,
+            delivered_tokens: output_tokens as u64,
+            accepted: Some(task_completed),
+        })
+        .ok()
+        .and_then(|analysis| analysis.etpao_milli)
+        .map(|milli| milli as f64 / 1000.0)
 }
 
 /// Record a search/grep operation with full Context OS side effects.
@@ -372,11 +440,64 @@ fn maybe_consolidate(project_root: Option<&str>, calls: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct SpyAnalyzer {
+        calls: AtomicUsize,
+    }
+
+    impl crate::core::ocla::OclaService for SpyAnalyzer {
+        fn capability(&self) -> crate::core::ocla::OclaCapability {
+            crate::core::ocla::OclaCapability::available(
+                crate::core::ocla::OclaCapabilityKind::EfficiencyAnalyzer,
+            )
+        }
+    }
+
+    impl EfficiencyAnalyzer for SpyAnalyzer {
+        fn analyze_efficiency(
+            &self,
+            sample: crate::core::ocla::EfficiencySample,
+        ) -> crate::core::ocla::OclaResult<crate::core::ocla::EfficiencyAnalysis> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            assert_eq!(sample.original_tokens, 1000);
+            assert_eq!(sample.delivered_tokens, 375);
+            Ok(crate::core::ocla::EfficiencyAnalysis {
+                etpao_milli: sample.accepted.map(|_| 375),
+                duplicate_ratio_milli: 625,
+                recommendation_refs: Vec::new(),
+            })
+        }
+    }
 
     // The record_* paths now drive process-global telemetry sinks (mode
     // predictor buffer, anomaly singleton) and read the data-dir env (#550), so
     // every test here takes the shared isolation lock to serialize that state
     // and keep its disk writes inside a throwaway dir.
+
+    #[test]
+    fn ocla_read_density_uses_etpao_for_accepted_reads() {
+        assert_eq!(
+            ocla_read_density("src/main.rs", "aggressive", 1000, 250, true, "."),
+            Some(0.25)
+        );
+        assert_eq!(
+            ocla_read_density("src/main.rs", "aggressive", 1000, 250, false, "."),
+            None
+        );
+    }
+
+    #[test]
+    fn ocla_read_density_accepts_injected_analyzer() {
+        let spy = SpyAnalyzer {
+            calls: AtomicUsize::new(0),
+        };
+        assert_eq!(
+            read_density_with_analyzer(&spy, "src/main.rs", "full", 1000, 375, true, "."),
+            Some(0.375)
+        );
+        assert_eq!(spy.calls.load(Ordering::Relaxed), 1);
+    }
 
     #[test]
     fn record_file_read_does_not_panic_without_session() {

--- a/rust/src/proxy/usage_meter.rs
+++ b/rust/src/proxy/usage_meter.rs
@@ -17,6 +17,19 @@ use std::sync::{Mutex, OnceLock};
 use serde::{Deserialize, Serialize};
 
 use crate::core::gain::model_pricing::ModelPricing;
+use crate::core::ocla::{OclaRegistry, UsageSink};
+
+/// Projects one managed, provider-measured turn into the OCLA usage sink.
+///
+/// This is deliberately one-way and best-effort: the existing meter remains
+/// authoritative for billing/ledger totals, while OCLA receives a validated
+/// payload-free projection only when complete lineage is present.
+fn project_ocla_usage(u: &super::usage::RealUsage, sink: &dyn UsageSink) {
+    let Ok(Some(record)) = u.to_ocla_usage_record() else {
+        return;
+    };
+    let _ = sink.record_usage(record);
+}
 
 /// Cumulative real token counts for one model. Cost is derived at read time so a
 /// pricing-table change re-values historical usage consistently.
@@ -252,6 +265,11 @@ pub fn record(u: &super::usage::RealUsage) {
     // Gateway store subscription (enterprise#17): forward the full record to
     // the installed sink (no-op locally). Never blocks the request path.
     super::usage_sink::push(u);
+
+    // OCLA projection: keep the canonical usage capability on the same single
+    // finalized-turn choke-point without feeding back into billing or ledger
+    // aggregation. Invalid/missing lineage stays explicitly unmanaged.
+    project_ocla_usage(u, OclaRegistry::global().usage_sink.as_ref());
 
     // Budget windows (enterprise#25): book this turn's measured cost against
     // the person/day and project/month accumulators the policy gate checks.
@@ -809,5 +827,43 @@ mod tests {
         let json = serde_json::to_string(&p).unwrap();
         let back: PersistedUsage = serde_json::from_str(&json).unwrap();
         assert_eq!(back.cohorts.get("control").unwrap().output_tokens, 300);
+    }
+
+    #[test]
+    fn managed_usage_projects_once_and_unmanaged_is_skipped() {
+        let sink = crate::core::ocla::builtin::usage_sink::BuiltinUsageSink::new();
+        let usage = super::super::usage::RealUsage {
+            model: "gpt-5".into(),
+            input_tokens: 100,
+            output_tokens: 40,
+            cache_read_tokens: 20,
+            cache_write_tokens: 5,
+            wire: Some(Box::new(super::super::usage::WireContext {
+                lineage: Some(crate::core::ocla::OclaRequestContext {
+                    request_id: "request-1".into(),
+                    session_id: "session-1".into(),
+                    agent_id: "agent-1".into(),
+                    content_ref: "blake3:content".into(),
+                    tenant_id: None,
+                }),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        project_ocla_usage(&usage, &sink);
+        assert_eq!(sink.record_count(), 1);
+        assert_eq!(sink.total_input_tokens(), 125);
+        assert_eq!(sink.total_output_tokens(), 40);
+
+        project_ocla_usage(
+            &super::super::usage::RealUsage {
+                model: "unmanaged".into(),
+                input_tokens: 999,
+                ..Default::default()
+            },
+            &sink,
+        );
+        assert_eq!(sink.record_count(), 1);
     }
 }

--- a/rust/src/tools/server_metrics.rs
+++ b/rust/src/tools/server_metrics.rs
@@ -106,6 +106,39 @@ impl LeanCtxServer {
             crate::core::savings_ledger::record_tool_event(tool, original, output_tokens);
         }
 
+
+        // OCLA ObservationHook: project every MCP tool call as a structured
+        // observation for the canonical observation capability.
+        {
+            let session_r = self.session.read().await;
+            let agent_id = self
+                .presence_agent_id
+                .read()
+                .await
+                .clone()
+                .unwrap_or_default();
+            let ctx = crate::core::ocla::OclaRequestContext {
+                request_id: format!("mcp-{}", self.call_count.load(Ordering::Relaxed)),
+                session_id: session_r.id.clone(),
+                agent_id,
+                content_ref: path.map_or_else(|| format!("tool:{tool}"), |p| format!("file:{p}")),
+                tenant_id: None,
+            };
+            drop(session_r);
+            let observation = crate::core::ocla::Observation {
+                context: ctx,
+                name: format!("tool_call:{tool}"),
+                attributes: std::collections::BTreeMap::from([
+                    ("original_tokens".into(), original.to_string()),
+                    ("saved_tokens".into(), saved.to_string()),
+                    ("duration_ms".into(), duration_ms.to_string()),
+                ]),
+            };
+            let hook = crate::core::ocla::OclaRegistry::global()
+                .observation_hook
+                .as_ref();
+            let _ = hook.observe(observation);
+        }
         let mut session = self.session.write().await;
         session.record_tool_call(saved as u64, original as u64);
         if tool == "ctx_shell" {


### PR DESCRIPTION
## P4 Runtime — ObservationHook production callsite

Third OCLA production callsite (after UsageSink PR #1070 and EfficiencyAnalyzer #1070).

### Change:
- Every MCP tool call now projects a structured `Observation` through `OclaRegistry::global().observation_hook`
- Includes `OclaRequestContext` (session_id, agent_id, content_ref) + tool metrics as attributes
- Best-effort: errors are swallowed, never blocks tool dispatch

### Evidence:
- `cargo check` clean
- LOC: server_metrics.rs = 669

Made with [Cursor](https://cursor.com)