### PR TITLE
Cleanup/clippy fmt flaky tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ What does this PR change and why?
 
 ## Test plan
 
-- [ ] `cd rust && cargo test`
+- [ ] `cd rust && cargo test -- --test-threads=1` (the suite shares process-global state; CI serializes it too)
 - [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
 - [ ] `cd rust && cargo fmt --check`
 - [ ] If cookbook/packages changed: relevant `npm test` / build steps

--- a/.github/workflows/dep-update.yml
+++ b/.github/workflows/dep-update.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo build
-          cargo test
+          cargo test -- --test-threads=1
           cargo clippy -- -D warnings
       # or set to workflow_run?
       - name: Create or update pull request

--- a/rust/src/core/context_os/context_bus.rs
+++ b/rust/src/core/context_os/context_bus.rs
@@ -217,6 +217,14 @@ struct Inner {
 
 impl Inner {
     fn open_read_conn(path: &PathBuf) -> Connection {
+        // The process-global runtime (context_os::runtime) captures its DB path
+        // once, from LEAN_CTX_DATA_DIR. Under `cargo test`, a parallel
+        // `isolated_data_dir` can delete that directory after the runtime bound
+        // to it, so a lazily-opened read connection would hit a missing dir.
+        // Recreating the parent keeps opens infallible (matches `open_at`).
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
         let conn = Connection::open(path).expect("open read context-os db");
         let _ = conn.busy_timeout(std::time::Duration::from_secs(5));
         let _ = conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA query_only=ON;");

--- a/rust/src/core/ocla/builtin/compression_provider.rs
+++ b/rust/src/core/ocla/builtin/compression_provider.rs
@@ -10,13 +10,13 @@ use std::sync::OnceLock;
 
 use crate::core::compressor;
 use crate::core::config::Config;
+use crate::core::ocla::OclaError;
 use crate::core::ocla::content_port::CompressionContentPort;
 use crate::core::ocla::traits::{CompressionProvider, OclaService};
 use crate::core::ocla::types::{
-    CompressionRequest, CompressionResult, OclaCapability, OclaCapabilityKind,
-    OclaCapabilityStatus, OclaResult, OCLA_API_VERSION,
+    CompressionRequest, CompressionResult, OCLA_API_VERSION, OclaCapability, OclaCapabilityKind,
+    OclaCapabilityStatus, OclaResult,
 };
-use crate::core::ocla::OclaError;
 use crate::core::ocla_bus::{self, OclaEvent};
 use crate::core::tokens;
 

--- a/rust/src/core/ocla/content_port.rs
+++ b/rust/src/core/ocla/content_port.rs
@@ -214,8 +214,7 @@ mod tests {
         let err = port.resolve("file:link.txt").unwrap_err();
         assert!(
             err.to_string().contains("symlink"),
-            "expected symlink rejection, got: {}",
-            err
+            "expected symlink rejection, got: {err}"
         );
     }
 

--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -444,6 +444,32 @@ fn maybe_consolidate(project_root: Option<&str>, calls: u32) {
     }
 }
 
+/// Project an aggressive-mode compression event into the OCLA CompressionProvider.
+/// Best-effort: silently drops if provider is unavailable or source_ref can't be
+/// constructed. This is the canonical production callsite for the compression capability.
+fn project_ocla_compression(path: &str, source_tokens: u64, output_tokens: u64) {
+    use crate::core::ocla::OclaRegistry;
+    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
+
+    let reg = OclaRegistry::global();
+    let source_ref = format!("file:{path}");
+    let request = CompressionRequest {
+        context: OclaRequestContext {
+            request_id: format!("cli-read-{}", path.len()),
+            session_id: SessionState::load_latest()
+                .map(|s| s.id)
+                .unwrap_or_default(),
+            agent_id: String::new(),
+            content_ref: source_ref.clone(),
+            tenant_id: None,
+        },
+        source_ref,
+        source_tokens,
+        target_tokens: output_tokens,
+        quality_policy_ref: None,
+    };
+    let _ = reg.compression_provider.compress(request);
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -660,32 +686,4 @@ mod tests {
         assert_eq!(item.output_tokens, 120);
         assert!(item.duration_us > 0, "a real duration must be recorded");
     }
-}
-
-/// Project an aggressive-mode compression event into the OCLA CompressionProvider.
-/// Best-effort: silently drops if provider is unavailable or source_ref can't be
-/// constructed. This is the canonical production callsite for the compression capability.
-fn project_ocla_compression(path: &str, source_tokens: u64, output_tokens: u64) {
-    use crate::core::ocla::traits::CompressionProvider;
-    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
-    use crate::core::ocla::OclaRegistry;
-
-    let reg = OclaRegistry::global();
-    let source_ref = format!("file:{path}");
-    let request = CompressionRequest {
-        context: OclaRequestContext {
-            request_id: format!("cli-read-{}", path.len()),
-            session_id: SessionState::load_latest()
-                .map(|s| s.id)
-                .unwrap_or_default(),
-            agent_id: String::new(),
-            content_ref: source_ref.clone(),
-            tenant_id: None,
-        },
-        source_ref,
-        source_tokens,
-        target_tokens: output_tokens,
-        quality_policy_ref: None,
-    };
-    let _ = reg.compression_provider.compress(request);
 }

--- a/rust/src/core/wrapped.rs
+++ b/rust/src/core/wrapped.rs
@@ -428,6 +428,11 @@ mod tests {
 
     #[test]
     fn wrapped_ascii_box_lines_have_uniform_width() {
+        // `format_ascii` calls `Config::load()` for the theme; serialize against
+        // tests that mutate the data-dir / env (they hold the same lock via
+        // `isolated_data_dir`) so a parallel run can't swap the config — and thus
+        // the theme's box glyphs / brand width — out from under us mid-format.
+        let _env = crate::core::data_dir::test_env_lock();
         // In the test runner, stdout is not a TTY, so colors are auto-disabled.
         let out = sample().format_ascii();
         let widths: Vec<usize> = out

--- a/rust/src/ipc/process.rs
+++ b/rust/src/ipc/process.rs
@@ -489,15 +489,23 @@ mod tests {
     fn protected_pids_cover_own_process_group() {
         // SAFETY: getpgrp() takes no arguments and cannot fail.
         let pgid = unsafe { libc::getpgrp() };
-        // Snapshot before `protected_self_pids`: querying with another `pgrep`
-        // afterwards races with that query process joining the same foreground
-        // group and tests an impossible temporal invariant.
-        let members = process_group_pids(pgid);
+        // Bracket `protected_self_pids` with two group snapshots. A single
+        // snapshot is racy under `cargo test` parallelism: sibling tests spawn
+        // short-lived subprocesses (git/ps/pgrep) that transiently join this
+        // foreground process group, so a member seen once may already be gone
+        // when `protected_self_pids` runs — or appear only afterwards. Only PIDs
+        // present in BOTH snapshots were alive across the whole window and must
+        // therefore be covered by the protected set.
+        let members_before = process_group_pids(pgid);
         let protected = protected_self_pids();
-        for pid in members {
+        let members_after = process_group_pids(pgid);
+        for pid in members_before {
+            if !members_after.contains(&pid) {
+                continue; // transient foreign subprocess from a parallel test
+            }
             assert!(
                 protected.contains(&pid),
-                "group member {pid} missing from protected set"
+                "stable group member {pid} missing from protected set"
             );
         }
     }

--- a/rust/src/terminal_ui.rs
+++ b/rust/src/terminal_ui.rs
@@ -354,48 +354,6 @@ impl ProgressIndicator {
     }
 }
 
-#[cfg(test)]
-mod progress_tests {
-    use super::*;
-
-    #[test]
-    fn determinate_includes_arrow_and_percent() {
-        let line = ProgressIndicator::render_determinate("BM25", 50, 100);
-        assert!(line.contains("BM25"), "{line}");
-        assert!(line.contains('→'), "{line}");
-        assert!(line.contains("50%"), "{line}");
-        assert!(line.contains('['), "{line}");
-    }
-
-    #[test]
-    fn determinate_full_is_100() {
-        let line = ProgressIndicator::render_determinate("semantic", 10, 10);
-        assert!(line.contains("100%"), "{line}");
-        assert!(line.contains('→'), "{line}");
-    }
-
-    #[test]
-    fn indeterminate_bounces_left_and_right() {
-        let right = ProgressIndicator::render_indeterminate("graph", 0);
-        assert!(right.contains('→'), "{right}");
-        assert!(!right.contains('%'), "{right}");
-
-        let max = PROGRESS_BAR_WIDTH.saturating_sub(1).max(1);
-        let left = ProgressIndicator::render_indeterminate("graph", max + 1);
-        assert!(left.contains('←'), "{left}");
-    }
-
-    #[test]
-    fn set_and_indeterminate_toggle() {
-        let mut p = ProgressIndicator::new("BM25");
-        p.tty = false;
-        p.set(2, 8);
-        assert!(p.render_line().contains("25%"));
-        p.indeterminate();
-        assert!(!p.render_line().contains('%'));
-    }
-}
-
 /// Animated dashboard intro: logo wave, then KPI count-up, then section-by-section reveal.
 /// `header_box` is the pre-rendered KPI box (with placeholder values for frame 0).
 /// `kpi_values` are (final_value, width) for the 4 KPI counters.
@@ -485,4 +443,46 @@ pub fn print_setup_header() {
     println!("  {dim}│{rst}  {dim}Configuring your development environment{rst} {dim}│{rst}");
     println!("  {dim}╰──────────────────────────────────────────╯{rst}");
     println!();
+}
+
+#[cfg(test)]
+mod progress_tests {
+    use super::*;
+
+    #[test]
+    fn determinate_includes_arrow_and_percent() {
+        let line = ProgressIndicator::render_determinate("BM25", 50, 100);
+        assert!(line.contains("BM25"), "{line}");
+        assert!(line.contains('→'), "{line}");
+        assert!(line.contains("50%"), "{line}");
+        assert!(line.contains('['), "{line}");
+    }
+
+    #[test]
+    fn determinate_full_is_100() {
+        let line = ProgressIndicator::render_determinate("semantic", 10, 10);
+        assert!(line.contains("100%"), "{line}");
+        assert!(line.contains('→'), "{line}");
+    }
+
+    #[test]
+    fn indeterminate_bounces_left_and_right() {
+        let right = ProgressIndicator::render_indeterminate("graph", 0);
+        assert!(right.contains('→'), "{right}");
+        assert!(!right.contains('%'), "{right}");
+
+        let max = PROGRESS_BAR_WIDTH.saturating_sub(1).max(1);
+        let left = ProgressIndicator::render_indeterminate("graph", max + 1);
+        assert!(left.contains('←'), "{left}");
+    }
+
+    #[test]
+    fn set_and_indeterminate_toggle() {
+        let mut p = ProgressIndicator::new("BM25");
+        p.tty = false;
+        p.set(2, 8);
+        assert!(p.render_line().contains("25%"));
+        p.indeterminate();
+        assert!(!p.render_line().contains('%'));
+    }
 }

--- a/rust/src/tools/ctx_search.rs
+++ b/rust/src/tools/ctx_search.rs
@@ -1221,12 +1221,16 @@ mod tests {
     #[test]
     fn include_glob_filters_by_brace_expansion() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("a.rs"), "needle\n").unwrap();
-        std::fs::write(dir.path().join("b.ts"), "needle\n").unwrap();
-        std::fs::write(dir.path().join("c.py"), "needle\n").unwrap();
+        // Unique needle: the global search-delta tracker (src/core/search_delta.rs)
+        // is keyed by pattern, so sharing "needle" with sibling tests lets a
+        // parallel run mark our matches "unchanged" and drop them. A pattern
+        // unique to this test guarantees a fresh tracker key. (#flaky)
+        std::fs::write(dir.path().join("a.rs"), "brace_glob_needle\n").unwrap();
+        std::fs::write(dir.path().join("b.ts"), "brace_glob_needle\n").unwrap();
+        std::fs::write(dir.path().join("c.py"), "brace_glob_needle\n").unwrap();
 
         let out = handle(
-            "needle",
+            "brace_glob_needle",
             dir.path().to_string_lossy().as_ref(),
             Some("*.{rs,ts}"),
             10,


### PR DESCRIPTION
## What & why

`origin/main` currently fails the PR gates (`cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`) and has several tests that flake under `cargo test`'s default parallel harness. This branch makes the gates green.

### Clippy (`-D warnings`)
- `core/tool_lifecycle.rs`: move `project_ocla_compression` above the test module (`items_after_test_module`) and drop the unused `CompressionProvider` import
- `core/ocla/content_port.rs`: inline format arg (`uninlined_format_args`)
- `terminal_ui.rs`: move `progress_tests` module to end of file (`items_after_test_module`)

### fmt
- `core/ocla/builtin/compression_provider.rs`, `core/tool_lifecycle.rs`

### Flaky tests (pre-existing, parallel-only)
Root cause is shared process-global state:
- `ctx_search::include_glob_filters_by_brace_expansion` — unique search pattern so the global `search_delta` tracker (keyed by pattern) can't mark our matches "unchanged" from a sibling test's identical `needle` query
- `core::wrapped::wrapped_ascii_box_lines_have_uniform_width` — hold `test_env_lock` so a parallel `isolated_data_dir` can't swap the config/theme mid-format
- `ipc::process::protected_pids_cover_own_process_group` — bracket `protected_self_pids` with two group snapshots; assert only on the stable intersection, ignoring transient foreign subprocesses

### Serialize the test gate (`--test-threads=1`)
The lib suite is **green single-threaded** (8132 passed) but shares extensive process-global state, so it flakes across threads. The main CI test jobs already pass `-- --test-threads=1`; this aligns the remaining entry points:
- PR checklist (`pull_request_template.md`) and `dep-update.yml` now run serialized
- `ContextBus::open_read_conn` now creates its DB parent dir before opening (matching `open_at`), so a lazy read connection can't panic if the data dir was removed under the process-global runtime

## Test plan
- [x] `cd rust && cargo test -- --test-threads=1` — green (8132 passed)
- [x] `cd rust && cargo fmt --check` — clean
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — clean **except** 6 pre-existing `undocumented_unsafe_blocks` in `hooks/tests.rs`

## ⚠️ Merge order
The 6 remaining `hooks/tests.rs` clippy errors are fixed by the **Mistral Vibe PR** #1096 (which converts those raw `unsafe env::set_var` calls to the serialized `test_env` helpers). Merge that PR **before or together with** this one and `main` is fully green on all three gates.
