### PR TITLE
fix(ci): unblock main — drop unused CompressionProvider import, apply rustfmt

### DIFF
--- a/rust/src/core/ocla/builtin/compression_provider.rs
+++ b/rust/src/core/ocla/builtin/compression_provider.rs
@@ -10,13 +10,13 @@ use std::sync::OnceLock;
 
 use crate::core::compressor;
 use crate::core::config::Config;
+use crate::core::ocla::OclaError;
 use crate::core::ocla::content_port::CompressionContentPort;
 use crate::core::ocla::traits::{CompressionProvider, OclaService};
 use crate::core::ocla::types::{
-    CompressionRequest, CompressionResult, OclaCapability, OclaCapabilityKind,
-    OclaCapabilityStatus, OclaResult, OCLA_API_VERSION,
+    CompressionRequest, CompressionResult, OCLA_API_VERSION, OclaCapability, OclaCapabilityKind,
+    OclaCapabilityStatus, OclaResult,
 };
-use crate::core::ocla::OclaError;
 use crate::core::ocla_bus::{self, OclaEvent};
 use crate::core::tokens;
 

--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -666,9 +666,8 @@ mod tests {
 /// Best-effort: silently drops if provider is unavailable or source_ref can't be
 /// constructed. This is the canonical production callsite for the compression capability.
 fn project_ocla_compression(path: &str, source_tokens: u64, output_tokens: u64) {
-    use crate::core::ocla::traits::CompressionProvider;
-    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
     use crate::core::ocla::OclaRegistry;
+    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
 
     let reg = OclaRegistry::global();
     let source_ref = format!("file:{path}");


### PR DESCRIPTION
## Why

Every CI job on `main` (and every PR branched off it) is failing. Single root cause:

```
error: unused import: `crate::core::ocla::traits::CompressionProvider`
  = note: `-D unused-imports` implied by `-D warnings`
```

`reg.compression_provider.compress()` resolves to an inherent method, so the trait import in `project_ocla_compression` was never needed. Since `RUSTFLAGS: -Dwarnings`, this took down Clippy, all three Test jobs, Coverage, Docs, Benchmarks and the SDK jobs — everything.

`cargo fmt --check` was also red on the OCLA import blocks left unformatted by the recent OCLA commits.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)