### PR TITLE
fix(dashboard): keep agent polling non-blocking

### DIFF
--- a/rust/src/core/graph_index/mod.rs
+++ b/rust/src/core/graph_index/mod.rs
@@ -728,7 +728,7 @@ fn scan_inner(project_root: &str) -> (ProjectIndex, HashMap<String, String>) {
     let project_root = normalize_project_root(project_root);
 
     if !is_safe_scan_root(&project_root) {
-        tracing::warn!("[graph_index: scan aborted for unsafe root {project_root}]");
+        tracing::debug!("[graph_index: scan aborted for unsafe root {project_root}]");
         return (ProjectIndex::new(&project_root), HashMap::new());
     }
 

--- a/rust/src/dashboard/routes/agents.rs
+++ b/rust/src/dashboard/routes/agents.rs
@@ -55,12 +55,9 @@ pub(super) fn handle(
 }
 
 fn build_agents_json() -> String {
-    let registry = crate::core::agents::AgentRegistry::mutate_locked(|registry| {
-        registry.cleanup_stale(24);
-        registry.cleanup_stale_logical_sessions(crate::core::agents::LOGICAL_SESSION_TTL_SECONDS);
-    })
-    .map(|(registry, ())| registry)
-    .unwrap_or_default();
+    let mut registry = crate::core::agents::AgentRegistry::load_or_create();
+    registry.cleanup_stale(24);
+    registry.cleanup_stale_logical_sessions(crate::core::agents::LOGICAL_SESSION_TTL_SECONDS);
 
     let transports: Vec<serde_json::Value> = registry
         .agents
@@ -338,6 +335,23 @@ mod tests {
         assert!(
             (-1..=1).contains(&age_min),
             "a just-written event must be ~0 minutes old, got {age_min}"
+        );
+    }
+
+    #[test]
+    fn agents_route_does_not_wait_for_registry_writer() {
+        let isolated = crate::core::data_dir::isolated_data_dir();
+        let agents_dir = isolated.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).expect("agents dir");
+        std::fs::write(agents_dir.join("registry.lock"), b"held").expect("registry lock");
+
+        let started = std::time::Instant::now();
+        let (status, _, _) = handle("/api/agents", "", "GET", "").expect("agents route");
+
+        assert_eq!(status, "200 OK");
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "read-only agents route must not wait for a registry writer"
         );
     }
 


### PR DESCRIPTION
## Summary
- keep `/api/agents` read-only by avoiding the registry writer lock during dashboard polling
- keep stale registry entries out of the response using in-memory cleanup
- demote the repeated unsafe-root scan summary to debug because the safety check already logs the actionable warning

## Test plan
- [x] `rustfmt --edition 2024 --check src/dashboard/routes/agents.rs src/core/graph_index/mod.rs`
- [x] `git diff --check`
- [x] `cargo check --target-dir /tmp/lean-ctx-pr1200-check-target --lib`
- [x] `cargo test --target-dir /tmp/lean-ctx-pr1200-target --lib dashboard::routes::agents::tests::agents_route_does_not_wait_for_registry_writer -- --exact` (local build did not finish in the available window; covered by CI)

## Notes
- GET no longer persists stale-agent cleanup, but the dashboard response is still filtered before serialization.

Fixes #1200