### PR TITLE
fix(mcp): make secret memento env names injective

### DIFF
--- a/docs/reference/05-advanced.md
+++ b/docs/reference/05-advanced.md
@@ -743,7 +743,25 @@ args = ["/path/to/project"]
 name = "linear"
 transport = "http"                       # connect to a remote server
 url = "https://mcp.linear.app/mcp"
-headers = { Authorization = "Bearer ${LINEAR_TOKEN}" }
+secret_headers = { Authorization = { id = "mcp/linear/default", format = "Bearer {secret}" } }
+```
+
+Supply the value at runtime, preferably through your process supervisor or secret
+manager rather than a shell history entry:
+
+```bash
+export LEAN_CTX_SECRET_6D63702F6C696E6561722F64656661756C74='<token>'
+```
+
+The config stores only the opaque memento id. lean-ctx hex-encodes the id's UTF-8
+bytes after the `LEAN_CTX_SECRET_` prefix, producing a shell-safe environment name
+without aliasing distinct ids, then restores the value only when resolving the
+transport. Missing mementos fail closed. Embedders can instead seed
+`SecretMementoStore`; stdio servers use the same pattern through `secret_env`, for
+example:
+
+```toml
+secret_env = { GITLAB_TOKEN = { id = "mcp/gitlab/default" } }
 ```
 
 Then, from the agent:

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -221,6 +221,8 @@ Downstream MCP servers (array of tables: `[[gateway.servers]]`)
 - `env` (table, default `{}`) — Extra environment variables for the child process (stdio transport)
 - `headers` (table, default `{}`) — Extra request headers, e.g. Authorization (http transport)
 - `name` (string, default `""`) — Stable server id; becomes the catalog namespace (`name::tool`)
+- `secret_env` (table, default `{}`) — Secret environment variables mapped to memento references (stdio transport)
+- `secret_headers` (table, default `{}`) — Secret HTTP headers mapped to memento references (http transport)
 - `transport` (string, default `stdio`) — Transport: stdio (spawn command) or http (connect to url)
 - `url` (string, default `""`) — Streamable-HTTP endpoint (http transport)
 

--- a/rust/src/core/addons/manifest.rs
+++ b/rust/src/core/addons/manifest.rs
@@ -241,9 +241,11 @@ impl AddonManifest {
             command: self.mcp.command.clone(),
             args: self.mcp.args.clone(),
             env: self.mcp.env.clone(),
+            secret_env: BTreeMap::new(),
             binary_sha256: self.mcp.sha256.clone(),
             url: self.mcp.url.clone(),
             headers: self.mcp.headers.clone(),
+            secret_headers: BTreeMap::new(),
             capabilities: self.capabilities.clone(),
             // L4 routing: resolved from the explicit manifest field or derived
             // from the addon's categories (#1096). Empty = generic L1-L3 only.

--- a/rust/src/core/config/schema/sections_features.rs
+++ b/rust/src/core/config/schema/sections_features.rs
@@ -572,6 +572,14 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         ),
     );
     gateway_servers.insert(
+        "secret_env".into(),
+        key(
+            "table",
+            serde_json::json!({}),
+            "Secret environment variables mapped to memento references (stdio transport)",
+        ),
+    );
+    gateway_servers.insert(
         "url".into(),
         key(
             "string",
@@ -585,6 +593,14 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             "table",
             serde_json::json!({}),
             "Extra request headers, e.g. Authorization (http transport)",
+        ),
+    );
+    gateway_servers.insert(
+        "secret_headers".into(),
+        key(
+            "table",
+            serde_json::json!({}),
+            "Secret HTTP headers mapped to memento references (http transport)",
         ),
     );
     sections.insert(

--- a/rust/src/core/mcp_catalog/client.rs
+++ b/rust/src/core/mcp_catalog/client.rs
@@ -11,6 +11,7 @@
 //! The catalog-listing cost is additionally amortized by the TTL cache in
 //! [`super::catalog`].
 
+use std::collections::{BTreeMap, HashMap};
 use std::time::Duration;
 
 use rmcp::ServiceExt;
@@ -40,6 +41,7 @@ pub async fn open(
                 env,
                 binary_sha256,
                 capabilities,
+                ..
             } => {
                 // Binary-hash pin (#403, P3): if the addon pinned its binary's
                 // sha256, verify the file on PATH before doing anything else, so
@@ -64,18 +66,14 @@ pub async fn open(
                     .await
                     .map_err(|e| format!("MCP handshake failed (stdio): {e}"))
             }
-            ResolvedTransport::Http { url, headers } => {
+            ResolvedTransport::Http {
+                url,
+                headers,
+                secret_fingerprints,
+            } => {
                 let mut cfg = StreamableHttpClientTransportConfig::with_uri(url.clone());
                 if !headers.is_empty() {
-                    let mut custom = std::collections::HashMap::new();
-                    for (k, v) in headers {
-                        let name = http::HeaderName::from_bytes(k.as_bytes())
-                            .map_err(|e| format!("invalid header name `{k}`: {e}"))?;
-                        let val = http::HeaderValue::from_str(v)
-                            .map_err(|e| format!("invalid header value for `{k}`: {e}"))?;
-                        custom.insert(name, val);
-                    }
-                    cfg = cfg.custom_headers(custom);
+                    cfg = cfg.custom_headers(http_headers(headers, secret_fingerprints)?);
                 }
                 let t = StreamableHttpClientTransport::from_config(cfg);
                 ().serve(t)
@@ -87,6 +85,46 @@ pub async fn open(
     tokio::time::timeout(timeout, connect)
         .await
         .map_err(|_| "downstream connect timed out".to_string())?
+}
+
+fn http_headers(
+    headers: &BTreeMap<String, String>,
+    secret_fingerprints: &BTreeMap<String, String>,
+) -> Result<HashMap<http::HeaderName, http::HeaderValue>, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let header_name = http::HeaderName::from_bytes(name.as_bytes())
+                .map_err(|error| format!("invalid header name `{name}`: {error}"))?;
+            let mut header_value = http::HeaderValue::from_str(value)
+                .map_err(|error| format!("invalid header value for `{name}`: {error}"))?;
+            if secret_fingerprints
+                .keys()
+                .any(|secret| secret.eq_ignore_ascii_case(name))
+            {
+                header_value.set_sensitive(true);
+            }
+            Ok((header_name, header_value))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memento_headers_are_marked_sensitive() {
+        let headers = BTreeMap::from([
+            ("Accept".into(), "application/json".into()),
+            ("Authorization".into(), "Bearer private-token".into()),
+        ]);
+        let secrets = BTreeMap::from([("authorization".into(), "fingerprint".into())]);
+        let converted = http_headers(&headers, &secrets).expect("valid headers");
+
+        assert!(!converted[&http::header::ACCEPT].is_sensitive());
+        assert!(converted[&http::header::AUTHORIZATION].is_sensitive());
+    }
 }
 
 /// List tools on an already-connected session (bounded by `timeout`).

--- a/rust/src/core/mcp_catalog/config.rs
+++ b/rust/src/core/mcp_catalog/config.rs
@@ -7,8 +7,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt;
 
 use crate::core::addons::capabilities::AddonCapabilities;
+use crate::core::mcp_catalog::memento::{SecretMementoStore, fingerprint};
 
 /// Which transport a downstream MCP server speaks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
@@ -30,6 +32,39 @@ impl TransportKind {
     }
 }
 
+/// Opaque reference to a runtime-restored secret.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecretMementoRef {
+    /// Opaque identifier restored by [`SecretMementoStore`].
+    pub id: String,
+    /// Optional template containing `{secret}` for the restored value.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub format: String,
+}
+
+impl SecretMementoRef {
+    fn restore(&self, field: &str) -> Result<(String, String), String> {
+        if self.id.trim().is_empty() {
+            return Err(format!("secret memento for `{field}` has an empty `id`"));
+        }
+        if !self.format.is_empty() && !self.format.contains("{secret}") {
+            return Err(format!(
+                "secret memento `{}` for `{field}` has a format without `{{secret}}`",
+                self.id
+            ));
+        }
+        let secret = SecretMementoStore::global()
+            .restore(&self.id)
+            .ok_or_else(|| format!("missing secret memento `{}` for `{field}`", self.id))?;
+        let value = if self.format.is_empty() {
+            secret
+        } else {
+            self.format.replace("{secret}", &secret)
+        };
+        let fingerprint = fingerprint(&value);
+        Ok((value, fingerprint))
+    }
+}
 /// A single downstream MCP server entry (`[[gateway.servers]]`).
 ///
 /// Flat shape (rather than an internally-tagged enum) so it round-trips
@@ -52,6 +87,9 @@ pub struct GatewayServer {
     pub args: Vec<String>,
     /// Extra environment variables for the child process.
     pub env: BTreeMap<String, String>,
+    /// Environment variable names mapped to secret memento references.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub secret_env: BTreeMap<String, SecretMementoRef>,
     /// Optional SHA-256 pin of the stdio `command` binary (P3). When set, the
     /// spawn point ([`crate::core::mcp_catalog::client`]) verifies the resolved
     /// binary's hash and refuses to launch a swapped executable. Empty =
@@ -65,6 +103,9 @@ pub struct GatewayServer {
     pub url: String,
     /// Extra request headers (e.g. auth) for the http transport.
     pub headers: BTreeMap<String, String>,
+    /// HTTP header names mapped to secret memento references.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub secret_headers: BTreeMap<String, SecretMementoRef>,
 
     /// Declared capabilities (P1). `None` keeps the legacy `addons.sandbox`
     /// behaviour; `Some` enforces a per-server OS sandbox + env allowlist
@@ -92,9 +133,11 @@ impl Default for GatewayServer {
             command: String::new(),
             args: Vec::new(),
             env: BTreeMap::new(),
+            secret_env: BTreeMap::new(),
             binary_sha256: String::new(),
             url: String::new(),
             headers: BTreeMap::new(),
+            secret_headers: BTreeMap::new(),
             capabilities: None,
             integration: String::new(),
         }
@@ -102,7 +145,7 @@ impl Default for GatewayServer {
 }
 
 /// A validated transport ready to open a connection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ResolvedTransport {
     Stdio {
         command: String,
@@ -110,13 +153,71 @@ pub enum ResolvedTransport {
         env: BTreeMap<String, String>,
         /// SHA-256 pin of `command` to verify before spawn (empty = unpinned).
         binary_sha256: String,
+        secret_fingerprints: BTreeMap<String, String>,
         /// Declared capabilities to enforce at spawn (`None` = legacy path).
         capabilities: Option<AddonCapabilities>,
     },
     Http {
         url: String,
         headers: BTreeMap<String, String>,
+        secret_fingerprints: BTreeMap<String, String>,
     },
+}
+
+impl fmt::Debug for ResolvedTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stdio {
+                command,
+                args,
+                env,
+                binary_sha256,
+                secret_fingerprints,
+                capabilities,
+            } => formatter
+                .debug_struct("Stdio")
+                .field("command", command)
+                .field("args", args)
+                .field("env", &redacted_values(env, secret_fingerprints))
+                .field("binary_sha256", binary_sha256)
+                .field(
+                    "secret_fields",
+                    &secret_fingerprints.keys().collect::<Vec<_>>(),
+                )
+                .field("capabilities", capabilities)
+                .finish(),
+            Self::Http {
+                url,
+                headers,
+                secret_fingerprints,
+            } => formatter
+                .debug_struct("Http")
+                .field("url", url)
+                .field("headers", &redacted_values(headers, secret_fingerprints))
+                .field(
+                    "secret_fields",
+                    &secret_fingerprints.keys().collect::<Vec<_>>(),
+                )
+                .finish(),
+        }
+    }
+}
+
+fn redacted_values<'a>(
+    values: &'a BTreeMap<String, String>,
+    secret_fingerprints: &BTreeMap<String, String>,
+) -> BTreeMap<&'a str, &'a str> {
+    values
+        .iter()
+        .map(|(name, value)| {
+            let value = if secret_fingerprints.contains_key(name) {
+                "<redacted>"
+            } else {
+                value.as_str()
+            };
+            (name.as_str(), value)
+        })
+        .collect()
 }
 
 impl GatewayServer {
@@ -134,11 +235,20 @@ impl GatewayServer {
                         self.name
                     ));
                 }
+                let mut env = self.env.clone();
+                let mut secret_fingerprints = BTreeMap::new();
+                for (name, memento) in &self.secret_env {
+                    let (value, fingerprint) = memento.restore(name)?;
+                    env.insert(name.clone(), value);
+                    secret_fingerprints.insert(name.clone(), fingerprint);
+                }
+
                 Ok(ResolvedTransport::Stdio {
                     command: self.command.clone(),
                     args: self.args.clone(),
-                    env: self.env.clone(),
+                    env,
                     binary_sha256: self.binary_sha256.clone(),
+                    secret_fingerprints,
                     capabilities: self.capabilities.clone(),
                 })
             }
@@ -150,9 +260,28 @@ impl GatewayServer {
                         self.name
                     ));
                 }
+                let mut headers = self.headers.clone();
+                let mut secret_fingerprints = BTreeMap::new();
+                for (name, memento) in &self.secret_headers {
+                    if secret_fingerprints
+                        .keys()
+                        .any(|existing: &String| existing.eq_ignore_ascii_case(name))
+                    {
+                        return Err(format!(
+                            "gateway server `{}` declares duplicate secret header `{name}`",
+                            self.name
+                        ));
+                    }
+                    let (value, fingerprint) = memento.restore(name)?;
+                    headers.retain(|existing, _| !existing.eq_ignore_ascii_case(name));
+                    headers.insert(name.clone(), value);
+                    secret_fingerprints.insert(name.clone(), fingerprint);
+                }
+
                 Ok(ResolvedTransport::Http {
                     url: url.to_string(),
-                    headers: self.headers.clone(),
+                    headers,
+                    secret_fingerprints,
                 })
             }
         }
@@ -314,6 +443,7 @@ integration = "codebase-pack"
                 args: vec!["/tmp".into()],
                 env: BTreeMap::new(),
                 binary_sha256: String::new(),
+                secret_fingerprints: BTreeMap::new(),
                 capabilities: None,
             }
         );
@@ -346,6 +476,205 @@ integration = "codebase-pack"
             ..Default::default()
         };
         assert!(bad.resolve().is_err());
+    }
+
+    #[test]
+    fn stdio_secret_env_restores_from_memento() {
+        crate::core::mcp_catalog::memento::SecretMementoStore::global()
+            .put("mcp/gitlab/default", "test-secret");
+        let s = GatewayServer {
+            name: "gitlab".into(),
+            transport: TransportKind::Stdio,
+            command: "gitlab-mcp".into(),
+            secret_env: BTreeMap::from([(
+                "GITLAB_TOKEN".into(),
+                SecretMementoRef {
+                    id: "mcp/gitlab/default".into(),
+                    format: String::new(),
+                },
+            )]),
+            ..Default::default()
+        };
+        let resolved = s.resolve().expect("resolve");
+        match resolved {
+            ResolvedTransport::Stdio {
+                env,
+                secret_fingerprints,
+                ..
+            } => {
+                assert_eq!(
+                    env.get("GITLAB_TOKEN").map(String::as_str),
+                    Some("test-secret")
+                );
+                assert!(secret_fingerprints.contains_key("GITLAB_TOKEN"));
+            }
+            _ => panic!("expected stdio"),
+        }
+        crate::core::mcp_catalog::memento::SecretMementoStore::global()
+            .remove("mcp/gitlab/default");
+    }
+
+    #[test]
+    fn http_secret_header_uses_format_template() {
+        crate::core::mcp_catalog::memento::SecretMementoStore::global()
+            .put("mcp/gitlab/header", "test-secret");
+        let s = GatewayServer {
+            name: "gitlab".into(),
+            transport: TransportKind::Http,
+            url: "https://gitlab.example/mcp".into(),
+            secret_headers: BTreeMap::from([(
+                "Authorization".into(),
+                SecretMementoRef {
+                    id: "mcp/gitlab/header".into(),
+                    format: "Bearer {secret}".into(),
+                },
+            )]),
+            ..Default::default()
+        };
+        let resolved = s.resolve().expect("resolve");
+        match resolved {
+            ResolvedTransport::Http {
+                url: _,
+                headers,
+                secret_fingerprints,
+                ..
+            } => {
+                assert_eq!(
+                    headers.get("Authorization").map(String::as_str),
+                    Some("Bearer test-secret")
+                );
+                assert!(secret_fingerprints.contains_key("Authorization"));
+            }
+            _ => panic!("expected http"),
+        }
+        crate::core::mcp_catalog::memento::SecretMementoStore::global().remove("mcp/gitlab/header");
+    }
+
+    #[test]
+    fn http_secret_header_overrides_public_header_case_insensitively() {
+        let store = SecretMementoStore::global();
+        store.put("mcp/gitlab/header-case", "private-token");
+        let server = GatewayServer {
+            name: "gitlab".into(),
+            transport: TransportKind::Http,
+            url: "https://gitlab.example/mcp".into(),
+            headers: BTreeMap::from([("authorization".into(), "public-value".into())]),
+            secret_headers: BTreeMap::from([(
+                "Authorization".into(),
+                SecretMementoRef {
+                    id: "mcp/gitlab/header-case".into(),
+                    format: "Bearer {secret}".into(),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let resolved = server.resolve().expect("resolve");
+        match resolved {
+            ResolvedTransport::Http {
+                url: _,
+                headers,
+                secret_fingerprints,
+            } => {
+                assert_eq!(headers.len(), 1);
+                assert_eq!(
+                    headers.get("Authorization").map(String::as_str),
+                    Some("Bearer private-token")
+                );
+                assert_eq!(secret_fingerprints.len(), 1);
+                assert!(secret_fingerprints.contains_key("Authorization"));
+            }
+            _ => panic!("expected http"),
+        }
+        store.remove("mcp/gitlab/header-case");
+    }
+
+    #[test]
+    fn secret_memento_toml_round_trip_never_serializes_value() {
+        let store = SecretMementoStore::global();
+        store.put("mcp/gitlab/toml", "private-token");
+        let source = r#"
+enabled = true
+
+[[servers]]
+name = "gitlab"
+transport = "http"
+url = "https://gitlab.example/mcp"
+secret_headers = { Authorization = { id = "mcp/gitlab/toml", format = "Bearer {secret}" } }
+"#;
+        let config: GatewayConfig = toml::from_str(source).expect("parse memento config");
+        config.servers[0].resolve().expect("restore memento");
+        let serialized = toml::to_string(&config).expect("serialize memento config");
+
+        assert!(serialized.contains("mcp/gitlab/toml"));
+        assert!(!serialized.contains("private-token"));
+        store.remove("mcp/gitlab/toml");
+    }
+
+    #[test]
+    fn malformed_secret_memento_fails_closed() {
+        let store = SecretMementoStore::global();
+        store.put("mcp/gitlab/malformed", "private-token");
+        let server = GatewayServer {
+            name: "gitlab".into(),
+            transport: TransportKind::Stdio,
+            command: "gitlab-mcp".into(),
+            secret_env: BTreeMap::from([(
+                "GITLAB_TOKEN".into(),
+                SecretMementoRef {
+                    id: "mcp/gitlab/malformed".into(),
+                    format: "Bearer".into(),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        assert!(
+            server
+                .resolve()
+                .expect_err("invalid template")
+                .contains("{secret}")
+        );
+        store.remove("mcp/gitlab/malformed");
+    }
+
+    #[test]
+    fn resolved_transport_debug_redacts_memento_values() {
+        let transport = ResolvedTransport::Http {
+            url: "https://gitlab.example/mcp".into(),
+            headers: BTreeMap::from([
+                ("Accept".into(), "application/json".into()),
+                ("Authorization".into(), "private-value".into()),
+            ]),
+            secret_fingerprints: BTreeMap::from([("Authorization".into(), "abc123".into())]),
+        };
+
+        let debug = format!("{transport:?}");
+        assert!(debug.contains("application/json"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("private-value"));
+    }
+
+    #[test]
+    fn missing_secret_memento_fails_closed() {
+        let s = GatewayServer {
+            name: "gitlab".into(),
+            transport: TransportKind::Stdio,
+            command: "gitlab-mcp".into(),
+            secret_env: BTreeMap::from([(
+                "GITLAB_TOKEN".into(),
+                SecretMementoRef {
+                    id: "mcp/gitlab/missing".into(),
+                    format: String::new(),
+                },
+            )]),
+            ..Default::default()
+        };
+        assert!(
+            s.resolve()
+                .expect_err("missing secret")
+                .contains("missing secret memento")
+        );
     }
 
     #[test]

--- a/rust/src/core/mcp_catalog/memento.rs
+++ b/rust/src/core/mcp_catalog/memento.rs
@@ -1,0 +1,121 @@
+//! Secret mementos for downstream MCP auth.
+//!
+//! Gateway config stores opaque memento ids. Secret material is restored at the
+//! transport edge and kept out of serialized config/debug output.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+/// Runtime secret store used by gateway mementos.
+///
+/// In-memory values take precedence over the deterministic environment fallback
+/// returned by [`env_name`]. Empty values are treated as unavailable.
+#[derive(Default)]
+pub struct SecretMementoStore {
+    values: Mutex<BTreeMap<String, String>>,
+}
+
+impl SecretMementoStore {
+    #[must_use]
+    pub fn global() -> &'static Self {
+        static STORE: OnceLock<SecretMementoStore> = OnceLock::new();
+        STORE.get_or_init(Self::default)
+    }
+
+    pub fn put(&self, id: impl Into<String>, secret: impl Into<String>) {
+        self.values
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(id.into(), secret.into());
+    }
+
+    pub fn remove(&self, id: &str) {
+        self.values
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(id);
+    }
+
+    #[must_use]
+    pub fn restore(&self, id: &str) -> Option<String> {
+        if let Some(secret) = self
+            .values
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(id)
+            .cloned()
+        {
+            return (!secret.is_empty()).then_some(secret);
+        }
+        std::env::var(env_name(id)).ok().filter(|v| !v.is_empty())
+    }
+}
+
+#[must_use]
+pub fn env_name(id: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    let mut name = String::with_capacity("LEAN_CTX_SECRET_".len() + id.len() * 2);
+    name.push_str("LEAN_CTX_SECRET_");
+    for byte in id.as_bytes() {
+        name.push(char::from(HEX[usize::from(byte >> 4)]));
+        name.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    name
+}
+
+#[must_use]
+pub fn fingerprint(secret: &str) -> String {
+    blake3::hash(secret.as_bytes()).to_hex()[..12].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_name_is_stable_and_shell_safe() {
+        assert_eq!(
+            env_name("mcp/gitlab/default"),
+            "LEAN_CTX_SECRET_6D63702F6769746C61622F64656661756C74"
+        );
+    }
+
+    #[test]
+    fn env_name_is_injective_for_previously_colliding_ids() {
+        let encoded = ["a/b", "a-b", "A_B"].map(env_name);
+        let names = encoded
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(names.len(), 3);
+    }
+
+    #[test]
+    fn store_restores_seeded_secret() {
+        let store = SecretMementoStore::global();
+        store.put("mcp/test/store", "secret");
+        assert_eq!(store.restore("mcp/test/store").as_deref(), Some("secret"));
+        store.remove("mcp/test/store");
+    }
+
+    #[test]
+    fn store_falls_back_to_derived_environment_name() {
+        let id = "mcp/test/env-fallback";
+        let name = env_name(id);
+        crate::test_env::set_var(&name, "environment-secret");
+        assert_eq!(
+            SecretMementoStore::global().restore(id).as_deref(),
+            Some("environment-secret")
+        );
+        crate::test_env::remove_var(&name);
+    }
+
+    #[test]
+    fn empty_seeded_secret_is_unavailable() {
+        let store = SecretMementoStore::global();
+        store.put("mcp/test/empty", "");
+        assert_eq!(store.restore("mcp/test/empty"), None);
+        store.remove("mcp/test/empty");
+    }
+}

--- a/rust/src/core/mcp_catalog/mod.rs
+++ b/rust/src/core/mcp_catalog/mod.rs
@@ -15,12 +15,16 @@ pub mod adapters;
 pub mod catalog;
 pub mod client;
 pub mod config;
+pub mod memento;
 pub mod pool;
 pub mod postprocess;
 pub mod router;
 
 pub use catalog::Catalog;
-pub use config::{GatewayConfig, GatewayServer, ResolvedTransport, TransportKind};
+pub use config::{
+    GatewayConfig, GatewayServer, ResolvedTransport, SecretMementoRef, TransportKind,
+};
+pub use memento::SecretMementoStore;
 pub use router::ScoredTool;
 
 use serde_json::{Map, Value};

--- a/rust/src/core/mcp_catalog/pool.rs
+++ b/rust/src/core/mcp_catalog/pool.rs
@@ -19,8 +19,8 @@
 //! sections (the slow `open()` runs outside the lock), which keeps [`clear`]
 //! callable from the synchronous config/catalog paths.
 
-use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -42,14 +42,49 @@ fn pool() -> &'static Mutex<HashMap<u64, Entry>> {
     POOL.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Stable identity for a resolved transport: same wiring → same key → same
-/// pooled session. Derived from the transport's `Debug` form so every field
-/// (command/args/env/binary pin/capabilities, or url/headers) is captured.
+/// Stable identity for a resolved transport: same wiring -> same key -> same
+/// pooled session. Secret values are replaced by memento fingerprints.
 #[must_use]
 pub fn key(transport: &ResolvedTransport) -> u64 {
     let mut h = DefaultHasher::new();
-    format!("{transport:?}").hash(&mut h);
+    pool_identity(transport).hash(&mut h);
     h.finish()
+}
+
+#[must_use]
+fn pool_identity(transport: &ResolvedTransport) -> String {
+    match transport {
+        ResolvedTransport::Stdio {
+            command,
+            args,
+            env,
+            binary_sha256,
+            secret_fingerprints,
+            capabilities,
+        } => format!(
+            "stdio|command={command:?}|args={args:?}|env={:?}|binary_sha256={binary_sha256:?}|secrets={secret_fingerprints:?}|capabilities={capabilities:?}",
+            public_values(env, secret_fingerprints)
+        ),
+        ResolvedTransport::Http {
+            url,
+            headers,
+            secret_fingerprints,
+        } => format!(
+            "http|url={url:?}|headers={:?}|secrets={secret_fingerprints:?}",
+            public_values(headers, secret_fingerprints)
+        ),
+    }
+}
+
+fn public_values(
+    values: &BTreeMap<String, String>,
+    secret_fingerprints: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    values
+        .iter()
+        .filter(|(name, _)| !secret_fingerprints.contains_key(*name))
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect()
 }
 
 /// A live session for `transport`, reusing a pooled one when present + fresh, or
@@ -126,6 +161,7 @@ mod tests {
             args: vec![],
             env: BTreeMap::new(),
             binary_sha256: String::new(),
+            secret_fingerprints: BTreeMap::new(),
             capabilities: None,
         }
     }
@@ -138,6 +174,76 @@ mod tests {
             key(&stdio("b")),
             "different command → different key"
         );
+    }
+
+    #[test]
+    fn key_identity_uses_secret_fingerprint_not_raw_value() {
+        let mut env = BTreeMap::new();
+        env.insert("GITLAB_TOKEN".into(), "raw-token-one".into());
+        let mut secrets = BTreeMap::new();
+        secrets.insert("GITLAB_TOKEN".into(), "fp-one".into());
+        let first = ResolvedTransport::Stdio {
+            command: "gitlab-mcp".into(),
+            args: vec![],
+            env: env.clone(),
+            binary_sha256: String::new(),
+            secret_fingerprints: secrets.clone(),
+            capabilities: None,
+        };
+        assert!(!pool_identity(&first).contains("raw-token-one"));
+        env.insert("GITLAB_TOKEN".into(), "raw-token-two".into());
+        let same_fingerprint = ResolvedTransport::Stdio {
+            command: "gitlab-mcp".into(),
+            args: vec![],
+            env,
+            binary_sha256: String::new(),
+            secret_fingerprints: secrets.clone(),
+            capabilities: None,
+        };
+        assert_eq!(key(&first), key(&same_fingerprint));
+        secrets.insert("GITLAB_TOKEN".into(), "fp-two".into());
+        let rotated = ResolvedTransport::Stdio {
+            command: "gitlab-mcp".into(),
+            args: vec![],
+            env: BTreeMap::from([("GITLAB_TOKEN".into(), "raw-token-two".into())]),
+            binary_sha256: String::new(),
+            secret_fingerprints: secrets,
+            capabilities: None,
+        };
+        assert_ne!(key(&first), key(&rotated));
+    }
+
+    #[test]
+    fn key_changes_when_secret_format_changes() {
+        use super::super::config::{GatewayServer, SecretMementoRef, TransportKind};
+        use super::super::memento::SecretMementoStore;
+
+        let store = SecretMementoStore::global();
+        store.put("mcp/test/pool-format", "token");
+        let mut server = GatewayServer {
+            name: "remote".into(),
+            transport: TransportKind::Http,
+            url: "https://example.com/mcp".into(),
+            secret_headers: BTreeMap::from([(
+                "Authorization".into(),
+                SecretMementoRef {
+                    id: "mcp/test/pool-format".into(),
+                    format: String::new(),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let raw = server.resolve().expect("resolve raw secret");
+        server
+            .secret_headers
+            .get_mut("Authorization")
+            .expect("secret header")
+            .format = "Bearer {secret}".into();
+        let bearer = server.resolve().expect("resolve formatted secret");
+        store.remove("mcp/test/pool-format");
+
+        assert_ne!(key(&raw), key(&bearer));
     }
 
     #[test]

--- a/rust/tests/suite/gateway_e2e.rs
+++ b/rust/tests/suite/gateway_e2e.rs
@@ -201,6 +201,7 @@ fn fixture_transport() -> ResolvedTransport {
         env: BTreeMap::new(),
         binary_sha256: String::new(),
         capabilities: None,
+        secret_fingerprints: BTreeMap::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- hex-encode secret memento ids into shell-safe environment names
- add regression coverage for previously colliding ids (`a/b`, `a-b`, `A_B`)
- document the derived environment variable format

Fixes #1203

## Validation
- rustfmt --edition 2024 --check rust/src/core/mcp_catalog/client.rs rust/src/core/mcp_catalog/config.rs rust/src/core/mcp_catalog/memento.rs rust/src/core/mcp_catalog/pool.rs
- git diff --check

Note: local cargo test compilation exceeded the available foreground timeout due concurrent Rust builds; CI is the source of truth for the full matrix.