### PR TITLE
test(addons): isolate the data dir in signing-path publish tests

### DIFF
--- a/rust/src/core/addons/publish.rs
+++ b/rust/src/core/addons/publish.rs
@@ -257,6 +257,10 @@ sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
     #[test]
     fn builds_a_signed_verifying_addon_pack() {
+        // Signing reads the machine key under `data_dir()` (LEAN_CTX_DATA_DIR).
+        // Isolate it — and hold test_env_lock — so a concurrent isolated_data_dir
+        // test can't delete the key dir mid-`chmod` (flaky "No such file").
+        let _iso = crate::core::data_dir::isolated_data_dir();
         let dir = tempfile::tempdir().expect("tempdir");
         let path = write_manifest(&dir, GOOD_TOML);
 
@@ -280,6 +284,9 @@ sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
     #[test]
     fn embedded_toml_is_verbatim() {
+        // See builds_a_signed_verifying_addon_pack: signing touches the shared
+        // machine-key dir, so isolate the data dir to avoid the cross-test race.
+        let _iso = crate::core::data_dir::isolated_data_dir();
         let dir = tempfile::tempdir().expect("tempdir");
         let path = write_manifest(&dir, GOOD_TOML);
 
@@ -319,6 +326,9 @@ sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
     #[test]
     fn build_addon_pack_forwards_declared_dependencies() {
+        // See builds_a_signed_verifying_addon_pack: signing touches the shared
+        // machine-key dir, so isolate the data dir to avoid the cross-test race.
+        let _iso = crate::core::data_dir::isolated_data_dir();
         let dir = std::env::temp_dir().join(format!("lc-addon-deps-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("tmp dir");
         let path = dir.join("lean-ctx-addon.toml");


### PR DESCRIPTION
Three `addons::publish` tests reach `build_addon_pack`'s signing step, which loads/creates the machine ed25519 key under `data_dir()` (`LEAN_CTX_DATA_DIR`, default `<data_dir>/keys/ctxpkg-ed25519.key`). They read that ambient path without isolating it, so a concurrent test using `isolated_data_dir()` — which repoints `LEAN_CTX_DATA_DIR` at a tempdir and removes it on drop — can delete the key directory mid-`chmod`:

```
thread '...builds_a_signed_verifying_addon_pack' panicked at src/core/addons/publish.rs:263:
  plan: "chmod signing key: No such file or directory (os error 2)"
```

Same env-race class as #1187 / #975: reads of env-derived global state must hold `test_env_lock`. `isolated_data_dir()` does that **and** gives the key a private home, so the machine-key write can't collide. `paths.rs`'s own `data_dir_matches_lean_ctx_data_dir` test already uses it as precedent.

Fix: add `let _iso = crate::core::data_dir::isolated_data_dir();` to the three signing-path tests (`builds_a_signed_verifying_addon_pack`, `embedded_toml_is_verbatim`, `build_addon_pack_forwards_declared_dependencies`). The `refuses_*` tests fail validation before signing and don't touch the key dir, so they're left alone.

## Verification

4× full `cargo test --lib`: zero `addons::publish` failures (was ~1-in-3 before). This flake took down `Test (ubuntu-latest)` on an unrelated PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)