### PR TITLE
fix(clippy): resolve -D warnings under --all-targets --all-features

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,1 @@
+[{"label":"Debug","adapter":"auto","request":"launch","program":"$ZED_FILE","cwd":"$ZED_WORKTREE_ROOT"}]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "label": "Git Status",
+    "command": "git",
+    "args": ["status"],
+    "use_new_terminal": false
+  },
+  {
+    "label": "Format Code",
+    "co  {nd": "echo",
+    "args": ["Code formatting..."],
+    "use_new_terminal": false
+  }
+]

--- a/rust/src/core/ocla/response_cache.rs
+++ b/rust/src/core/ocla/response_cache.rs
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn cache_hit_and_miss_update_stats() {
-        let cache = ResponseCache::new(4, Duration::from_secs(60));
+        let cache = ResponseCache::new(4, Duration::from_mins(1));
         let key = cache_key("model-a");
         cache.put(key, response(b"answer", Instant::now(), Duration::ZERO));
 
@@ -223,14 +223,14 @@ mod tests {
 
     #[test]
     fn expired_entries_count_as_misses() {
-        let cache = ResponseCache::with_ttl(Duration::from_secs(60));
+        let cache = ResponseCache::with_ttl(Duration::from_mins(1));
         let key = cache_key("model-a");
         cache.put(
             key,
             response(
                 b"old",
-                Instant::now() - Duration::from_secs(61),
-                Duration::from_secs(60),
+                Instant::now().checked_sub(Duration::from_secs(61)).unwrap(),
+                Duration::from_mins(1),
             ),
         );
 
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn lru_eviction_removes_least_recently_used_entry() {
-        let cache = ResponseCache::new(2, Duration::from_secs(60));
+        let cache = ResponseCache::new(2, Duration::from_mins(1));
         let first = cache_key("first");
         let second = cache_key("second");
         let third = cache_key("third");
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn capacity_is_hard_capped() {
-        let cache = ResponseCache::new(MAX_ENTRIES + 1, Duration::from_secs(60));
+        let cache = ResponseCache::new(MAX_ENTRIES + 1, Duration::from_mins(1));
         for index in 0..=MAX_ENTRIES {
             cache.put(
                 ResponseCacheKey { hash: index as u64 },
@@ -284,7 +284,9 @@ mod tests {
             key,
             response(
                 b"answer",
-                Instant::now() - Duration::from_secs(301),
+                Instant::now()
+                    .checked_sub(Duration::from_secs(301))
+                    .unwrap(),
                 Duration::ZERO,
             ),
         );

--- a/rust/src/core/ocla/wire_middleware.rs
+++ b/rust/src/core/ocla/wire_middleware.rs
@@ -258,12 +258,11 @@ mod tests {
         });
         let mut service = ocla_middleware().service(service);
         let request = |key| {
-            let request = Request::builder()
+            Request::builder()
                 .method(Method::POST)
                 .header("Idempotency-Key", key)
                 .body(Body::empty())
-                .expect("request");
-            request
+                .expect("request")
         };
 
         for key in ["same-key", "same-key", "new-key"] {

--- a/rust/src/core/redaction.rs
+++ b/rust/src/core/redaction.rs
@@ -669,7 +669,7 @@ mod tests {
             r#"if token == "" {"#,
             r#"if token, err = checkPulsares(); token == "" || err != nil {"#,
             r#"if password != "" {"#,
-            r#"assert secret == expected_value"#,
+            r"assert secret == expected_value",
         ] {
             assert_eq!(redact_text(s), s, "comparison operator corrupted: {s}");
         }

--- a/rust/src/core/tool_lifecycle.rs
+++ b/rust/src/core/tool_lifecycle.rs
@@ -514,6 +514,34 @@ fn project_ocla_compression(path: &str, source_tokens: u64, output_tokens: u64) 
     };
     let _ = reg.compression_provider.compress(request);
 }
+
+/// Project a realized read-savings event into the OCLA SavingsLedger.
+/// Best-effort: silently drops if the provider is unavailable. Canonical
+/// production callsite for the savings-evidence capability.
+fn project_ocla_savings(path: &str, original_tokens: u64, output_tokens: u64) {
+    use crate::core::ocla::OclaRegistry;
+    use crate::core::ocla::types::{OclaRequestContext, SavingsEvidence};
+
+    let context = OclaRequestContext {
+        request_id: format!("cli-read-{}", path.len()),
+        session_id: SessionState::load_latest()
+            .map_or_else(|| "cli-read".to_string(), |session| session.id),
+        agent_id: "lean-ctx".to_string(),
+        content_ref: format!("file:{path}"),
+        tenant_id: None,
+        trace_id: String::new(),
+    };
+    let evidence = SavingsEvidence {
+        context,
+        original_tokens,
+        delivered_tokens: output_tokens,
+        quality_ref: None,
+        evidence_ref: format!("read:{path}:{original_tokens}:{output_tokens}"),
+    };
+    let _ = OclaRegistry::global()
+        .savings_ledger
+        .record_savings(evidence);
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -732,28 +760,4 @@ mod tests {
         assert_eq!(item.output_tokens, 120);
         assert!(item.duration_us > 0, "a real duration must be recorded");
     }
-}
-fn project_ocla_savings(path: &str, original_tokens: u64, output_tokens: u64) {
-    use crate::core::ocla::OclaRegistry;
-    use crate::core::ocla::types::{OclaRequestContext, SavingsEvidence};
-
-    let context = OclaRequestContext {
-        request_id: format!("cli-read-{}", path.len()),
-        session_id: SessionState::load_latest()
-            .map_or_else(|| "cli-read".to_string(), |session| session.id),
-        agent_id: "lean-ctx".to_string(),
-        content_ref: format!("file:{path}"),
-        tenant_id: None,
-        trace_id: String::new(),
-    };
-    let evidence = SavingsEvidence {
-        context,
-        original_tokens,
-        delivered_tokens: output_tokens,
-        quality_ref: None,
-        evidence_ref: format!("read:{path}:{original_tokens}:{output_tokens}"),
-    };
-    let _ = OclaRegistry::global()
-        .savings_ledger
-        .record_savings(evidence);
 }

--- a/rust/src/setup/mod.rs
+++ b/rust/src/setup/mod.rs
@@ -28,6 +28,8 @@ pub(crate) struct EnvVarGuard {
 impl EnvVarGuard {
     pub(crate) fn set(key: &'static str, value: &str) -> Self {
         let previous = std::env::var_os(key);
+        // SAFETY: EnvVarGuard is test-only; env-mutating tests are serialized,
+        // so no other thread reads or writes the environment concurrently.
         unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
@@ -37,8 +39,12 @@ impl EnvVarGuard {
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         if let Some(previous) = &self.previous {
+            // SAFETY: EnvVarGuard is test-only; env-mutating tests are serialized,
+            // so no other thread reads or writes the environment concurrently.
             unsafe { std::env::set_var(self.key, previous) };
         } else {
+            // SAFETY: EnvVarGuard is test-only; env-mutating tests are serialized,
+            // so no other thread reads or writes the environment concurrently.
             unsafe { std::env::remove_var(self.key) };
         }
     }

--- a/rust/src/tools/registered/ctx_patch.rs
+++ b/rust/src/tools/registered/ctx_patch.rs
@@ -636,7 +636,7 @@ mod batch_grouping_tests {
             "args mapped correctly"
         );
         assert!(
-            args.get("dry_run").and_then(|v| v.as_bool()) == Some(true),
+            args.get("dry_run").and_then(Value::as_bool) == Some(true),
             "dry_run flag preserved in original args"
         );
     }

--- a/rust/tests/etpao_benchmark_suite.rs
+++ b/rust/tests/etpao_benchmark_suite.rs
@@ -91,7 +91,7 @@ fn with_routing_etpao() {
 #[test]
 fn with_cache_etpao() {
     let requests = requests();
-    let mut cache = ResponseCache::new(16, Duration::from_secs(60));
+    let mut cache = ResponseCache::new(16, Duration::from_mins(1));
     let mut cache_hits = 0_u64;
     let cached_tokens: u64 = requests
         .iter()
@@ -116,7 +116,7 @@ fn with_cache_etpao() {
 #[test]
 fn combined_etpao() {
     let requests = requests();
-    let mut cache = ResponseCache::new(16, Duration::from_secs(60));
+    let mut cache = ResponseCache::new(16, Duration::from_mins(1));
     let combined_tokens: u64 = requests
         .iter()
         .map(|request| {


### PR DESCRIPTION
- redaction: drop needless hashes on raw string literal (needless_raw_string_hashes)
- response_cache + etpao_benchmark_suite: Duration::from_secs(60) -> from_mins(1) (duration_suboptimal_units)
- response_cache: Instant::now() - Duration -> checked_sub().unwrap() (unchecked_time_subtraction)
- wire_middleware: return Request::builder() chain directly (let_and_return)
- tool_lifecycle: move project_ocla_savings above the test module (items_after_test_module)
- ctx_patch: and_then(Value::as_bool) instead of a closure (redundant_closure_for_method_calls)
- setup: add SAFETY comments to the test-only EnvVarGuard env mutations (undocumented_unsafe_blocks)

## Summary

What does this PR change and why?

## Test plan

- [X] `cd rust && cargo test -- --test-threads=1` (the suite shares process-global state; CI serializes it too)
- [X] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [X] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

- Risk areas / edge cases:
- Backwards compatibility:
- Docs updated (links/files):

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`
