### PR TITLE
fix(vscode-extension): probe ~/.local/bin for lean-ctx binary (#1202)

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **lean-ctx** VS Code extension are documented here.
 
 ### Fixed
 
+- **Binary discovery for default installs** — auto-detection now probes `~/.local/bin`, matching the installer and `dev-install`, so editor-presence heartbeats still start when VS Code inherits a stripped `PATH`.
 - **Session stats never loaded** (#347, thanks [@shawonis08](https://github.com/shawonis08)): the sidebar and status bar always showed zeros because `getSessionStats()` invoked `lean-ctx metrics --json`, a subcommand that does not exist, so every call threw and fell back to empty defaults. Stats are now sourced from `lean-ctx stats json` — the authoritative per-tool breakdown — mapping `commands.ctx_read` / `ctx_search` / `ctx_shell` counts and deriving tokens saved from the lifetime input/output totals, so reads, searches, shells and savings populate with real numbers.
 
 ## [0.1.0] — 2026-06-04

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -63,7 +63,7 @@ npm run watch
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `leanctx.binaryPath` | `""` (auto-detect) | Path to the lean-ctx binary. Empty → auto-detect on `PATH`, `~/.cargo/bin`, Homebrew |
+| `leanctx.binaryPath` | `""` (auto-detect) | Path to the lean-ctx binary. Empty → auto-detect on `PATH`, `~/.local/bin`, `~/.cargo/bin`, Homebrew |
 | `leanctx.refreshInterval` | `30` | Status bar refresh interval (seconds) |
 
 ## Commands

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -115,7 +115,7 @@
         "leanctx.binaryPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the lean-ctx binary. Leave empty to auto-detect (PATH, ~/.cargo/bin, Homebrew)."
+          "description": "Path to the lean-ctx binary. Leave empty to auto-detect (PATH, ~/.local/bin, ~/.cargo/bin, Homebrew)."
         },
         "leanctx.refreshInterval": {
           "type": "number",

--- a/vscode-extension/src/leanctx.ts
+++ b/vscode-extension/src/leanctx.ts
@@ -35,7 +35,7 @@ let cachedBinaryPath: string | null = null;
  * Resolves the lean-ctx binary. An explicit `leanctx.binaryPath` setting always wins.
  * Otherwise we probe the common install locations, because GUI-launched editors
  * (VS Code, Cursor, VSCodium) frequently inherit a stripped PATH that omits
- * `~/.cargo/bin` and Homebrew — the usual reason "lean-ctx not found" despite a
+ * `~/.local/bin`, `~/.cargo/bin`, and Homebrew — the usual reason "lean-ctx not found" despite a
  * working terminal. The first responsive candidate is cached for the session.
  */
 function getBinaryPath(): string {
@@ -57,6 +57,7 @@ function getBinaryPath(): string {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
   const candidates = [
     "lean-ctx",
+    home ? `${home}/.local/bin/lean-ctx` : "",
     home ? `${home}/.cargo/bin/lean-ctx` : "",
     "/opt/homebrew/bin/lean-ctx",
     "/usr/local/bin/lean-ctx",


### PR DESCRIPTION
Fixes #1202

## Changes
- Add `~/.local/bin` to binary search path, matching default install location  
- Extensions using `dev-install` can now find the binary despite stripped `PATH`
- Update configuration descriptions and CHANGELOG to reflect all search locations

## Validation
- TypeScript compilation passes
- VSIX packaging passes
- VSCode extension was installed and activated successfully