### PR TITLE
fix: preserve cached provider response status

### DIFF
--- a/rust/src/core/ocla/response_cache.rs
+++ b/rust/src/core/ocla/response_cache.rs
@@ -65,6 +65,7 @@ impl ResponseCacheKey {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CachedResponse {
     pub body: Vec<u8>,
+    pub status: u16,
     pub tokens: u64,
     pub created_at: Instant,
     pub ttl: Duration,
@@ -265,6 +266,7 @@ mod tests {
     fn response(body: &[u8], created_at: Instant, ttl: Duration) -> CachedResponse {
         CachedResponse {
             body: body.to_vec(),
+            status: 200,
             tokens: body.len() as u64,
             created_at,
             ttl,

--- a/rust/src/proxy/forward/mod.rs
+++ b/rust/src/proxy/forward/mod.rs
@@ -211,9 +211,12 @@ pub async fn forward_request(
         .and_then(|m| m.as_str());
     let cache_prompt_hash = super::ocla_cache_bridge::prompt_hash(&body_bytes);
     if let (Some(cache), Some(model)) = (&state.ocla_cache, model)
-        && let Some(body) = cache.try_cache_hit(model, &cache_prompt_hash, 0.0, 0)
+        && let Some(cached) = cache.try_cache_hit(model, &cache_prompt_hash, 0.0, 0)
     {
-        let mut response = Response::new(Body::from(body));
+        let mut response = Response::builder()
+            .status(cached.status)
+            .body(Body::from(cached.body))
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         trace_id::inject_trace_id(&mut response, &trace_id);
         return Ok(response);
     }

--- a/rust/src/proxy/forward/transport.rs
+++ b/rust/src/proxy/forward/transport.rs
@@ -172,6 +172,7 @@ pub(crate) async fn build_response(
             cache_prompt_hash,
             0.0,
             0,
+            status,
             &resp_bytes,
             measured_output_tokens,
         );

--- a/rust/src/proxy/ocla_cache_bridge.rs
+++ b/rust/src/proxy/ocla_cache_bridge.rs
@@ -3,12 +3,20 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use axum::http::StatusCode;
+
 use crate::core::ocla::response_cache::{CachedResponse, ResponseCache, ResponseCacheKey};
 
 /// Shared proxy adapter for the OCLA response cache.
 #[derive(Clone, Debug)]
 pub struct OclaCacheBridge {
     cache: Arc<ResponseCache>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CachedProviderResponse {
+    pub body: Vec<u8>,
+    pub status: StatusCode,
 }
 
 impl OclaCacheBridge {
@@ -24,10 +32,13 @@ impl OclaCacheBridge {
         prompt_hash: &str,
         temp: f32,
         max_tokens: u32,
-    ) -> Option<Vec<u8>> {
+    ) -> Option<CachedProviderResponse> {
         self.cache
             .get(&cache_key(model, prompt_hash, temp, max_tokens))
-            .map(|response| response.body)
+            .map(|response| CachedProviderResponse {
+                body: response.body,
+                status: StatusCode::from_u16(response.status).unwrap_or(StatusCode::OK),
+            })
     }
 
     /// Records a response for matching request fields.
@@ -37,6 +48,7 @@ impl OclaCacheBridge {
         prompt_hash: &str,
         temp: f32,
         max_tokens: u32,
+        status: StatusCode,
         body: &[u8],
         tokens: u64,
     ) {
@@ -44,6 +56,7 @@ impl OclaCacheBridge {
             cache_key(model, prompt_hash, temp, max_tokens),
             CachedResponse {
                 body: body.to_vec(),
+                status: status.as_u16(),
                 tokens,
                 created_at: Instant::now(),
                 ttl: Duration::ZERO,
@@ -85,11 +98,22 @@ mod tests {
         let hash = prompt_hash(br#"{"prompt":"hello"}"#);
 
         assert!(bridge.try_cache_hit("model", &hash, 0.2, 128).is_none());
-        bridge.record_response("model", &hash, 0.2, 128, b"answer", 7);
+        bridge.record_response(
+            "model",
+            &hash,
+            0.2,
+            128,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            b"answer",
+            7,
+        );
 
         assert_eq!(
             bridge.try_cache_hit("model", &hash, 0.2, 128),
-            Some(b"answer".to_vec())
+            Some(CachedProviderResponse {
+                body: b"answer".to_vec(),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            })
         );
         assert!(bridge.try_cache_hit("model", &hash, 0.3, 128).is_none());
         assert!(

--- a/rust/tests/ocla_integration_suite.rs
+++ b/rust/tests/ocla_integration_suite.rs
@@ -182,6 +182,7 @@ fn test_full_pipeline() {
         key.clone(),
         CachedResponse {
             body: b"cached response".to_vec(),
+            status: 200,
             tokens: 40,
             created_at: Instant::now(),
             ttl: Duration::ZERO,


### PR DESCRIPTION
Summary:
- preserve upstream HTTP status in OCLA cached provider responses
- replay cached responses with the stored status instead of implicit 200
- update cache fixtures for the new stored status field

Tests:
- cargo check --lib
- cargo test core::ocla::response_cache::tests --lib -- --test-threads=1
- cargo test proxy::ocla_cache_bridge::tests --lib -- --test-threads=1
- cargo test --test ocla_integration_suite -- --test-threads=1
- cargo fmt --all -- --check

Fixes #1169
