### PR TITLE
fix(shell): settle the ctx_shell long-running command lifecycle

### DIFF
--- a/rust/src/server/background_shell.rs
+++ b/rust/src/server/background_shell.rs
@@ -31,6 +31,9 @@ struct Job {
 
 static JOBS: LazyLock<Mutex<HashMap<String, Job>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// How often a foreground run reports progress to the MCP client (#1173).
+const TICK: Duration = Duration::from_secs(5);
+
 fn prune_finished_jobs(jobs: &mut HashMap<String, Job>, now: Instant) {
     prune_finished_jobs_with_limits(
         jobs,
@@ -131,6 +134,12 @@ pub fn start(
             &extra_env,
             timeout_ms,
             Some(&worker_cancel),
+            // #1113/#1173: a managed job is bounded by output, not wall clock —
+            // a monitor loop emitting a line every 45s must survive. Applies to
+            // foreground runs too: they detach at the soft cap and become
+            // exactly such a job. Runaway output still stops the clock, because
+            // the byte cap freezes the captured length.
+            true,
         );
         let mut jobs = JOBS
             .lock()
@@ -166,15 +175,22 @@ pub enum ForegroundResult {
 /// (~120s) and hands back a task id that `background_action=status` cannot
 /// resolve. By detaching *before* that deadline we always return a real
 /// `shell_*` job id the caller can poll or cancel (#1106).
+///
+/// `on_tick` is called roughly every `TICK` while the command is still
+/// running, so the caller can emit MCP progress notifications and a 3-minute
+/// build stops being indistinguishable from a hang (#1173).
 pub fn run_foreground_or_detach(
     command: String,
     cwd: String,
     extra_env: std::collections::HashMap<String, String>,
     timeout_ms: Option<u64>,
     soft_cap: Duration,
+    on_tick: Option<&dyn Fn(Duration)>,
 ) -> ForegroundResult {
     let id = start(command, cwd, extra_env, timeout_ms);
-    let deadline = Instant::now() + soft_cap;
+    let started = Instant::now();
+    let deadline = started + soft_cap;
+    let mut next_tick = started + TICK;
     loop {
         match status(&id) {
             Some(JobState::Completed { output, exit_code }) => {
@@ -193,8 +209,15 @@ pub fn run_foreground_or_detach(
             }
             _ => {}
         }
-        if Instant::now() >= deadline {
+        let now = Instant::now();
+        if now >= deadline {
             return ForegroundResult::Detached { job_id: id };
+        }
+        if let Some(tick) = on_tick
+            && now >= next_tick
+        {
+            tick(started.elapsed());
+            next_tick = now + TICK;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
@@ -228,7 +251,9 @@ pub fn cancel(id: &str) -> Option<JobState> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ForegroundResult, JobState, cancel, run_foreground_or_detach, start, status};
+    use super::{
+        ForegroundResult, JobState, TICK, cancel, run_foreground_or_detach, start, status,
+    };
     use std::time::Duration;
 
     #[test]
@@ -300,6 +325,7 @@ mod tests {
             std::collections::HashMap::default(),
             Some(10_000),
             Duration::from_secs(10),
+            None,
         );
         match result {
             ForegroundResult::Finished { output, exit_code } => {
@@ -319,6 +345,7 @@ mod tests {
             std::collections::HashMap::default(),
             Some(10_000),
             Duration::from_millis(100),
+            None,
         );
         let ForegroundResult::Detached { job_id } = result else {
             panic!("slow command should detach");
@@ -327,6 +354,58 @@ mod tests {
         // The returned id must resolve via status — the core #1106 guarantee.
         assert!(status(&job_id).is_some());
         cancel(&job_id);
+    }
+
+    /// #1173: a `timeout_ms` far beyond the soft cap must NOT keep the command
+    /// in the foreground. Raising the cap past the MCP host's ~120s abort is
+    /// what stranded results behind an unresolvable task id; the caller must
+    /// still get a real `shell_*` job id at the cap.
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn large_timeout_ms_still_detaches_at_the_soft_cap() {
+        let result = run_foreground_or_detach(
+            "sleep 5; printf NEVER_INLINE".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(600_000),
+            Duration::from_millis(100),
+            None,
+        );
+        let ForegroundResult::Detached { job_id } = result else {
+            panic!("timeout_ms must not extend the foreground wait");
+        };
+        assert!(status(&job_id).is_some());
+        cancel(&job_id);
+    }
+
+    /// #1173: a foreground run reports progress while it waits, so a slow
+    /// command is distinguishable from a hang. Deliberately slower than the
+    /// other tests here — it has to outlive one real [`TICK`].
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn foreground_run_reports_progress_while_waiting() {
+        let ticks = std::sync::atomic::AtomicUsize::new(0);
+        let tick = |elapsed: Duration| {
+            assert!(elapsed >= TICK, "tick must report real elapsed time");
+            ticks.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        };
+        let result = run_foreground_or_detach(
+            "sleep 30".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(60_000),
+            TICK + Duration::from_millis(500),
+            Some(&tick),
+        );
+        let ForegroundResult::Detached { job_id } = result else {
+            panic!("slow command should detach");
+        };
+        cancel(&job_id);
+        assert!(
+            ticks.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+            "no progress reported during a {}s+ foreground wait",
+            TICK.as_secs()
+        );
     }
 
     #[test]

--- a/rust/src/server/background_shell.rs
+++ b/rust/src/server/background_shell.rs
@@ -134,11 +134,8 @@ pub fn start(
             &extra_env,
             timeout_ms,
             Some(&worker_cancel),
-            // #1113/#1173: a managed job is bounded by output, not wall clock —
-            // a monitor loop emitting a line every 45s must survive. Applies to
-            // foreground runs too: they detach at the soft cap and become
-            // exactly such a job. Runaway output still stops the clock, because
-            // the byte cap freezes the captured length.
+            // #1113/#1173: bounded by output, not wall clock — a monitor loop
+            // emitting a line every 45s must survive. See `idle_keyed`.
             true,
         );
         let mut jobs = JOBS

--- a/rust/src/server/call_tool.rs
+++ b/rust/src/server/call_tool.rs
@@ -1252,20 +1252,10 @@ fn is_shell_error(outcome: crate::server::tool_trait::ShellOutcome, output: &str
             // Timeout with partial output: return as success so the client
             // sees the captured data. The ERROR marker in the text body still
             // signals the timeout to the agent.
-            !has_partial_output_before_timeout(output)
+            crate::server::execute::output_before_timeout_marker(output).is_none_or(str::is_empty)
         }
         crate::server::tool_trait::ShellOutcome::Exit(_)
         | crate::server::tool_trait::ShellOutcome::Blocked => true,
-    }
-}
-
-/// True when the output contains real content before the timeout marker.
-fn has_partial_output_before_timeout(output: &str) -> bool {
-    if let Some(idx) = output.find("ERROR: command timed out after") {
-        let before = output[..idx].trim();
-        !before.is_empty()
-    } else {
-        false
     }
 }
 

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -5,6 +5,22 @@ use std::time::{Duration, Instant};
 
 const READER_RESULT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Prefix of the timeout notice this module appends to a killed command.
+const TIMEOUT_MARKER: &str = "ERROR: command timed out after ";
+
+/// The child's own output preceding the timeout marker, or `None` when the
+/// output carries no marker. `Some("")` means the command timed out having
+/// produced nothing recoverable.
+///
+/// Single source of truth for "was anything captured before the timeout?":
+/// `call_tool` decides `isError` with it (#1086) and `ctx_shell` decides
+/// whether the notice is worth archiving (#995). It lives beside the code that
+/// writes the marker because both callers previously re-derived it by matching
+/// the whole output, so enriching the notice broke them silently (#1173).
+pub(crate) fn output_before_timeout_marker(output: &str) -> Option<&str> {
+    output.find(TIMEOUT_MARKER).map(|idx| output[..idx].trim())
+}
+
 #[cfg(test)]
 pub(crate) fn execute_command_in(command: &str, cwd: &str) -> (String, i32) {
     execute_command_with_env(command, cwd, &std::collections::HashMap::new(), None)
@@ -27,10 +43,14 @@ pub(crate) fn execute_command_with_env(
 /// `idle_keyed` turns `timeout_ms` into an *idle* budget instead of a wall-clock
 /// one: the clock resets whenever the child produces new bytes (#1113/#1173). A
 /// poll loop emitting a few hundred bytes over ten minutes is not the runaway
-/// this watchdog protects against, so background jobs run output-keyed while
-/// foreground runs keep the strict wall-clock bound. An absolute ceiling
-/// (`LEAN_CTX_SHELL_BG_MAX_MS`, default 1h) still applies so a chatty runaway
-/// cannot live in the daemon forever.
+/// this watchdog protects against.
+///
+/// Every job managed by `background_shell` sets it, foreground runs included —
+/// those detach at the soft cap and become exactly such a job. Only the
+/// degraded no-session path runs strict wall-clock. Two bounds keep it honest:
+/// genuinely runaway output hits the byte cap, which freezes the captured
+/// length and so restarts the clock, and `LEAN_CTX_SHELL_BG_MAX_MS` (default
+/// 1h) caps lifetime absolutely.
 pub(crate) fn execute_command_with_env_cancellable(
     command: &str,
     cwd: &str,
@@ -198,7 +218,7 @@ pub(crate) fn execute_command_with_env_cancellable(
             text.push('\n');
         }
         text.push_str(&format!(
-            "ERROR: command timed out after {}ms{}",
+            "{TIMEOUT_MARKER}{}ms{}",
             timeout.as_millis(),
             if idle_keyed {
                 " without new output"

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -16,19 +16,28 @@ pub(crate) fn execute_command_with_env(
     extra_env: &std::collections::HashMap<String, String>,
     timeout_ms: Option<u64>,
 ) -> (String, i32) {
-    execute_command_with_env_cancellable(command, cwd, extra_env, timeout_ms, None)
+    execute_command_with_env_cancellable(command, cwd, extra_env, timeout_ms, None, false)
 }
 
 /// Execute a command under the normal shell policy, with an optional cooperative
 /// cancellation signal used by explicit background jobs. The signal is checked
 /// by the same watchdog that enforces `timeout_ms`, so cancellation kills the
 /// complete Unix process group rather than only the shell leader.
+///
+/// `idle_keyed` turns `timeout_ms` into an *idle* budget instead of a wall-clock
+/// one: the clock resets whenever the child produces new bytes (#1113/#1173). A
+/// poll loop emitting a few hundred bytes over ten minutes is not the runaway
+/// this watchdog protects against, so background jobs run output-keyed while
+/// foreground runs keep the strict wall-clock bound. An absolute ceiling
+/// (`LEAN_CTX_SHELL_BG_MAX_MS`, default 1h) still applies so a chatty runaway
+/// cannot live in the daemon forever.
 pub(crate) fn execute_command_with_env_cancellable(
     command: &str,
     cwd: &str,
     extra_env: &std::collections::HashMap<String, String>,
     timeout_ms: Option<u64>,
     cancel: Option<&AtomicBool>,
+    idle_keyed: bool,
 ) -> (String, i32) {
     let (shell, flag) = crate::shell::shell_and_flag();
     let normalized_cmd = crate::tools::ctx_shell::normalize_command_for_shell(command);
@@ -109,6 +118,11 @@ pub(crate) fn execute_command_with_env_cancellable(
 
     let timeout = command_timeout(command, timeout_ms);
     let start = Instant::now();
+    let hard_deadline = idle_keyed.then(|| start + streaming_max_lifetime());
+    let mut last_len = 0usize;
+    let mut last_output_at = start;
+    // Named on timeout so a multi-segment pipeline says *which* part hung (#1086).
+    let mut still_running: Vec<String> = Vec::new();
     let (code, timed_out, cancelled) = loop {
         match child.try_wait() {
             Ok(Some(status)) => break (status.code().unwrap_or(1), false, false),
@@ -118,7 +132,18 @@ pub(crate) fn execute_command_with_env_cancellable(
                     let _ = child.wait();
                     break (130, false, true);
                 }
-                if start.elapsed() >= timeout {
+                let idle_for = if idle_keyed {
+                    let len = captured_len(&out_buf) + captured_len(&err_buf);
+                    if len != last_len {
+                        last_len = len;
+                        last_output_at = Instant::now();
+                    }
+                    last_output_at.elapsed()
+                } else {
+                    start.elapsed()
+                };
+                if idle_for >= timeout || hard_deadline.is_some_and(|d| Instant::now() >= d) {
+                    still_running = running_segments(&child, &normalized_cmd);
                     kill_timed_out_child(&mut child);
                     let _ = child.wait();
                     break (124, true, false);
@@ -173,9 +198,24 @@ pub(crate) fn execute_command_with_env_cancellable(
             text.push('\n');
         }
         text.push_str(&format!(
-            "ERROR: command timed out after {}ms",
-            timeout.as_millis()
+            "ERROR: command timed out after {}ms{}",
+            timeout.as_millis(),
+            if idle_keyed {
+                " without new output"
+            } else {
+                ""
+            }
         ));
+        // #1086: for a compound command the captured output is often complete
+        // for every segment but one. Name the segment(s) still alive in the
+        // child's process group so the caller can fix that part instead of
+        // re-running the whole pipeline.
+        if !still_running.is_empty() {
+            text.push_str(&format!(
+                "\n[still running at timeout: {}]",
+                still_running.join(" | ")
+            ));
+        }
     }
     if cancelled {
         if !text.ends_with('\n') && !text.is_empty() {
@@ -262,6 +302,75 @@ fn snapshot(buf: &Arc<Mutex<CaptureBuf>>) -> (Vec<u8>, bool) {
     (s.bytes.clone(), s.truncated)
 }
 
+/// Bytes captured so far, used as the liveness signal for an idle-keyed
+/// timeout. Cheaper than [`snapshot`], which clones the whole buffer.
+fn captured_len(buf: &Arc<Mutex<CaptureBuf>>) -> usize {
+    buf.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .bytes
+        .len()
+}
+
+/// Absolute ceiling on an idle-keyed (background) job, so a command that keeps
+/// emitting output forever still cannot outlive the daemon's patience (#1173).
+fn streaming_max_lifetime() -> Duration {
+    Duration::from_millis(
+        std::env::var("LEAN_CTX_SHELL_BG_MAX_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&ms: &u64| ms > 0)
+            .unwrap_or(3_600_000),
+    )
+}
+
+/// Command lines still alive in the timed-out child's process group, i.e. the
+/// pipeline segment(s) that did not finish (#1086). Rows still carrying the
+/// *whole* command are the un-exec'd shell wrapper and say nothing specific, so
+/// they are dropped — note the leader is not simply skipped by pid, because
+/// `sh -c 'a; b'` execs into its final segment and so *is* the leader.
+/// Best-effort: an unavailable or unparsable `ps` yields no attribution.
+#[cfg(unix)]
+fn running_segments(child: &std::process::Child, command: &str) -> Vec<String> {
+    let pgid = child.id();
+    // POSIX-portable field selection; `ps -g` differs between BSD and Linux.
+    let Ok(out) = std::process::Command::new("ps")
+        .args(["-A", "-o", "pid=,pgid=,args="])
+        .output()
+    else {
+        return Vec::new();
+    };
+    let needle = command.split_whitespace().collect::<Vec<_>>().join(" ");
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| parse_ps_row(line, pgid, &needle))
+        .collect()
+}
+
+/// One `pid pgid args` row: `Some(args)` iff it belongs to `pgid` and names a
+/// narrower command than the one we launched. `needle` is the whole command
+/// with runs of whitespace collapsed, matching how `ps` renders `args`.
+#[cfg(unix)]
+fn parse_ps_row(line: &str, pgid: u32, needle: &str) -> Option<String> {
+    let rest = line.trim_start();
+    let (_pid, rest) = rest.split_once(char::is_whitespace)?;
+    let args = rest
+        .trim_start()
+        .split_once(char::is_whitespace)
+        .and_then(|(row_pgid, args)| {
+            (row_pgid.parse::<u32>().ok()? == pgid).then_some(args.trim())
+        })?;
+    if args.is_empty() || args.contains(needle) {
+        return None;
+    }
+    Some(args.chars().take(200).collect())
+}
+
+#[cfg(not(unix))]
+fn running_segments(_child: &std::process::Child, _command: &str) -> Vec<String> {
+    // No process groups here, so a descendant cannot be attributed to this run.
+    Vec::new()
+}
+
 /// Block until the reader signals completion or `deadline` passes. Returns true
 /// iff the reader completed (reached EOF) within the deadline.
 fn wait_for_reader(done: &mpsc::Receiver<()>, deadline: Instant) -> bool {
@@ -317,6 +426,82 @@ mod tests {
         if let Some(v) = saved {
             crate::test_env::set_var("LEAN_CTX_SHELL_TIMEOUT_MS", v);
         }
+    }
+
+    /// #1113/#1173: a poll loop that emits a short line every so often must
+    /// outlive the wall-clock budget — the cap protects against runaway output,
+    /// not against a long-lived monitor. Wall-clock mode still kills it.
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn idle_keyed_timeout_survives_a_trickling_loop() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        let env = std::collections::HashMap::new();
+        // Emits every 100ms for ~900ms under a 400ms budget.
+        let cmd = "for i in 1 2 3 4 5 6 7 8 9; do printf T; sleep 0.1; done; printf DONE";
+
+        let (idle_out, idle_code) =
+            super::execute_command_with_env_cancellable(cmd, ".", &env, Some(400), None, true);
+        assert_eq!(
+            idle_code, 0,
+            "output kept resetting the idle clock: {idle_out}"
+        );
+        assert!(idle_out.contains("DONE"));
+
+        let (wall_out, wall_code) =
+            super::execute_command_with_env_cancellable(cmd, ".", &env, Some(400), None, false);
+        assert_eq!(wall_code, 124, "wall-clock mode must still enforce the cap");
+        assert!(wall_out.contains("timed out"));
+    }
+
+    /// #1086: a timed-out pipeline names the segment that was still running,
+    /// so the caller fixes that part instead of re-running everything.
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn timeout_names_the_still_running_segment() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::remove_var("LEAN_CTX_SHELL_TIMEOUT_MS");
+        let env = std::collections::HashMap::new();
+        let (out, code) = super::execute_command_with_env_cancellable(
+            "printf FIRST_OK; sleep 47",
+            ".",
+            &env,
+            Some(600),
+            None,
+            false,
+        );
+        assert_eq!(code, 124);
+        assert!(
+            out.contains("FIRST_OK"),
+            "partial output must survive: {out}"
+        );
+        assert!(
+            out.contains("still running at timeout") && out.contains("47"),
+            "the hung segment must be named: {out}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ps_row_names_segments_and_drops_the_whole_command() {
+        let whole = "printf hi; grep -rn needle /repo";
+        assert_eq!(
+            super::parse_ps_row(" 4242  4200 grep -rn needle /repo", 4200, whole).as_deref(),
+            Some("grep -rn needle /repo"),
+            "a segment must be named"
+        );
+        // The un-exec'd shell wrapper still carries the whole command.
+        assert_eq!(
+            super::parse_ps_row(
+                "4200 4200 /bin/sh -c printf hi; grep -rn needle /repo",
+                4200,
+                whole
+            ),
+            None
+        );
+        // Another job's process group.
+        assert_eq!(super::parse_ps_row("4242 9999 sleep 5", 4200, whole), None);
+        assert_eq!(super::parse_ps_row("garbage", 4200, whole), None);
     }
 
     #[test]

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -472,15 +472,13 @@ fn resolve_shell_raw_flags(
 
 /// A timeout notice is framework metadata, not recoverable command output. Do
 /// not archive it as a tee artifact: expanding it cannot recover any bytes (#995).
+///
+/// Keyed on what precedes the marker rather than on the notice's exact shape,
+/// so enriching it (the idle-timeout wording, the still-running segment list)
+/// cannot silently turn every timeout back into an archived artifact (#1173).
 fn is_timeout_notice_only(output: &str, exit_code: i32) -> bool {
     exit_code == 124
-        && output
-            .trim()
-            .strip_prefix("ERROR: command timed out after ")
-            .is_some_and(|rest| {
-                rest.strip_suffix("ms")
-                    .is_some_and(|n| n.trim().parse::<u128>().is_ok())
-            })
+        && crate::server::execute::output_before_timeout_marker(output).is_some_and(str::is_empty)
 }
 
 fn search_tool_nudge(command: &str) -> &'static str {
@@ -732,5 +730,20 @@ mod tests {
             "ERROR: command timed out after 200ms",
             1
         ));
+        // #1173: the notice now carries the idle wording and the still-running
+        // segment list. It is still pure metadata — nothing to recover — so it
+        // must not become a tee artifact just because it grew.
+        assert!(is_timeout_notice_only(
+            "ERROR: command timed out after 200ms without new output\n\
+             [still running at timeout: sleep 300]",
+            124
+        ));
+        assert!(!is_timeout_notice_only(
+            "useful output\nERROR: command timed out after 200ms\n\
+             [still running at timeout: sleep 300]",
+            124
+        ));
+        // Exit 124 from something that is not our watchdog carries no marker.
+        assert!(!is_timeout_notice_only("some tool output", 124));
     }
 }

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -30,7 +30,7 @@ impl McpTool for CtxShellTool {
                     "raw": { "type": "boolean", "description": "Skip compression (verbatim)" },
                     "inline": { "type": "boolean", "description": "Return verbatim output inline up to archive.inline_max_bytes; larger output uses the archive/firewall" },
                     "cwd": { "type": "string", "description": "Working dir (persists across calls)" },
-                    "timeout_ms": { "type": "integer", "description": "Per-call timeout in ms (max 3600000). Overridden by LEAN_CTX_SHELL_TIMEOUT_MS." },
+                    "timeout_ms": { "type": "integer", "description": "Job lifetime in ms (max 3600000) — NOT the inline wait. A command still running at the ~110s foreground cap detaches to a pollable shell_* job and keeps running up to timeout_ms. Overridden by LEAN_CTX_SHELL_TIMEOUT_MS." },
                     "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } },
                     "run_in_background": { "type": "boolean", "description": "Detach immediately and return a job id. The command keeps timeout_ms; poll or cancel with background_action and job_id." },
                     "background_action": { "type": "string", "enum": ["status", "cancel"], "description": "Inspect or cancel a background ctx_shell job." },
@@ -303,15 +303,35 @@ impl McpTool for CtxShellTool {
             // Foreground runs still detach onto a pollable job if they outlast
             // the soft cap, so the MCP host's ~120s abort never strands the
             // result behind an unresolvable task id (#1106).
-            // #1106: honour explicit timeout_ms — if the caller requested a
-            // longer wait, raise the foreground cap so long builds (clippy, fmt)
-            // finish inline instead of being pushed to background+poll.
-            let default_cap = foreground_soft_cap_ms();
-            let effective_cap = match timeout_ms {
-                Some(t) if t > default_cap => t,
-                _ => default_cap,
+            //
+            // #1173: `timeout_ms` is the *job's* lifetime, never the foreground
+            // wait, so it must not raise this cap. Raising it bought no extra
+            // inline wait — the host aborts at ~120s regardless — it only
+            // suppressed our own detach, producing exactly the unresolvable
+            // task id the cap exists to prevent. Separate knobs, one direction:
+            // `LEAN_CTX_SHELL_FG_CAP_MS` moves the cap, `timeout_ms` does not.
+            let soft_cap = std::time::Duration::from_millis(foreground_soft_cap_ms());
+            let progress_sender = ctx.progress_sender.clone();
+            let progress_label: String = cmd_clone.chars().take(60).collect();
+            let cap_secs = soft_cap.as_secs_f64();
+            let on_tick = |elapsed: std::time::Duration| {
+                #[allow(clippy::unwrap_or_default)]
+                if let Some(ref ps) = progress_sender
+                    && let Some(sender) = ps
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .as_ref()
+                {
+                    sender.send(
+                        elapsed.as_secs_f64(),
+                        Some(cap_secs),
+                        Some(format!(
+                            "ctx_shell: {}s elapsed — {progress_label}",
+                            elapsed.as_secs()
+                        )),
+                    );
+                }
             };
-            let soft_cap = std::time::Duration::from_millis(effective_cap);
             let (raw_output, exit_code) =
                 match crate::server::background_shell::run_foreground_or_detach(
                     cmd_clone.clone(),
@@ -319,6 +339,7 @@ impl McpTool for CtxShellTool {
                     extra_env.clone(),
                     timeout_ms,
                     soft_cap,
+                    Some(&on_tick),
                 ) {
                     crate::server::background_shell::ForegroundResult::Finished {
                         output,
@@ -328,8 +349,11 @@ impl McpTool for CtxShellTool {
                         return Ok(ToolOutput {
                             shell_outcome: Some(ShellOutcome::Exit(0)),
                             content_blocks: None,
+                            // #1173: a detach is not a failure — the command is
+                            // alive and its output is recoverable, so say so
+                            // rather than leaving the caller to infer a hang.
                             ..ToolOutput::simple(format!(
-                                "[auto-background:{job_id} started — command exceeded the {}s foreground cap and keeps running; use ctx_shell(background_action=\"status\", job_id=\"{job_id}\") to poll or background_action=\"cancel\" to stop it]",
+                                "[auto-background:{job_id} still running — passed the {}s foreground cap, not an error; output is kept and delivered by ctx_shell(background_action=\"status\", job_id=\"{job_id}\"), or background_action=\"cancel\" to stop it]",
                                 soft_cap.as_secs()
                             ))
                         });


### PR DESCRIPTION
Closes #1173. Supersedes #1106.

Implements the proposed contract in full — all four work items — plus the coverage each needs.

## The contradiction, removed

`ctx_shell.rs` raised the foreground cap whenever the caller passed a larger `timeout_ms`, directly against the doc comment on `foreground_soft_cap_ms()` above it. Raising the cap past the host's ~120s abort bought no extra inline wait; it only suppressed our own detach, which was the thing producing a usable `shell_*` job id.

```diff
-let default_cap = foreground_soft_cap_ms();
-let effective_cap = match timeout_ms {
-    Some(t) if t > default_cap => t,
-    _ => default_cap,
-};
-let soft_cap = std::time::Duration::from_millis(effective_cap);
+let soft_cap = std::time::Duration::from_millis(foreground_soft_cap_ms());
```

`timeout_ms` keeps feeding `background_shell::start`, so it still bounds the job — it just no longer touches the detach decision. Two names, two jobs: `LEAN_CTX_SHELL_FG_CAP_MS` moves the cap, `timeout_ms` does not.

## Work items

- [x] **Clamp `effective_cap` to `foreground_soft_cap_ms()`** (contract 1-3, supersedes #1106) — `ctx_shell.rs`. The tool-def description for `timeout_ms` now states the contract, and the detach payload says "still running … not an error" rather than "started".

- [x] **Reshape the timeout/detach payload** (contract 4, from #1086) — `execute.rs`. On timeout, `ps -A -o pid=,pgid=,args=` snapshots the child's process group *before* the kill and names what is still alive:

  ```
  FIRST_OK
  ERROR: command timed out after 600ms
  [still running at timeout: grep -rln "func SetInt" /repo]
  ```

  Rows still carrying the whole command are dropped as the un-exec'd shell wrapper. Filtering by "is the group leader" would have missed the common case — `sh -c 'a; b'` execs into its final segment and so *becomes* the leader; the first draft of this patch failed its own test that way. Best-effort: an unavailable or unparsable `ps` simply yields no attribution, and non-Unix returns empty. The other half of #1086 — partial output as a success result — already landed in `finalize_call_result`.

- [x] **Output-keyed limit for streaming jobs** (contract 5, from #1113 part 1) — new `idle_keyed` mode in `execute_command_with_env_cancellable` resets the timeout clock whenever the child produces new bytes. All managed jobs use it, so `while true; do gh pr checks …; sleep 45; done` survives. Two bounds keep it honest: the byte cap freezes the captured length, which restarts the clock on genuinely runaway output, and `LEAN_CTX_SHELL_BG_MAX_MS` (default 1h) caps lifetime absolutely. The degraded no-session path stays strict wall-clock.

- [x] **Wire progress into `ctx_shell`'s foreground path** (contract 6) — `run_foreground_or_detach` gained an `on_tick` callback, fired every 5s; `ctx_shell` connects it to the existing `SharedProgressSender`. Message is `ctx_shell: 45s elapsed — <command>`.

## On the progress `message`

It carries elapsed time but deliberately **not** the last output line — that is the part that depends on `\r` resolution (#1140), and shipping it now would inherit the glued-line bug. Elapsed-only is the dependency-free subset and already delivers what the issue asks for: a 3-minute `cargo clippy` stops being indistinguishable from a hang. Add the output line once #1140 lands.

Per `basic/lifecycle` § Timeouts a client MAY reset its timeout on progress but SHOULD always enforce a maximum, so this is opportunistic visibility only. The clamp is the correctness fix and stands alone.

## Verification

```
cargo test --lib          8830 passed; 0 failed; 15 ignored
cargo clippy --all-targets    no warnings in the three changed files
cargo fmt                     clean
```

New tests:

| Test | Guards |
|---|---|
| `large_timeout_ms_still_detaches_at_the_soft_cap` | `timeout_ms: 600_000` must not extend the foreground wait — the regression this PR exists to prevent |
| `foreground_run_reports_progress_while_waiting` | progress actually fires during a wait, with real elapsed time |
| `idle_keyed_timeout_survives_a_trickling_loop` | a loop trickling output outlives its budget; wall-clock mode still kills it |
| `timeout_names_the_still_running_segment` | partial output survives *and* the hung segment is named |
| `ps_row_names_segments_and_drops_the_whole_command` | the `ps` row filter, including the exec'd-leader case |

## Not in scope

#1113 part 2 (`comm` missing from the allowlist — belongs with #1147), and the output/compression, scoping, exit-code and gating issues: #1084, #1089, #1090, #1110, #1127, #1129, #1130, #1140, #1142, #1147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
