### PR TITLE
Fix dashboard refresh broadcasting to all panels

### DIFF
--- a/rust/src/dashboard/static/index.html
+++ b/rust/src/dashboard/static/index.html
@@ -818,6 +818,14 @@ function bootCockpit() {
     if (sb) sb.textContent = sessionBarLabel(sess);
   }
 
+  function refreshActiveView() {
+    var router = window.LctxRouter;
+    if (!router || typeof router.getActiveViewId !== 'function' ||
+        typeof router.navigateTo !== 'function') return false;
+    router.navigateTo(router.getActiveViewId());
+    return true;
+  }
+
   window.checkPulse = async function checkPulse() {
     var refreshBtn = document.getElementById('refreshBtn');
     try {
@@ -832,7 +840,7 @@ function bootCockpit() {
         // stayed static until a reload. When hidden, just flag the button; the
         // visibilitychange handler catches up the moment the tab is focused.
         if (document.visibilityState === 'visible') {
-          document.dispatchEvent(new CustomEvent('lctx:refresh'));
+          refreshActiveView();
           if (refreshBtn) refreshBtn.classList.remove('has-update');
         } else if (refreshBtn) {
           refreshBtn.classList.add('has-update');
@@ -890,11 +898,8 @@ function bootCockpit() {
       refreshBtn.classList.add('spinning');
       refreshBtn.classList.remove('has-update');
       setTimeout(function () { refreshBtn.classList.remove('spinning'); }, 600);
-      document.dispatchEvent(new CustomEvent('lctx:refresh'));
+      refreshActiveView();
       pollCockpit();
-      if (window.LctxRouter && window.LctxRouter.getActiveViewId) {
-        window.LctxRouter.navigateTo(window.LctxRouter.getActiveViewId());
-      }
     });
   }
 
@@ -918,8 +923,9 @@ function bootCockpit() {
   document.addEventListener('visibilitychange', function () {
     if (document.visibilityState !== 'visible') return;
     var rb = document.getElementById('refreshBtn');
+    var hasPendingUpdate = !!(rb && rb.classList.contains('has-update'));
     if (rb) rb.classList.remove('has-update');
-    document.dispatchEvent(new CustomEvent('lctx:refresh'));
+    if (hasPendingUpdate) refreshActiveView();
     pollCockpit();
   });
 

--- a/rust/src/dashboard/static/lib/doctor.js
+++ b/rust/src/dashboard/static/lib/doctor.js
@@ -208,10 +208,11 @@
             : 'Fix ran with warnings \u2014 re-checking\u2026';
           status.className = 'doctor-fix-status ' + (ok ? 'ok' : 'warn');
         }
-        // Other cards (settings/provenance) may have changed too.
-        try {
-          window.dispatchEvent(new CustomEvent('lctx:refresh'));
-        } catch (_) {}
+        var router = window.LctxRouter;
+        if (router && typeof router.getActiveViewId === 'function' &&
+            typeof router.navigateTo === 'function') {
+          router.navigateTo(router.getActiveViewId());
+        }
         return refresh(true);
       })
       .catch(function (e) {

--- a/rust/src/dashboard/static/tests/dashboard-refresh.test.js
+++ b/rust/src/dashboard/static/tests/dashboard-refresh.test.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Regression test for targeted dashboard refreshes.
+ * Run with: node rust/src/dashboard/static/tests/dashboard-refresh.test.js
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const indexPath = path.join(__dirname, '..', 'index.html');
+const html = fs.readFileSync(indexPath, 'utf8');
+const doctorPath = path.join(__dirname, '..', 'lib', 'doctor.js');
+const doctorSource = fs.readFileSync(doctorPath, 'utf8');
+
+let scriptStart = html.indexOf('<script');
+while (scriptStart >= 0) {
+  const sourceStart = html.indexOf('>', scriptStart) + 1;
+  const sourceEnd = html.indexOf('</script>', sourceStart);
+  if (sourceStart === 0 || sourceEnd < 0) {
+    throw new Error('unterminated inline script in dashboard shell');
+  }
+  const source = html.slice(sourceStart, sourceEnd).trim();
+  if (source) Function(source);
+  scriptStart = html.indexOf('<script', sourceEnd + '</script>'.length);
+}
+const helperMarker = 'function refreshActiveView()';
+const routerInitMarker = 'if (window.LctxRouter && window.LctxRouter.init)';
+const helperStart = html.indexOf(helperMarker);
+const routerInit = html.indexOf(routerInitMarker, helperStart);
+
+if (helperStart < 0 || routerInit < 0) {
+  throw new Error('targeted refresh coordinator is missing');
+}
+
+const coordinator = html.slice(helperStart, routerInit);
+const refreshCalls = coordinator.match(/refreshActiveView\(\);/g) || [];
+
+if (!coordinator.includes('router.navigateTo(router.getActiveViewId())')) {
+  throw new Error('refresh does not target the active view loader');
+}
+if (refreshCalls.length !== 3) {
+  throw new Error(`expected 3 targeted refresh paths, found ${refreshCalls.length}`);
+}
+if (!coordinator.includes('hasPendingUpdate')) {
+  throw new Error('visibility observer ignores pending updates');
+}
+if (coordinator.includes("CustomEvent('lctx:refresh')")) {
+  throw new Error('refresh coordinator still broadcasts to every panel');
+}
+if (!doctorSource.includes('router.navigateTo(router.getActiveViewId())')) {
+  throw new Error('Doctor fix does not target the active view loader');
+}
+if (doctorSource.includes("CustomEvent('lctx:refresh')")) {
+  throw new Error('Doctor fix still broadcasts to every panel');
+}
+
+console.log('PASS: dashboard refresh targets only the active view');

--- a/rust/src/dashboard/tests.rs
+++ b/rust/src/dashboard/tests.rs
@@ -658,3 +658,19 @@ fn topbar_uses_explicit_editor_presence_not_transport_alias() {
     assert!(!function.contains("total_active"));
     assert!(function.contains("Sessions \\u2014"));
 }
+
+#[test]
+fn pulse_refresh_targets_only_the_active_view() {
+    let coordinator = COCKPIT_INDEX_HTML
+        .split_once("function refreshActiveView()")
+        .expect("targeted refresh helper")
+        .1
+        .split_once("if (window.LctxRouter && window.LctxRouter.init)")
+        .expect("router initialization")
+        .0;
+
+    assert!(coordinator.contains("router.navigateTo(router.getActiveViewId())"));
+    assert_eq!(coordinator.matches("refreshActiveView();").count(), 3);
+    assert!(coordinator.contains("hasPendingUpdate"));
+    assert!(!coordinator.contains("CustomEvent('lctx:refresh')"));
+}


### PR DESCRIPTION
## Summary

- target dashboard pulse, manual refresh, visibility catch-up, and Doctor fix refreshes through the active view loader
- stop broadcasting lctx:refresh to every cockpit component from those paths
- add JS and Rust regression coverage for targeted refresh behavior

Fixes #1210

## Tests

- node src/dashboard/static/tests/dashboard-refresh.test.js
- node --check src/dashboard/static/lib/doctor.js
- rustfmt --check src/dashboard/tests.rs
- git diff --check HEAD~1..HEAD
- cargo test dashboard::tests::pulse_refresh_targets_only_the_active_view (still running locally after cold build)