### PR TITLE
feat(agents): Mistral Vibe pre_tool arg-rewrite hook

### DIFF
--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -737,7 +737,7 @@ pub fn run() {
                 // inside the handler (#1035), so they must NOT also carry the
                 // force-exit watchdog (which would `exit(1)` with no decision and
                 // wedge the host). The remaining hooks keep the simple zombie-guard.
-                if !matches!(action, "rewrite" | "redirect" | "deny") {
+                if !matches!(action, "rewrite" | "redirect" | "deny" | "vibe-pre-tool") {
                     hook_handlers::arm_watchdog(std::time::Duration::from_secs(5));
                 }
                 match action {
@@ -750,9 +750,10 @@ pub fn run() {
                     "codex-pretooluse" => hook_handlers::handle_codex_pretooluse(),
                     "codex-session-start" => hook_handlers::handle_codex_session_start(),
                     "rewrite-inline" => hook_handlers::handle_rewrite_inline(),
+                    "vibe-pre-tool" => hook_handlers::handle_vibe_pre_tool(),
                     _ => {
                         eprintln!(
-                            "Usage: lean-ctx hook <rewrite|redirect|deny|read-dedup|observe|copilot|codex-pretooluse|codex-session-start|rewrite-inline>"
+                            "Usage: lean-ctx hook <rewrite|redirect|deny|read-dedup|observe|copilot|codex-pretooluse|codex-session-start|rewrite-inline|vibe-pre-tool>"
                         );
                         eprintln!(
                             "  Internal commands used by agent hooks (Claude, Cursor, Copilot, etc.)"

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -26,8 +26,10 @@ mod redirect;
 // Search/dir-list rewriting and shell tokenization extracted to
 // `search_rewrite` submodule (#660 LOC gate).
 mod search_rewrite;
+mod vibe;
 pub(crate) use codex::emit_session_start_additional_context;
 pub use codex::{handle_codex_pretooluse, handle_codex_session_start};
+pub use vibe::handle_vibe_pre_tool;
 // Test-only re-export: only `hook_handlers::tests` (cfg(test)) reaches these
 // through this path; codex.rs's own production use of them is internal.
 #[cfg(test)]

--- a/rust/src/hook_handlers/vibe.rs
+++ b/rust/src/hook_handlers/vibe.rs
@@ -1,0 +1,280 @@
+//! Mistral Vibe `pre_tool` hook handler.
+//!
+//! Implements transparent **arg-rewrite** (shadow mode) for the `bash` tool —
+//! the agent's native shell call is transparently rerouted through the lean-ctx
+//! compression CLI — plus **Replace-mode denials** that steer `read_file` and
+//! `grep` onto the lean-ctx MCP tools (`ctx_read` / `ctx_search`).
+//!
+//! Vibe's contract (`vibe.core.hooks`, v2.21.0+):
+//! * stdin — `PreToolInvocation` JSON: `tool_name`, `tool_call_id`,
+//!   `tool_input` (dict), plus session context; `hook_event_name == "pre_tool"`.
+//! * stdout — exit 0 + a JSON `HookStructuredResponse` (Pydantic
+//!   `extra="ignore"`): `decision` ("allow"|"deny", default allow), `reason`,
+//!   `system_message`, and `hook_specific_output.tool_input` — a dict that
+//!   *fully replaces* the tool input. Empty stdout is treated as passthrough.
+
+use super::file_rewrite::rewrite_candidate;
+use super::{HOOK_STDIN_TIMEOUT, is_disabled, read_stdin_with_timeout, resolve_binary};
+
+/// `hook_specific_output.tool_input` fully replaces the invocation's input, so
+/// we clone the original object and swap only the field(s) we change — keeping
+/// `timeout` and any future keys Vibe adds intact.
+pub(super) fn vibe_rewrite_output(tool_input: &serde_json::Value, note: &str) -> String {
+    serde_json::json!({
+        "decision": "allow",
+        "system_message": note,
+        "hook_specific_output": { "tool_input": tool_input },
+    })
+    .to_string()
+}
+
+pub(super) fn vibe_deny_output(reason: &str) -> String {
+    serde_json::json!({
+        "decision": "deny",
+        "reason": reason,
+    })
+    .to_string()
+}
+
+pub fn handle_vibe_pre_tool() {
+    // Disabled → passthrough (empty stdout).
+    if is_disabled() {
+        return;
+    }
+    let binary = resolve_binary();
+    let Some(input) = read_stdin_with_timeout(HOOK_STDIN_TIMEOUT) else {
+        return;
+    };
+    // serde_json handles deeply nested / escaped payloads that an ad-hoc field
+    // scanner would mis-parse (#809).
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&input) else {
+        return;
+    };
+    let mode = crate::hooks::recommend_hook_mode("vibe");
+    if let Some(out) = decide(&parsed, &binary, mode) {
+        print!("{out}");
+    }
+}
+
+/// Pure decision core: maps a `pre_tool` invocation to the JSON stdout string,
+/// or `None` for passthrough (empty stdout). Factored out of the I/O wrapper so
+/// every tool × mode combination is deterministically testable.
+fn decide(
+    parsed: &serde_json::Value,
+    binary: &str,
+    mode: crate::hooks::HookMode,
+) -> Option<String> {
+    let tool = parsed
+        .get("tool_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    match tool {
+        "bash" => {
+            let cmd = parsed
+                .get("tool_input")
+                .and_then(|ti| ti.get("command"))
+                .and_then(|v| v.as_str())?;
+
+            if let Some(rewritten) = rewrite_candidate(cmd, binary) {
+                // `tool_input` fully replaces the input: clone the original and
+                // swap only `command`, preserving `timeout` / future keys.
+                let mut new_input = parsed
+                    .get("tool_input")
+                    .and_then(serde_json::Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                new_input.insert("command".to_string(), serde_json::Value::String(rewritten));
+                return Some(vibe_rewrite_output(
+                    &serde_json::Value::Object(new_input),
+                    "lean-ctx: routed native bash through the compression CLI",
+                ));
+            }
+
+            // Commands already routed through lean-ctx must pass through —
+            // denying them would block lean-ctx's own CLI surface (#801).
+            if cmd.starts_with("lean-ctx ") || cmd.starts_with(&format!("{binary} ")) {
+                return None;
+            }
+
+            // Replace mode: deny non-rewritable native bash (agent must use ctx_shell).
+            if mode == crate::hooks::HookMode::Replace {
+                return Some(vibe_deny_output(&format!(
+                    "lean-ctx replace mode is active — use the ctx_shell MCP tool \
+                     instead of native bash for: {cmd:.80}"
+                )));
+            }
+            None
+        }
+        // read_file / grep cannot be arg-rewritten into a lean-ctx call (their
+        // inputs are a path / pattern, not a shell command), so they are only
+        // redirected in Replace mode, onto the equivalent MCP tool.
+        "read_file" | "grep" if mode == crate::hooks::HookMode::Replace => {
+            let (native, mcp) = if tool == "read_file" {
+                ("read_file", "ctx_read")
+            } else {
+                ("grep", "ctx_search")
+            };
+            Some(vibe_deny_output(&format!(
+                "lean-ctx replace mode is active — native {native} is denied. \
+                 Use the {mcp} MCP tool instead."
+            )))
+        }
+        _ => None, // passthrough (empty stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pre_tool_json(tool: &str, tool_input: &serde_json::Value) -> String {
+        serde_json::json!({
+            "hook_event_name": "pre_tool",
+            "session_id": "s1",
+            "transcript_path": "/tmp/t.jsonl",
+            "cwd": "/repo",
+            "tool_name": tool,
+            "tool_call_id": "tc1",
+            "tool_input": tool_input.clone(),
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn rewrite_output_carries_tool_input_and_allow_decision() {
+        let ti = serde_json::json!({ "command": "lean-ctx -c 'git status'", "timeout": 30 });
+        let out = vibe_rewrite_output(&ti, "note");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(v["hook_specific_output"]["tool_input"]["timeout"], 30);
+        assert_eq!(
+            v["hook_specific_output"]["tool_input"]["command"],
+            "lean-ctx -c 'git status'"
+        );
+    }
+
+    #[test]
+    fn deny_output_is_valid_deny_json() {
+        let v: serde_json::Value = serde_json::from_str(&vibe_deny_output("nope")).unwrap();
+        assert_eq!(v["decision"], "deny");
+        assert_eq!(v["reason"], "nope");
+    }
+
+    #[test]
+    fn pre_tool_payload_shape_parses() {
+        // Guards the exact wire shape we build stdin fixtures against.
+        let s = pre_tool_json("bash", &serde_json::json!({ "command": "cat a.txt" }));
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["hook_event_name"], "pre_tool");
+        assert_eq!(v["tool_name"], "bash");
+        assert_eq!(v["tool_input"]["command"], "cat a.txt");
+    }
+
+    use crate::hooks::HookMode;
+
+    fn inv(tool: &str, tool_input: &serde_json::Value) -> serde_json::Value {
+        serde_json::from_str(&pre_tool_json(tool, tool_input)).unwrap()
+    }
+
+    #[test]
+    fn bash_rewrites_file_read_in_every_mode() {
+        // Arg-rewrite is unconditional — it is the only compression surface for
+        // Vibe's native bash, so it fires in Mcp/Hybrid/Replace alike.
+        for mode in [HookMode::Mcp, HookMode::Hybrid, HookMode::Replace] {
+            let out = decide(
+                &inv("bash", &serde_json::json!({ "command": "cat a.txt" })),
+                "lean-ctx",
+                mode,
+            )
+            .expect("bash cat should rewrite");
+            let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+            assert_eq!(v["decision"], "allow");
+            let cmd = v["hook_specific_output"]["tool_input"]["command"]
+                .as_str()
+                .unwrap();
+            assert!(cmd.starts_with("lean-ctx read"), "got: {cmd}");
+        }
+    }
+
+    #[test]
+    fn bash_wraps_general_command_and_preserves_timeout() {
+        let out = decide(
+            &inv(
+                "bash",
+                &serde_json::json!({ "command": "git status", "timeout": 42 }),
+            ),
+            "lean-ctx",
+            HookMode::Mcp,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let ti = &v["hook_specific_output"]["tool_input"];
+        assert_eq!(ti["command"], "lean-ctx -c 'git status'");
+        assert_eq!(ti["timeout"], 42, "non-command fields must be preserved");
+    }
+
+    #[test]
+    fn bash_already_leanctx_passes_through() {
+        let out = decide(
+            &inv(
+                "bash",
+                &serde_json::json!({ "command": "lean-ctx read a.txt" }),
+            ),
+            "lean-ctx",
+            HookMode::Replace,
+        );
+        assert!(
+            out.is_none(),
+            "lean-ctx's own CLI must not be denied (#801)"
+        );
+    }
+
+    #[test]
+    fn bash_nonrewritable_denied_only_in_replace() {
+        // Heredocs cannot survive the quoting round-trip, so `rewrite_candidate`
+        // declines them (#140) — the ideal non-rewritable probe.
+        let heredoc = serde_json::json!({ "command": "cat <<EOF\nhi\nEOF" });
+        assert!(
+            decide(&inv("bash", &heredoc), "lean-ctx", HookMode::Mcp).is_none(),
+            "non-rewritable bash passes through outside Replace"
+        );
+        let out = decide(&inv("bash", &heredoc), "lean-ctx", HookMode::Replace).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "deny");
+        assert!(v["reason"].as_str().unwrap().contains("ctx_shell"));
+    }
+
+    #[test]
+    fn read_file_and_grep_denied_only_in_replace() {
+        let rf = inv("read_file", &serde_json::json!({ "file_path": "/a" }));
+        let gp = inv("grep", &serde_json::json!({ "pattern": "x" }));
+
+        // Non-Replace → passthrough.
+        for mode in [HookMode::Mcp, HookMode::Hybrid] {
+            assert!(decide(&rf, "lean-ctx", mode).is_none());
+            assert!(decide(&gp, "lean-ctx", mode).is_none());
+        }
+
+        // Replace → deny, steering to the matching MCP tool.
+        let rf_out = decide(&rf, "lean-ctx", HookMode::Replace).unwrap();
+        assert!(rf_out.contains("\"deny\"") && rf_out.contains("ctx_read"));
+        let gp_out = decide(&gp, "lean-ctx", HookMode::Replace).unwrap();
+        assert!(gp_out.contains("\"deny\"") && gp_out.contains("ctx_search"));
+    }
+
+    #[test]
+    fn unknown_and_write_tools_pass_through() {
+        for tool in ["write_file", "edit", "web_search", "todo"] {
+            assert!(
+                decide(
+                    &inv(tool, &serde_json::json!({})),
+                    "lean-ctx",
+                    HookMode::Replace
+                )
+                .is_none(),
+                "{tool} must never be intercepted"
+            );
+        }
+    }
+}

--- a/rust/src/hooks/agents/vibe.rs
+++ b/rust/src/hooks/agents/vibe.rs
@@ -1,56 +1,234 @@
-use super::super::resolve_binary_path;
+use std::path::Path;
 
+use super::super::{
+    mcp_server_quiet_mode, resolve_binary_path, resolve_hook_command_binary, should_register_mcp,
+};
+use crate::core::editor_registry::{
+    ConfigType, EditorTarget, WriteAction, WriteOptions, vibe_config_path,
+    write_config_with_options,
+};
+
+/// Name of the lean-ctx entry inside `~/.vibe/hooks.toml`. Stable so re-runs
+/// upsert instead of appending duplicates (Vibe rejects duplicate hook names).
+pub(crate) const VIBE_HOOK_NAME: &str = "lean-ctx-redirect";
+
+/// Tools the pre_tool hook intercepts: `bash` (arg-rewritten through the
+/// compression CLI) plus `read_file`/`grep` (denied → MCP tools in Replace
+/// mode). `re:` regex is fullmatch + case-insensitive in Vibe's `name_matches`.
+pub(crate) const VIBE_HOOK_MATCH: &str = "re:(bash|read_file|grep)";
+
+/// Configure Mistral Vibe: the MCP server (exposes `ctx_*` tools) **and** the
+/// `pre_tool` hook (arg-rewrites native `bash` onto lean-ctx transparently).
+/// Both are MCP-gated — Vibe has no non-MCP surface for lean-ctx.
 pub(crate) fn install_vibe_hook() {
-    // Mistral Vibe is MCP-only (no shell hooks), so an
-    // MCP-disabled environment writes nothing here.
-    if !super::super::should_register_mcp() {
+    if !should_register_mcp() {
         return;
     }
-    let binary = resolve_binary_path();
     let home = crate::core::home::resolve_home_dir().unwrap_or_default();
-    let config_path = home.join(".vibe/config.toml");
+    install_vibe_mcp(&home);
+    install_vibe_hooks_toml(&home);
+}
+
+/// Register the MCP server via the shared editor-registry writer
+/// (`ConfigType::VibeToml`) — the single source of truth for the Vibe schema.
+/// It parses `~/.vibe/config.toml` with `toml_edit`, upserts the
+/// `[[mcp_servers]]` `lean-ctx` entry, creates the parent dir, and writes
+/// atomically with a backup (no clobbering of a config that lacks the array).
+fn install_vibe_mcp(home: &Path) {
+    let binary = resolve_binary_path();
     let display_path = "~/.vibe/config.toml";
+    let target = EditorTarget {
+        name: "Mistral Vibe",
+        agent_key: "vibe".to_string(),
+        config_path: vibe_config_path(home),
+        detect_path: home.join(".vibe"),
+        config_type: ConfigType::VibeToml,
+    };
 
-    // Mistral Vibe expects MCP servers in config.toml as [[mcp_servers]]
-    // We write the lean-ctx server entry
-    let server_entry = format!(
-        r#"[[mcp_servers]]
-name = "lean-ctx"
-transport = "stdio"
-command = "{}"
-args = ["serve"]
-"#,
-        { binary }
-    );
-
-    if config_path.exists() {
-        let content = std::fs::read_to_string(&config_path).unwrap_or_default();
-        if content.contains("name = \"lean-ctx\"") || content.contains("name = 'lean-ctx'") {
-            eprintln!("Vibe MCP server already configured in {display_path}");
-            return;
-        }
-
-        // Check if file has mcp_servers array
-        if content.contains("[[mcp_servers]]") {
-            // Append to existing mcp_servers
-            let updated_content = if content.ends_with('\n') {
-                format!("{content}{server_entry}")
-            } else {
-                format!("{content}\n{server_entry}")
-            };
-            if let Err(e) = std::fs::write(&config_path, &updated_content) {
-                tracing::error!("Failed to update Vibe config: {}", e);
+    match write_config_with_options(&target, &binary, WriteOptions::default()) {
+        Ok(result) => {
+            if mcp_server_quiet_mode() {
                 return;
             }
-            eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP server added to {display_path}");
-            return;
+            match result.action {
+                WriteAction::Already => {
+                    eprintln!("Vibe MCP already configured at {display_path}");
+                }
+                WriteAction::Created | WriteAction::Updated => {
+                    eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP configured at {display_path}");
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!("Failed to configure Vibe MCP: {e}");
+            if !mcp_server_quiet_mode() {
+                eprintln!("  \x1b[31m✗\x1b[0m Vibe MCP configuration failed: {e}");
+            }
         }
     }
+}
 
-    // Create new config file with mcp_servers
-    if let Err(e) = std::fs::write(&config_path, &server_entry) {
-        tracing::error!("Failed to create Vibe config: {}", e);
+/// Upsert the lean-ctx `pre_tool` hook into `~/.vibe/hooks.toml`. Idempotent:
+/// re-runs update the existing `lean-ctx-redirect` entry in place, preserving
+/// any other user hooks and (via `toml_edit`) their comments/formatting.
+fn install_vibe_hooks_toml(home: &Path) {
+    let hooks_path = home.join(".vibe/hooks.toml");
+    let display_path = "~/.vibe/hooks.toml";
+    // `hook <agent>-<event>` dispatch, honoring the portable-binary override (#708).
+    let command = format!("{} hook vibe-pre-tool", resolve_hook_command_binary());
+
+    // Refuse to clobber a config we cannot parse (#443-style guard).
+    let doc_res: Result<toml_edit::DocumentMut, String> = match std::fs::read_to_string(&hooks_path)
+    {
+        Ok(existing) if !existing.trim().is_empty() => existing
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|e| e.to_string()),
+        _ => Ok(toml_edit::DocumentMut::new()),
+    };
+    let mut doc = match doc_res {
+        Ok(doc) => doc,
+        Err(e) => {
+            tracing::error!("Failed to parse Vibe hooks.toml: {e}");
+            if !mcp_server_quiet_mode() {
+                eprintln!("  \x1b[31m✗\x1b[0m Vibe hooks.toml is invalid TOML — left untouched");
+            }
+            return;
+        }
+    };
+
+    if !upsert_vibe_hook(&mut doc, &command) {
+        if !mcp_server_quiet_mode() {
+            eprintln!("Vibe hook already configured in {display_path}");
+        }
         return;
     }
-    eprintln!("  \x1b[32m✓\x1b[0m Vibe MCP server written to {display_path}");
+
+    if let Err(e) = crate::config_io::write_atomic_with_backup(&hooks_path, &doc.to_string()) {
+        tracing::error!("Failed to write Vibe hooks.toml: {e}");
+        if !mcp_server_quiet_mode() {
+            eprintln!("  \x1b[31m✗\x1b[0m Vibe hook configuration failed: {e}");
+        }
+        return;
+    }
+    if !mcp_server_quiet_mode() {
+        eprintln!("  \x1b[32m✓\x1b[0m Vibe pre_tool hook configured at {display_path}");
+    }
+}
+
+/// Build the lean-ctx `[[hooks]]` entry for `~/.vibe/hooks.toml`.
+fn vibe_hook_entry(command: &str) -> toml_edit::Table {
+    let mut entry = toml_edit::Table::new();
+    entry.insert("name", toml_edit::value(VIBE_HOOK_NAME));
+    entry.insert("type", toml_edit::value("pre_tool"));
+    entry.insert("match", toml_edit::value(VIBE_HOOK_MATCH));
+    entry.insert("command", toml_edit::value(command));
+    entry.insert("timeout", toml_edit::value(60.0));
+    entry.insert(
+        "description",
+        toml_edit::value("Route native bash through lean-ctx; steer read_file/grep to ctx_* tools"),
+    );
+    entry
+}
+
+/// Upsert the lean-ctx pre_tool hook into a parsed `hooks.toml` document,
+/// keyed by `name`. Returns `true` if the document changed (a write is
+/// needed), `false` if the existing entry already matches. Pure — no I/O — so
+/// the on-disk format and idempotency are unit-testable.
+fn upsert_vibe_hook(doc: &mut toml_edit::DocumentMut, command: &str) -> bool {
+    // Ensure a top-level `hooks` array-of-tables exists.
+    if !matches!(doc.get("hooks"), Some(toml_edit::Item::ArrayOfTables(_))) {
+        doc.insert(
+            "hooks",
+            toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new()),
+        );
+    }
+    let Some(toml_edit::Item::ArrayOfTables(hooks)) = doc.get_mut("hooks") else {
+        return false;
+    };
+
+    let entry = vibe_hook_entry(command);
+    for table in hooks.iter_mut() {
+        if table.get("name").and_then(|n| n.as_str()) == Some(VIBE_HOOK_NAME) {
+            // Already current → no write.
+            if table.get("command").and_then(|c| c.as_str()) == Some(command)
+                && table.get("match").and_then(|m| m.as_str()) == Some(VIBE_HOOK_MATCH)
+            {
+                return false;
+            }
+            *table = entry;
+            return true;
+        }
+    }
+    hooks.push(entry);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CMD: &str = "/usr/local/bin/lean-ctx hook vibe-pre-tool";
+
+    #[test]
+    fn fresh_doc_gets_well_formed_hook_entry() {
+        let mut doc = toml_edit::DocumentMut::new();
+        assert!(upsert_vibe_hook(&mut doc, CMD));
+
+        // Re-parse the rendered TOML to assert the on-disk shape Vibe will read.
+        let round: toml_edit::DocumentMut = doc.to_string().parse().unwrap();
+        let hooks = round.get("hooks").unwrap().as_array_of_tables().unwrap();
+        assert_eq!(hooks.len(), 1);
+        let t = hooks.get(0).unwrap();
+        assert_eq!(t.get("name").unwrap().as_str(), Some(VIBE_HOOK_NAME));
+        assert_eq!(t.get("type").unwrap().as_str(), Some("pre_tool"));
+        assert_eq!(t.get("match").unwrap().as_str(), Some(VIBE_HOOK_MATCH));
+        assert_eq!(t.get("command").unwrap().as_str(), Some(CMD));
+        assert_eq!(t.get("timeout").unwrap().as_float(), Some(60.0));
+    }
+
+    #[test]
+    fn rerun_is_idempotent() {
+        let mut doc = toml_edit::DocumentMut::new();
+        assert!(upsert_vibe_hook(&mut doc, CMD));
+        // Second run with identical command → no change.
+        assert!(!upsert_vibe_hook(&mut doc, CMD));
+        let hooks = doc.get("hooks").unwrap().as_array_of_tables().unwrap();
+        assert_eq!(hooks.len(), 1, "must not append a duplicate");
+    }
+
+    #[test]
+    fn changed_command_updates_in_place() {
+        let mut doc = toml_edit::DocumentMut::new();
+        upsert_vibe_hook(&mut doc, CMD);
+        assert!(upsert_vibe_hook(
+            &mut doc,
+            "/new/path/lean-ctx hook vibe-pre-tool"
+        ));
+        let hooks = doc.get("hooks").unwrap().as_array_of_tables().unwrap();
+        assert_eq!(hooks.len(), 1, "same name → update, not append");
+        assert_eq!(
+            hooks.get(0).unwrap().get("command").unwrap().as_str(),
+            Some("/new/path/lean-ctx hook vibe-pre-tool")
+        );
+    }
+
+    #[test]
+    fn preserves_unrelated_user_hooks() {
+        let existing = r#"[[hooks]]
+name = "my-linter"
+type = "post_tool"
+match = "edit"
+command = "eslint --quiet"
+"#;
+        let mut doc: toml_edit::DocumentMut = existing.parse().unwrap();
+        assert!(upsert_vibe_hook(&mut doc, CMD));
+        let hooks = doc.get("hooks").unwrap().as_array_of_tables().unwrap();
+        assert_eq!(hooks.len(), 2, "user's own hook must survive");
+        let names: Vec<_> = hooks
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert!(names.contains(&"my-linter"));
+        assert!(names.contains(&VIBE_HOOK_NAME));
+    }
 }

--- a/rust/src/hooks/tests.rs
+++ b/rust/src/hooks/tests.rs
@@ -690,26 +690,31 @@ fn rewrite_script_skips_multiline_commands() {
 
 #[test]
 fn codex_is_replace() {
+    let _env = crate::core::data_dir::test_env_lock();
     assert_eq!(recommend_hook_mode("codex"), HookMode::Replace);
 }
 
 #[test]
 fn cursor_is_replace() {
+    let _env = crate::core::data_dir::test_env_lock();
     assert_eq!(recommend_hook_mode("cursor"), HookMode::Replace);
 }
 
 #[test]
 fn gemini_is_replace() {
+    let _env = crate::core::data_dir::test_env_lock();
     assert_eq!(recommend_hook_mode("gemini"), HookMode::Replace);
 }
 
 #[test]
 fn claude_is_replace() {
+    let _env = crate::core::data_dir::test_env_lock();
     assert_eq!(recommend_hook_mode("claude"), HookMode::Replace);
 }
 
 #[test]
 fn hybrid_fallback_agents() {
+    let _env = crate::core::data_dir::test_env_lock();
     assert_eq!(recommend_hook_mode("crush"), HookMode::Hybrid);
     assert_eq!(recommend_hook_mode("cline"), HookMode::Hybrid);
     assert_eq!(recommend_hook_mode("kiro"), HookMode::Hybrid);
@@ -717,6 +722,7 @@ fn hybrid_fallback_agents() {
 
 #[test]
 fn unknown_agent_falls_back_to_mcp() {
+    let _env = crate::core::data_dir::test_env_lock();
     assert_eq!(recommend_hook_mode("unknown-agent"), HookMode::Mcp);
 }
 
@@ -775,25 +781,28 @@ fn roundtrip_unix_path() {
 
 #[test]
 fn disabled_env_caps_replace_at_hybrid() {
-    unsafe { std::env::set_var("LEAN_CTX_DISABLED", "1") };
+    let _env = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_DISABLED", "1");
     assert_eq!(recommend_hook_mode("claude"), HookMode::Hybrid);
     assert_eq!(recommend_hook_mode("cursor"), HookMode::Hybrid);
     assert_eq!(recommend_hook_mode("crush"), HookMode::Hybrid);
     assert_eq!(recommend_hook_mode("unknown-agent"), HookMode::Mcp);
-    unsafe { std::env::remove_var("LEAN_CTX_DISABLED") };
+    crate::test_env::remove_var("LEAN_CTX_DISABLED");
 }
 
 #[test]
 fn shadow_mode_false_env_caps_replace_at_hybrid() {
-    unsafe { std::env::set_var("LEAN_CTX_SHADOW_MODE", "false") };
+    let _env = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHADOW_MODE", "false");
     assert_eq!(recommend_hook_mode("claude"), HookMode::Hybrid);
     assert_eq!(recommend_hook_mode("gemini"), HookMode::Hybrid);
-    unsafe { std::env::remove_var("LEAN_CTX_SHADOW_MODE") };
+    crate::test_env::remove_var("LEAN_CTX_SHADOW_MODE");
 }
 
 #[test]
 fn heal_off_env_caps_replace_at_hybrid() {
-    unsafe { std::env::set_var("LEAN_CTX_HEAL", "off") };
+    let _env = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_HEAL", "off");
     assert_eq!(recommend_hook_mode("claude"), HookMode::Hybrid);
-    unsafe { std::env::remove_var("LEAN_CTX_HEAL") };
+    crate::test_env::remove_var("LEAN_CTX_HEAL");
 }


### PR DESCRIPTION
Add a pre_tool hook that transparently reroutes Vibe's native bash through the lean-ctx compression CLI (cat/head/tail -> lean-ctx read, grep -> lean-ctx grep, else lean-ctx -c '...'), mirroring the Codex PreToolUse pattern. read_file/grep are steered onto ctx_read/ctx_search in Replace mode; write tools always pass through.

- hook_handlers/vibe.rs: handler + pure, testable decide() core
- cli dispatch: 'hook vibe-pre-tool' subcommand (watchdog-exempt)
- hooks/agents/vibe.rs: install MCP via registry writer (fixes config overwrite bug) + idempotent ~/.vibe/hooks.toml writer
- hooks/tests.rs: serialize env-mutating mode tests via test_env_lock to fix a latent parallelism race

Verified end-to-end through Vibe's own HookExecutor + HookConfig.

## Summary

Enhance Mistral Vibe support

## Test plan

- [X] `cd rust && cargo test`
- [X] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases:
- Backwards compatibility: Mistral Vibe 2.21.0 necessary
- Docs updated (links/files):

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
