### PR TITLE
docs(pi-lean-ctx): advise against long inline sleeps/polling in ctx_shell in favor of background watchers

### DIFF
--- a/packages/pi-lean-ctx/README.md
+++ b/packages/pi-lean-ctx/README.md
@@ -44,7 +44,7 @@ Adds `ctx_`-prefixed tools alongside Pi's builtins (or replaces them in `replace
 | Tool | Replaces | Compression |
 |------|----------|-------------|
 | `ctx_read` | `read` | Smart mode selection (full/map/signatures) based on file type and size |
-| `ctx_shell` | `bash` | All shell commands compressed via lean-ctx's 95+ patterns |
+| `ctx_shell` | `bash` | All shell commands compressed via lean-ctx's 95+ patterns. *(Note: for long sleep/monitoring tasks, prefer background watchers like `/monitor`)* |
 | `ctx_grep` | `grep` | Results grouped and compressed via ripgrep + lean-ctx |
 | `ctx_find` | `find` | File listings compressed and .gitignore-aware |
 | `ctx_ls` | `ls` | Directory output compressed |

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -360,10 +360,12 @@ export default async function (pi: ExtensionAPI) {
       + "IMPORTANT: Do NOT use ctx_shell to read files (cat/head/tail) — use ctx_read instead. "
       + "Do NOT use ctx_shell for grep/find/ls — use ctx_grep, ctx_find, ctx_ls. "
       + "Set raw=true to skip compression when exact output matters. "
-      + "Use timeout (seconds) to prevent hanging commands.",
+      + "Use timeout (seconds) to prevent hanging commands. "
+      + "For extremely long sleep or monitoring commands, prefer background watcher tools (such as /monitor) instead of inline ctx_shell.",
     promptSnippet: "Run shell commands (not for file reading — use ctx_read)",
     promptGuidelines: [
       "Use ctx_shell only for commands with side effects: build, test, install, git, run scripts.",
+      "When launching extremely long sleep or monitoring commands, prefer using background watcher commands (such as /monitor) rather than inline ctx_shell scripts to keep your interactive prompt active and completely unblocked.",
     ],
     parameters: bashSchemaWithRaw,
     renderCall(args, theme, context) {


### PR DESCRIPTION
### Summary
Adds explicit `promptGuidelines` and description advice to `ctx_shell` in `packages/pi-lean-ctx`, guiding AI agents to prefer background watchers (such as `/monitor` or background process tools) rather than running inline `sleep` or polling loops in `ctx_shell` which block the interactive agent prompt.

### Changes
- **`packages/pi-lean-ctx/extensions/index.ts`**: Added guideline to `promptGuidelines` and `description` of `ctx_shell`.
- **`packages/pi-lean-ctx/README.md`**: Noted recommendation in tool table.