### PR TITLE
fix(security): pin patched Hono adapter

### DIFF
--- a/packages/pi-lean-ctx/package-lock.json
+++ b/packages/pi-lean-ctx/package-lock.json
@@ -2438,13 +2438,13 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/packages/pi-lean-ctx/package.json
+++ b/packages/pi-lean-ctx/package.json
@@ -52,6 +52,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
+    "@hono/node-server": "^2.0.5",
     "brace-expansion": "^5.0.7",
     "vite": "^6.4.2",
     "esbuild": "^0.28.1"

--- a/packages/pi-lean-ctx/test/security-lock.test.ts
+++ b/packages/pi-lean-ctx/test/security-lock.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = resolve(__dirname, "..");
+
+interface PackageManifest {
+  overrides?: Record<string, string>;
+}
+
+interface PackageLock {
+  packages?: Record<string, { version?: string }>;
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function isAtLeast(version: string, minimum: [number, number, number]): boolean {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return false;
+  const actual = match.slice(1).map(Number);
+  for (let index = 0; index < minimum.length; index += 1) {
+    if (actual[index] > minimum[index]) return true;
+    if (actual[index] < minimum[index]) return false;
+  }
+  return true;
+}
+
+describe("security dependency lock", () => {
+  it("keeps @hono/node-server at or above the patched version", () => {
+    const manifest = readJson<PackageManifest>(resolve(packageRoot, "package.json"));
+    const lock = readJson<PackageLock>(resolve(packageRoot, "package-lock.json"));
+    const honoVersion = lock.packages?.["node_modules/@hono/node-server"]?.version ?? "";
+
+    expect(manifest.overrides?.["@hono/node-server"]).toBe("^2.0.5");
+    expect(honoVersion).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(isAtLeast(honoVersion, [2, 0, 5])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Pins the transitive `@hono/node-server` adapter used by `packages/pi-lean-ctx` to the patched `^2.0.5` range and updates the lockfile to `2.0.11`. Adds a deterministic Vitest regression guard so the package lock cannot drift back below the patched Hono version.

Refs #1201.

## Test plan

- [x] `cd rust && cargo test -- --test-threads=1` (the suite shares process-global state; CI serializes it too)
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [x] `cd packages/pi-lean-ctx && npm run typecheck`
- [x] `cd packages/pi-lean-ctx && npm test -- --run`
- [x] `cd packages/pi-lean-ctx && npm test -- --run test/security-lock.test.ts`
- [x] `cd packages/pi-lean-ctx && npm pack --dry-run --ignore-scripts`

## Notes for reviewers

- Risk areas / edge cases: `npm audit` still reports the nested `protobufjs@7.6.4` advisory because `@earendil-works/pi-coding-agent@0.81.1` publishes a shrinkwrap that pins `@google/genai -> protobufjs`. Downstream root overrides do not replace that nested shrinkwrapped copy. Tracked upstream at https://github.com/earendil-works/pi/issues/7005.
- Backwards compatibility: package runtime now uses `@hono/node-server@2.0.11`, whose package engine requires Node >=20; this matches the existing Pi package engine.
- Docs updated (links/files): issue investigation documented in #1201.

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`