### PR TITLE
perf(ci): run tests under nextest for process-isolated parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,23 +34,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # --test-threads=1 (env-race legacy, v3.3.5) serializes ~70 binaries that
-    # now include heavy property/fuzz/benchmark suites (#291, #493, #551) —
-    # well beyond 90 min on hosted runners. Parallelization is tracked
-    # separately; until then the gate gets the time it actually needs.
+    # Tests run under cargo-nextest, which executes each test in its OWN
+    # process. That process isolation removes the env-race that historically
+    # forced `cargo test -- --test-threads=1` (a test mutating process-global
+    # state — LEAN_CTX_* env, the Config cache, the graph-idx lock — could no
+    # longer leak into another), so the suite runs core-parallel instead of
+    # serialized across ~70 binaries. Config lives in rust/.config/nextest.toml
+    # (test-threads=-4, retries=2, a `serial-state` group for the few binaries
+    # sharing a fixed /tmp path, and a tmpdir setup-script isolating the data
+    # dir for every test).
     #
-    # Tried switching to cargo-nextest (rust/.config/nextest.toml already
-    # exists and documents the same env-race for 3 known binaries via a
-    # `serial-state` test-group). Reverted: nextest's default parallelism
-    # (test-threads = -4) surfaced several more tests with hidden wall-clock
-    # timing assumptions (e.g. core::cache::tests::hebbian_eviction_bonus_is_wired
-    # depends on two calls landing in the same real-time 500ms window) that a
-    # `max-threads=1` test-group does NOT fix — that only serializes tests
-    # *within* the group against each other, it doesn't protect them from
-    # being scheduling-delayed by the many *other* tests still running in
-    # parallel elsewhere on the same runner. Revisit once those tests are
-    # made robust to scheduling jitter (or the burst window is made
-    # injectable for tests) rather than papering over it with test-groups.
+    # An earlier flip was reverted because a handful of tests carried hidden
+    # wall-clock timing assumptions that parallelism exposed — the named one,
+    # core::cache::tests::hebbian_eviction_bonus_is_wired, needed two calls
+    # inside a real-time 500ms burst window. That is now fixed at the source:
+    # the burst window is injectable (see CoAccessMatrix::set_burst_window), so
+    # the test no longer depends on wall-clock scheduling. retries=2 is the net
+    # for any similar test not yet hardened; if one recurs, make it injectable
+    # rather than reintroducing global serialization.
     timeout-minutes: 180
     env:
       # ~60 integration-test binaries each statically link the full lib
@@ -116,7 +117,32 @@ jobs:
             /usr/local/share/boost /usr/lib/jvm /usr/local/julia* || true
           sudo docker system prune -af --volumes >/dev/null 2>&1 || true
           df -h /
-      - name: Run tests
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2 # v2
+        with:
+          tool: nextest
+      - name: Run tests (nextest)
+        working-directory: rust
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            CARGO="${CARGO_HOME}/bin/cargo"
+          else
+            CARGO="cargo"
+          fi
+          # Parallelism, retries and serial-state groups come from
+          # .config/nextest.toml; process isolation makes --test-threads=1
+          # unnecessary (see the job comment above).
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            JEMALLOC_OVERRIDE="${{ steps.jemalloc.outputs.jemalloc-override }}" \
+            CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-L ${{ steps.jemalloc.outputs.dummy-dir }}" \
+            "$CARGO" nextest run --target x86_64-pc-windows-gnu --all-features
+          else
+            "$CARGO" nextest run --all-features
+          fi
+      # nextest does not run doctests — cover them separately so the flip loses
+      # no coverage. Cheap and inherently parallel, so no --test-threads pin.
+      - name: Run doctests
         working-directory: rust
         shell: bash
         run: |
@@ -128,9 +154,9 @@ jobs:
           if [[ "${{ runner.os }}" == "Windows" ]]; then
             JEMALLOC_OVERRIDE="${{ steps.jemalloc.outputs.jemalloc-override }}" \
             CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-L ${{ steps.jemalloc.outputs.dummy-dir }}" \
-            "$CARGO" test --target x86_64-pc-windows-gnu --all-features -- --test-threads=1
+            "$CARGO" test --target x86_64-pc-windows-gnu --all-features --doc
           else
-            "$CARGO" test --all-features -- --test-threads=1
+            "$CARGO" test --all-features --doc
           fi
 
       # #581: lock in the parallel BM25 (incremental) rebuild win against silent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     # forced `cargo test -- --test-threads=1` (a test mutating process-global
     # state — LEAN_CTX_* env, the Config cache, the graph-idx lock — could no
     # longer leak into another), so the suite runs core-parallel instead of
-    # serialized across ~70 binaries. Config lives in rust/.config/nextest.toml
+    # serialized across ~50 binaries. Config lives in rust/.config/nextest.toml
     # (test-threads=-4, retries=2, a `serial-state` group for the few binaries
     # sharing a fixed /tmp path, and a tmpdir setup-script isolating the data
     # dir for every test).
@@ -54,7 +54,7 @@ jobs:
     # rather than reintroducing global serialization.
     timeout-minutes: 180
     env:
-      # ~60 integration-test binaries each statically link the full lib
+      # ~50 integration-test binaries each statically link the full lib
       # (tree-sitter ×18, rten, aws-lc, resvg, …). With default full debug
       # info that is 25-40 GB and the ubuntu runner dies with ENOSPC / the
       # linker with SIGBUS. Line tables keep file:line in panic backtraces

--- a/rust/src/core/cache.rs
+++ b/rust/src/core/cache.rs
@@ -433,6 +433,14 @@ impl SessionCache {
         self.co_access.end_burst();
     }
 
+    /// Widen the co-access burst window. Test-only: lets a test keep several
+    /// `store()` calls in one burst without depending on them landing inside
+    /// the real-time 500ms window (a scheduling-jitter flake under nextest).
+    #[cfg(test)]
+    pub fn set_co_access_burst_window(&mut self, window: std::time::Duration) {
+        self.co_access.set_burst_window(window);
+    }
+
     /// Per-entry Hebbian eviction bonus (#3): each cached entry that is
     /// co-accessed with the recently-active working set earns a positive bonus
     /// that is added to its RRF score, so clustered files survive eviction
@@ -1209,13 +1217,14 @@ mod tests {
         // #3: files read together build a Hebbian association via store()'s
         // recording, and that association must feed the eviction bonus.
         //
-        // Warm up tiktoken first: the very first count_tokens() in the process
-        // lazily loads the BPE tables (can exceed the 500ms co-access burst
-        // window). store() calls count_tokens() internally, so without warming
-        // up, the two store() calls below straddle that window and never
-        // associate — a flaky-empty bonus. Warming up keeps them in one burst.
-        let _ = count_tokens("warmup");
+        // Widen the burst window so the two store() calls below always land in
+        // one burst — independent of real time. Previously this test warmed up
+        // tiktoken and hoped the calls stayed inside the real 500ms window; that
+        // still flaked under parallel runners (nextest) when scheduling jitter
+        // delayed one store() past the window. An injected window removes the
+        // wall-clock dependency entirely.
         let mut cache = SessionCache::new();
+        cache.set_co_access_burst_window(std::time::Duration::from_secs(3600));
         cache.store("/a.rs", "fn a() {}");
         cache.store("/b.rs", "fn b() {}");
         cache.flush_co_access(); // commit the burst → association (a,b) forms

--- a/rust/src/core/hebbian_cache.rs
+++ b/rust/src/core/hebbian_cache.rs
@@ -8,7 +8,7 @@
 //!   lowest-value entries evicted), High T = stochastic (prevents thrashing).
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Maximum number of co-access pairs tracked (prevents unbounded growth).
 const MAX_ASSOCIATIONS: usize = 10_000;
@@ -26,6 +26,11 @@ pub struct CoAccessMatrix {
     /// Current access burst (files read in the same tool-call window)
     current_burst: Vec<u64>,
     burst_start: Instant,
+    /// How long a burst stays open. Real tool calls read their files within a
+    /// few ms, so 500ms in production. Injectable so tests can widen it and stop
+    /// depending on two `store()` calls landing in the same real-time window —
+    /// a scheduling-jitter flake under parallel test runners (nextest).
+    burst_window: Duration,
 }
 
 impl Default for CoAccessMatrix {
@@ -41,16 +46,24 @@ impl CoAccessMatrix {
             timestamps: HashMap::with_capacity(256),
             current_burst: Vec::with_capacity(8),
             burst_start: Instant::now(),
+            burst_window: Duration::from_millis(500),
         }
+    }
+
+    /// Widen (or narrow) the burst window. Test-only: production always uses the
+    /// 500ms default set in `new`.
+    #[cfg(test)]
+    pub fn set_burst_window(&mut self, window: Duration) {
+        self.burst_window = window;
+        self.burst_start = Instant::now();
     }
 
     /// Record a file access. If within the burst window (500ms), strengthens
     /// associations with other files in the same burst.
     pub fn record_access(&mut self, path_hash: u64) {
         let now = Instant::now();
-        let burst_window = std::time::Duration::from_millis(500);
 
-        if now.duration_since(self.burst_start) > burst_window {
+        if now.duration_since(self.burst_start) > self.burst_window {
             self.flush_burst();
             self.burst_start = now;
         }


### PR DESCRIPTION
The `test` job serializes ~70 binaries with `--test-threads=1` — the single biggest cost in CI (Windows ~30 min). That flag exists **only** to dodge an env-race: tests mutating process-global state (`LEAN_CTX_*` env, the Config cache, the graph-idx lock) leaking into one another within a shared process.

nextest runs **each test in its own process**, so that leakage is structurally impossible and the flag becomes unnecessary — the suite runs core-parallel. The config already exists in-repo (`rust/.config/nextest.toml`: `test-threads=-4`, `retries=2`, a `serial-state` group for the binaries sharing a fixed `/tmp` path, and a tmpdir setup-script that isolates the data dir per test).

## Addressing the prior revert head-on

An earlier flip was reverted (the job comment documented it) because a few tests had hidden wall-clock timing assumptions that parallelism exposed. The named example:

> `core::cache::tests::hebbian_eviction_bonus_is_wired` depends on two calls landing in the same real-time 500ms window

This PR fixes that **at the source**, the way the revert note asked for ("or the burst window is made injectable for tests"):

- `CoAccessMatrix` gains a test-only `set_burst_window`. Production keeps the 500ms default; the test widens it to an hour, so the two `store()` calls are always one burst regardless of scheduling jitter. The old tiktoken-warmup hack is gone.
- `retries = 2` stays as the net for any not-yet-hardened test. **The prescribed fix for a recurrence is to make that test injectable too — not to reintroduce `--test-threads=1`.** The updated job comment says so.

## Coverage & platform parity
- nextest doesn't run doctests → a separate `cargo test --all-features --doc` step preserves that coverage.
- macOS / Windows-GNU jemalloc env and `--target` flags are unchanged.
- `taiki-e/install-action@v2` installs nextest; tag-pinned like `actions/checkout@v4` here.

## This PR is the experiment
The speedup is real but the risk is empirical: parallelism could surface *another* timing-fragile test the revert warned about. That will show up on **this PR's own matrix runs**, caught first by `retries=2`. If one fails hard, it gets the same injectable-window treatment — incrementally, without giving up the parallelism. Please watch the Test matrix wall-clock and any retried tests here before merging.

Local check: `hebbian_eviction_bonus_is_wired` + all `hebbian_cache` tests pass with the injectable window; `.config/nextest.toml` parses.

Independent of the mold (#1204) and sccache (#1205) PRs — those cut compile/link time, this cuts test wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)