### PR TITLE
fix(ctx_read): reject malformed line-range modes instead of failing silently (#1209)

### DIFF
--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -143,9 +143,9 @@ impl ParseModeError {
             ParseModeError::Malformed(s) if s.starts_with("anchored:") => format!(
                 "invalid read mode \"{s}\": expected anchored:START-END (dash), e.g. anchored:72-92"
             ),
-            ParseModeError::Malformed(s) if s.starts_with("density:") => format!(
-                "invalid read mode \"{s}\": expected density:0.NN, e.g. density:0.40"
-            ),
+            ParseModeError::Malformed(s) if s.starts_with("density:") => {
+                format!("invalid read mode \"{s}\": expected density:0.NN, e.g. density:0.40")
+            }
             ParseModeError::Malformed(s) | ParseModeError::Unknown(s) => format!(
                 "invalid read mode \"{s}\": expected one of full, signatures, map, auto, raw, \
                  anchored, reference, diff, lines:N-M, anchored:N-M, density:0.NN"

--- a/rust/src/tools/ctx_read/mode.rs
+++ b/rust/src/tools/ctx_read/mode.rs
@@ -125,6 +125,35 @@ impl fmt::Display for ParseModeError {
     }
 }
 
+impl ParseModeError {
+    /// Actionable, caller-facing message for a rejected mode string (#1209).
+    ///
+    /// `Display` states *what* is wrong; this also says *what to type instead* —
+    /// critical for the `lines:N:M` colon-typo trap, where a second colon reads
+    /// natural (muscle memory from `file:line:col`) but is malformed. Without
+    /// this the range failed silently: a small file returned an empty window
+    /// ("No lines matched"), a large one bounced to a full-file dump.
+    #[must_use]
+    pub(crate) fn user_message(&self) -> String {
+        match self {
+            ParseModeError::Malformed(s) if s.starts_with("lines:") => format!(
+                "invalid read mode \"{s}\": expected lines:START-END (dash), e.g. lines:72-92 \
+                 (or a comma multi-select like lines:5,10-20)"
+            ),
+            ParseModeError::Malformed(s) if s.starts_with("anchored:") => format!(
+                "invalid read mode \"{s}\": expected anchored:START-END (dash), e.g. anchored:72-92"
+            ),
+            ParseModeError::Malformed(s) if s.starts_with("density:") => format!(
+                "invalid read mode \"{s}\": expected density:0.NN, e.g. density:0.40"
+            ),
+            ParseModeError::Malformed(s) | ParseModeError::Unknown(s) => format!(
+                "invalid read mode \"{s}\": expected one of full, signatures, map, auto, raw, \
+                 anchored, reference, diff, lines:N-M, anchored:N-M, density:0.NN"
+            ),
+        }
+    }
+}
+
 impl std::error::Error for ParseModeError {}
 
 /// Validate a comma multi-select payload (`"5,10-20"`) and return it verbatim
@@ -150,10 +179,12 @@ fn parse_line_multi(payload: &str) -> Result<String, ParseModeError> {
     Ok(payload.to_string())
 }
 
-/// Parse the payload of a `lines:` mode (`"5-10"`, `"5-999999"`, or a bare
-/// `"5"` meaning "from line 5 to EOF").
-fn parse_line_range(payload: &str) -> Result<LineRange, ParseModeError> {
-    let malformed = || ParseModeError::Malformed(format!("lines:{payload}"));
+/// Parse the payload of a line-range mode (`"5-10"`, `"5-999999"`, or a bare
+/// `"5"` meaning "from line N to EOF"). `whole` is the full original mode string
+/// (`"lines:…"` or `"anchored:…"`) so a rejection names the mode the caller
+/// actually typed — #1209: an `anchored:` typo must not be reported as `lines:`.
+fn parse_line_range(payload: &str, whole: &str) -> Result<LineRange, ParseModeError> {
+    let malformed = || ParseModeError::Malformed(whole.to_string());
     if let Some((a, b)) = payload.split_once('-') {
         let start = a.trim().parse::<u32>().map_err(|_| malformed())?;
         let end = b.trim().parse::<u32>().map_err(|_| malformed())?;
@@ -188,10 +219,10 @@ impl FromStr for ReadMode {
                     if payload.contains(',') {
                         ReadMode::LinesMulti(parse_line_multi(payload)?)
                     } else {
-                        ReadMode::Lines(parse_line_range(payload)?)
+                        ReadMode::Lines(parse_line_range(payload, other)?)
                     }
                 } else if let Some(payload) = other.strip_prefix("anchored:") {
-                    ReadMode::Anchored(Some(parse_line_range(payload)?))
+                    ReadMode::Anchored(Some(parse_line_range(payload, other)?))
                 } else if let Some(payload) = other.strip_prefix("density:") {
                     let target = payload
                         .trim()
@@ -419,6 +450,28 @@ mod tests {
             "density:nope".parse::<ReadMode>(),
             Err(ParseModeError::Malformed("density:nope".to_string()))
         );
+    }
+
+    #[test]
+    fn user_message_names_the_dash_form_for_colon_typo() {
+        // #1209: the `lines:44:48` colon typo must yield an actionable message
+        // naming the dash form, not a silent empty window or full-file bounce.
+        let err = "lines:44:48".parse::<ReadMode>().unwrap_err();
+        let msg = err.user_message();
+        assert!(msg.contains("lines:44:48"), "echoes the offending input");
+        assert!(msg.contains("lines:START-END"), "names the expected form");
+        assert!(
+            msg.contains("lines:72-92") || msg.contains("dash"),
+            "shows a dash example"
+        );
+
+        // The same trap on the anchored line-range mode.
+        let anchored = "anchored:44:48".parse::<ReadMode>().unwrap_err();
+        assert!(anchored.user_message().contains("anchored:START-END"));
+
+        // A wholly unknown keyword still lists the valid vocabulary.
+        let unknown = "wat".parse::<ReadMode>().unwrap_err();
+        assert!(unknown.user_message().contains("lines:N-M"));
     }
 
     #[test]

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -154,6 +154,19 @@ impl CtxReadTool {
         let arg_raw = get_bool(args, "raw").unwrap_or(false);
         let explicit_mode_arg = resolve_raw_alias(arg_raw, get_str(args, "mode"));
         let explicit_mode = explicit_mode_arg.is_some();
+        // #1209: a malformed line-range payload (e.g. `lines:44:48` with a colon
+        // instead of a dash) must fail loudly, not silently return an empty
+        // window on small files or bounce to a full-file dump on large ones.
+        // `lines:` and `anchored:` share `parse_line_range`, so validating both
+        // line-range modes at the boundary catches the typo for either. Other
+        // modes are left untouched: bare `density:` is a valid fallback and
+        // unknown keywords keep the historical warn-and-fall-back behaviour.
+        if let Some(ref requested) = explicit_mode_arg
+            && (requested.starts_with("lines:") || requested.starts_with("anchored:"))
+            && let Err(e) = requested.parse::<crate::tools::ctx_read::ReadMode>()
+        {
+            return Err(ErrorData::invalid_params(e.user_message(), None));
+        }
         // #673 — when the caller omits `mode`, a context policy pack's
         // `default_read_mode` (if set) takes precedence over the profile/auto
         // selection. An explicit `mode` arg always wins; line windows below may


### PR DESCRIPTION
## Summary
Fixes #1209. A `lines:` / `anchored:` payload with a **colon** instead of a dash (`lines:44:48`) is malformed but failed silently and inconsistently:
- small file → `No lines matched the range.` (empty result)
- large file → bounced to `full`, dumping the whole file

The token already contains one colon (`lines:`), so a second reads natural (muscle memory from `file:line:col`) — the typo gave no signal it was wrong.

## Fix
- Validate the explicit line-range mode at the MCP boundary (`ctx_read.rs`). On a malformed payload, return `invalid_params` with an actionable message naming the dash form:
  ```
  invalid read mode "lines:44:48": expected lines:START-END (dash), e.g. lines:72-92 (or a comma multi-select like lines:5,10-20)
  ```
- `lines:` and `anchored:` share `parse_line_range`, so **both** line-range modes are covered — the anchored typo (`anchored:44:48`) reports the anchored form.
- Other modes untouched: bare `density:` stays a valid fallback; unknown keywords keep their historical warn-and-fall-back behaviour.
- Also fixed `parse_line_range` mislabeling an `anchored:` rejection as `lines:` in the error string.

## Test
`user_message_names_the_dash_form_for_colon_typo` in `ctx_read/mode.rs` covers the `lines:`, `anchored:`, and unknown-keyword cases. Full `ctx_read::mode` suite: 15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)