### PR TITLE
fix: defer routing feedback until measured outcome

### DIFF
--- a/rust/src/proxy/routing.rs
+++ b/rust/src/proxy/routing.rs
@@ -169,9 +169,6 @@ pub fn route_request(
         local: resolved.local,
         xlat: resolved.xlat,
     };
-    ROUTING_FEEDBACK
-        .get_or_init(RoutingFeedback::new)
-        .record_decision(&decision.routed_from, &decision.model, "routing");
     Some(decision)
 }
 
@@ -379,6 +376,26 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
         }
+    }
+
+    #[test]
+    fn route_decision_does_not_record_feedback_before_outcome() {
+        let feedback = ROUTING_FEEDBACK.get_or_init(RoutingFeedback::new);
+        let before = feedback.stats();
+        let mut body = json!({"model":"expensive","messages":[{"role":"user","content":"hi"}]});
+
+        let decision = route_request(
+            &mut body,
+            "OpenAI",
+            &upstreams_with_foundry(),
+            &rules(&[("expensive", "fast")], &[]),
+            false,
+        )
+        .expect("alias should route");
+
+        assert_eq!(decision.routed_from, "expensive");
+        assert_eq!(decision.model, "fast");
+        assert_eq!(feedback.stats(), before);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- stop recording routing feedback at route-selection time
- leave routing feedback attribution to the measured usage/outcome path
- add a regression test that route decisions alone do not change feedback stats

Tests:
- cargo test proxy::routing::tests::route_decision_does_not_record_feedback_before_outcome --lib -- --test-threads=1
- cargo test proxy::routing::tests --lib -- --test-threads=1
- cargo check --lib
- cargo fmt --all -- --check

Fixes #1170
