### PR TITLE
fix(ctx_read): carry cache-hit on ReadOutput instead of sniffing the output

### DIFF
--- a/rust/src/tools/ctx_read/mod.rs
+++ b/rust/src/tools/ctx_read/mod.rs
@@ -33,6 +33,11 @@ pub struct ReadOutput {
     /// Approximate output token count from mode processing.
     /// The dispatch layer recounts the final assembled string for accurate savings.
     pub output_tokens: usize,
+    /// Whether this read was served from the cache instead of re-delivering
+    /// content (#1133). Set by whoever served the read — the dispatch layer must
+    /// not re-derive it by inspecting `content`, which cannot distinguish a stub
+    /// from a file that merely quotes one.
+    pub cache_hit: bool,
 }
 
 /// SSOT via [`ReadMode`] (#528): the `map`/`signatures` summaries whose rendered
@@ -261,6 +266,7 @@ fn try_disk_anchored_window(
         content: out,
         resolved_mode: mode.to_string(),
         output_tokens: sent,
+        cache_hit: false,
     })
 }
 
@@ -753,6 +759,7 @@ fn render_unchanged_stub(file_ref: &str, path: &str, line_count: usize) -> ReadO
         content: out,
         resolved_mode: "full".into(),
         output_tokens: sent,
+        cache_hit: true,
     }
 }
 
@@ -885,6 +892,7 @@ fn handle_with_options_inner(
                 content: warning.to_string(),
                 resolved_mode: "diff".into(),
                 output_tokens: count_tokens(warning),
+                cache_hit: false,
             };
         }
         cache.invalidate(path);
@@ -907,6 +915,7 @@ fn handle_with_options_inner(
             content: out,
             resolved_mode: "diff".into(),
             output_tokens: sent,
+            cache_hit: false,
         };
     }
 
@@ -961,6 +970,7 @@ fn handle_with_options_inner(
                             content: msg,
                             resolved_mode: "error".into(),
                             output_tokens: 0,
+                            cache_hit: false,
                         };
                     }
                 };
@@ -971,6 +981,7 @@ fn handle_with_options_inner(
                     content: out,
                     resolved_mode: "full-compact".into(),
                     output_tokens: sent,
+                    cache_hit: false,
                 };
             }
             let (out, _) = handle_full_with_auto_delta(cache, path, &file_ref, &short, ext, task);
@@ -980,6 +991,7 @@ fn handle_with_options_inner(
                 content: out,
                 resolved_mode: "full".into(),
                 output_tokens: sent,
+                cache_hit: false,
             };
         }
 
@@ -1000,6 +1012,7 @@ fn handle_with_options_inner(
                     content: out,
                     resolved_mode,
                     output_tokens: sent,
+                    cache_hit: true,
                 };
             }
         }
@@ -1044,6 +1057,7 @@ fn handle_with_options_inner(
                 content: out,
                 resolved_mode,
                 output_tokens: sent,
+                cache_hit: false,
             };
         }
         cache.invalidate(path);
@@ -1065,6 +1079,7 @@ fn handle_with_options_inner(
                     content: msg,
                     resolved_mode: "error".into(),
                     output_tokens: tokens,
+                    cache_hit: false,
                 };
             }
         }
@@ -1099,6 +1114,7 @@ fn handle_with_options_inner(
                 content: output,
                 resolved_mode: "full-compact".into(),
                 output_tokens: sent,
+                cache_hit: false,
             };
         }
 
@@ -1130,6 +1146,7 @@ fn handle_with_options_inner(
             content: output,
             resolved_mode: "full".into(),
             output_tokens: sent,
+            cache_hit: false,
         };
     }
 
@@ -1191,6 +1208,7 @@ fn handle_with_options_inner(
         content: output,
         resolved_mode,
         output_tokens: final_tokens,
+        cache_hit: false,
     }
 }
 

--- a/rust/src/tools/ctx_read/tests_delta.rs
+++ b/rust/src/tools/ctx_read/tests_delta.rs
@@ -230,6 +230,38 @@ fn conversation_scoped_stub_withheld_for_other_conversation() {
     );
 }
 
+/// #1133: cache-hit-ness travels on `ReadOutput`, so a file that merely quotes
+/// the stub markers in its own text is not mistaken for a cache hit.
+#[test]
+fn cache_hit_flag_is_structural_not_sniffed_from_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("quotes_the_stub.rs");
+    let p = path.to_string_lossy().to_string();
+    // Content deliberately contains every marker the old substring check used.
+    std::fs::write(
+        &path,
+        "// renders \"[unchanged 12L]\" and \"[delta:full]\" for a cached read\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let mut cache = SessionCache::new();
+    let first = handle_with_task_resolved(&mut cache, &p, "full", CrpMode::Off, None);
+    assert!(
+        first.content.contains("[unchanged"),
+        "fixture must carry the marker the old substring check keyed on: {}",
+        first.content
+    );
+    assert!(
+        !first.cache_hit,
+        "first read delivers content — quoting the markers must not score a hit"
+    );
+
+    let delivered = cache.get(&p).unwrap().delivered_conversation.clone();
+    let stub = try_stub_hit_readonly_scoped(&cache, &p, delivered.as_deref())
+        .expect("same-conversation re-read serves the stub");
+    assert!(stub.cache_hit, "a served stub is a cache hit");
+}
+
 #[test]
 fn conversation_scoped_stub_served_when_no_context() {
     let dir = tempfile::tempdir().unwrap();

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -372,12 +372,10 @@ impl CtxReadTool {
                     && let Some(read_output) =
                         crate::tools::ctx_read::try_stub_hit_readonly(&cache, path)
                 {
+                    let hit = read_output.cache_hit;
                     let content = read_output.content;
                     let rmode = read_output.resolved_mode;
                     let orig = cache.get(path).map_or(0, |e| e.original_tokens);
-                    let hit = content.contains(" cached ")
-                        || content.contains("[unchanged")
-                        || content.contains("[delta:");
                     let fref = cache.file_ref_map().get(path).cloned();
                     let stats = cache.get_stats();
                     let stats_snapshot = (stats.total_reads(), stats.cache_hits());
@@ -410,12 +408,10 @@ impl CtxReadTool {
                         &protect,
                     )
                 };
+                let hit = read_output.cache_hit;
                 let content = read_output.content;
                 let rmode = read_output.resolved_mode;
                 let orig = cache.get(path).map_or(0, |e| e.original_tokens);
-                let hit = content.contains(" cached ")
-                    || content.contains("[unchanged")
-                    || content.contains("[delta:");
                 let fref = cache.file_ref_map().get(path).cloned();
                 let stats = cache.get_stats();
                 let stats_snapshot = (stats.total_reads(), stats.cache_hits());


### PR DESCRIPTION
## Summary

Fixes #1133.

`is_cache_hit` was re-derived in the dispatch layer by substring-matching the rendered read output:

```rust
let hit = content.contains(" cached ")
    || content.contains("[unchanged")
    || content.contains("[delta:");
```

at `registered/ctx_read.rs:378-380` and `:416-418`. On a full read the content *is* the file, so any file whose own text contains one of those markers scores a cache hit on a genuine miss. `" cached "` shows up in ordinary prose, and lean-ctx's own `ctx_read/mod.rs` carries the literal `[unchanged {line_count}L]` inside `render_unchanged_stub` — reading that file fresh counted as a hit. The flag drives `session.record_cache_hit()` (`:908`) and gates the graph hint (`:1073`), so the miscount lands in the counters behind #1104/#1105.

The producers already know the answer, so it is now passed down instead of reconstructed: `ReadOutput` gains a `cache_hit` field, set `true` by `render_unchanged_stub` and by the compressed-output cache hit, `false` at every other construction site. Both `contains(...)` chains are deleted. The field is mandatory, so a future construction site has to state its answer rather than inherit a guess — `registered/ctx_read.rs:481` already answered this structurally (`let hit = true;`), and the two sites now agree.

Two deliberate behavior notes:

- `[delta:` is emitted by `core/predictive_coding.rs:26`, not by any ctx_read path, so that clause only ever fired on coincidence.
- The `[using cached version — file read failed]` fallback in `handle_full_with_auto_delta` previously matched `" cached "` and counted as a hit. It now counts as a miss. That path serves stale cache because the file became unreadable; recording it as a savings hit overstated the cache. Say the word if you'd rather keep it counted and I'll thread the flag out of that helper.

## Test plan

- [x] `cd rust && cargo test --lib -- --test-threads=1` — 8344 passed / 0 failed.
- [x] `cd rust && cargo fmt --check` — clean.
- [x] New test `cache_hit_flag_is_structural_not_sniffed_from_content`: a fixture whose body quotes `[unchanged` and `[delta:` is asserted to still report `cache_hit == false` on a first read, and the served stub asserts `cache_hit == true`. The test also asserts the delivered content really does contain `[unchanged`, so it documents the exact input the old substring check got wrong.
- [ ] cookbook/packages untouched.

Verification caveat, since it affects how you read the results above: `origin/main` (2168ac047) does not currently compile its lib tests — `error[E0432]: unresolved import 'super::GrpcConfig'` at `core/config/sections.rs:1103`, reproduced with a clean tree and no changes of mine. The suite numbers above were produced by applying this diff to c69d0b07b, the last commit where `cargo test --lib` builds. `cargo build` and `cargo fmt --check` were run on the branch as based on current `main`.

## Notes for reviewers

- Risk areas / edge cases: 13 `ReadOutput` construction sites gained an explicit `cache_hit`; worth a skim that `false` is right for the diff, full-compact, and error paths, since those were also excluded before (none of their strings matched the old chain).
- Backwards compatibility: no output-format change. Only the internal hit accounting moves, in the direction of being correct.
- Docs updated: none needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
