### PR TITLE
fix(dashboard): ignore broken ancestor gitfiles

### DIFF
--- a/rust/LOCK_ORDERING.md
+++ b/rust/LOCK_ORDERING.md
@@ -82,17 +82,18 @@ All `std::sync::Mutex` unless noted otherwise.
 | L69 | `DASHBOARD_PROJECT` | `core/runtime_flags.rs:10` | `OnceLock<Mutex<Option<String>>>` | Caches the active project name for dashboard display; independent leaf lock, never nested |
 | L70 | `ALLOW_PATHS` | `core/runtime_flags.rs:11` | `OnceLock<Mutex<Vec<PathBuf>>>` | Runtime-configured additional allowed paths for PathJail; independent leaf lock, never nested |
 | L71 | `GRPC_TASK` | `core/ocla/grpc_bridge.rs:20` | `OnceLock<Mutex<Option<JoinHandle<()>>>>` | Handle to the spawned OCLA gRPC listener task, checked/replaced by `start_grpc_server`/`stop_grpc_server`; critical section never spans an `.await`, independent leaf lock, never nested |
-| L72 | `IDENTITY_LEDGER` | `core/context_kernel/proxy_bridge.rs:13` | `OnceLock<Mutex<IdentityLedger>>` | Per-user identity tracking in the proxy-to-kernel bridge; independent leaf lock, never nested |
-| L73 | `ETPAO_TRACKER` | `core/context_kernel/proxy_bridge.rs:14` | `OnceLock<Mutex<EtpaoLive>>` | ETPAO efficiency tracking for proxy requests; independent leaf lock, never nested |
-| L74 | `CHAIN` | `core/context_kernel/receipt_chain.rs:37` | `OnceLock<Mutex<ReceiptChain>>` | Evidence chain for context delivery lifecycles; independent leaf lock, never nested |
+| L72 | `IDENTITY_LEDGER` | `core/context_kernel/proxy_bridge.rs:13` | `OnceLock<Mutex<IdentityLedger>>` | Per-user identity tracking in the proxy-to-kernel bridge; updated after proxy ETPAO tracking, independent leaf lock |
+| L73 | `ETPAO_TRACKER` | `core/context_kernel/proxy_bridge.rs:14` | `OnceLock<Mutex<EtpaoLive>>` | ETPAO efficiency tracking for proxy requests; locked and released before `IDENTITY_LEDGER` |
+| L74 | `CHAIN` | `core/context_kernel/receipt_chain.rs:37` | `OnceLock<Mutex<ReceiptChain>>` | Evidence chain for context delivery lifecycles and monotonic ids; independent leaf lock, never nested |
 | L75 | `RECEIPTS` | `core/context_kernel/mcp_receipt.rs:46` | `OnceLock<Mutex<McpReceiptStore>>` | Receipt recording and honest accounting for MCP tool calls; independent leaf lock, never nested |
-| L76 | `DEDUP` | `core/context_kernel/dedup_wiring.rs:8` | `OnceLock<Mutex<ContextDedup>>` | Global content-deduplication cache for context delivery hot paths; independent leaf lock, never nested |
-| L77 | `SEEN_PATHS` | `core/context_kernel/dedup_wiring.rs:9` | `OnceLock<Mutex<HashSet<String>>>` | Tracks previously-seen file paths for dedup modified-vs-fresh distinction; independent leaf lock, never nested |
-| L78 | `MCP_ETPAO` | `core/context_kernel/mcp_bridge.rs:12` | `OnceLock<Mutex<EtpaoLive>>` | ETPAO efficiency tracking for MCP tool calls; independent leaf lock, never nested |
-| L79 | `MCP_IDENTITY` | `core/context_kernel/mcp_bridge.rs:13` | `OnceLock<Mutex<IdentityLedger>>` | Per-user identity tracking for MCP clients; independent leaf lock, never nested |
-| L80 | `SAVINGS` | `core/context_kernel/schema_wiring.rs:47` | `OnceLock<Mutex<SavingsState>>` | Cumulative schema optimization savings tracking; independent leaf lock, never nested |
-| L81 | `NORMALIZER` | `core/context_kernel/usage_normalizer.rs:73` | `OnceLock<Mutex<SessionUsage>>` | Session-level token usage aggregation from canonical envelopes; independent leaf lock, never nested |
-| L82 | `FEATURES` | `core/context_kernel/kernel_config.rs:47` | `OnceLock<Mutex<KernelFeatures>>` | Central runtime feature toggles for all kernel modules; independent leaf lock, never nested |
+| L76 | `DEDUP` | `core/context_kernel/dedup_wiring.rs:8` | `OnceLock<Mutex<ContextDedup>>` | Global content-deduplication cache for context delivery hot paths; acquired before `SEEN_PATHS`/`STATS` in reset paths |
+| L77 | `SEEN_PATHS` | `core/context_kernel/dedup_wiring.rs:9` | `OnceLock<Mutex<HashSet<String>>>` | Tracks previously seen file paths for dedup modified-vs-fresh distinction; may be touched after `DEDUP` |
+| L78 | `STATS` | `core/context_kernel/dedup_wiring.rs:10` | `OnceLock<Mutex<DedupStats>>` | Cumulative content-deduplication counters; may be reset after `DEDUP` and `SEEN_PATHS` |
+| L79 | `MCP_ETPAO` | `core/context_kernel/mcp_bridge.rs:12` | `OnceLock<Mutex<EtpaoLive>>` | ETPAO efficiency tracking for MCP tool calls; locked and released before `MCP_IDENTITY` |
+| L80 | `MCP_IDENTITY` | `core/context_kernel/mcp_bridge.rs:13` | `OnceLock<Mutex<IdentityLedger>>` | Per-user identity tracking for MCP clients; independent leaf lock |
+| L81 | `SAVINGS` | `core/context_kernel/schema_wiring.rs:47` | `OnceLock<Mutex<SavingsState>>` | Cumulative schema optimization savings tracking; independent leaf lock, never nested |
+| L82 | `NORMALIZER` | `core/context_kernel/usage_normalizer.rs:73` | `OnceLock<Mutex<SessionUsage>>` | Session-level token usage aggregation from canonical envelopes; independent leaf lock, never nested |
+| L83 | `FEATURES` | `core/context_kernel/kernel_config.rs:47` | `OnceLock<Mutex<KernelFeatures>>` | Central runtime feature toggles for all kernel modules; independent leaf lock, never nested |
 
 ### Test / Environment Locks (serialise env-var mutations)
 

--- a/rust/src/core/context_kernel/activation_e2e.rs
+++ b/rust/src/core/context_kernel/activation_e2e.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::dedup_wiring::{self, DedupAction};
     use super::super::envelope_wiring;

--- a/rust/src/core/context_kernel/envelope_e2e.rs
+++ b/rust/src/core/context_kernel/envelope_e2e.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::accounting_fix;
     use super::super::live_dashboard;

--- a/rust/src/core/context_kernel/envelope_wiring.rs
+++ b/rust/src/core/context_kernel/envelope_wiring.rs
@@ -124,7 +124,7 @@ pub fn reset_evidence() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::{
         EvidenceSummary, evidence_summary, process_mcp_evidence, process_proxy_evidence,

--- a/rust/src/core/context_kernel/kernel_config.rs
+++ b/rust/src/core/context_kernel/kernel_config.rs
@@ -133,7 +133,7 @@ mod tests {
         KernelFeatures, features, from_env, is_enabled, is_feature_enabled, reset_features,
         update_features,
     };
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     fn setup() -> MutexGuard<'static, ()> {
         let guard = super::KERNEL_TEST_LOCK

--- a/rust/src/dashboard/routes/helpers.rs
+++ b/rust/src/dashboard/routes/helpers.rs
@@ -172,10 +172,47 @@ fn promote_to_git_root(path: &str) -> String {
 fn git_root_for(path: &str) -> Option<String> {
     let mut p = Path::new(path);
     loop {
-        let git = p.join(".git");
-        if git.exists() {
+        if is_valid_git_boundary(&p.join(".git")) {
             return Some(p.to_string_lossy().to_string());
         }
         p = p.parent()?;
     }
+}
+
+fn is_valid_git_boundary(git: &Path) -> bool {
+    const MAX_GITFILE_BYTES: u64 = 4096;
+
+    let Ok(metadata) = git.metadata() else {
+        return false;
+    };
+    if metadata.is_dir() {
+        return true;
+    }
+    if !metadata.is_file() || metadata.len() > MAX_GITFILE_BYTES {
+        return false;
+    }
+
+    let Ok(contents) = std::fs::read_to_string(git) else {
+        return false;
+    };
+    let Some(gitdir) = contents
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix("gitdir:"))
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    else {
+        return false;
+    };
+    let gitdir = Path::new(gitdir);
+    let target = if gitdir.is_absolute() {
+        gitdir.to_path_buf()
+    } else {
+        let Some(parent) = git.parent() else {
+            return false;
+        };
+        parent.join(gitdir)
+    };
+
+    target.is_dir()
 }

--- a/rust/src/dashboard/tests.rs
+++ b/rust/src/dashboard/tests.rs
@@ -22,6 +22,44 @@ fn dashboard_project_root_honors_general_env_override() {
 }
 
 #[test]
+fn dashboard_project_root_ignores_broken_ancestor_gitfile() {
+    let _g = ENV_LOCK.lock().expect("env lock");
+    let td = tempdir().expect("tempdir");
+    let workspace = td.path().join("workspace");
+    let root = workspace.join("project");
+    std::fs::create_dir_all(&root).expect("mkdir");
+    std::fs::write(workspace.join(".git"), "gitdir: ../missing/git-dir\n").expect("write gitfile");
+    let root_s = root.to_string_lossy().to_string();
+
+    crate::test_env::remove_var("LEAN_CTX_DASHBOARD_PROJECT");
+    crate::test_env::set_var("LEAN_CTX_PROJECT_ROOT", &root_s);
+    let detected = detect_project_root_for_dashboard();
+    crate::test_env::remove_var("LEAN_CTX_PROJECT_ROOT");
+
+    assert_eq!(detected, root_s);
+}
+
+#[test]
+fn dashboard_project_root_honors_resolvable_ancestor_gitfile() {
+    let _g = ENV_LOCK.lock().expect("env lock");
+    let td = tempdir().expect("tempdir");
+    let checkout = td.path().join("checkout");
+    let root = checkout.join("nested");
+    std::fs::create_dir_all(&root).expect("mkdir checkout");
+    std::fs::create_dir(td.path().join("git-data")).expect("mkdir gitdir");
+    std::fs::write(checkout.join(".git"), "gitdir: ../git-data\n").expect("write gitfile");
+    let root_s = root.to_string_lossy().to_string();
+    let checkout_s = checkout.to_string_lossy().to_string();
+
+    crate::test_env::remove_var("LEAN_CTX_DASHBOARD_PROJECT");
+    crate::test_env::set_var("LEAN_CTX_PROJECT_ROOT", &root_s);
+    let detected = detect_project_root_for_dashboard();
+    crate::test_env::remove_var("LEAN_CTX_PROJECT_ROOT");
+
+    assert_eq!(detected, checkout_s);
+}
+
+#[test]
 fn check_auth_with_valid_bearer() {
     let req = "GET /api/stats HTTP/1.1\r\nAuthorization: Bearer lctx_abc123\r\n\r\n";
     assert!(check_auth(req, "lctx_abc123"));


### PR DESCRIPTION
## Summary
- validate `.git` boundaries before dashboard project-root promotion
- ignore broken ancestor gitfiles instead of promoting explicit project roots to home
- preserve promotion for valid gitfile worktrees

Fixes #1178

## Test plan
- [x] `cargo test dashboard_project_root_ --lib`
- [x] `rustfmt --edition 2024 --check src/dashboard/routes/helpers.rs src/dashboard/tests.rs`
- [x] `git diff --check`
- [ ] `cd rust && cargo test -- --test-threads=1`
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`

Note: after rebasing onto current `upstream/main`, a repeat of the targeted cargo test was canceled after it stayed in the build phase for an extended period on the local machine. The same targeted test passed on the clean branch immediately before the rebase, and the rebase applied cleanly without changing the patch.
