### PR TITLE
fix(pi-lean-ctx): start MCP bridge without blocking TUI startup

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -851,11 +851,9 @@ export default async function (pi: ExtensionAPI) {
       }
     });
 
-    try {
-      await mcpBridge.start(pi);
-    } catch (err) {
+    void mcpBridge.start(pi).catch((err: unknown) => {
       console.error(`[pi-lean-ctx] MCP bridge startup failed: ${err}`);
-    }
+    });
   }
 
   pi.registerCommand("lean-ctx", {


### PR DESCRIPTION
## Problem

The pi-lean-ctx extension factory blocks for ~1.9s on startup because
`await mcpBridge.start(pi)` waits for the lean-ctx engine to fully
initialize (tree-sitter grammars, code index, session/knowledge/vector
stores) before returning.

This delays the entire pi TUI from appearing, even though no code after
the `await` depends on the bridge being ready.

## Solution

Make `mcpBridge.start(pi)` fire-and-forget with `void ... .catch()`.

The factory returns immediately and the bridge connects in the
background. All bridge consumers already guard with
`mcpBridge?.isConnected()` and fall back to the CLI subprocess path,
so this change is safe.

## Benchmark

Local macOS, pi v0.81.1, lean-ctx v3.9.8:

| Metric | Before | After |
|--------|--------|-------|
| Factory return time | 1856ms | 9ms |
| Bridge ready | 1856ms | ~6700ms (background) |

> **Note**: The "Bridge ready" time appears longer in the async case because bridge initialization now runs concurrently with other pi startup tasks (TUI rendering, other extensions, MCP servers) and competes for CPU/IO. The engine init itself takes the same ~1.9s — the wall-clock difference is resource contention, not a regression.

During the async startup window (~6s), tool calls use the existing CLI
fallback — functionally correct, just slightly slower per-call.

## Test plan

- [x] Verified factory returns immediately with async start
- [x] Verified bridge connects successfully in background
- [x] Verified all bridge consumers guard with `isConnected()` + CLI fallback
- [x] `npm ci && npm test` passes for `packages/pi-lean-ctx`

## Related

- #669 (MCP server startup race — server-side fix)
- #733 (pi bridge process leak on disconnect)
