### PR TITLE
fix(dashboard): clarify context telemetry provenance

### DIFF
--- a/rust/src/core/context_kernel/activation_e2e.rs
+++ b/rust/src/core/context_kernel/activation_e2e.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::dedup_wiring::{self, DedupAction};
     use super::super::envelope_wiring;

--- a/rust/src/core/context_kernel/envelope_e2e.rs
+++ b/rust/src/core/context_kernel/envelope_e2e.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::accounting_fix;
     use super::super::live_dashboard;

--- a/rust/src/core/context_kernel/envelope_wiring.rs
+++ b/rust/src/core/context_kernel/envelope_wiring.rs
@@ -124,7 +124,7 @@ pub fn reset_evidence() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::{
         EvidenceSummary, evidence_summary, process_mcp_evidence, process_proxy_evidence,

--- a/rust/src/core/context_kernel/kernel_config.rs
+++ b/rust/src/core/context_kernel/kernel_config.rs
@@ -133,7 +133,7 @@ mod tests {
         KernelFeatures, features, from_env, is_enabled, is_feature_enabled, reset_features,
         update_features,
     };
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     fn setup() -> MutexGuard<'static, ()> {
         let guard = super::KERNEL_TEST_LOCK

--- a/rust/src/core/context_radar.rs
+++ b/rust/src/core/context_radar.rs
@@ -407,10 +407,20 @@ pub fn default_window_for_client(client: &str) -> usize {
     if let Some((_model, window)) = crate::hook_handlers::load_detected_model() {
         return window;
     }
-    match client.to_lowercase().as_str() {
-        "gemini" => 1_000_000,
-        "windsurf" | "zed" | "copilot" => 128_000,
-        _ => 200_000,
+    client_default_window(client)
+}
+
+fn client_default_window(client: &str) -> usize {
+    let client = client.to_lowercase();
+    if client.contains("gemini") {
+        1_000_000
+    } else if ["windsurf", "zed", "copilot"]
+        .iter()
+        .any(|name| client.contains(name))
+    {
+        128_000
+    } else {
+        200_000
     }
 }
 
@@ -486,6 +496,12 @@ mod tests {
         let display = radar.format_display();
         assert!(display.contains("CONTEXT RADAR"));
         assert!(display.contains("200k"));
+    }
+
+    #[test]
+    fn client_default_window_recognizes_composite_ids() {
+        assert_eq!(client_default_window("vscode-copilot"), 128_000);
+        assert_eq!(client_default_window("github-copilot/1.2"), 128_000);
     }
 
     #[test]

--- a/rust/src/dashboard/routes/context/aggregated.rs
+++ b/rust/src/dashboard/routes/context/aggregated.rs
@@ -111,6 +111,45 @@ fn capabilities() -> (&'static str, &'static str, String) {
     ("200 OK", "application/json", json)
 }
 
+pub(super) fn resolve_context_model(
+    introspect: &serde_json::Value,
+    client_id: &str,
+) -> (String, usize, &'static str) {
+    let proxy_model = (introspect
+        .get("proxy_active")
+        .and_then(serde_json::Value::as_bool)
+        == Some(true))
+    .then(|| {
+        introspect
+            .get("last_breakdown")?
+            .get("model")?
+            .as_str()
+            .map(str::trim)
+            .filter(|model| {
+                !model.is_empty()
+                    && !model.eq_ignore_ascii_case("unknown")
+                    && !model.to_ascii_lowercase().starts_with("model-")
+            })
+    })
+    .flatten();
+
+    if let Some(model) = proxy_model {
+        return (
+            model.to_string(),
+            crate::core::model_registry::context_window_for_model(model),
+            "proxy_request",
+        );
+    }
+    if let Some((model, window)) = crate::hook_handlers::load_detected_model() {
+        return (model, window, "hook_detected");
+    }
+    (
+        "unknown".to_string(),
+        crate::core::context_radar::default_window_for_client(client_id),
+        "client_default",
+    )
+}
+
 /// Merges introspect + radar + events + model + bounce.
 fn history() -> (&'static str, &'static str, String) {
     let persisted = crate::proxy::introspect::load_persisted(300);
@@ -139,8 +178,8 @@ fn history() -> (&'static str, &'static str, String) {
         .unwrap_or_else(|_| std::path::PathBuf::from("."));
     let client_id = crate::core::client_capabilities::load_persisted(86400)
         .map_or_else(|| "cursor".to_string(), |c| c.client_id);
-    let window = crate::core::context_radar::default_window_for_client(&client_id);
-    let radar = crate::core::context_radar::ContextRadar::load(&data_dir, window);
+    let (model_name, model_window, model_source) = resolve_context_model(&introspect, &client_id);
+    let radar = crate::core::context_radar::ContextRadar::load(&data_dir, model_window);
     let breakdown = radar.budget_breakdown();
 
     let recent_events: Vec<serde_json::Value> = radar
@@ -168,12 +207,6 @@ fn history() -> (&'static str, &'static str, String) {
         .iter()
         .map(|(path, tokens)| serde_json::json!({ "path": path, "tokens": tokens }))
         .collect();
-
-    let detected = crate::hook_handlers::load_detected_model();
-    let (model_name, model_window) = detected.unwrap_or_else(|| {
-        let w = crate::core::context_radar::default_window_for_client(&client_id);
-        ("unknown".to_string(), w)
-    });
 
     let bounce = match crate::core::bounce_tracker::global().lock() {
         Ok(bt) => {
@@ -204,7 +237,7 @@ fn history() -> (&'static str, &'static str, String) {
             "model": model_name,
             "window_size": model_window,
             "client_id": client_id,
-            "source": if model_name == "unknown" { "client_default" } else { "hook_detected" },
+            "source": model_source,
         },
         "bounce": bounce,
     });

--- a/rust/src/dashboard/routes/context/diagnostics.rs
+++ b/rust/src/dashboard/routes/context/diagnostics.rs
@@ -229,18 +229,16 @@ fn transcript() -> (&'static str, &'static str, String) {
 }
 
 fn model() -> (&'static str, &'static str, String) {
-    let detected = crate::hook_handlers::load_detected_model();
     let client = crate::core::client_capabilities::load_persisted(86400)
         .map_or_else(|| "unknown".to_string(), |c| c.client_id);
-    let (model, window) = detected.unwrap_or_else(|| {
-        let w = crate::core::context_radar::default_window_for_client(&client);
-        ("unknown".to_string(), w)
-    });
+    let introspect = crate::proxy::introspect::load_persisted(300)
+        .unwrap_or_else(|| serde_json::json!({ "proxy_active": false }));
+    let (model, window, source) = super::aggregated::resolve_context_model(&introspect, &client);
     let payload = serde_json::json!({
         "model": model,
         "window_size": window,
         "client_id": client,
-        "source": if model == "unknown" { "client_default" } else { "hook_detected" },
+        "source": source,
     });
     let json = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
     ("200 OK", "application/json", json)

--- a/rust/src/dashboard/routes/memory.rs
+++ b/rust/src/dashboard/routes/memory.rs
@@ -106,6 +106,8 @@ fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str
                         })
                 })
                 .unwrap_or_default();
+            let session_stats =
+                serde_json::to_value(&session.stats).unwrap_or_else(|_| serde_json::json!({}));
             let global = crate::core::stats::load_for_display();
             let g_cmds = global.total_commands;
             let g_input = global.total_input_tokens;
@@ -128,7 +130,12 @@ fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str
                     session.updated_at = utc;
                 }
             }
-            let json = serde_json::to_string(&session)
+            let mut payload =
+                serde_json::to_value(&session).unwrap_or_else(|_| serde_json::json!({}));
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("session_stats".to_string(), session_stats);
+            }
+            let json = serde_json::to_string(&payload)
                 .unwrap_or_else(|_| "{\"error\":\"failed to serialize session\"}".to_string());
             Some(("200 OK", "application/json", json))
         }

--- a/rust/src/dashboard/static/components/cockpit-context.js
+++ b/rust/src/dashboard/static/components/cockpit-context.js
@@ -91,6 +91,30 @@ function normalizeLedgerEntries(items) {
   );
 }
 
+function contextScopeLabel(measured, logicalSessionCount) {
+  if (measured && logicalSessionCount === 0) {
+    return 'measured recent request \u00b7 no active editor';
+  }
+  if (measured && Number.isInteger(logicalSessionCount) && logicalSessionCount > 1) {
+    return 'measured latest request \u00b7 ' + logicalSessionCount + ' editor sessions';
+  }
+  if (measured) return 'measured latest request';
+  if (!Number.isInteger(logicalSessionCount)) return 'shared estimate';
+  if (logicalSessionCount === 0) return 'no active editor session';
+  return logicalSessionCount + ' editor session' +
+    (logicalSessionCount === 1 ? '' : 's') + ' \u00b7 shared estimate';
+}
+
+function contextUsage(exact, proxyInputTokens, visibleTokens, windowSize) {
+  const candidate = exact ? proxyInputTokens : visibleTokens;
+  const total = Math.max(0, Number(candidate) || 0);
+  const windowTokens = Math.max(0, Number(windowSize) || 0);
+  return {
+    total,
+    utilization: windowTokens > 0 ? Math.min(1, total / windowTokens) : 0,
+  };
+}
+
 class CockpitContext extends HTMLElement {
   constructor() {
     super();
@@ -118,7 +142,7 @@ class CockpitContext extends HTMLElement {
     const fetch1 = p => fetchJson(p, { timeoutMs: 12000 }).catch(e => ({ __error: e?.error || String(e), __path: p }));
     const ok = r => r && !r.__error;
 
-    const [summary, capabilities, hist, control, overlayHist, plan, pipeline, intent, session, handles, transcript] = await Promise.all([
+    const [summary, capabilities, hist, control, overlayHist, plan, pipeline, intent, session, handles, agents, transcript] = await Promise.all([
       fetch1('/api/context-summary'),
       fetch1('/api/context-capabilities'),
       fetch1('/api/context-history'),
@@ -129,6 +153,7 @@ class CockpitContext extends HTMLElement {
       fetch1('/api/intent'),
       fetch1('/api/session'),
       fetch1('/api/context-handles'),
+      fetch1('/api/agents'),
       fetch1('/api/context-transcript'),
     ]);
 
@@ -161,6 +186,7 @@ class CockpitContext extends HTMLElement {
       handles: ok(handles) ? handles : null,
       contextEvents: Array.isArray(h.events) ? h.events : null,
       modelInfo: h.model || null,
+      agentPresence: ok(agents) ? agents : null,
       transcript: ok(transcript) ? transcript : null,
     };
     if (this._data.history && !Array.isArray(this._data.history)) this._data.history = [];
@@ -232,24 +258,31 @@ class CockpitContext extends HTMLElement {
     const rulesTok = (radar?.rules?.total_tokens) || 0;
     const filesTok = entries.reduce((s, e) => s + (e.sent_tokens || 0), 0);
 
-    // Utilization precedence: exact proxy counts > backend pressure (ledger-
-    // based, ignores transcript noise) > local sum. The raw transcript can
-    // exceed the window (the IDE summarizes old messages), which would pin a
-    // naive estimate at 100% while the triage line below says "Healthy".
-    const estTotal = proxyActive && pb ? (pb.total_input_tokens || 0) : (rulesTok + filesTok + chatTok);
-    const backendUtil = typeof pressure?.utilization === 'number' ? pressure.utilization : null;
-    const util = proxyActive && pb
-      ? Math.min(1, estTotal / win)
-      : (backendUtil ?? Math.min(1, estTotal / win));
+    // Only proxy introspection measures an actual LLM request. Without it,
+    // show the share of the assumed window represented by visible telemetry;
+    // ledger pressure is a separate, historical file-management signal.
+    const exact = proxyActive && !!pb;
+    const usage = contextUsage(
+      exact,
+      pb?.total_input_tokens,
+      rulesTok + filesTok + chatTok,
+      win
+    );
+    const estTotal = usage.total;
+    const util = usage.utilization;
     const pctUsed = Math.round(util * 100);
     const col = gaugeColor(util);
+    const scopeLabel = contextScopeLabel(
+      exact,
+      this._data.agentPresence?.logical_session_count
+    );
 
     const ideName = clientId === 'unknown' ? 'Unknown IDE' : esc(clientId.charAt(0).toUpperCase() + clientId.slice(1));
     const hookTiers = { cursor: 1, claude: 2, windsurf: 3, codex: 4, copilot: 4, gemini: 4 };
     const tierKey = Object.keys(hookTiers).find(k => (clientId || '').toLowerCase().includes(k));
     const tier = tierKey ? hookTiers[tierKey] : 5;
 
-    const st = session?.stats ?? {};
+    const st = session?.session_stats ?? session?.stats ?? {};
     const tokSaved = st.total_tokens_saved || 0;
     const tokInput = st.total_tokens_input || 0;
     const comprPct = tokInput > 0 ? Math.round(tokSaved / tokInput * 100) : 0;
@@ -257,12 +290,19 @@ class CockpitContext extends HTMLElement {
     let h = '<div class="card" style="margin-bottom:16px">';
 
     // Header row: Model + progress bar
-    h += '<div style="display:flex;align-items:center;gap:16px;margin-bottom:12px">';
+    h += '<div style="display:flex;align-items:center;flex-wrap:wrap;gap:16px;margin-bottom:12px">';
+    const modelBadge = modelSource === 'proxy_request'
+      ? 'latest proxy request'
+      : modelSource === 'hook_detected' ? 'recent hook' : 'client default';
     if (detectedModel) {
       h += '<div style="font-size:20px;font-weight:700">' + esc(detectedModel) + '</div>';
-      h += '<span class="badge" style="font-size:9px">' + (modelSource === 'hook_detected' ? 'auto-detected' : 'default') + '</span>';
+      h += '<span class="badge" style="font-size:9px">' + modelBadge + '</span>';
     }
-    h += '<div style="margin-left:auto;font-size:13px;color:var(--muted)">' + fmtTok(win) + ' context window</div>';
+    h += '<span class="badge" style="font-size:9px">' + esc(scopeLabel) + '</span>';
+    const windowLabel = modelSource === 'proxy_request'
+      ? 'registered model window'
+      : modelSource === 'hook_detected' ? 'detected window' : 'assumed window';
+    h += '<div style="margin-left:auto;font-size:13px;color:var(--muted)">' + fmtTok(win) + ' ' + windowLabel + '</div>';
     h += '</div>';
 
     // Progress bar
@@ -298,17 +338,19 @@ class CockpitContext extends HTMLElement {
     const hookLabel = hookLabels[tier] || 'MCP Only';
     const hookCol = tier <= 2 ? 'var(--green)' : tier <= 3 ? 'var(--yellow)' : 'var(--muted)';
 
+    const contextLabel = exact ? 'Context' : 'Tracked';
+    const contextPrefix = exact ? '' : '\u2248';
     h += cell('IDE', ideName, hookLabel, hookCol);
-    h += cell('Context', (proxyActive ? '' : '\u2248') + pctUsed + '%', fmtTok(Math.round(util * win)) + ' / ' + fmtTok(win), col);
-    h += cell('Files', String(entries.length), fmtTok(filesTok) + ' tokens');
-    h += cell('Saved', fmtTok(tokSaved), comprPct + '% compression', 'var(--green)');
-    h += cell('Tool Calls', ff(st.total_tool_calls || 0), ff(st.files_read || 0) + ' reads');
+    h += cell(contextLabel, contextPrefix + pctUsed + '%', fmtTok(estTotal) + ' / ' + fmtTok(win), col);
+    h += cell('Files Shown', String(entries.length), fmtTok(filesTok) + ' tokens');
+    h += cell('Saved', fmtTok(tokSaved), 'session \u00b7 ' + comprPct + '% compression', 'var(--green)');
+    h += cell('Tool Calls', ff(st.total_tool_calls || 0), 'session \u00b7 ' + ff(st.files_read || 0) + ' reads');
     h += '</div>';
 
     // Breakdown table
     if (proxyActive && pb) {
       h += '<div style="font-size:11px;color:var(--muted);margin-bottom:8px">';
-      h += '<span class="badge" style="background:#10b981;color:#fff;font-size:9px;margin-right:6px">PROXY</span>Exact counts from LLM API request.</div>';
+      h += '<span class="badge" style="background:#10b981;color:#fff;font-size:9px;margin-right:6px">PROXY</span>Measured counts from latest LLM API request.</div>';
       const cats = [
         { l: 'System prompt', t: pb.system_prompt_tokens || 0, c: '#6b7280' },
         { l: 'Tools', t: pb.tool_definition_tokens || 0, c: '#8b5cf6' },
@@ -373,10 +415,9 @@ class CockpitContext extends HTMLElement {
 
   // Maps the backend pressure band to a concrete operator action.
   _renderTriageBanner(esc, pressure, util, exact) {
-    // Prefer the backend recommendation; fall back to the local utilization band.
-    // With exact proxy counts the hero already shows the authoritative number,
-    // so the triage band must use the same value or the card contradicts itself.
-    const rec = pressure?.recommendation || '';
+    // Measured proxy tokens describe the request. Otherwise this banner reports
+    // the ledger's historical pressure heuristic, not model-window occupancy.
+    const rec = exact ? '' : (pressure?.recommendation || '');
     const u = exact ? util
       : (typeof pressure?.utilization === 'number' ? pressure.utilization : util);
     let band;
@@ -395,7 +436,7 @@ class CockpitContext extends HTMLElement {
     }
     let h = '<div style="margin-top:12px;display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;background:var(--surface);border-left:3px solid ' + band.color + '">';
     h += '<span style="color:' + band.color + ';font-size:13px">' + band.icon + '</span>';
-    h += '<div style="font-size:12px"><strong style="color:' + band.color + '">' + band.label + ' \u00b7 ' + Math.round(u * 100) + '%</strong>';
+    h += '<div style="font-size:12px"><strong style="color:' + band.color + '">' + band.label + ' \u00b7 ' + (exact ? 'measured request / window ' : 'historical ledger pressure ') + Math.round(u * 100) + '%</strong>';
     h += '<span style="color:var(--muted);margin-left:8px">' + esc(band.action) + '</span></div>';
     h += '</div>';
     return h;

--- a/rust/src/dashboard/static/components/cockpit-nav.js
+++ b/rust/src/dashboard/static/components/cockpit-nav.js
@@ -56,7 +56,7 @@ const COCKPIT_NAV_SECTIONS = [
     area: 'context',
     items: [
       { id: 'commander', label: 'Context Triage', desc: 'Context-window pressure and what to trim — your to-do list.' },
-      { id: 'context', label: 'Context Contents', desc: 'Everything currently loaded into the model context.' },
+      { id: 'context', label: 'Context Contents', desc: 'Best available estimate; request tokens are measured when proxy telemetry is active.' },
       { id: 'live', label: 'Live Activity', desc: 'What lean-ctx is doing right now.' },
       { id: 'compression', label: 'Compression Lab', desc: 'Which files and read modes saved the most tokens.' },
       { id: 'settings', label: 'Quick Settings', desc: 'Flip compression, tool profile, structure-first and terse from the UI.' },

--- a/rust/src/dashboard/static/lib/router.js
+++ b/rust/src/dashboard/static/lib/router.js
@@ -146,7 +146,7 @@ const ROUTE_DESCRIPTIONS = {
   learning: 'How your savings and efficiency change over time.',
   leaderboard: 'Submit your tokens saved to the community leaderboard.',
   commander: 'Context-window pressure and what to trim — your to-do list.',
-  context: 'Everything currently loaded into the model context.',
+  context: 'Best available estimate; request tokens are measured when proxy telemetry is active.',
   live: 'What lean-ctx is doing right now.',
   knowledge: 'Facts lean-ctx has learned about your project.',
   deps: 'How your modules depend on each other.',

--- a/rust/src/dashboard/static/lib/shared.js
+++ b/rust/src/dashboard/static/lib/shared.js
@@ -438,17 +438,17 @@
   registerValueLabelPlugin();
 
   var TIPS = {
-    token_budget: 'Percentage of context window currently in use. Green means plenty of headroom.',
+    token_budget: 'Best available tracked-token share of the reported window. Proxy telemetry measures the latest request.',
     tokens_saved: 'Total tokens saved across all tool calls \u2013 difference between input and output tokens.',
     compression: 'Overall compression rate \u2013 percentage of input tokens that were saved.',
-    pressure: 'Action recommendation based on current token budget utilization.',
-    token_pressure: 'Remaining vs. total token budget with visual fill indicator.',
+    pressure: 'Action recommendation from the persisted lean-ctx ledger, not active model-window occupancy.',
+    token_pressure: 'Persisted ledger tokens versus its configured budget, with a visual fill indicator.',
     mode_distribution: 'Distribution of read modes used: full, map, signatures, aggressive, etc.',
-    context_radar: 'Shows how your context window is currently filled. Token estimates are based on IDE hook events and rule file scans.',
-    context_items: 'Files currently loaded in the context window with their mode, token count, and compression details.',
+    context_radar: 'Shared telemetry estimate from hooks and rule scans; proxy mode measures the latest request.',
+    context_items: 'Files retained in the lean-ctx ledger; this does not prove an IDE currently includes them.',
     overlays: 'Manual context adjustments \u2013 pinned, excluded, or view-mode-changed files. Use the actions in the table above to add overlays.',
     context_plan: 'Auto-generated loading plan: which files to include with which compression mode.',
-    session: 'Current session with tool calls, token savings, and project metadata. Stats are live-merged with global counters.',
+    session: 'Most recent persisted session with tool calls, token savings, and project metadata. Some views merge global counters.',
     pipeline: 'Compression pipeline layers and their input/output token throughput.',
     active_intent: 'Auto-detected task type and target files based on recent tool activity.',
     overlay_history: 'Chronological log of all manual overlay operations in this project.',

--- a/rust/src/dashboard/static/tests/cockpit-context.test.js
+++ b/rust/src/dashboard/static/tests/cockpit-context.test.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for context telemetry scope labels.
+ * Run with: node rust/src/dashboard/static/tests/cockpit-context.test.js
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const componentPath = path.join(__dirname, '..', 'components', 'cockpit-context.js');
+const source = fs.readFileSync(componentPath, 'utf8').replace(
+  'export { CockpitContext };',
+  'globalThis.CockpitContext = CockpitContext; globalThis.contextScopeLabel = contextScopeLabel; globalThis.contextUsage = contextUsage;'
+);
+
+class HTMLElement {}
+const context = {
+  console,
+  customElements: { define() {} },
+  document: { querySelector() { return null; } },
+  HTMLElement,
+  window: {},
+};
+context.globalThis = context;
+vm.runInNewContext(source, context, { filename: componentPath });
+
+const label = context.contextScopeLabel;
+const cases = [
+  [true, undefined, 'measured latest request'],
+  [true, 0, 'measured recent request \u00b7 no active editor'],
+  [true, 4, 'measured latest request \u00b7 4 editor sessions'],
+  [false, undefined, 'shared estimate'],
+  [false, 0, 'no active editor session'],
+  [false, 1, '1 editor session \u00b7 shared estimate'],
+  [false, 3, '3 editor sessions \u00b7 shared estimate'],
+];
+
+for (const [measured, count, expected] of cases) {
+  const actual = label(measured, count);
+  if (actual !== expected) {
+    throw new Error(`scope label mismatch: expected "${expected}", got "${actual}"`);
+  }
+}
+
+const estimated = context.contextUsage(false, 190000, 12000, 128000);
+if (estimated.total !== 12000 || estimated.utilization !== 0.09375) {
+  throw new Error('shared estimate did not use visible telemetry');
+}
+
+const measured = context.contextUsage(true, 64000, 12000, 128000);
+if (measured.total !== 64000 || measured.utilization !== 0.5) {
+  throw new Error('measured request did not use proxy telemetry');
+}
+
+console.log('PASS: Context telemetry distinguishes measured requests and shared estimates');

--- a/rust/src/dashboard/tests.rs
+++ b/rust/src/dashboard/tests.rs
@@ -94,6 +94,62 @@ fn api_path_detection() {
 }
 
 #[test]
+fn api_session_exposes_unmodified_session_stats() {
+    let _guard = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _iso = crate::core::data_dir::isolated_data_dir();
+
+    let (status, _content_type, body) =
+        routes::route_response("/api/session", "", None, None, true, "GET", "");
+    assert_eq!(status, "200 OK");
+
+    let payload: serde_json::Value = serde_json::from_str(&body).expect("session JSON");
+    assert!(payload["session_stats"].is_object());
+    assert_eq!(payload["session_stats"]["total_tool_calls"], 0);
+}
+
+#[test]
+fn context_endpoints_pair_proxy_model_with_its_window() {
+    let _guard = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let iso = crate::core::data_dir::isolated_data_dir();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let snapshot = serde_json::json!({
+        "ts": now,
+        "proxy_active": true,
+        "last_breakdown": {
+            "model": "gpt-5.5",
+            "total_input_tokens": 64_000
+        }
+    });
+    std::fs::write(
+        iso.path().join("proxy-introspect.json"),
+        snapshot.to_string(),
+    )
+    .expect("proxy snapshot");
+
+    for path in ["/api/context-history", "/api/context-model"] {
+        let (status, _content_type, body) =
+            routes::route_response(path, "", None, None, true, "GET", "");
+        assert_eq!(status, "200 OK");
+        let payload: serde_json::Value = serde_json::from_str(&body).expect("context JSON");
+        let model = if path == "/api/context-history" {
+            &payload["model"]
+        } else {
+            &payload
+        };
+        assert_eq!(model["model"], "gpt-5.5");
+        assert_eq!(model["window_size"], 1_048_576);
+        assert_eq!(model["source"], "proxy_request");
+    }
+}
+
+#[test]
 fn dashboard_responding_true_for_lean_ctx_version_endpoint() {
     use std::io::{Read, Write};
     use std::net::TcpListener;


### PR DESCRIPTION
## Summary
- distinguish measured proxy request tokens from shared dashboard estimates
- align context model/window resolution across history and diagnostics endpoints
- expose unmerged session stats for dashboard context rendering

## Tests
- node rust/src/dashboard/static/tests/cockpit-context.test.js
- node rust/src/dashboard/static/tests/cockpit-commander.test.js
- node rust/src/dashboard/static/tests/cockpit-compression.test.js
- node --check rust/src/dashboard/static/components/cockpit-context.js
- cargo test client_default_window_recognizes_composite_ids --lib
- cargo test api_session_exposes_unmodified_session_stats --lib
- cargo test context_endpoints_pair_proxy_model_with_its_window --lib
- cargo clippy --all-features -- -D warnings
- cargo fmt --check
- git diff --check

Fixes #1174