### PR TITLE
fix(ocla): fail-closed CompressionProvider + TOCTOU-hardened ContentPort

### DIFF
--- a/rust/src/core/ocla/builtin/compression_provider.rs
+++ b/rust/src/core/ocla/builtin/compression_provider.rs
@@ -1,27 +1,27 @@
-//! BuiltinCompressionProvider — real compression via ContentPort + core::compressor.
+//! BuiltinCompressionProvider — fail-closed compression via ContentPort + core::compressor.
 //!
-//! Resolves source bytes through CompressionContentPort, runs the existing
-//! aggressive_compress pipeline, persists the result as a BLAKE3 ref, and
-//! emits CompressionApplied events. Falls back to token-count estimation
-//! when the source_ref cannot be resolved (non-file refs).
+//! Resolves source bytes through CompressionContentPort, runs aggressive_compress,
+//! counts output tokens via core::tokens, persists as BLAKE3 CAS. Rejects non-file refs
+//! and propagates all errors (fail-closed, no fabricated fallbacks).
 
 use std::path::Path;
 use std::sync::OnceLock;
 
 use crate::core::compressor;
-use crate::core::ocla::OclaError;
 use crate::core::ocla::content_port::CompressionContentPort;
 use crate::core::ocla::traits::{CompressionProvider, OclaService};
 use crate::core::ocla::types::{
     CompressionRequest, CompressionResult, OclaCapability, OclaCapabilityKind, OclaResult,
 };
+use crate::core::ocla::OclaError;
 use crate::core::ocla_bus::{self, OclaEvent};
+use crate::core::tokens;
 
 static DEFAULT_PORT: OnceLock<CompressionContentPort> = OnceLock::new();
 
 fn default_port() -> &'static CompressionContentPort {
     DEFAULT_PORT.get_or_init(|| {
-        let root = std::env::current_dir().unwrap_or_else(|_| ".".into());
+        let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
         CompressionContentPort::new(root)
     })
 }
@@ -31,6 +31,67 @@ pub struct BuiltinCompressionProvider;
 impl BuiltinCompressionProvider {
     pub fn new() -> Self {
         Self
+    }
+
+    fn compress_with_port(
+        &self,
+        request: CompressionRequest,
+        port: &CompressionContentPort,
+    ) -> OclaResult<CompressionResult> {
+        if request.source_tokens == 0 {
+            return Err(OclaError::InvalidRequest(
+                "source_tokens must be > 0".into(),
+            ));
+        }
+        if request.target_tokens == 0 {
+            return Err(OclaError::InvalidRequest(
+                "target_tokens must be > 0".into(),
+            ));
+        }
+
+        if !request.source_ref.starts_with("file:") {
+            return Err(OclaError::InvalidRequest(format!(
+                "only file: refs supported, got: {}",
+                request.source_ref.split(':').next().unwrap_or("unknown")
+            )));
+        }
+
+        let bytes = port.resolve(&request.source_ref)?;
+
+        let source_text = std::str::from_utf8(&bytes)
+            .map_err(|_| OclaError::InvalidRequest("source is not valid UTF-8".into()))?;
+
+        let ext = request
+            .source_ref
+            .strip_prefix("file:")
+            .and_then(|p| Path::new(p).extension())
+            .and_then(|e| e.to_str());
+
+        let compressed = compressor::aggressive_compress(source_text, ext);
+        let delivered_tokens = tokens::count_tokens(&compressed) as u64;
+
+        if delivered_tokens >= request.source_tokens {
+            return Err(OclaError::InvalidRequest(
+                "compression produced no gain (output >= source)".into(),
+            ));
+        }
+
+        let capped_tokens = delivered_tokens.min(request.target_tokens);
+
+        let ref_key = port.persist(compressed.as_bytes())?;
+
+        ocla_bus::emit(OclaEvent::CompressionApplied {
+            path: Some(request.source_ref.clone()),
+            before_tokens: request.source_tokens,
+            after_tokens: capped_tokens,
+            strategy: "aggressive_compress".to_string(),
+        });
+
+        Ok(CompressionResult {
+            delivered_ref: ref_key,
+            delivered_tokens: capped_tokens,
+            recovery_ref: Some(request.source_ref),
+        })
     }
 }
 
@@ -48,58 +109,8 @@ impl OclaService for BuiltinCompressionProvider {
 
 impl CompressionProvider for BuiltinCompressionProvider {
     fn compress(&self, request: CompressionRequest) -> OclaResult<CompressionResult> {
-        let port = default_port();
-
-        let (delivered_ref, delivered_tokens) = if request.source_ref.starts_with("file:") {
-            match port.resolve(&request.source_ref) {
-                Ok(bytes) => {
-                    let source_text = String::from_utf8_lossy(&bytes);
-                    let ext = request
-                        .source_ref
-                        .strip_prefix("file:")
-                        .and_then(|p| Path::new(p).extension())
-                        .and_then(|e| e.to_str());
-
-                    let compressed = compressor::aggressive_compress(&source_text, ext);
-                    let compressed_bytes = compressed.as_bytes();
-                    let compressed_tokens =
-                        (compressed_bytes.len() as u64 / 4).min(request.target_tokens);
-
-                    let ref_key = port
-                        .persist(compressed_bytes)
-                        .map_err(|e| OclaError::InvalidRequest(format!("persist failed: {e}")))?;
-
-                    (ref_key, compressed_tokens)
-                }
-                Err(_) => fallback_estimate(&request),
-            }
-        } else {
-            fallback_estimate(&request)
-        };
-
-        ocla_bus::emit(OclaEvent::CompressionApplied {
-            path: Some(request.source_ref.clone()),
-            before_tokens: request.source_tokens,
-            after_tokens: delivered_tokens,
-            strategy: if delivered_ref.starts_with("blake3:") {
-                "aggressive_compress"
-            } else {
-                "estimate"
-            }
-            .to_string(),
-        });
-
-        Ok(CompressionResult {
-            delivered_ref,
-            delivered_tokens,
-            recovery_ref: Some(request.source_ref),
-        })
+        self.compress_with_port(request, default_port())
     }
-}
-
-fn fallback_estimate(request: &CompressionRequest) -> (String, u64) {
-    let tokens = request.target_tokens.min(request.source_tokens);
-    (format!("estimate:{}", request.source_ref), tokens)
 }
 
 #[cfg(test)]
@@ -119,62 +130,143 @@ mod tests {
     }
 
     #[test]
-    fn compress_non_file_ref_falls_back_to_estimate() {
+    fn compress_rejects_non_file_ref() {
+        let port = CompressionContentPort::new(std::env::temp_dir());
         let provider = BuiltinCompressionProvider::new();
-        let result = provider
-            .compress(CompressionRequest {
-                context: ctx(),
-                source_ref: "mem:buffer-123".into(),
-                source_tokens: 1000,
-                target_tokens: 300,
-                quality_policy_ref: None,
-            })
-            .unwrap();
-
-        assert!(result.delivered_ref.starts_with("estimate:"));
-        assert_eq!(result.delivered_tokens, 300);
+        let err = provider
+            .compress_with_port(
+                CompressionRequest {
+                    context: ctx(),
+                    source_ref: "mem:buffer-123".into(),
+                    source_tokens: 1000,
+                    target_tokens: 300,
+                    quality_policy_ref: None,
+                },
+                &port,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("only file: refs"));
     }
 
     #[test]
-    fn compress_does_not_exceed_source() {
+    fn compress_rejects_zero_source_tokens() {
+        let port = CompressionContentPort::new(std::env::temp_dir());
         let provider = BuiltinCompressionProvider::new();
-        let result = provider
-            .compress(CompressionRequest {
-                context: ctx(),
-                source_ref: "mem:small".into(),
-                source_tokens: 200,
-                target_tokens: 500,
-                quality_policy_ref: None,
-            })
-            .unwrap();
-
-        assert_eq!(result.delivered_tokens, 200);
+        let err = provider
+            .compress_with_port(
+                CompressionRequest {
+                    context: ctx(),
+                    source_ref: "file:test.rs".into(),
+                    source_tokens: 0,
+                    target_tokens: 300,
+                    quality_policy_ref: None,
+                },
+                &port,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("source_tokens"));
     }
 
     #[test]
-    fn compress_with_real_file_produces_blake3_ref() {
+    fn compress_rejects_zero_target_tokens() {
+        let port = CompressionContentPort::new(std::env::temp_dir());
+        let provider = BuiltinCompressionProvider::new();
+        let err = provider
+            .compress_with_port(
+                CompressionRequest {
+                    context: ctx(),
+                    source_ref: "file:test.rs".into(),
+                    source_tokens: 100,
+                    target_tokens: 0,
+                    quality_policy_ref: None,
+                },
+                &port,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("target_tokens"));
+    }
+
+    #[test]
+    fn compress_with_real_file_returns_blake3_ref() {
         let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("test.rs");
-        fs::write(&file, "fn main() {\n    println!(\"hello\");\n}\n").unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let content = "use std::collections::HashMap;\n\
+            use std::io::{self, Read, Write, BufReader, BufWriter};\n\
+            use std::fs::File;\n\n\
+            /// This function demonstrates a verbose implementation with many comments\n\
+            /// that should be highly compressible by the aggressive compressor.\n\
+            /// It includes redundant type annotations and verbose variable names.\n\
+            fn main() -> io::Result<()> {\n    \
+            // Initialize the hashmap for storing key-value pairs\n    \
+            let mut hash_map_instance: HashMap<String, String> = HashMap::new();\n    \
+            // Insert the first key-value pair into the hashmap\n    \
+            hash_map_instance.insert(String::from(\"key_one\"), String::from(\"value_one\"));\n    \
+            // Insert the second key-value pair into the hashmap\n    \
+            hash_map_instance.insert(String::from(\"key_two\"), String::from(\"value_two\"));\n    \
+            // Insert the third key-value pair into the hashmap\n    \
+            hash_map_instance.insert(String::from(\"key_three\"), String::from(\"value_three\"));\n    \
+            // Iterate over all key-value pairs in the hashmap and print them\n    \
+            for (key_variable, value_variable) in hash_map_instance.iter() {\n        \
+            // Print the current key and its corresponding value\n        \
+            println!(\"Key: {}, Value: {}\", key_variable, value_variable);\n    \
+            }\n    \
+            // Open a file for reading input data from the filesystem\n    \
+            let input_file_handle: File = File::open(\"input.txt\")?;\n    \
+            // Create a buffered reader wrapper around the file handle\n    \
+            let mut buffered_reader_instance: BufReader<File> = BufReader::new(input_file_handle);\n    \
+            // Read all contents of the file into a string buffer\n    \
+            let mut file_contents_buffer: String = String::new();\n    \
+            buffered_reader_instance.read_to_string(&mut file_contents_buffer)?;\n    \
+            // Print the length of the file contents that were read\n    \
+            println!(\"Read {} bytes from input file\", file_contents_buffer.len());\n    \
+            Ok(())\n\
+            }\n";
+        fs::write(root.join("test.rs"), content).unwrap();
 
-        let port = CompressionContentPort::new(dir.path());
-        DEFAULT_PORT.set(port).ok();
-
+        let port = CompressionContentPort::new(&root);
         let provider = BuiltinCompressionProvider::new();
-        let result = provider
-            .compress(CompressionRequest {
+        let source_tokens = tokens::count_tokens(content) as u64;
+
+        let result = provider.compress_with_port(
+            CompressionRequest {
                 context: ctx(),
                 source_ref: "file:test.rs".into(),
-                source_tokens: 100,
-                target_tokens: 50,
+                source_tokens,
+                target_tokens: source_tokens,
                 quality_policy_ref: None,
-            })
-            .unwrap();
-
-        assert!(
-            result.delivered_ref.starts_with("blake3:")
-                || result.delivered_ref.starts_with("estimate:")
+            },
+            &port,
         );
-        assert!(result.delivered_tokens <= 50);
+
+        let r = result.unwrap();
+        assert!(r.delivered_ref.starts_with("blake3:"));
+        assert!(r.delivered_tokens < source_tokens);
+        assert_eq!(r.recovery_ref, Some("file:test.rs".into()));
+    }
+
+    #[test]
+    fn compress_propagates_resolve_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let port = CompressionContentPort::new(&root);
+
+        let provider = BuiltinCompressionProvider::new();
+        let err = provider
+            .compress_with_port(
+                CompressionRequest {
+                    context: ctx(),
+                    source_ref: "file:nonexistent.rs".into(),
+                    source_tokens: 100,
+                    target_tokens: 50,
+                    quality_policy_ref: None,
+                },
+                &port,
+            )
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("resolve") || msg.contains("No such file") || msg.contains("not found"),
+            "unexpected error: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Resolves **SECURITY-HOLD** (TOCTOU race in ContentPort) and **URGENT** CompressionProvider audit findings.

### CompressionProvider (fail-closed)
- **Reject non-file refs** with `OclaError` (no more fabricated `estimate:` refs)
- **Strict UTF-8**: `from_utf8` error propagation (no lossy conversion)
- **Real token counting**: uses `core::tokens::count_tokens` (not `bytes/4`)
- **No-gain rejection**: if output >= source tokens → error (not silent pass-through)
- **Zero-token validation**: source_tokens and target_tokens must be > 0
- **Only emits CompressionApplied on actual compression** (not estimates)

### ContentPort (TOCTOU hardening)
- **symlink_metadata (lstat) on every path component** — rejects symlinks at both final and intermediate positions
- **Canonicalize project_root** once (handles `/tmp` → `/private/tmp` on macOS)
- **Bounded read with double-gate** (pre-read size check + post-read length check)
- Removed old `canonicalize == jailed` comparison that was ineffective (jail_path already canonicalizes)

### Tests
- 9 content_port tests (including symlink_final_component + symlink_intermediate_dir)
- 5 compression_provider tests (fail-closed validation)


Made with [Cursor](https://cursor.com)