### PR TITLE
perf(ci): drop macOS from the PR test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS runners are ~2x slower (Test step ~32 min vs ~24 win / ~16 ubuntu)
+        # and bill ~10x the minutes, so keep them off the PR critical path: PRs
+        # run ubuntu + windows only. macOS still runs on every push to main (i.e.
+        # at merge), on workflow_dispatch, and in release.yml — so platform
+        # regressions are still caught before release, just not on every PR push.
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
     runs-on: ${{ matrix.os }}
     # --test-threads=1 (env-race legacy, v3.3.5) serializes ~70 binaries that
     # now include heavy property/fuzz/benchmark suites (#291, #493, #551) —


### PR DESCRIPTION
## What

Make the `Test` job matrix event-conditional so **PRs run ubuntu + windows only**; macOS runs on push-to-main / `workflow_dispatch` / `release.yml`.

```yaml
os: ${{ github.event_name == 'pull_request'
        && fromJSON('["ubuntu-latest", "windows-latest"]')
        || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
```

## Why

macOS is the Test job's long pole. Measured on a recent run (#1225):

| OS | `Run tests` step |
|----|------------------|
| **macOS** | **~32 min** |
| Windows | ~24 min |
| ubuntu | ~16 min |

macOS runners are ~2x slower **and** bill ~10x the minutes, yet rarely catch a bug the other two miss. They gate every PR push for little marginal signal.

## Coverage preserved

macOS still runs:
- on every **push to `main`** (i.e. at merge — CI triggers on `push: [main]`),
- on **`workflow_dispatch`**,
- in **`release.yml`** (release builds already test macOS).

So platform regressions are still caught before release — just not on every PR iteration.

## Effect

PR-blocking Test wall-clock drops from ~32 min → ~24 min, and the priciest runner leaves the hot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)