### PR TITLE
fix(ci): document the QUERY_TOKENS static lock (r29)

### DIFF
--- a/rust/LOCK_ORDERING.md
+++ b/rust/LOCK_ORDERING.md
@@ -94,6 +94,7 @@ All `std::sync::Mutex` unless noted otherwise.
 | L81 | `SAVINGS` | `core/context_kernel/schema_wiring.rs:47` | `OnceLock<Mutex<SavingsState>>` | Cumulative schema optimization savings tracking; independent leaf lock, never nested |
 | L82 | `NORMALIZER` | `core/context_kernel/usage_normalizer.rs:73` | `OnceLock<Mutex<SessionUsage>>` | Session-level token usage aggregation from canonical envelopes; independent leaf lock, never nested |
 | L83 | `FEATURES` | `core/context_kernel/kernel_config.rs:47` | `OnceLock<Mutex<KernelFeatures>>` | Central runtime feature toggles for all kernel modules; independent leaf lock, never nested |
+| L84 | `QUERY_TOKENS` | `tools/search_kernel.rs:10` | `LazyLock<Mutex<HashMap<u64, usize>>>` | Per-session repeated-query tracking for the search tool (r29): maps a query hash to its result-token count so repeat searches are counted; locked only to record or read a single entry, never held across another lock or an `.await`; independent leaf lock, never nested |
 
 ### Test / Environment Locks (serialise env-var mutations)
 


### PR DESCRIPTION
**Main's CI is red at 87d944654 and it blocks every open PR.**

r29 added a static lock without a `LOCK_ORDERING.md` entry, so the `all_static_locks_documented` gate fails:

```
thread 'all_static_locks_documented' panicked at tests/lock_ordering_check.rs:141:5:
Undocumented static Mutex/RwLock found! Add them to LOCK_ORDERING.md:
  QUERY_TOKENS at src/tools/search_kernel.rs:10
```

That fails `Test` on every platform → `CI Green` → every open PR that merges against main.

## The lock

```rust
// src/tools/search_kernel.rs:10
static QUERY_TOKENS: LazyLock<Mutex<HashMap<u64, usize>>> = LazyLock::new(Default::default);
```

Session-local map from query hash to result-token count. Locked only to record or read a single entry, never held across another lock or an `.await` — a leaf lock. Documented as **L84**. Sibling `TOTAL_SEARCHES`/`TOTAL_TOKENS` are `AtomicUsize`, which the gate does not track.

## Verification

```
cargo test --test lock_ordering_check → 1 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)