### PR TITLE
perf(ci): link the Linux test job with mold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     # injectable for tests) rather than papering over it with test-groups.
     timeout-minutes: 180
     env:
-      # ~60 integration-test binaries each statically link the full lib
+      # ~50 integration-test binaries each statically link the full lib
       # (tree-sitter ×18, rten, aws-lc, resvg, …). With default full debug
       # info that is 25-40 GB and the ubuntu runner dies with ENOSPC / the
       # linker with SIGBUS. Line tables keep file:line in panic backtraces
@@ -116,11 +116,13 @@ jobs:
             /usr/local/share/boost /usr/lib/jvm /usr/local/julia* || true
           sudo docker system prune -af --volumes >/dev/null 2>&1 || true
           df -h /
-      # mold is a much faster drop-in ELF linker. The ~60 integration-test
+      # mold is a much faster drop-in ELF linker. The ~50 integration-test
       # binaries each statically link the full lib (tree-sitter ×18, rten,
       # aws-lc, resvg, …), so linking — not compilation — dominates the Linux
-      # job. mold is Linux/ELF only, so macOS and the Windows-GNU target keep
-      # their default linkers.
+      # job. (#1146 already merged 93 of the old ~145 test files into one
+      # binary; the ~50 that remain still each pay the full-lib link.) mold is
+      # Linux/ELF only, so macOS and the Windows-GNU target keep their default
+      # linkers.
       - name: Install mold linker
         if: runner.os == 'Linux'
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,15 @@ jobs:
             /usr/local/share/boost /usr/lib/jvm /usr/local/julia* || true
           sudo docker system prune -af --volumes >/dev/null 2>&1 || true
           df -h /
+      # mold is a much faster drop-in ELF linker. The ~60 integration-test
+      # binaries each statically link the full lib (tree-sitter ×18, rten,
+      # aws-lc, resvg, …), so linking — not compilation — dominates the Linux
+      # job. mold is Linux/ELF only, so macOS and the Windows-GNU target keep
+      # their default linkers.
+      - name: Install mold linker
+        if: runner.os == 'Linux'
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y mold
       - name: Run tests
         working-directory: rust
         shell: bash
@@ -129,6 +138,11 @@ jobs:
             JEMALLOC_OVERRIDE="${{ steps.jemalloc.outputs.jemalloc-override }}" \
             CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-L ${{ steps.jemalloc.outputs.dummy-dir }}" \
             "$CARGO" test --target x86_64-pc-windows-gnu --all-features -- --test-threads=1
+          elif [[ "${{ runner.os }}" == "Linux" ]]; then
+            # `mold -run` redirects child linker invocations to mold without
+            # touching RUSTFLAGS (which is pinned to `-Dwarnings` job-wide and
+            # would override any .cargo/config.toml rustflags).
+            mold -run "$CARGO" test --all-features -- --test-threads=1
           else
             "$CARGO" test --all-features -- --test-threads=1
           fi


### PR DESCRIPTION
On Linux the `test` job spends most of its wall-clock **linking**, not compiling: ~60 integration-test binaries each statically link the full lib (tree-sitter ×18, rten, aws-lc, resvg, …). That's the same pressure the workflow already fights with `CARGO_PROFILE_*_DEBUG: line-tables-only` and the ENOSPC/SIGBUS notes. mold is a drop-in, much faster ELF linker.

## Why `mold -run`, not a config rustflag

RUSTFLAGS is pinned `-Dwarnings` job-wide (`ci.yml:23`). Env `RUSTFLAGS` **overrides** `.cargo/config.toml` `[target.*].rustflags` entirely, so a config-level `-Clink-arg=-fuse-ld=mold` would be silently dropped (and keeping `-Dwarnings` in an env override is its own footgun). `mold -run` wraps the command and redirects child linker invocations to mold without touching RUSTFLAGS.

## Scope

- **Linux only.** mold is ELF-only. macOS and the Windows-GNU target keep their default linkers, untouched.
- The Windows path (jemalloc `-L` shim, GNU target) is byte-for-byte unchanged.
- No new GitHub Action — mold comes from `apt`, so nothing to pin or vet.

## Verification

YAML validates. The real proof is the CI run on this PR: compare the Linux `Test` job link/wall time against main. I can't benchmark hosted-runner linking locally, so this is the one to watch on the PR itself.

Pairs with the sccache PR (compilation caching) and is independent of the nextest discussion (parallelism). This one is pure linker swap — lowest risk of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)