### PR TITLE
test(vibe): make bash-wrap quote assertion platform-aware

### DIFF
--- a/rust/src/hook_handlers/vibe.rs
+++ b/rust/src/hook_handlers/vibe.rs
@@ -210,7 +210,14 @@ mod tests {
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let ti = &v["hook_specific_output"]["tool_input"];
-        assert_eq!(ti["command"], "lean-ctx -c 'git status'");
+        // `wrap_single_command` quotes with `"..."` on Windows (cmd) and
+        // `'...'` on POSIX shells, so the expected wrapping is platform-aware.
+        let expected = if cfg!(windows) {
+            "lean-ctx -c \"git status\""
+        } else {
+            "lean-ctx -c 'git status'"
+        };
+        assert_eq!(ti["command"], expected);
         assert_eq!(ti["timeout"], 42, "non-command fields must be preserved");
     }
 


### PR DESCRIPTION
wrap_single_command quotes with double quotes on Windows (cmd) and single quotes on POSIX shells, but bash_wraps_general_command_and_preserves_timeout hardcoded the single-quoted form, so the test failed only on windows-latest (left: "lean-ctx -c \"git status\"", right: "lean-ctx -c 'git status'").

Mirror the existing platform-aware expect_wrapped helper: pick the expected wrapping via cfg!(windows). Unix expectation is byte-identical to before.

## Summary

What does this PR change and why

## Test plan

- [X] `cd rust && cargo test -- --test-threads=1` (the suite shares process-global state; CI serializes it too)
- [X] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases:
- Backwards compatibility:
- Docs updated (links/files):

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
