### PR TITLE
fix: enforce ocla budgets on proxy requests

### DIFF
--- a/rust/src/core/ocla/wire_api.rs
+++ b/rust/src/core/ocla/wire_api.rs
@@ -57,6 +57,30 @@ fn budget_store() -> &'static Mutex<BudgetStore> {
     BUDGET_STORE.get_or_init(|| Mutex::new(BudgetStore::default()))
 }
 
+pub fn admit_budgeted_request(scope: &str, tokens: u64, usd: f64) -> Result<(), String> {
+    let scope = parse_budget_scope(scope)?;
+    let mut store = budget_store()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    store
+        .ledger
+        .check_budget_with_cost(&scope, tokens, usd)
+        .map_err(|err| err.to_string())?;
+    store.ledger.record_consumption(&scope, tokens, usd);
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn set_test_budget_limit(limit: BudgetLimit) {
+    let mut store = budget_store()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    store.ledger = BudgetLedger::new();
+    store.limits.clear();
+    store.ledger.set_limit(limit.clone());
+    store.limits.insert(limit.scope.clone(), limit);
+}
+
 #[derive(Debug, Deserialize)]
 struct SetBudgetRequest {
     scope: String,

--- a/rust/src/proxy/forward/mod.rs
+++ b/rust/src/proxy/forward/mod.rs
@@ -47,6 +47,8 @@ use headers::should_forward_request_header;
 pub(super) use prepare::{cohort_arm, prepare_request_body, wire_context};
 
 const HEADROOM_COMPRESSED_HEADER: &str = "x-headroom-compressed";
+const OCLA_BUDGET_SCOPE_HEADER: &str = "x-ocla-budget-scope";
+const ESTIMATED_CHARS_PER_TOKEN: u64 = 4;
 
 /// Check whether an incoming request was already compressed by Headroom.
 pub(super) fn is_headroom_compressed(parts: &axum::http::request::Parts) -> bool {
@@ -70,6 +72,25 @@ pub(super) fn max_body_bytes() -> usize {
         .filter(|mb| *mb > 0)
         .unwrap_or(DEFAULT_MAX_BODY_MB)
         .saturating_mul(1024 * 1024)
+}
+
+fn apply_ocla_budget_admission(
+    parts: &axum::http::request::Parts,
+    estimated_bytes: usize,
+) -> Result<(), StatusCode> {
+    let Some(scope) = parts
+        .headers
+        .get(OCLA_BUDGET_SCOPE_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+    let estimated_tokens = (estimated_bytes as u64).saturating_add(ESTIMATED_CHARS_PER_TOKEN - 1)
+        / ESTIMATED_CHARS_PER_TOKEN;
+    crate::core::ocla::wire_api::admit_budgeted_request(scope, estimated_tokens, 0.0)
+        .map_err(|_| StatusCode::PAYMENT_REQUIRED)
 }
 
 pub async fn forward_request(
@@ -157,6 +178,7 @@ pub async fn forward_request(
         upstream_base,
         provider_label == "OpenAI",
     )?;
+    apply_ocla_budget_admission(&parts, prepared.body.len())?;
     let original_size = prepared.original_size;
     let compressed_size = prepared.compressed_size;
     let compression_candidate = prepared.compression_candidate;

--- a/rust/src/proxy/forward/tests.rs
+++ b/rust/src/proxy/forward/tests.rs
@@ -43,6 +43,26 @@ fn add_test_marker(mut value: serde_json::Value, original_size: usize) -> (Vec<u
 }
 
 #[test]
+fn ocla_budget_admission_rejects_over_limit_scope() {
+    let mut parts = parts_for("/v1/chat/completions");
+    parts.headers.insert(
+        OCLA_BUDGET_SCOPE_HEADER,
+        axum::http::HeaderValue::from_static("user:budget-forward-test"),
+    );
+    let scope = crate::core::ocla::budget::BudgetScope::User("budget-forward-test".into());
+    let limit = crate::core::ocla::budget::BudgetLimit {
+        scope,
+        max_tokens_per_day: 2,
+        max_usd_per_day: 1.0,
+    };
+    crate::core::ocla::wire_api::set_test_budget_limit(limit);
+
+    let err = apply_ocla_budget_admission(&parts, 12).unwrap_err();
+
+    assert_eq!(err, StatusCode::PAYMENT_REQUIRED);
+}
+
+#[test]
 fn proxy_cycle_invokes_and_stores_intent_classification() {
     let calls = Arc::new(AtomicUsize::new(0));
     let mut registry = crate::core::ocla::OclaRegistry::with_builtins();


### PR DESCRIPTION
Closes #1167

## Summary
- enforce OCLA budget admission before proxy forwarding
- reject proxy requests when the declared budget is invalid or exhausted
- add focused proxy forwarding tests for budget rejection

## Validation
- focused proxy/OCLA tests for the forwarding path