### PR TITLE
perf(ci): add sccache compilation caching to the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,16 @@ jobs:
       # the 180-min timeout. 64 cases keep the properties exercised on every
       # push at a quarter of the cost; local runs keep the full default.
       PROPTEST_CASES: 64
+      # sccache caches individual rustc invocations in the GitHub Actions cache
+      # (shared across runs), salvaging unchanged crates when Swatinem/rust-cache
+      # misses — a Cargo.lock or toolchain bump otherwise triggers a full
+      # recompile of the whole dep tree. Composing the two is safe: on a
+      # rust-cache HIT cargo skips compilation and never invokes sccache; on a
+      # MISS sccache backfills. Incremental must be off for sccache, which also
+      # shrinks `target/` (helps the ENOSPC pressure above).
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4 # v4
         with:
@@ -81,6 +91,11 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust -> target
+      # Installs sccache and wires the GHA cache backend (SCCACHE_GHA_ENABLED
+      # above). Tag-pinned like actions/checkout in this file; a maintainer may
+      # prefer a full-SHA pin.
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6 # v0.0.6
 
       # ---- Windows: MSYS2 + GNU target + jemalloc -------------------------
       # The default MSVC toolchain can't build jemalloc (autotools mismatch).


### PR DESCRIPTION
`Swatinem/rust-cache` already caches `target/` — but only pays off on a cache **HIT**. A `Cargo.lock` or toolchain bump misses and forces a full recompile of the whole dep tree (tree-sitter ×18, rten, aws-lc, resvg, …), the single most expensive event in the job. sccache caches individual `rustc` invocations in the GitHub Actions cache, shared across runs, so those bumps still reuse every unchanged crate.

## Composes with rust-cache, doesn't fight it
- rust-cache HIT → cargo skips compilation → sccache never invoked (no overhead).
- rust-cache MISS → sccache backfills the unchanged crates.

`CARGO_INCREMENTAL=0` is required by sccache and also shrinks `target/`, easing the ENOSPC pressure the `line-tables-only` debug trim already fights.

## Shape
- `RUSTC_WRAPPER` / `SCCACHE_GHA_ENABLED` / `CARGO_INCREMENTAL` at **job level**, so the `Run tests` script is untouched — **no merge conflict with the mold-linker PR (#1204)**.
- The sccache-action is **tag-pinned** (`@v0.0.6`) to match `actions/checkout@v4` already in this file. It's a third-party action; a maintainer may prefer a full-SHA pin — noted inline.

## Verification
YAML validates. Real proof is on the PR's own CI: the first run seeds the sccache cache (no speedup), the second (after a rebase/push) should show `sccache --show-stats` hits and a faster cold-miss rebuild. Marginal next to rust-cache on steady state; the win is specifically on lockfile/toolchain churn.

Independent of the mold linker (#1204) and the nextest parallelism discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)