### PR TITLE
fix(ci): drop unused Mutex imports breaking the test build

### DIFF
--- a/rust/src/core/context_kernel/activation_e2e.rs
+++ b/rust/src/core/context_kernel/activation_e2e.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::dedup_wiring::{self, DedupAction};
     use super::super::envelope_wiring;

--- a/rust/src/core/context_kernel/envelope_e2e.rs
+++ b/rust/src/core/context_kernel/envelope_e2e.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::accounting_fix;
     use super::super::live_dashboard;

--- a/rust/src/core/context_kernel/envelope_wiring.rs
+++ b/rust/src/core/context_kernel/envelope_wiring.rs
@@ -124,7 +124,7 @@ pub fn reset_evidence() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::{
         EvidenceSummary, evidence_summary, process_mcp_evidence, process_proxy_evidence,

--- a/rust/src/core/context_kernel/kernel_config.rs
+++ b/rust/src/core/context_kernel/kernel_config.rs
@@ -133,7 +133,7 @@ mod tests {
         KernelFeatures, features, from_env, is_enabled, is_feature_enabled, reset_features,
         update_features,
     };
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     fn setup() -> MutexGuard<'static, ()> {
         let guard = super::KERNEL_TEST_LOCK


### PR DESCRIPTION
`main` has been red since 533d56ce0. `Test` on all three platforms and `Coverage` fail at the **compile** step, which fails `CI Green` and therefore blocks every open PR.

```
error: unused import: `Mutex`
 --> src/core/context_kernel/activation_e2e.rs:3:21
  |
3 |     use std::sync::{Mutex, MutexGuard};
  |                     ^^^^^
  = note: `-D unused-imports` implied by `-D warnings`

error: could not compile `lean-ctx` (lib test) due to 4 previous errors
```

Four `mod tests` blocks import `Mutex` next to `MutexGuard` without using it. The shared lock they take is spelled out in full at `kernel_config.rs:129` —

```rust
pub static KERNEL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
```

— so the test modules only ever name `MutexGuard`, as the return type of their setup helper. Dropping `Mutex` from those four imports is the whole change.

The non-test import at `kernel_config.rs:3` also names `Mutex`, but there it is genuinely used (`static FEATURES: OnceLock<Mutex<KernelFeatures>>`). Left alone.

## Why a local build misses it

`cargo build` and `cargo clippy` both pass — `unused_imports` is a warning by default. It only becomes an error under the `-D warnings` the CI test job sets, and only for the `--lib --no-run` test target. Reproducing the failure locally needs the same gate:

```
RUSTFLAGS="-D warnings" cargo test --lib --no-run
```

## Verification

```
RUSTFLAGS="-D warnings" cargo test --lib --no-run
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 20s
```

Clean. (The one remaining `linker_messages` note about `__eh_frame` is pre-existing and, as it says itself, "the `linker_messages` lint ignores `-D warnings`".)

Files touched: `activation_e2e.rs`, `envelope_e2e.rs`, `envelope_wiring.rs`, `kernel_config.rs` — one import line each, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
