### PR TITLE
fix(cli): align box borders in gain, cheatsheet and config show

### DIFF
--- a/rust/src/cli/cheatsheet_cmd.rs
+++ b/rust/src/cli/cheatsheet_cmd.rs
@@ -1,9 +1,13 @@
 pub fn cmd_cheatsheet() {
     let ver = env!("CARGO_PKG_VERSION");
+    // Right-aligned in the 31 columns the title leaves inside the 62-column
+    // frame, minus the 2-space gutter before the border. A fixed literal run of
+    // spaces here drifts as soon as the version string changes length.
+    // ponytail: overflows past a 29-char version; cargo versions never get there.
     let ver_pad = format!("v{ver}");
     let header = format!(
         "\x1b[1;36m╔══════════════════════════════════════════════════════════════╗\x1b[0m
-\x1b[1;36m║\x1b[0m  \x1b[1;37mlean-ctx Workflow Cheat Sheet\x1b[0m                     \x1b[2m{ver_pad:>6}\x1b[0m  \x1b[1;36m║\x1b[0m
+\x1b[1;36m║\x1b[0m  \x1b[1;37mlean-ctx Workflow Cheat Sheet\x1b[0m\x1b[2m{ver_pad:>29}\x1b[0m  \x1b[1;36m║\x1b[0m
 \x1b[1;36m╚══════════════════════════════════════════════════════════════╝\x1b[0m");
     println!(
         "{header}

--- a/rust/src/cli/config_cmd.rs
+++ b/rust/src/cli/config_cmd.rs
@@ -1136,73 +1136,73 @@ fn cmd_show_effective() {
     let compression = config::CompressionLevel::effective(&cfg);
     let policy = cfg.memory_policy_effective().unwrap_or_default();
 
-    println!("╭─── Simplified (high-level) ───────────────────────────────╮");
-    println!(
-        "│ compression_level   = {:10}  {}",
+    println!("{}", box_top("Simplified (high-level)"));
+    box_row(&format!(
+        " compression_level   = {:10}  {}",
         format!("{compression:?}"),
         source_hint(
             "LEAN_CTX_COMPRESSION",
             cfg.compression_level != config::CompressionLevel::Off
         )
-    );
-    println!(
-        "│ max_disk_mb         = {:10}  {}",
+    ));
+    box_row(&format!(
+        " max_disk_mb         = {:10}  {}",
         cfg.max_disk_mb_effective(),
         source_hint("LEAN_CTX_MAX_DISK_MB", cfg.max_disk_mb > 0)
-    );
-    println!(
-        "│ max_ram_percent     = {:10}  {}",
+    ));
+    box_row(&format!(
+        " max_ram_percent     = {:10}  {}",
         cfg.max_ram_percent,
         source_hint("LEAN_CTX_MAX_RAM_PERCENT", cfg.max_ram_percent != 5)
-    );
-    println!(
-        "│ max_staleness_days  = {:10}  {}",
+    ));
+    box_row(&format!(
+        " max_staleness_days  = {:10}  {}",
         cfg.max_staleness_days_effective(),
         source_hint("LEAN_CTX_MAX_STALENESS_DAYS", cfg.max_staleness_days > 0)
-    );
-    println!(
-        "│ memory_profile      = {:10}  {}",
+    ));
+    box_row(&format!(
+        " memory_profile      = {:10}  {}",
         format!("{:?}", cfg.memory_profile),
         source_hint("LEAN_CTX_MEMORY_PROFILE", false)
-    );
-    println!("╰────────────────────────────────────────────────────────────╯");
+    ));
+    println!("{}", box_bottom());
 
     println!();
-    println!("╭─── Derived effective limits ────────────────────────────────╮");
-    println!(
-        "│ archive_max_disk_mb    = {:>6} MB",
+    println!("{}", box_top("Derived effective limits"));
+    box_row(&format!(
+        " archive_max_disk_mb    = {:>6} MB",
         cfg.archive_max_disk_mb_effective()
-    );
-    println!(
-        "│ bm25_max_cache_mb      = {:>6} MB",
+    ));
+    box_row(&format!(
+        " bm25_max_cache_mb      = {:>6} MB",
         cfg.bm25_max_cache_mb_effective()
-    );
-    println!(
-        "│ archive_max_age_hours  = {:>6} h",
+    ));
+    box_row(&format!(
+        " archive_max_age_hours  = {:>6} h",
         cfg.archive_max_age_hours_effective()
-    );
-    println!(
-        "│ graph_index_max_files  = {:>6}",
+    ));
+    box_row(&format!(
+        " graph_index_max_files  = {:>6}",
         cfg.graph_index_max_files
-    );
-    println!("│");
-    println!(
-        "│ memory.knowledge.max_facts     = {:>6}",
+    ));
+    box_row("");
+    box_row(&format!(
+        " memory.knowledge.max_facts     = {:>6}",
         policy.knowledge.max_facts
-    );
-    println!(
-        "│ memory.knowledge.max_patterns  = {:>6}",
+    ));
+    box_row(&format!(
+        " memory.knowledge.max_patterns  = {:>6}",
         policy.knowledge.max_patterns
-    );
-    println!(
-        "│ memory.episodic.max_episodes   = {:>6}",
+    ));
+    box_row(&format!(
+        " memory.episodic.max_episodes   = {:>6}",
         policy.episodic.max_episodes
-    );
-    println!(
-        "│ memory.procedural.max_procedures = {:>4}",
+    ));
+    box_row(&format!(
+        " memory.procedural.max_procedures = {:>4}",
         policy.procedural.max_procedures
-    );
-    println!("╰────────────────────────────────────────────────────────────╯");
+    ));
+    println!("{}", box_bottom());
 
     if cfg.max_disk_mb_effective() > 0 {
         println!();
@@ -1212,6 +1212,26 @@ fn cmd_show_effective() {
             (cfg.max_disk_mb_effective() as f64 / 500.0).clamp(0.5, 10.0)
         );
     }
+}
+
+/// Interior width of the `config show` frames, in terminal columns.
+const SHOW_BOX_W: usize = 60;
+
+/// `╭─── Label ───…───╮`, always `SHOW_BOX_W` columns wide inside the corners.
+fn box_top(label: &str) -> String {
+    let head = format!("─── {label} ");
+    let fill = SHOW_BOX_W.saturating_sub(crate::core::theme::visual_len(&head));
+    format!("╭{head}{}╮", "─".repeat(fill))
+}
+
+fn box_bottom() -> String {
+    format!("╰{}╯", "─".repeat(SHOW_BOX_W))
+}
+
+/// Print one framed row, padded (or truncated) to the frame's interior width so
+/// the right border lines up regardless of the value's length.
+fn box_row(content: &str) {
+    println!("│{}│", crate::core::theme::pad_right(content, SHOW_BOX_W));
 }
 
 fn source_hint(env_var: &str, config_set: bool) -> &'static str {
@@ -1242,6 +1262,19 @@ fn dir_size(path: &std::path::Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn show_box_borders_line_up() {
+        use crate::core::theme::{pad_right, visual_len};
+        let bottom = visual_len(&box_bottom());
+        for label in ["Simplified (high-level)", "Derived effective limits", ""] {
+            assert_eq!(visual_len(&box_top(label)), bottom, "top border: {label:?}");
+        }
+        // Rows track the same width, short and overlong alike.
+        for row in ["", " x = 1", &" long ".repeat(40)] {
+            assert_eq!(visual_len(&pad_right(row, SHOW_BOX_W)) + 2, bottom);
+        }
+    }
 
     // Reproduces `Config::save()`'s on-disk merge without touching the real
     // config path: serialize `cfg`, then merge it onto `existing` exactly as

--- a/rust/src/core/stats/format/dashboard.rs
+++ b/rust/src/core/stats/format/dashboard.rs
@@ -169,20 +169,24 @@ pub fn format_gain_hero_themed(t: &Theme) -> String {
             .sum();
         if week_saved > 0 {
             let accent = t.accent.fg();
-            out.push(format!("  {}", t.box_top(42)));
+            let nw = 42;
             let nside = t.box_side();
-            out.push(format!(
-                "  {nside} {accent}{bold}Your first week!{rst}                          {nside}"
-            ));
-            out.push(format!(
-                "  {nside} You saved {c1}{bold}{}{rst} tokens this week.      {nside}",
+            // Pad to visual width: the token count is variable-length and the
+            // labels carry ANSI colour, so hardcoded spacing skews the border.
+            let nudge_line = |content: &str| -> String {
+                format!("  {nside}{}{nside}", theme::pad_right(content, nw))
+            };
+            out.push(format!("  {}", t.box_top(nw)));
+            out.push(nudge_line(&format!(" {accent}{bold}Your first week!{rst}")));
+            out.push(nudge_line(&format!(
+                " You saved {c1}{bold}{}{rst} tokens this week.",
                 crate::core::wrapped::format_tokens(week_saved),
-            ));
-            out.push(format!(
-                "  {nside} Share your card? {sec}lean-ctx gain --wrapped{rst} {nside}",
+            )));
+            out.push(nudge_line(&format!(
+                " Share your card? {sec}lean-ctx gain --wrapped{rst}",
                 sec = t.secondary.fg(),
-            ));
-            out.push(format!("  {}", t.box_bottom(42)));
+            )));
+            out.push(format!("  {}", t.box_bottom(nw)));
             out.push(String::new());
         }
     }


### PR DESCRIPTION
Several CLI dashboards draw framed boxes by padding rows with a hardcoded run of spaces. That only lines up for one specific input — as soon as the interpolated value changes length, or carries ANSI colour, the right border drifts. `theme::pad_right` / `theme::visual_len` already solve this correctly (ANSI-aware, wide-char-aware); these three sites just weren't using them.

## Before

```
lean-ctx gain
  ╭──────────────────────────────────────────╮
  │ Your first week!                         │
  │ You saved 5.1M tokens this week.      │     <- drifts with the token count
  │ Share your card? lean-ctx gain --wrapped │
  ╰──────────────────────────────────────────╯

lean-ctx cheatsheet
╔══════════════════════════════════════════════════════════════╗
║  lean-ctx Workflow Cheat Sheet                     v3.9.12  ║   <- 1 col short, grows with version
╚══════════════════════════════════════════════════════════════╝

lean-ctx config show
╭─── Simplified (high-level) ───────────────────────────────╮     <- 59
│ compression_level   = Lite        ← config                       <- no right border
╰────────────────────────────────────────────────────────────╯    <- 60
```

## After

All rows pad to a named interior width; every border lines up.

```
╭─── Simplified (high-level) ────────────────────────────────╮
│ compression_level   = Lite        ← config                 │
│ memory_profile      = Performance  ← default               │
╰────────────────────────────────────────────────────────────╯
```

## Changes
- `core/stats/format/dashboard.rs` — weekly-nudge card builds rows through a `pad_right` closure, matching the hero box right above it
- `cli/cheatsheet_cmd.rs` — version right-aligned in a computed field instead of a literal space run (was also 1 column short of the frame)
- `cli/config_cmd.rs` — `box_top`/`box_bottom`/`box_row` helpers; rows now actually close, and both frames share one `SHOW_BOX_W`

## Verification
Swept 86 read-only subcommands with a script that strips ANSI, measures each box row in terminal columns (wide chars = 2, combining/VS = 0) and flags rows whose width differs from the rest of their box. 26 boxes rendered; 3 misaligned rows before, 0 after.

Static sweep of every source literal containing `│ ┃ ║` plus every `box_side()` row builder found no further instances of the same bug shape.

Scope caveat: 78 of the 86 commands print no box in a fresh environment (no data / not provisioned), so those paths are covered by the static sweep only.

Added `show_box_borders_line_up` — asserts top, bottom and padded rows agree in visual width, including an overlong row that must truncate rather than overflow. `cargo fmt`/`clippy` clean (the one remaining clippy warning, a wildcard import in `core/ocla/registry.rs`, is pre-existing and untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)