### PR TITLE
fix(ctx_read): never mint an [unchanged] stub in the full-read fallback

### DIFF
--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -1382,26 +1382,13 @@ fn handle_full_with_auto_delta(
     let store_result = cache.store(path, &disk_content);
 
     if store_result.was_hit {
-        let policy_allows_stub =
-            crate::server::compaction_sync::effective_cache_policy() != "safe" && !force_full;
-        if policy_allows_stub && store_result.full_content_delivered {
-            let out = if crate::core::protocol::meta_visible() {
-                format!(
-                    "{file_ref}={short} [unchanged {}L]\nUnchanged on disk. Use fresh=true to force re-read.",
-                    store_result.line_count
-                )
-            } else {
-                // #498 determinism: byte-stable cache-hit stub (see
-                // try_stub_hit_readonly). The `fresh=true` escape is a static
-                // suffix, so non-meta re-readers still see how to force content (#513).
-                format!(
-                    "{file_ref}={short} [unchanged {}L · fresh=true to re-read]",
-                    store_result.line_count
-                )
-            };
-            let sent = count_tokens(&out);
-            return (out, sent);
-        }
+        // #1128: no stub here. Whether an unchanged file may collapse to
+        // `[unchanged …]` is decided once, by `try_stub_hit_readonly`, which the
+        // caller already consulted before routing here — and only that gate knows
+        // whether THIS conversation received the content (#954/#955). A second
+        // decision built from `StoreResult` cannot: `full_content_delivered` is
+        // carried over from the cache entry, so it answers "some conversation got
+        // this", which is the question the gate exists to stop trusting.
         cache.mark_full_delivered(path);
         return format_full_output(
             file_ref,

--- a/rust/src/tools/ctx_read/tests_delta.rs
+++ b/rust/src/tools/ctx_read/tests_delta.rs
@@ -230,6 +230,31 @@ fn conversation_scoped_stub_withheld_for_other_conversation() {
     );
 }
 
+/// #1128: the full-read fallback must never mint a stub of its own. The gate
+/// above is the single decision point, so once a read reaches
+/// `handle_full_with_auto_delta` it owes the caller content — regardless of what
+/// an earlier (possibly foreign) conversation was delivered.
+#[test]
+fn full_read_fallback_never_serves_a_stub() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("warm.rs");
+    let p = path.to_string_lossy().to_string();
+    std::fs::write(&path, "fn main() { let x = 1; }\n").unwrap();
+
+    let mut cache = primed_full_cache(&p);
+    // Same bytes on disk, so `store` reports a hit and the old code took the
+    // ungated `full_content_delivered` branch here.
+    let (out, _) = super::handle_full_with_auto_delta(&mut cache, &p, "F1", &p, "rs", None);
+    assert!(
+        !out.contains("[unchanged"),
+        "full-read fallback must not decide stubbing on its own: {out}"
+    );
+    assert!(
+        out.contains("fn main"),
+        "full-read fallback must deliver content: {out}"
+    );
+}
+
 #[test]
 fn conversation_scoped_stub_served_when_no_context() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes #1128.

A `mode="full"` read decided stubbing twice. First through `try_stub_hit_readonly`, the conversation-scoped gate from #954/#955 — which correctly withholds the stub when a *different* conversation received the content. Then again inside `handle_full_with_auto_delta`, off `store_result.full_content_delivered`, with no conversation context at all: that flag is copied from the cache entry (`core/cache.rs:608`), so it answers "some conversation got this content", which is the question the gate exists to stop trusting.

Result: a first read of a file in a fresh conversation could come back as `[unchanged 143L · fresh=true to re-read]` with no content — indistinguishable from a successful read, because the daemon outlives individual chats and an earlier session's delivery satisfied the flag.

The fix removes the duplicate decision rather than adding a second gate to it. Stubbing is now decided in exactly one place, by the one function that has the conversation identity, and `handle_full_with_auto_delta` is a pure content-deliverer — so a future caller cannot reintroduce an unscoped stub by reaching the fallback. `render_unchanged_stub` is now the only site that formats the `[unchanged …]` string.

Same-conversation re-reads are unaffected: they collapse at the gate and never reach the fallback, so cache-hit savings stay as they were.

## Test plan

- [x] `cd rust && cargo test -- --test-threads=1` — lib suite 8344 passed / 0 failed. One pre-existing failure in `tests/critical_module_integration.rs::pathjail_blocks_traversal`, reproduced identically on unmodified `origin/main` in this environment.
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — fails on two warnings that also fail on unmodified `origin/main` (`core/ocla/tracing.rs:225` items-after-test-module, `proxy/ocla_cache_bridge.rs:84` Duration unit). Nothing new from this change.
- [x] `cd rust && cargo fmt --check` — clean.
- [x] New regression test `full_read_fallback_never_serves_a_stub` verified red before the change (asserts on the stub text) and green after.
- [ ] cookbook/packages untouched.

## Notes for reviewers

- Risk areas / edge cases: the deleted branch was reachable only when the gate had already declined to stub, so the only behavior it produced was the bug. Worth a second opinion on whether any caller reaches `handle_full_with_auto_delta` *without* consulting `try_stub_hit_readonly` first — `mod.rs:952` is the only call site I found.
- Backwards compatibility: no API or output-format change for same-conversation reads. Foreign-conversation reads now return content where they previously returned a stub, which is the intended #954 behavior.
- Docs updated: none needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
