### PR TITLE
fix(shell-allowlist): don't treat a `#` comment line as a command (#1109)

### DIFF
--- a/rust/src/core/shell_allowlist/mod.rs
+++ b/rust/src/core/shell_allowlist/mod.rs
@@ -66,10 +66,14 @@ fn enforce_shell_allowlist(command: &str) -> Result<(), ShellError> {
     // #876: quoted-delimiter heredoc body = literal stdin, not commands.
     // Substitution checks ($(), backticks) need the quoted-only strip so they
     // can still flag expanding substitutions in unquoted bodies.
-    let quoted_stripped = strip_quoted_heredoc_bodies(&normalized);
+    // #1109: a shell comment (`# …`) is not a command. Strip comments after the
+    // heredoc bodies are gone, so a `#` inside a (now-removed) body can't be
+    // mistaken for a comment and, conversely, a real comment line between
+    // commands isn't diced into a bogus `#` segment and blocked.
+    let quoted_stripped = strip_comments(&strip_quoted_heredoc_bodies(&normalized));
     // #931: for command-segment and redirect checks, strip ALL heredoc bodies
     // (quoted + unquoted) — a `>` or command word in any body is opaque data.
-    let all_stripped = strip_all_heredoc_bodies(&normalized);
+    let all_stripped = strip_comments(&strip_all_heredoc_bodies(&normalized));
     let cmd = quoted_stripped.as_str();
     let cmd_all = all_stripped.as_str();
 
@@ -157,6 +161,110 @@ pub fn strip_all_heredoc_bodies(command: &str) -> String {
         }
     }
     out.join("\n")
+}
+
+/// Strip shell comments (`#` to end-of-line) so the allowlist tokenizer never
+/// mistakes a comment for a command (#1109).
+///
+/// Per POSIX, `#` only starts a comment when it is unquoted and begins a word:
+/// at the start of the command, or immediately after whitespace or one of the
+/// unquoted metacharacters `;`, `&`, `|`, `(`. Anywhere else the `#` is part of
+/// a word, so this deliberately leaves intact:
+///   - `#` inside single or double quotes (`echo "# not a comment"`),
+///   - parameter expansions like `${#arr}` and `${var#prefix}`,
+///   - arithmetic bases like `$((16#ff))`,
+///   - URLs / fragments like `http://host/path#frag`,
+///   - an escaped `\#`.
+///
+/// Run this AFTER heredoc bodies are stripped: a body line may legitimately
+/// contain `#`, and once the body is gone it can't be misread here.
+fn strip_comments(command: &str) -> String {
+    if !command.contains('#') {
+        return command.to_string();
+    }
+    let bytes = command.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut in_single = false;
+    let mut in_double = false;
+    // The start of the command counts as a word boundary.
+    let mut at_boundary = true;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_single {
+            out.push(c);
+            if c == b'\'' {
+                in_single = false;
+            }
+            at_boundary = false;
+            i += 1;
+            continue;
+        }
+        if in_double {
+            // A backslash inside double quotes escapes the next byte; copy both
+            // so a `\"` doesn't prematurely close the quote.
+            if c == b'\\' && i + 1 < bytes.len() {
+                out.push(c);
+                out.push(bytes[i + 1]);
+                at_boundary = false;
+                i += 2;
+                continue;
+            }
+            out.push(c);
+            if c == b'"' {
+                in_double = false;
+            }
+            at_boundary = false;
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' => {
+                in_single = true;
+                out.push(c);
+                at_boundary = false;
+                i += 1;
+            }
+            b'"' => {
+                in_double = true;
+                out.push(c);
+                at_boundary = false;
+                i += 1;
+            }
+            b'\\' => {
+                // An unquoted backslash escapes the next byte, so `\#` is a
+                // literal `#`, never a comment.
+                out.push(c);
+                if i + 1 < bytes.len() {
+                    out.push(bytes[i + 1]);
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                at_boundary = false;
+            }
+            b'#' if at_boundary => {
+                // Comment: drop everything up to (but not including) the newline.
+                while i < bytes.len() && bytes[i] != b'\n' && bytes[i] != b'\r' {
+                    i += 1;
+                }
+                // `at_boundary` stays true; the newline (if any) is emitted next.
+            }
+            b'\n' | b'\r' | b' ' | b'\t' | b';' | b'&' | b'|' | b'(' => {
+                out.push(c);
+                at_boundary = true;
+                i += 1;
+            }
+            _ => {
+                out.push(c);
+                at_boundary = false;
+                i += 1;
+            }
+        }
+    }
+    // Every non-ASCII (multi-byte) byte is copied verbatim through the `_` arm,
+    // so the result is always valid UTF-8; fall back to the input if not.
+    String::from_utf8(out).unwrap_or_else(|_| command.to_string())
 }
 
 /// Scan one line for heredoc operators with a **quoted** delimiter and return

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -339,6 +339,78 @@ fn strip_leaves_unquoted_heredoc_body_intact() {
     assert_eq!(strip_quoted_heredoc_bodies(cmd), cmd);
 }
 
+// --- Comment stripping (#1109) ---
+
+#[test]
+fn strip_comments_drops_standalone_comment_line() {
+    // #1109: a bare `#` comment line between commands must be removed, not diced
+    // into a `#` segment that the allowlist then rejects.
+    assert_eq!(
+        strip_comments("cd /repo\n# drop the block\nsed s/a/b/ f"),
+        "cd /repo\n\nsed s/a/b/ f"
+    );
+}
+
+#[test]
+fn strip_comments_drops_trailing_and_post_operator_comment() {
+    assert_eq!(strip_comments("ls -la # list files"), "ls -la ");
+    assert_eq!(strip_comments("ls;# c"), "ls;");
+    assert_eq!(strip_comments("ls |# c"), "ls |");
+}
+
+#[test]
+fn strip_comments_keeps_hash_inside_quotes() {
+    assert_eq!(
+        strip_comments("echo \"# not a comment\""),
+        "echo \"# not a comment\""
+    );
+    assert_eq!(strip_comments("echo '#nope'"), "echo '#nope'");
+}
+
+#[test]
+fn strip_comments_keeps_hash_in_words_and_expansions() {
+    // `#` mid-word, `${#arr}` length, `${v#pre}` prefix removal, `16#ff`
+    // arithmetic base, a URL fragment, and an escaped `\#` are not comments.
+    assert_eq!(strip_comments("echo ${#arr}"), "echo ${#arr}");
+    assert_eq!(strip_comments("echo ${v#pre}"), "echo ${v#pre}");
+    assert_eq!(strip_comments("echo $((16#ff))"), "echo $((16#ff))");
+    assert_eq!(
+        strip_comments("curl http://h/p#frag"),
+        "curl http://h/p#frag"
+    );
+    assert_eq!(strip_comments("echo a\\#b"), "echo a\\#b");
+}
+
+#[test]
+fn comment_line_between_commands_does_not_block() {
+    // #1109 end-to-end: a `#` comment line in a multi-line command was parsed as
+    // a command named `#` and blocked the whole pipeline.
+    // #975: mutating the environment without the lock races every other test.
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "cd,sed,grep");
+    let cmd = "cd /repo\n# drop the conflict block\nsed s/a/b/ f\ngrep -c x f";
+    let result = super::enforce_shell_allowlist(cmd);
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+    assert!(
+        result.is_ok(),
+        "a comment line must not be treated as a command: {result:?}"
+    );
+}
+
+#[test]
+fn commented_out_command_is_not_executed_but_does_not_leak() {
+    // A `#`-commented command is dropped (as the shell would), so an unlisted
+    // command hidden behind `#` neither runs nor blocks the allowed prefix.
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "ls");
+    let result = super::enforce_shell_allowlist("ls # rm -rf /");
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+    assert!(
+        result.is_ok(),
+        "trailing comment must not block: {result:?}"
+    );
+}
+
 #[test]
 fn heredoc_delims_variants() {
     assert_eq!(


### PR DESCRIPTION
Fixes #1109.

## Problem

A standalone `#` comment line inside a multi-line `ctx_shell` command is split into its own segment by the newline-splitter, its base is extracted as `#`, and it's rejected:

```
[BLOCKED — DO NOT RETRY] '#' is not in the shell allowlist.
[pipeline: segment N/M blocked — the entire command was rejected before execution, no part of the pipeline ran]
```

There was no comment handling anywhere in the allowlist path — `normalize_line_continuations`, the heredoc strippers, `split_on_operators`, and `shell_tokenize` all pass `#` through untouched.

## Fix

Add a `strip_comments()` pass in `enforce_shell_allowlist`, applied **after** the heredoc bodies are stripped — so a `#` inside a (now-removed) heredoc body can't be misread, and a real comment line between commands is removed before the operator-splitter can dice it into a bogus `#` segment.

`strip_comments` is quote- and word-boundary-aware. Per POSIX, `#` starts a comment only when it is unquoted and begins a word: at the start of the command, or immediately after whitespace or one of the unquoted metacharacters `;`, `&`, `|`, `(`. It therefore deliberately leaves intact:

- `#` inside single or double quotes — `echo "# not a comment"`
- parameter expansions — `${#arr}` (length), `${var#prefix}` (prefix removal)
- arithmetic bases — `$((16#ff))`
- URLs / fragments — `http://host/path#frag`
- an escaped `\#`

It's byte-oriented but copies every multi-byte (non-ASCII) byte verbatim, so the result is always valid UTF-8.

This mirrors the existing heredoc-body mechanism (`strip_quoted_heredoc_bodies` / `strip_all_heredoc_bodies`) rather than adding a special case deep in the tokenizer.

## Security

A `#`-commented command is dropped exactly as a real shell would drop it, so it neither runs nor blocks the allowed prefix (`ls # rm -rf /` → `ls`). Comment stripping stops at the newline, so it can never swallow a following command line. Covered by a test.

## Tests

`rust/src/core/shell_allowlist/tests.rs`:

- `strip_comments_drops_standalone_comment_line`
- `strip_comments_drops_trailing_and_post_operator_comment`
- `strip_comments_keeps_hash_inside_quotes`
- `strip_comments_keeps_hash_in_words_and_expansions`
- `comment_line_between_commands_does_not_block` (end-to-end #1109 repro)
- `commented_out_command_is_not_executed_but_does_not_leak`

## Verification

`cargo fmt` clean. The changed files (`shell_allowlist/`) are clippy-clean — the new `strip_comments` and its tests produce no warnings. `cargo test shell_allowlist` passes all six new tests and the rest of the module.

> Verified on a newer local toolchain (cargo/clippy 1.97), which surfaces a few pre-existing issues in files this PR does not touch — please confirm against CI's pinned toolchain:
> - `cargo clippy -D warnings` reports `undocumented_unsafe_blocks` at `src/hooks/tests.rs:798` and `items_after_test_module` at `src/terminal_ui.rs:358`.
> - `gh391_strict_mode_blocks_substitution_in_args` fails locally; it exercises `check_substitution_in_args` (not the comment path) and asserts an allowlisted inner command passes in strict mode (#1024), which depends on the machine's default allowlist config.
>
> None of these touch `strip_comments` / `enforce_shell_allowlist`.
