### PR TITLE
fix(dashboard): clarify verified ledger bridge

### DIFF
--- a/rust/src/core/context_kernel/activation_e2e.rs
+++ b/rust/src/core/context_kernel/activation_e2e.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::dedup_wiring::{self, DedupAction};
     use super::super::envelope_wiring;

--- a/rust/src/core/context_kernel/envelope_e2e.rs
+++ b/rust/src/core/context_kernel/envelope_e2e.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::accounting_fix;
     use super::super::live_dashboard;

--- a/rust/src/core/context_kernel/envelope_wiring.rs
+++ b/rust/src/core/context_kernel/envelope_wiring.rs
@@ -124,7 +124,7 @@ pub fn reset_evidence() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::{
         EvidenceSummary, evidence_summary, process_mcp_evidence, process_proxy_evidence,

--- a/rust/src/core/context_kernel/kernel_config.rs
+++ b/rust/src/core/context_kernel/kernel_config.rs
@@ -133,7 +133,7 @@ mod tests {
         KernelFeatures, features, from_env, is_enabled, is_feature_enabled, reset_features,
         update_features,
     };
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     fn setup() -> MutexGuard<'static, ()> {
         let guard = super::KERNEL_TEST_LOCK

--- a/rust/src/dashboard/static/components/cockpit-overview.js
+++ b/rust/src/dashboard/static/components/cockpit-overview.js
@@ -366,13 +366,19 @@ class CockpitOverview extends HTMLElement {
 
     var trend = roiPayload.trend || [];
     var since = trend.length && trend[0] && trend[0][0] ? String(trend[0][0]) : '';
+    var verificationTag = '<span class="tag ty">unsigned</span>';
+    if (roi.chain_valid === false) {
+      verificationTag = '<span class="tag td">chain BROKEN</span>';
+    } else if (roi.chain_valid && roi.signed) {
+      verificationTag = '<span class="tag tg">verified</span>';
+    }
 
     return (
       '<p class="hs cko-bridge" id="cko-verifiedBridge" role="link" tabindex="0" ' +
       'title="Open ROI & Plan" style="cursor:pointer;margin-top:6px">' +
-      '<span class="tag tg">verified</span> ' +
-      '<b>' + esc(ff(roi.net_saved_tokens)) + '</b> tokens \u00b7 <b>' +
-      esc(fu(roi.saved_usd)) + '</b> in the independent local ledger' +
+      verificationTag + ' ' +
+      '<b>' + esc(ff(roi.net_saved_tokens)) + '</b> net tokens saved \u00b7 <b>' +
+      esc(fu(roi.saved_usd)) + '</b> \u00b7 separate measured ledger' +
       (since ? ' (recording since ' + esc(since) + ')' : '') +
       ' <span class="hc-health-go">ROI &amp; Plan \u2192</span></p>'
     );

--- a/rust/src/dashboard/static/tests/cockpit-overview.test.js
+++ b/rust/src/dashboard/static/tests/cockpit-overview.test.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for honest savings-ledger status on the Overview bridge.
+ * Run with: node rust/src/dashboard/static/tests/cockpit-overview.test.js
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const componentPath = path.join(__dirname, '..', 'components', 'cockpit-overview.js');
+const source = fs.readFileSync(componentPath, 'utf8').replace(
+  'export { CockpitOverview };',
+  'globalThis.CockpitOverview = CockpitOverview;'
+);
+
+class HTMLElement {}
+const context = {
+  console,
+  customElements: { define() {} },
+  document: { querySelector() { return null; } },
+  HTMLElement,
+  window: {},
+};
+context.globalThis = context;
+vm.runInNewContext(source, context, { filename: componentPath });
+
+const overview = new context.CockpitOverview();
+const format = (value) => String(value);
+
+function renderBridge(overrides) {
+  overview._data = {
+    roi: {
+      roi: {
+        total_events: 1,
+        net_saved_tokens: 100,
+        saved_usd: 0.25,
+        chain_valid: true,
+        signed: true,
+        ...overrides,
+      },
+      trend: [],
+    },
+  };
+  return overview._verifiedBridge(format, format, format);
+}
+
+const verified = renderBridge({});
+if (!verified.includes('<span class="tag tg">verified</span>')) {
+  throw new Error('valid signed ledger is not labelled verified');
+}
+if (!verified.includes('net tokens saved')) {
+  throw new Error('ledger total is not identified as net savings');
+}
+if (!verified.includes('separate measured ledger')) {
+  throw new Error('ledger scope is not distinguished from the estimate');
+}
+
+const broken = renderBridge({ chain_valid: false });
+if (!broken.includes('<span class="tag td">chain BROKEN</span>')) {
+  throw new Error('broken ledger chain is still presented as verified');
+}
+
+const unsigned = renderBridge({ signed: false });
+if (!unsigned.includes('<span class="tag ty">unsigned</span>')) {
+  throw new Error('unsigned ledger is still presented as verified');
+}
+
+console.log('PASS: Overview bridge reflects ledger verification state');


### PR DESCRIPTION
## Summary

- render the Overview bridge as `verified` only when the ROI ledger is both chain-valid and signed
- show explicit `chain BROKEN` and `unsigned` states for non-verified ledger payloads
- clarify that the bridge value is net token savings from a separate measured ledger
- add frontend regression coverage for verified, broken-chain, and unsigned states

Closes #1175

## Tests

- `node src/dashboard/static/tests/cockpit-overview.test.js`
- all dashboard static JS tests under `src/dashboard/static/tests/*.test.js`

## Notes

- `cargo test --lib dashboard::tests -- --test-threads=1 --nocapture` was attempted from the original workspace and failed on an unrelated dashboard test environment issue: project root `/home/E117506` collides with the global data directory, then subsequent tests cascade from a poisoned `ENV_LOCK`.
