### PR TITLE
fix(autonomy): take preload usefulness from the handlers, not their prose

### DIFF
--- a/rust/src/cli/overview_cmd.rs
+++ b/rust/src/cli/overview_cmd.rs
@@ -34,7 +34,8 @@ pub(crate) fn cmd_overview(args: &[String]) {
     }
 
     let cache = SessionCache::new();
-    let out = ctx_overview::handle(&cache, task.as_deref(), Some(&project_root), CrpMode::Off);
+    let (out, _complete) =
+        ctx_overview::handle(&cache, task.as_deref(), Some(&project_root), CrpMode::Off);
 
     if json {
         let payload = serde_json::json!({

--- a/rust/src/tools/autonomy.rs
+++ b/rust/src/tools/autonomy.rs
@@ -208,16 +208,14 @@ pub fn session_lifecycle_pre_hook(
         return None;
     }
 
-    let result = if let Some(task_desc) = task {
+    let (result, usable) = if let Some(task_desc) = task {
         crate::tools::ctx_preload::handle(cache, task_desc, Some(&root), crp_mode)
     } else {
         let cache_readonly = &*cache;
         crate::tools::ctx_overview::handle(cache_readonly, None, Some(&root), crp_mode)
     };
 
-    let empty = result.trim().is_empty()
-        || result.contains("No directly relevant files")
-        || result.contains("INDEXING IN PROGRESS");
+    let empty = !usable || result.trim().is_empty();
     decisions.push(AutonomyDriverDecisionV1 {
         driver: AutonomyDriverKindV1::Preload,
         verdict: AutonomyVerdictV1::Run,

--- a/rust/src/tools/ctx_overview.rs
+++ b/rust/src/tools/ctx_overview.rs
@@ -14,19 +14,22 @@ use crate::tools::CrpMode;
 ///
 /// This implements lazy evaluation for context: start with the overview,
 /// then zoom into specific files as needed.
+/// Returns the rendered overview plus whether it is the complete graph-backed
+/// view (#1134). `false` means the partial, still-indexing fallback — callers
+/// must take it from here rather than pattern-matching the body text.
 pub fn handle(
     _cache: &SessionCache,
     task: Option<&str>,
     path: Option<&str>,
     _crp_mode: CrpMode,
-) -> String {
+) -> (String, bool) {
     let project_root = path.map_or_else(|| ".".to_string(), std::string::ToString::to_string);
 
     let auto_loaded = crate::core::context_package::auto_load_packages(&project_root);
 
     let Some(open) = graph_provider::open_or_build(&project_root) else {
         crate::core::index_orchestrator::ensure_all_background(&project_root);
-        return partial_overview(&project_root);
+        return (partial_overview(&project_root), false);
     };
     let gp = &open.provider;
 
@@ -242,7 +245,7 @@ pub fn handle(
     output.push(String::new());
     output.push(crate::core::protocol::format_savings(original, compressed));
 
-    output.join("\n")
+    (output.join("\n"), true)
 }
 
 fn append_knowledge_task_section(output: &mut Vec<String>, project_root: &str, task: &str) {
@@ -669,7 +672,8 @@ mod tests {
         graph.save().expect("persist call graph");
 
         let cache = SessionCache::new();
-        let out = handle(&cache, None, Some(root_str), CrpMode::Off);
+        let (out, complete) = handle(&cache, None, Some(root_str), CrpMode::Off);
+        assert!(complete, "graph-backed overview must not report as partial");
         assert!(
             out.contains("1 call edges"),
             "overview header must show persisted call edges, got:\n{out}"

--- a/rust/src/tools/ctx_preload.rs
+++ b/rust/src/tools/ctx_preload.rs
@@ -10,21 +10,30 @@ const MAX_CRITICAL_LINES: usize = 15;
 const SIGNATURES_BUDGET: usize = 10;
 const TOTAL_TOKEN_BUDGET: usize = 4000;
 
+/// Returns the rendered preload plus whether it actually carries context
+/// (#1134). Callers must not re-derive that from the body: the guidance
+/// strings below are prose and drift, and a preloaded file may quote them.
 pub fn handle(
     cache: &mut SessionCache,
     task: &str,
     path: Option<&str>,
     crp_mode: CrpMode,
-) -> String {
+) -> (String, bool) {
     if task.trim().is_empty() {
-        return "ERROR: ctx_preload requires a task description".to_string();
+        return (
+            "ERROR: ctx_preload requires a task description".to_string(),
+            false,
+        );
     }
 
     let project_root = path.map_or_else(|| ".".to_string(), std::string::ToString::to_string);
     let jail_root = std::path::Path::new(&project_root);
 
     let Some(open) = graph_provider::open_or_build(&project_root) else {
-        return format!("[task: {task}]\nNo graph available. Use ctx_overview for project map.");
+        return (
+            format!("[task: {task}]\nNo graph available. Use ctx_overview for project map."),
+            false,
+        );
     };
     let gp = &open.provider;
 
@@ -57,8 +66,11 @@ pub fn handle(
         crate::core::pop_pruning::filter_candidates_by_pop(&project_root, &scored, &pop);
 
     if candidates.is_empty() {
-        return format!(
-            "[task: {task}]\nNo directly relevant files found. Use ctx_overview for project map."
+        return (
+            format!(
+                "[task: {task}]\nNo directly relevant files found. Use ctx_overview for project map."
+            ),
+            false,
         );
     }
 
@@ -269,13 +281,14 @@ pub fn handle(
     let preload_tokens = count_tokens(&preload_result);
     let savings = protocol::format_savings(total_estimated_saved, preload_tokens);
 
-    if crp_mode.is_tdd() {
+    let body = if crp_mode.is_tdd() {
         format!("{preload_result}\n{savings}")
     } else {
         format!(
             "{preload_result}\n\nNext: ctx_read(path, mode=\"full\") for any file above.\n{savings}"
         )
-    }
+    };
+    (body, true)
 }
 
 /// Boltzmann distribution for token budget allocation across files.
@@ -479,6 +492,24 @@ fn compute_heat(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1134: the "did this preload carry anything" answer travels with the
+    /// body. The guidance text is prose that has drifted before, so autonomy
+    /// must not have to recognise it.
+    #[test]
+    fn guidance_only_preloads_report_themselves_as_unusable() {
+        let mut cache = SessionCache::new();
+        let (body, usable) = handle(&mut cache, "   ", None, CrpMode::Off);
+        assert!(!usable, "an empty task carries no context: {body}");
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_string_lossy().to_string();
+        let (body, usable) = handle(&mut cache, "unrelated task", Some(&root), CrpMode::Off);
+        assert!(
+            !usable,
+            "a preload with no candidate files carries no context: {body}"
+        );
+    }
 
     #[test]
     fn extract_critical_lines_finds_keywords() {

--- a/rust/src/tools/registered/ctx_overview.rs
+++ b/rust/src/tools/registered/ctx_overview.rs
@@ -66,7 +66,7 @@ impl McpTool for CtxOverviewTool {
                 "[overview temporarily unavailable — cache busy]".to_string(),
             ));
         };
-        let result = crate::tools::ctx_overview::handle(
+        let (result, _complete) = crate::tools::ctx_overview::handle(
             &guard,
             task.as_deref(),
             resolved_path.as_deref(),

--- a/rust/src/tools/registered/ctx_preload.rs
+++ b/rust/src/tools/registered/ctx_preload.rs
@@ -77,7 +77,7 @@ impl McpTool for CtxPreloadTool {
                 "[preload skipped — cache temporarily unavailable]".to_string(),
             ));
         };
-        let mut result = crate::tools::ctx_preload::handle(
+        let (mut result, _usable) = crate::tools::ctx_preload::handle(
             &mut cache_guard,
             &task,
             resolved_path.as_deref(),


### PR DESCRIPTION
## Summary

Fixes #1137. Same defect class as #1133, except this one has already silently broken.

`autonomy.rs:218-220` decided whether a session-start preload was worth injecting by grepping the body it had just received:

```rust
let empty = result.trim().is_empty()
    || result.contains("No directly relevant files")
    || result.contains("INDEXING IN PROGRESS");
```

`"INDEXING IN PROGRESS"` exists nowhere in the tree. The partial-overview path emits `"PROJECT OVERVIEW (partial — knowledge graph indexing in background)"` (`ctx_overview.rs:541`), so that guard stopped matching when the banner was reworded, and a first tool call landing while the graph is still indexing has since had the depth-2 placeholder injected as if it were a real preload — the exact case the guard was added for.

`ctx_preload::handle` and `ctx_overview::handle` now return `(body, carries_context)` and autonomy reads the flag. Both handlers already know the answer at the point they pick a fallback branch, so nothing is recomputed.

Behavior changes beyond restoring the indexing guard, all in the same direction:

- `"ERROR: ctx_preload requires a task description"` and `"No graph available. Use ctx_overview for project map."` now count as unusable. Both are pure guidance with no context in them; both were being injected.
- Nothing else reads the new flag — `registered/ctx_preload.rs`, `registered/ctx_overview.rs`, and `cli/overview_cmd.rs` bind it as `_` and their output is unchanged.

## Test plan

- [x] `cd rust && cargo test --lib -- --test-threads=1` — 8390 passed / 0 failed.
- [x] `cd rust && cargo fmt --check` — clean.
- [x] New `guidance_only_preloads_report_themselves_as_unusable` covers the empty-task and no-candidates paths; the existing overview call-edges test now also asserts the graph-backed view reports itself complete.
- [ ] cookbook/packages untouched.

`cargo clippy --all-targets --all-features -- -D warnings` was not run to completion on this branch — flagging that rather than claiming it.

## Notes for reviewers

- Risk areas / edge cases: the flag is a bare `bool` in a tuple, matching the existing `ctx_tree::handle` convention in this codebase. Happy to make it a named type if you'd rather.
- The judgement call worth checking is whether the no-graph preload should really suppress injection, or whether pointing the model at `ctx_overview` is useful enough to keep. I took "carries no context" literally.
- Backwards compatibility: no tool output changes; only autonomy's internal decision moves.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
