### PR TITLE
refactor(cli): extract dispatch handlers

### DIFF
--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -43,48 +43,8 @@ pub fn run() {
         let rest = args[2..].to_vec();
 
         match args[1].as_str() {
-            "-c" | "exec" => {
-                let raw = rest.first().is_some_and(|a| a == "--raw");
-                let cmd_args = if raw { &args[3..] } else { &args[2..] };
-                let command = if cmd_args.len() == 1 {
-                    cmd_args[0].clone()
-                } else {
-                    shell::join_command(cmd_args)
-                };
-                // The `lean-ctx -c` wrapper runs inside the agent shell, which
-                // carries runtime/session vars the MCP server never sees. Bridge
-                // them so ctx_shell can forward them too (#370).
-                core::agent_runtime_env::capture();
-                if crate::shell::reentry::should_pass_through() {
-                    passthrough(&command);
-                }
-                if raw {
-                    // SAFETY: CLI dispatch is single-threaded; this runs before any
-                    // worker threads start (the process hands off to shell::exec below).
-                    unsafe { std::env::set_var("LEAN_CTX_RAW", "1") };
-                } else {
-                    // SAFETY: CLI dispatch is single-threaded; this runs before any
-                    // worker threads start (the process hands off to shell::exec below).
-                    unsafe { std::env::set_var("LEAN_CTX_COMPRESS", "1") };
-                }
-                let code = shell::exec(&command);
-                core::tool_lifecycle::flush_all();
-                std::process::exit(code);
-            }
-            "-t" | "--track" => {
-                let cmd_args = &args[2..];
-                let code = if cmd_args.len() > 1 {
-                    shell::exec_argv(cmd_args)
-                } else {
-                    let command = cmd_args[0].clone();
-                    if crate::shell::reentry::should_pass_through() {
-                        passthrough(&command);
-                    }
-                    shell::exec(&command)
-                };
-                core::tool_lifecycle::flush_all();
-                std::process::exit(code);
-            }
+            "-c" | "exec" => handle_exec(&args, &rest),
+            "-t" | "--track" => handle_track(&args),
             "shell" | "--shell" => {
                 shell::interactive();
                 return;
@@ -279,160 +239,19 @@ pub fn run() {
                 return;
             }
             "setup" => {
-                // Safety (#476 class): `--help`/`-h` — or any unknown flag —
-                // must NEVER fall through to a real setup run that mutates
-                // shell + agent configs. Short-circuit before any side effect.
-                if rest.iter().any(|a| a == "--help" || a == "-h") {
-                    print_setup_help();
-                    return;
-                }
-                const KNOWN: &[&str] = &[
-                    "--non-interactive",
-                    "--yes",
-                    "-y",
-                    "--fix",
-                    "--json",
-                    "--no-auto-approve",
-                    "--skip-rules",
-                    "--no-agent-aliases",
-                ];
-                if let Some(unknown) = rest
-                    .iter()
-                    .find(|a| a.starts_with('-') && !KNOWN.contains(&a.as_str()))
-                {
-                    eprintln!("setup: unknown flag '{unknown}'\n");
-                    print_setup_help();
-                    std::process::exit(2);
-                }
-                let non_interactive = rest.iter().any(|a| a == "--non-interactive");
-                let yes = rest.iter().any(|a| a == "--yes" || a == "-y");
-                let fix = rest.iter().any(|a| a == "--fix");
-                let json = rest.iter().any(|a| a == "--json");
-                let no_auto_approve = rest.iter().any(|a| a == "--no-auto-approve");
-                let skip_rules = rest.iter().any(|a| a == "--skip-rules");
-                let no_agent_aliases = rest.iter().any(|a| a == "--no-agent-aliases");
-
-                if no_agent_aliases {
-                    let _ = crate::core::config::setter::set_by_key("skip_agent_aliases", "true");
-                }
-
-                if non_interactive || fix || json || yes {
-                    let opts = setup::SetupOptions {
-                        non_interactive,
-                        yes,
-                        fix,
-                        json,
-                        no_auto_approve,
-                        skip_rules,
-                        ..Default::default()
-                    };
-                    match setup::run_setup_with_options(opts) {
-                        Ok(report) => {
-                            if json {
-                                println!(
-                                    "{}",
-                                    serde_json::to_string_pretty(&report)
-                                        .unwrap_or_else(|_| "{}".to_string())
-                                );
-                            }
-                            if !report.success {
-                                std::process::exit(1);
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("{e}");
-                            std::process::exit(1);
-                        }
-                    }
-                } else {
-                    setup::run_setup();
-                }
+                handle_setup(&rest);
                 return;
             }
             "onboard" => {
-                if rest.iter().any(|a| a == "--help" || a == "-h") {
-                    println!("Usage: lean-ctx onboard [--no-agent-aliases]");
-                    println!("Connect your AI tools with one command: detects installed");
-                    println!("agents, installs hooks/rules/MCP registrations, verifies.");
-                    println!();
-                    println!(
-                        "  --no-agent-aliases  Do not install claude/codex/gemini shell aliases"
-                    );
-                    println!();
-                    println!("Fine-grained control: lean-ctx setup --help");
-                    return;
-                }
-                if rest.iter().any(|a| a == "--no-agent-aliases") {
-                    let _ = crate::core::config::setter::set_by_key("skip_agent_aliases", "true");
-                }
-                setup::run_onboard();
+                handle_onboard(&rest);
                 return;
             }
             "install" => {
-                // Plain `lean-ctx install` is a natural thing to type after
-                // installing the binary — treat it as the guided setup rather
-                // than failing with a usage error. `--repair`/`--fix` keeps the
-                // non-interactive, merge-based repair path.
-                let repair = rest.iter().any(|a| a == "--repair" || a == "--fix");
-                let json = rest.iter().any(|a| a == "--json");
-                if !repair {
-                    setup::run_setup();
-                    return;
-                }
-                let opts = setup::SetupOptions {
-                    non_interactive: true,
-                    yes: true,
-                    fix: true,
-                    json,
-                    ..Default::default()
-                };
-                match setup::run_setup_with_options(opts) {
-                    Ok(report) => {
-                        if json {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(&report)
-                                    .unwrap_or_else(|_| "{}".to_string())
-                            );
-                        }
-                        if !report.success {
-                            std::process::exit(1);
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("{e}");
-                        std::process::exit(1);
-                    }
-                }
+                handle_install(&rest);
                 return;
             }
             "bootstrap" => {
-                let json = rest.iter().any(|a| a == "--json");
-                let opts = setup::SetupOptions {
-                    non_interactive: true,
-                    yes: true,
-                    fix: true,
-                    json,
-                    ..Default::default()
-                };
-                match setup::run_setup_with_options(opts) {
-                    Ok(report) => {
-                        if json {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(&report)
-                                    .unwrap_or_else(|_| "{}".to_string())
-                            );
-                        }
-                        if !report.success {
-                            std::process::exit(1);
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("{e}");
-                        std::process::exit(1);
-                    }
-                }
+                handle_bootstrap(&rest);
                 return;
             }
             "wrap" => {
@@ -779,26 +598,7 @@ pub fn run() {
             // The old "bypass" wording read to a model like a *security* bypass,
             // but this only skips compression — the shell allowlist and path jail
             // still apply (GH security audit, finding 5).
-            "raw" | "bypass" => {
-                if rest.is_empty() {
-                    eprintln!("Usage: lean-ctx raw \"command\"");
-                    eprintln!(
-                        "Runs the command with output passed through unchanged (no \
-                         compression). The shell allowlist still applies."
-                    );
-                    std::process::exit(1);
-                }
-                let command = if rest.len() == 1 {
-                    rest[0].clone()
-                } else {
-                    shell::join_command(&args[2..])
-                };
-                // SAFETY: CLI dispatch is single-threaded; this runs before the
-                // process hands off to shell::exec and exits below.
-                unsafe { std::env::set_var("LEAN_CTX_RAW", "1") };
-                let code = shell::exec(&command);
-                std::process::exit(code);
-            }
+            "raw" | "bypass" => handle_raw(&args, &rest),
             "safety-levels" | "safety" => {
                 println!("{}", core::compression_safety::format_safety_table());
                 return;
@@ -921,6 +721,189 @@ fn is_server_mode(args: &[String]) -> bool {
                 "mcp" | "daemon" | "proxy" | "serve" | "watch" | "dashboard" | "gateway"
             )
         })
+}
+
+fn handle_exec(args: &[String], rest: &[String]) -> ! {
+    let raw = rest.first().is_some_and(|a| a == "--raw");
+    let cmd_args = if raw { &args[3..] } else { &args[2..] };
+    let command = if cmd_args.len() == 1 {
+        cmd_args[0].clone()
+    } else {
+        shell::join_command(cmd_args)
+    };
+    // The `lean-ctx -c` wrapper runs inside the agent shell, which carries
+    // runtime/session vars the MCP server never sees. Bridge them so ctx_shell
+    // can forward them too (#370).
+    core::agent_runtime_env::capture();
+    if crate::shell::reentry::should_pass_through() {
+        passthrough(&command);
+    }
+    if raw {
+        // SAFETY: CLI dispatch is single-threaded; this runs before any worker
+        // threads start (the process hands off to shell::exec below).
+        unsafe { std::env::set_var("LEAN_CTX_RAW", "1") };
+    } else {
+        // SAFETY: CLI dispatch is single-threaded; this runs before any worker
+        // threads start (the process hands off to shell::exec below).
+        unsafe { std::env::set_var("LEAN_CTX_COMPRESS", "1") };
+    }
+    let code = shell::exec(&command);
+    core::tool_lifecycle::flush_all();
+    std::process::exit(code);
+}
+
+fn handle_track(args: &[String]) -> ! {
+    let cmd_args = &args[2..];
+    let code = if cmd_args.len() > 1 {
+        shell::exec_argv(cmd_args)
+    } else {
+        let command = cmd_args[0].clone();
+        if crate::shell::reentry::should_pass_through() {
+            passthrough(&command);
+        }
+        shell::exec(&command)
+    };
+    core::tool_lifecycle::flush_all();
+    std::process::exit(code);
+}
+
+fn handle_setup(rest: &[String]) {
+    // Safety (#476 class): `--help`/`-h` — or any unknown flag — must NEVER
+    // fall through to a real setup run that mutates shell + agent configs.
+    if rest.iter().any(|a| a == "--help" || a == "-h") {
+        print_setup_help();
+        return;
+    }
+    const KNOWN: &[&str] = &[
+        "--non-interactive",
+        "--yes",
+        "-y",
+        "--fix",
+        "--json",
+        "--no-auto-approve",
+        "--skip-rules",
+        "--no-agent-aliases",
+    ];
+    if let Some(unknown) = rest
+        .iter()
+        .find(|a| a.starts_with('-') && !KNOWN.contains(&a.as_str()))
+    {
+        eprintln!("setup: unknown flag '{unknown}'\n");
+        print_setup_help();
+        std::process::exit(2);
+    }
+    let non_interactive = rest.iter().any(|a| a == "--non-interactive");
+    let yes = rest.iter().any(|a| a == "--yes" || a == "-y");
+    let fix = rest.iter().any(|a| a == "--fix");
+    let json = rest.iter().any(|a| a == "--json");
+    let no_auto_approve = rest.iter().any(|a| a == "--no-auto-approve");
+    let skip_rules = rest.iter().any(|a| a == "--skip-rules");
+    let no_agent_aliases = rest.iter().any(|a| a == "--no-agent-aliases");
+
+    if no_agent_aliases {
+        let _ = crate::core::config::setter::set_by_key("skip_agent_aliases", "true");
+    }
+
+    if non_interactive || fix || json || yes {
+        let opts = setup::SetupOptions {
+            non_interactive,
+            yes,
+            fix,
+            json,
+            no_auto_approve,
+            skip_rules,
+            ..Default::default()
+        };
+        run_setup_options(opts, json);
+    } else {
+        setup::run_setup();
+    }
+}
+
+fn handle_onboard(rest: &[String]) {
+    if rest.iter().any(|a| a == "--help" || a == "-h") {
+        println!("Usage: lean-ctx onboard [--no-agent-aliases]");
+        println!("Connect your AI tools with one command: detects installed");
+        println!("agents, installs hooks/rules/MCP registrations, verifies.");
+        println!();
+        println!("  --no-agent-aliases  Do not install claude/codex/gemini shell aliases");
+        println!();
+        println!("Fine-grained control: lean-ctx setup --help");
+        return;
+    }
+    if rest.iter().any(|a| a == "--no-agent-aliases") {
+        let _ = crate::core::config::setter::set_by_key("skip_agent_aliases", "true");
+    }
+    setup::run_onboard();
+}
+
+fn handle_install(rest: &[String]) {
+    // Plain `lean-ctx install` is a natural thing to type after installing the
+    // binary; keep it as guided setup unless repair mode was explicitly asked.
+    let repair = rest.iter().any(|a| a == "--repair" || a == "--fix");
+    let json = rest.iter().any(|a| a == "--json");
+    if !repair {
+        setup::run_setup();
+        return;
+    }
+    run_repair_setup(json);
+}
+
+fn handle_bootstrap(rest: &[String]) {
+    let json = rest.iter().any(|a| a == "--json");
+    run_repair_setup(json);
+}
+
+fn run_repair_setup(json: bool) {
+    let opts = setup::SetupOptions {
+        non_interactive: true,
+        yes: true,
+        fix: true,
+        json,
+        ..Default::default()
+    };
+    run_setup_options(opts, json);
+}
+
+fn handle_raw(args: &[String], rest: &[String]) -> ! {
+    if rest.is_empty() {
+        eprintln!("Usage: lean-ctx raw \"command\"");
+        eprintln!(
+            "Runs the command with output passed through unchanged (no compression). \
+             The shell allowlist still applies."
+        );
+        std::process::exit(1);
+    }
+    let command = if rest.len() == 1 {
+        rest[0].clone()
+    } else {
+        shell::join_command(&args[2..])
+    };
+    // SAFETY: CLI dispatch is single-threaded; this runs before the process
+    // hands off to shell::exec and exits below.
+    unsafe { std::env::set_var("LEAN_CTX_RAW", "1") };
+    let code = shell::exec(&command);
+    std::process::exit(code);
+}
+
+fn run_setup_options(opts: setup::SetupOptions, json: bool) {
+    match setup::run_setup_with_options(opts) {
+        Ok(report) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".to_string())
+                );
+            }
+            if !report.success {
+                std::process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Restore the default SIGPIPE disposition for short-lived CLI invocations.

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -739,13 +739,9 @@ fn handle_exec(args: &[String], rest: &[String]) -> ! {
         passthrough(&command);
     }
     if raw {
-        // SAFETY: CLI dispatch is single-threaded; this runs before any worker
-        // threads start (the process hands off to shell::exec below).
-        unsafe { std::env::set_var("LEAN_CTX_RAW", "1") };
+        core::runtime_flags::enable_raw();
     } else {
-        // SAFETY: CLI dispatch is single-threaded; this runs before any worker
-        // threads start (the process hands off to shell::exec below).
-        unsafe { std::env::set_var("LEAN_CTX_COMPRESS", "1") };
+        core::runtime_flags::enable_compress();
     }
     let code = shell::exec(&command);
     core::tool_lifecycle::flush_all();
@@ -879,9 +875,7 @@ fn handle_raw(args: &[String], rest: &[String]) -> ! {
     } else {
         shell::join_command(&args[2..])
     };
-    // SAFETY: CLI dispatch is single-threaded; this runs before the process
-    // hands off to shell::exec and exits below.
-    unsafe { std::env::set_var("LEAN_CTX_RAW", "1") };
+    core::runtime_flags::enable_raw();
     let code = shell::exec(&command);
     std::process::exit(code);
 }

--- a/rust/src/cli/dispatch/network/mod.rs
+++ b/rust/src/cli/dispatch/network/mod.rs
@@ -1,4 +1,4 @@
-use crate::{dashboard, tui};
+use crate::{core, dashboard, tui};
 
 #[cfg(feature = "gateway-server")]
 mod gateway;
@@ -105,10 +105,8 @@ pub(super) fn cmd_dashboard(rest: &[String]) {
         .iter()
         .find_map(|p| p.strip_prefix("--project="))
         .map(String::from);
-    if let Some(ref p) = project {
-        // SAFETY: runs during single-threaded CLI argument parsing, before the
-        // dashboard server (and its threads) starts.
-        unsafe { std::env::set_var("LEAN_CTX_DASHBOARD_PROJECT", p) };
+    if let Some(ref project) = project {
+        core::runtime_flags::set_dashboard_project(project.clone());
     }
     // `--base-path` / `--prefix`: mount the dashboard behind a reverse-proxy
     // subpath (e.g. `/dashboard`). See dashboard::base_path (#355).

--- a/rust/src/cli/dispatch/server.rs
+++ b/rust/src/cli/dispatch/server.rs
@@ -13,9 +13,7 @@ pub(super) fn run_mcp_server() -> Result<()> {
     // process entry to the completed MCP initialize handshake.
     let started_at = std::time::Instant::now();
 
-    // SAFETY: set once at MCP server startup, before the Tokio runtime is built
-    // and any worker/blocking threads exist (runtime is constructed below).
-    unsafe { std::env::set_var("LEAN_CTX_MCP_SERVER", "1") };
+    crate::core::runtime_flags::enable_mcp_server();
 
     crate::core::startup_guard::crash_loop_backoff(crate::core::startup_guard::MCP_PROCESS_NAME);
 

--- a/rust/src/cli/init_cmd.rs
+++ b/rust/src/cli/init_cmd.rs
@@ -1,7 +1,7 @@
 use crate::hooks::to_bash_compatible_path;
 
 pub(crate) fn quiet_enabled() -> bool {
-    matches!(std::env::var("LEAN_CTX_QUIET"), Ok(v) if v.trim() == "1")
+    crate::core::runtime_flags::quiet_enabled()
 }
 
 macro_rules! qprintln {
@@ -190,10 +190,6 @@ pub fn cmd_init(args: &[String]) {
 }
 
 pub fn cmd_init_quiet(args: &[String]) {
-    // SAFETY: the `init` CLI command is single-threaded; no other thread reads
-    // the environment between this set and the matching remove below.
-    unsafe { std::env::set_var("LEAN_CTX_QUIET", "1") };
+    let _quiet_guard = crate::core::runtime_flags::scoped_quiet();
     cmd_init(args);
-    // SAFETY: single-threaded CLI command; pairs with the set above.
-    unsafe { std::env::remove_var("LEAN_CTX_QUIET") };
 }

--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -90,7 +90,7 @@ pub fn cmd_read(args: &[String]) {
     // The hook env (set by `mark_hook_environment`, inherited by the subprocess) forces
     // verbatim content on BOTH the daemon (`fresh:true`) and standalone (skip cli_cache)
     // paths. Direct CLI/MCP reads keep caching.
-    let force_fresh = should_force_fresh(args, std::env::var("LEAN_CTX_HOOK_CHILD").is_ok());
+    let force_fresh = should_force_fresh(args, crate::core::runtime_flags::hook_child_enabled());
     // Whether *we* choose the mode (auto): only then do we cap framing to raw.
     // An explicit mode is a deliberate view we return verbatim (#361).
     let requested_auto = mode == "auto";

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -38,6 +38,7 @@ pub mod rules_canonical;
 pub mod rules_channel;
 pub mod rules_overhead;
 pub mod rules_sections;
+pub mod runtime_flags;
 pub mod structural_tokenizer;
 pub mod structured_read;
 pub mod tabular_crush;

--- a/rust/src/core/ocla/builtin/compression_provider.rs
+++ b/rust/src/core/ocla/builtin/compression_provider.rs
@@ -10,13 +10,13 @@ use std::sync::OnceLock;
 
 use crate::core::compressor;
 use crate::core::config::Config;
+use crate::core::ocla::OclaError;
 use crate::core::ocla::content_port::CompressionContentPort;
 use crate::core::ocla::traits::{CompressionProvider, OclaService};
 use crate::core::ocla::types::{
-    CompressionRequest, CompressionResult, OclaCapability, OclaCapabilityKind,
-    OclaCapabilityStatus, OclaResult, OCLA_API_VERSION,
+    CompressionRequest, CompressionResult, OCLA_API_VERSION, OclaCapability, OclaCapabilityKind,
+    OclaCapabilityStatus, OclaResult,
 };
-use crate::core::ocla::OclaError;
 use crate::core::ocla_bus::{self, OclaEvent};
 use crate::core::tokens;
 

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -77,6 +77,9 @@ pub fn allow_paths_from_env_and_config() -> Vec<PathBuf> {
         out.push(canonicalize_secure(&expand_user_path(p)));
     }
 
+    for path in crate::core::runtime_flags::allow_paths() {
+        out.push(canonicalize_secure(&path));
+    }
     // Env entries are expanded too: MCP host configs pass env blocks verbatim
     // (no shell), so "$HOME/code" arrives literally there as well.
     let v = std::env::var("LCTX_ALLOW_PATH")
@@ -216,7 +219,7 @@ pub fn active_relaxations() -> Vec<JailRelaxation> {
         });
     }
 
-    if env_is_set("LEAN_CTX_ALLOW_PATH") || env_is_set("LCTX_ALLOW_PATH") {
+    if crate::core::runtime_flags::allow_path_enabled() {
         out.push(JailRelaxation {
             source: "LEAN_CTX_ALLOW_PATH",
             detail: "widens the read/write allow-list beyond the project root",

--- a/rust/src/core/runtime_flags.rs
+++ b/rust/src/core/runtime_flags.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+static RAW: AtomicBool = AtomicBool::new(false);
+static COMPRESS: AtomicBool = AtomicBool::new(false);
+static QUIET: AtomicBool = AtomicBool::new(false);
+static MCP_SERVER: AtomicBool = AtomicBool::new(false);
+static HOOK_CHILD: AtomicBool = AtomicBool::new(false);
+static DASHBOARD_PROJECT: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+static ALLOW_PATHS: OnceLock<Mutex<Vec<PathBuf>>> = OnceLock::new();
+
+pub struct FlagGuard {
+    flag: &'static AtomicBool,
+    previous: bool,
+}
+
+impl Drop for FlagGuard {
+    fn drop(&mut self) {
+        self.flag.store(self.previous, Ordering::Relaxed);
+    }
+}
+
+fn set_scoped(flag: &'static AtomicBool) -> FlagGuard {
+    let previous = flag.swap(true, Ordering::Relaxed);
+    FlagGuard { flag, previous }
+}
+
+pub fn enable_raw() {
+    RAW.store(true, Ordering::Relaxed);
+}
+
+pub fn enable_compress() {
+    COMPRESS.store(true, Ordering::Relaxed);
+}
+
+pub fn enable_mcp_server() {
+    MCP_SERVER.store(true, Ordering::Relaxed);
+}
+
+pub fn mark_hook_child() {
+    HOOK_CHILD.store(true, Ordering::Relaxed);
+}
+
+pub fn scoped_quiet() -> FlagGuard {
+    set_scoped(&QUIET)
+}
+
+pub fn set_dashboard_project(project: String) {
+    let slot = DASHBOARD_PROJECT.get_or_init(|| Mutex::new(None));
+    if let Ok(mut value) = slot.lock() {
+        *value = Some(project);
+    }
+}
+
+pub fn add_allow_paths(paths: Vec<PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+    let slot = ALLOW_PATHS.get_or_init(|| Mutex::new(Vec::new()));
+    if let Ok(mut value) = slot.lock() {
+        value.extend(paths);
+    }
+}
+
+pub fn raw_enabled() -> bool {
+    RAW.load(Ordering::Relaxed) || std::env::var("LEAN_CTX_RAW").is_ok()
+}
+
+pub fn compress_enabled() -> bool {
+    COMPRESS.load(Ordering::Relaxed) || std::env::var("LEAN_CTX_COMPRESS").is_ok()
+}
+
+pub fn quiet_enabled() -> bool {
+    QUIET.load(Ordering::Relaxed)
+        || matches!(std::env::var("LEAN_CTX_QUIET"), Ok(value) if value.trim() == "1")
+}
+
+pub fn mcp_server_enabled() -> bool {
+    MCP_SERVER.load(Ordering::Relaxed)
+        || std::env::var("LEAN_CTX_MCP_SERVER").is_ok_and(|value| value == "1")
+}
+
+pub fn hook_child_enabled() -> bool {
+    HOOK_CHILD.load(Ordering::Relaxed) || std::env::var("LEAN_CTX_HOOK_CHILD").is_ok()
+}
+
+pub fn dashboard_project() -> Option<String> {
+    if let Some(value) = DASHBOARD_PROJECT
+        .get()
+        .and_then(|slot| slot.lock().ok().and_then(|value| value.clone()))
+        && !value.trim().is_empty()
+    {
+        return Some(value);
+    }
+    std::env::var("LEAN_CTX_DASHBOARD_PROJECT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+pub fn allow_paths() -> Vec<PathBuf> {
+    ALLOW_PATHS
+        .get()
+        .and_then(|slot| slot.lock().ok().map(|value| value.clone()))
+        .unwrap_or_default()
+}
+
+pub fn allow_path_enabled() -> bool {
+    !allow_paths().is_empty()
+        || std::env::var("LEAN_CTX_ALLOW_PATH").is_ok()
+        || std::env::var("LCTX_ALLOW_PATH").is_ok()
+}

--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -666,9 +666,8 @@ mod tests {
 /// Best-effort: silently drops if provider is unavailable or source_ref can't be
 /// constructed. This is the canonical production callsite for the compression capability.
 fn project_ocla_compression(path: &str, source_tokens: u64, output_tokens: u64) {
-    use crate::core::ocla::traits::CompressionProvider;
-    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
     use crate::core::ocla::OclaRegistry;
+    use crate::core::ocla::types::{CompressionRequest, OclaRequestContext};
 
     let reg = OclaRegistry::global();
     let source_ref = format!("file:{path}");

--- a/rust/src/daemon_client.rs
+++ b/rust/src/daemon_client.rs
@@ -196,7 +196,7 @@ pub fn try_daemon_tool_call_blocking(
         // auto-starting one. This guard MUST stay inside `if !ready` — hoisting it
         // to the top of the function would also block hooks from reusing a running
         // daemon, silently regressing loop/bounce/adaptive parity.
-        if std::env::var("LEAN_CTX_HOOK_CHILD").is_ok() {
+        if crate::core::runtime_flags::hook_child_enabled() {
             return None;
         }
 

--- a/rust/src/dashboard/routes/helpers.rs
+++ b/rust/src/dashboard/routes/helpers.rs
@@ -87,9 +87,7 @@ pub fn is_windows_absolute_path(path: &str) -> bool {
 }
 
 pub fn detect_project_root_for_dashboard() -> String {
-    if let Ok(explicit) = std::env::var("LEAN_CTX_DASHBOARD_PROJECT")
-        && !explicit.trim().is_empty()
-    {
+    if let Some(explicit) = crate::core::runtime_flags::dashboard_project() {
         return promote_to_git_root(&explicit);
     }
 

--- a/rust/src/doctor/checks/environment.rs
+++ b/rust/src/doctor/checks/environment.rs
@@ -675,7 +675,7 @@ pub(crate) fn cwd_looks_like_agent_dir(cwd_str: &str) -> bool {
 /// .claude). This usually means the MCP client launched the process from the
 /// wrong CWD, causing "path escapes project root" errors for every tool call.
 pub(crate) fn mcp_server_cwd_outcome() -> Outcome {
-    let is_mcp = std::env::var("LEAN_CTX_MCP_SERVER").is_ok_and(|v| v == "1");
+    let is_mcp = crate::core::runtime_flags::mcp_server_enabled();
     if !is_mcp {
         return Outcome {
             ok: true,

--- a/rust/src/doctor/fix.rs
+++ b/rust/src/doctor/fix.rs
@@ -37,7 +37,7 @@ fn build_and_persist_fix_report(
         PlatformInfo, SetupItem, SetupReport, SetupStepReport, doctor_report_path,
     };
 
-    let _quiet_guard = quiet.then(|| crate::setup::EnvVarGuard::set("LEAN_CTX_QUIET", "1"));
+    let _quiet_guard = quiet.then(crate::core::runtime_flags::scoped_quiet);
     let started_at = Utc::now();
     let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
 

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -91,15 +91,13 @@ fn log_shadow_intercept(tool: &str, detail: &str) {
 }
 
 fn is_quiet() -> bool {
-    matches!(std::env::var("LEAN_CTX_QUIET"), Ok(v) if v.trim() == "1")
+    crate::core::runtime_flags::quiet_enabled()
 }
 
 /// Mark this process as a hook child so the daemon-client never auto-starts
 /// the daemon from inside a hook (which would create zombie processes).
 pub fn mark_hook_environment() {
-    // SAFETY: called once at hook-process startup (CLI dispatch), before any
-    // threads that read the environment are spawned.
-    unsafe { std::env::set_var("LEAN_CTX_HOOK_CHILD", "1") };
+    crate::core::runtime_flags::mark_hook_child();
 }
 
 /// Arms a watchdog that force-exits the process after the given duration.

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -170,8 +170,7 @@ use support::{
 };
 
 fn mcp_server_quiet_mode() -> bool {
-    std::env::var_os("LEAN_CTX_MCP_SERVER").is_some()
-        || matches!(std::env::var("LEAN_CTX_QUIET"), Ok(value) if value.trim() == "1")
+    crate::core::runtime_flags::mcp_server_enabled() || crate::core::runtime_flags::quiet_enabled()
 }
 
 /// Agents whose global shell-hook artifacts embed the binary path / command

--- a/rust/src/server/call_tool.rs
+++ b/rust/src/server/call_tool.rs
@@ -281,7 +281,7 @@ impl LeanCtxServer {
             arg_raw
                 || arg_bypass
                 || std::env::var("LEAN_CTX_DISABLED").is_ok()
-                || std::env::var("LEAN_CTX_RAW").is_ok()
+                || crate::core::runtime_flags::raw_enabled()
         };
 
         let pre_terse_len = result_text.len();

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -32,6 +32,7 @@ use rmcp::model::{
     InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
+use std::path::PathBuf;
 
 use crate::tools::{CrpMode, LeanCtxServer};
 mod call_tool;
@@ -141,17 +142,9 @@ fn detect_multi_root_workspace(dir: &std::path::Path) -> Option<String> {
     }
 
     if child_projects.len() >= 2 {
-        let existing = std::env::var("LEAN_CTX_ALLOW_PATH").unwrap_or_default();
-        let sep = if cfg!(windows) { ";" } else { ":" };
-        let merged = if existing.is_empty() {
-            child_projects.join(sep)
-        } else {
-            format!("{existing}{sep}{}", child_projects.join(sep))
-        };
-        // SAFETY: set during MCP `initialize` (connection bootstrap), before any
-        // tool-handler thread reads the jail allow-list via `pathjail`. The only
-        // concurrent startup tasks (proxy spawn, savings publish) never consult it.
-        unsafe { std::env::set_var("LEAN_CTX_ALLOW_PATH", &merged) };
+        crate::core::runtime_flags::add_allow_paths(
+            child_projects.iter().map(PathBuf::from).collect(),
+        );
         tracing::info!(
             "Multi-root workspace detected at {}: auto-allowing {} child projects",
             dir.display(),

--- a/rust/src/setup/mod.rs
+++ b/rust/src/setup/mod.rs
@@ -5,7 +5,6 @@ use crate::core::portable_binary::resolve_portable_binary;
 use crate::core::setup_report::{PlatformInfo, SetupItem, SetupReport, SetupStepReport};
 use crate::hooks::{HookMode, recommend_hook_mode};
 use chrono::Utc;
-use std::ffi::OsString;
 mod mcp;
 pub use mcp::*;
 mod helpers;
@@ -19,36 +18,31 @@ pub fn claude_config_dir(home: &std::path::Path) -> PathBuf {
     crate::core::editor_registry::claude_state_dir(home)
 }
 
+#[cfg(test)]
 pub(crate) struct EnvVarGuard {
     key: &'static str,
-    previous: Option<OsString>,
+    previous: Option<std::ffi::OsString>,
 }
 
+#[cfg(test)]
 impl EnvVarGuard {
     pub(crate) fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(key);
-        // SAFETY: `EnvVarGuard` is only used in single-threaded setup/doctor CLI
-        // flows (and serial-gated tests), so no other thread reads the
-        // environment while the guard mutates it.
         unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
 }
 
+#[cfg(test)]
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         if let Some(previous) = &self.previous {
-            // SAFETY: see `EnvVarGuard::set` — restoration runs on the same
-            // single-threaded setup/doctor path that created the guard.
             unsafe { std::env::set_var(self.key, previous) };
         } else {
-            // SAFETY: see `EnvVarGuard::set` — restoration runs on the same
-            // single-threaded setup/doctor path that created the guard.
             unsafe { std::env::remove_var(self.key) };
         }
     }
 }
-
 /// Determine the setup level from a first-run interactive menu.
 /// Returns (inject_rules, inject_skills).
 fn first_run_setup_level() -> (bool, bool) {
@@ -795,7 +789,7 @@ pub struct SetupOptions {
 }
 
 pub fn run_setup_with_options(opts: SetupOptions) -> Result<SetupReport, String> {
-    let _quiet_guard = opts.json.then(|| EnvVarGuard::set("LEAN_CTX_QUIET", "1"));
+    let _quiet_guard = opts.json.then(crate::core::runtime_flags::scoped_quiet);
     let started_at = Utc::now();
     let home = dirs::home_dir().ok_or_else(|| "Cannot determine home directory".to_string())?;
     let binary = resolve_portable_binary();

--- a/rust/src/shell/exec.rs
+++ b/rust/src/shell/exec.rs
@@ -475,7 +475,7 @@ fn exec_direct(args: &[String]) -> i32 {
 /// can run the command without lean-ctx anyway, so blocking adds friction, not
 /// a boundary) or when `LEAN_CTX_ALLOWLIST_WARN_ONLY=1` explicitly opts out.
 fn allowlist_must_enforce() -> bool {
-    let hook_child = std::env::var("LEAN_CTX_HOOK_CHILD").is_ok();
+    let hook_child = crate::core::runtime_flags::hook_child_enabled();
     let warn_only = std::env::var("LEAN_CTX_ALLOWLIST_WARN_ONLY")
         .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
     allowlist_must_enforce_inner(hook_child, warn_only, io::stderr().is_terminal())
@@ -595,8 +595,8 @@ pub fn exec(command: &str) -> i32 {
     }
 
     let cfg = config::Config::load();
-    let force_compress = std::env::var("LEAN_CTX_COMPRESS").is_ok();
-    let raw_mode = std::env::var("LEAN_CTX_RAW").is_ok();
+    let force_compress = crate::core::runtime_flags::compress_enabled();
+    let raw_mode = crate::core::runtime_flags::raw_enabled();
 
     if raw_mode {
         return exec_inherit_tracked(command, &shell, &shell_flag);

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -247,7 +247,7 @@ impl McpTool for CtxShellTool {
             let arg_raw = get_bool(args, "raw").unwrap_or(false);
             let arg_bypass = get_bool(args, "bypass").unwrap_or(false);
             let env_disabled = std::env::var("LEAN_CTX_DISABLED").is_ok();
-            let env_raw = std::env::var("LEAN_CTX_RAW").is_ok();
+            let env_raw = crate::core::runtime_flags::raw_enabled();
             let (raw, bypass) = resolve_shell_raw_flags(arg_raw, arg_bypass, env_disabled, env_raw);
 
             let crp_mode = ctx.crp_mode;


### PR DESCRIPTION
Closes #1103
Closes #1107

## Summary
- extract complex cli::dispatch::run branches into focused handler functions
- deduplicate setup repair handling shared by install/bootstrap
- replace internal runtime env mutation with centralized runtime flags while preserving env fallbacks
- keep CI-required OCLA import formatting and unused import cleanup

## Validation
- cargo fmt --all -- --check
- cargo clippy --lib -- -D warnings
- cargo test cli::dispatch --lib