### PR TITLE
fix(ctx_shell): stream partial output from a running background job's status (#1217)

### DIFF
--- a/rust/src/server/background_shell.rs
+++ b/rust/src/server/background_shell.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum JobState {
-    Running,
+    Running { output: String },
     Completed { output: String, exit_code: i32 },
     Cancelled { output: String },
 }
@@ -27,6 +27,9 @@ struct Job {
     cancel: Arc<AtomicBool>,
     state: JobState,
     finished_at: Option<Instant>,
+    // #1217: shared buffer the worker streams captured output into while the
+    // job runs, so `status` can report progress before the job completes.
+    live: Arc<Mutex<String>>,
 }
 
 static JOBS: LazyLock<Mutex<HashMap<String, Job>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -60,7 +63,7 @@ fn prune_finished_jobs_with_limits(
             let finished_at = job.finished_at?;
             let output_bytes = match &job.state {
                 JobState::Completed { output, .. } | JobState::Cancelled { output } => output.len(),
-                JobState::Running => 0,
+                JobState::Running { .. } => 0,
             };
             Some((finished_at, id.clone(), output_bytes))
         })
@@ -108,20 +111,28 @@ pub fn start(
     );
     let cancel = Arc::new(AtomicBool::new(false));
     let worker_cancel = Arc::clone(&cancel);
+    let live = Arc::new(Mutex::new(String::new()));
+    let worker_live = Arc::clone(&live);
     {
         let mut jobs = JOBS
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         prune_finished_jobs(&mut jobs, Instant::now());
-        if matches!(jobs.get(&id).map(|job| &job.state), Some(JobState::Running)) {
+        if matches!(
+            jobs.get(&id).map(|job| &job.state),
+            Some(JobState::Running { .. })
+        ) {
             return id;
         }
         jobs.insert(
             id.clone(),
             Job {
                 cancel,
-                state: JobState::Running,
+                state: JobState::Running {
+                    output: String::new(),
+                },
                 finished_at: None,
+                live,
             },
         );
     }
@@ -137,6 +148,8 @@ pub fn start(
             // #1113/#1173: bounded by output, not wall clock — a monitor loop
             // emitting a line every 45s must survive. See `idle_keyed`.
             true,
+            // #1217: stream captured output into the shared buffer as it arrives.
+            Some(&worker_live),
         );
         let mut jobs = JOBS
             .lock()
@@ -229,10 +242,22 @@ fn remove(id: &str) {
 }
 
 pub fn status(id: &str) -> Option<JobState> {
-    JOBS.lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .get(id)
-        .map(|job| job.state.clone())
+    let jobs = JOBS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let job = jobs.get(id)?;
+    Some(match &job.state {
+        // #1217: a running job's output lives in the shared buffer the worker
+        // streams into; surface the captured-so-far snapshot on each poll.
+        JobState::Running { .. } => JobState::Running {
+            output: job
+                .live
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+        },
+        other => other.clone(),
+    })
 }
 
 pub fn cancel(id: &str) -> Option<JobState> {
@@ -240,7 +265,7 @@ pub fn cancel(id: &str) -> Option<JobState> {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let job = jobs.get_mut(id)?;
-    if matches!(job.state, JobState::Running) {
+    if matches!(job.state, JobState::Running { .. }) {
         job.cancel.store(true, Ordering::Release);
     }
     Some(job.state.clone())
@@ -267,6 +292,7 @@ mod tests {
                         exit_code: 0,
                     },
                     finished_at: Some(now - Duration::from_secs((index + 1) as u64)),
+                    live: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
                 },
             );
         }
@@ -279,6 +305,7 @@ mod tests {
                     exit_code: 0,
                 },
                 finished_at: Some(now - super::COMPLETED_JOB_TTL - Duration::from_secs(1)),
+                live: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
             },
         );
 
@@ -303,6 +330,7 @@ mod tests {
                         exit_code: 0,
                     },
                     finished_at: Some(now - Duration::from_secs((3 - index) as u64)),
+                    live: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
                 },
             );
         }
@@ -414,7 +442,7 @@ mod tests {
             std::collections::HashMap::default(),
             Some(10_000),
         );
-        assert_eq!(status(&id), Some(JobState::Running));
+        assert!(matches!(status(&id), Some(JobState::Running { .. })));
         for _ in 0..40 {
             if let Some(JobState::Completed { output, exit_code }) = status(&id) {
                 assert_eq!(exit_code, 0);
@@ -435,7 +463,7 @@ mod tests {
             std::collections::HashMap::default(),
             Some(10_000),
         );
-        assert!(matches!(cancel(&id), Some(JobState::Running)));
+        assert!(matches!(cancel(&id), Some(JobState::Running { .. })));
         for _ in 0..40 {
             if let Some(JobState::Cancelled { output }) = status(&id) {
                 assert!(output.contains("command cancelled"));
@@ -444,5 +472,33 @@ mod tests {
             std::thread::sleep(Duration::from_millis(25));
         }
         panic!("background job was not cancelled");
+    }
+
+    /// #1217: a still-running job's `status` must surface the captured-so-far
+    /// output, not a bare "running" with no signal of progress.
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn running_background_job_status_streams_partial_output() {
+        let id = start(
+            "printf EARLY_LINE; sleep 5".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+        );
+        let mut saw_partial = false;
+        for _ in 0..80 {
+            if let Some(JobState::Running { output }) = status(&id)
+                && output.contains("EARLY_LINE")
+            {
+                saw_partial = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        cancel(&id);
+        assert!(
+            saw_partial,
+            "status never surfaced the running job's early output"
+        );
     }
 }

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -32,7 +32,7 @@ pub(crate) fn execute_command_with_env(
     extra_env: &std::collections::HashMap<String, String>,
     timeout_ms: Option<u64>,
 ) -> (String, i32) {
-    execute_command_with_env_cancellable(command, cwd, extra_env, timeout_ms, None, false)
+    execute_command_with_env_cancellable(command, cwd, extra_env, timeout_ms, None, false, None)
 }
 
 /// Execute a command under the normal shell policy, with an optional cooperative
@@ -58,6 +58,9 @@ pub(crate) fn execute_command_with_env_cancellable(
     timeout_ms: Option<u64>,
     cancel: Option<&AtomicBool>,
     idle_keyed: bool,
+    // #1217: while running, mirror the captured-so-far output here so a detached
+    // background job's `status` poll can show progress instead of nothing.
+    live: Option<&std::sync::Mutex<String>>,
 ) -> (String, i32) {
     let (shell, flag) = crate::shell::shell_and_flag();
     let normalized_cmd = crate::tools::ctx_shell::normalize_command_for_shell(command);
@@ -140,6 +143,7 @@ pub(crate) fn execute_command_with_env_cancellable(
     let start = Instant::now();
     let hard_deadline = idle_keyed.then(|| start + streaming_max_lifetime());
     let mut last_len = 0usize;
+    let mut live_last_len = 0usize;
     let mut last_output_at = start;
     // Named on timeout so a multi-segment pipeline says *which* part hung (#1086).
     let mut still_running: Vec<String> = Vec::new();
@@ -151,6 +155,27 @@ pub(crate) fn execute_command_with_env_cancellable(
                     kill_timed_out_child(&mut child);
                     let _ = child.wait();
                     break (130, false, true);
+                }
+                // #1217: mirror the captured-so-far output into the live buffer
+                // whenever it grows, so a background `status` poll sees progress.
+                // Gated on length change and bounded by the same cap as the final
+                // capture — the decode runs at most once per 25ms sleep tick.
+                if let Some(live) = live {
+                    let len = captured_len(&out_buf) + captured_len(&err_buf);
+                    if len != live_last_len {
+                        live_last_len = len;
+                        let (out_now, _) = snapshot(&out_buf);
+                        let (err_now, _) = snapshot(&err_buf);
+                        let so = crate::shell::resolve_carriage_returns(
+                            &crate::shell::decode_output(&out_now),
+                        );
+                        let se = crate::shell::resolve_carriage_returns(
+                            &crate::shell::decode_output(&err_now),
+                        );
+                        if let Ok(mut guard) = live.lock() {
+                            *guard = crate::shell::combine_streams(&so, &se, 0);
+                        }
+                    }
                 }
                 let idle_for = if idle_keyed {
                     let len = captured_len(&out_buf) + captured_len(&err_buf);
@@ -460,16 +485,30 @@ mod tests {
         // Emits every 100ms for ~900ms under a 400ms budget.
         let cmd = "for i in 1 2 3 4 5 6 7 8 9; do printf T; sleep 0.1; done; printf DONE";
 
-        let (idle_out, idle_code) =
-            super::execute_command_with_env_cancellable(cmd, ".", &env, Some(400), None, true);
+        let (idle_out, idle_code) = super::execute_command_with_env_cancellable(
+            cmd,
+            ".",
+            &env,
+            Some(400),
+            None,
+            true,
+            None,
+        );
         assert_eq!(
             idle_code, 0,
             "output kept resetting the idle clock: {idle_out}"
         );
         assert!(idle_out.contains("DONE"));
 
-        let (wall_out, wall_code) =
-            super::execute_command_with_env_cancellable(cmd, ".", &env, Some(400), None, false);
+        let (wall_out, wall_code) = super::execute_command_with_env_cancellable(
+            cmd,
+            ".",
+            &env,
+            Some(400),
+            None,
+            false,
+            None,
+        );
         assert_eq!(wall_code, 124, "wall-clock mode must still enforce the cap");
         assert!(wall_out.contains("timed out"));
     }
@@ -489,6 +528,7 @@ mod tests {
             Some(600),
             None,
             false,
+            None,
         );
         assert_eq!(code, 124);
         assert!(

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -71,8 +71,16 @@ impl McpTool for CtxShellTool {
                 });
             };
             let (text, exit_code) = match state {
-                crate::server::background_shell::JobState::Running => {
-                    (format!("[background:{id} running]"), 0)
+                crate::server::background_shell::JobState::Running { output } => {
+                    // #1217: show the captured-so-far output so a poll of a
+                    // long-running job reflects progress instead of a bare
+                    // "running" with no signal of whether it is advancing.
+                    let body = redact_shell_output_secrets(&output);
+                    if body.trim().is_empty() {
+                        (format!("[background:{id} running]"), 0)
+                    } else {
+                        (format!("[background:{id} running]\n{body}"), 0)
+                    }
                 }
                 crate::server::background_shell::JobState::Completed { output, exit_code } => (
                     format!(


### PR DESCRIPTION
## Summary
Fixes #1217. `background_action="status"` on a still-running job returned only `[background:<id> running]` — no stdout, no progress. All output arrived only at `completed`, so a long `cargo build`/`cargo test` was indistinguishable from a hang until the end (the exact case backgrounding exists for). Root cause: `JobState::Running` was a unit variant with no output buffer.

## Fix
The exec loop already streams stdout/stderr into cap-bounded shared buffers (for the idle-keyed timeout from #1185). This wires that live capture out to `status`:

- `execute_command_with_env_cancellable` gains an optional `live: &Mutex<String>` sink, refreshed (decoded, CR-resolved) whenever the capture grows — gated on length change, so the decode runs at most once per 25ms poll tick.
- `background_shell::Job` holds an `Arc<Mutex<String>>` the worker streams into. `JobState::Running { output }` now carries it; `status()` returns the captured-so-far snapshot per poll.
- `ctx_shell` renders that partial output under `[background:<id> running]`.

## Relationship to other issues
- **Complements #1185** (merged): that added foreground *elapsed-time* progress via `on_tick`; this adds *stdout* on the detached-job `status` path — a different surface (see my analysis on #1217).
- **Independent of #1140**: the output-line-in-progress piece #1185 deferred was about foreground progress-notification rendering; this returns already-CR-resolved captured output through the existing status result, so it doesn't depend on it.

## Verification
```
cargo test --lib server::background_shell   9 passed  (incl. new streaming test)
cargo test --lib server::execute           13 passed
cargo fmt --check                          clean
cargo clippy                               no new warnings in the 3 changed files
```

New test `running_background_job_status_streams_partial_output`: a job printing an early line then sleeping must surface that line via `status` while still `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)