### PR TITLE
fix(hooks): keep native Read for Claude auto memory (#1228)

### DIFF
--- a/docs/reference/appendix-paths-and-config.md
+++ b/docs/reference/appendix-paths-and-config.md
@@ -194,7 +194,7 @@ they overlap, so here is exactly what each one does:
 | Knob | Effect | Use when |
 |------|--------|----------|
 | `allow_paths = ["…"]` (root key) | **Adds** directories to PathJail's whitelist. Tools may read/edit under them, but `ctx_tree`/`ctx_search` do **not** scan them. | One extra directory needs to be readable/editable (e.g. a shared skills folder). |
-| `extra_roots = ["…"]` (root key) | Same whitelist effect as `allow_paths` **plus** multi-root scanning: `ctx_tree`, `ctx_search`, overview treat them as additional project roots. | Multi-repo workspaces; agent-harness memory/state dirs outside the project (e.g. Claude Code's `~/.claude/projects/<slug>/memory/`). |
+| `extra_roots = ["…"]` (root key) | Same whitelist effect as `allow_paths` **plus** multi-root scanning: `ctx_tree`, `ctx_search`, overview treat them as additional project roots. | Multi-repo workspaces; additional agent-harness state dirs beyond the built-in Claude/CodeBuddy auto-memory allow (see below). |
 | `path_jail = false` (root key) | **Disables PathJail entirely** — every absolute path is allowed. | Sandboxed environments (bwrap, containers, VMs) where the OS is the boundary. |
 | `allow_ide_config_dirs = true` (root key) | **Adds every supported editor's config dir** to the read whitelist — registry-derived (`~/.cursor`, VS Code, Cline/Roo, JetBrains, …). Opt-in; exposes other agents' sessions/credentials. | Letting the agent manage MCP setup across editors. |
 
@@ -203,6 +203,11 @@ Env equivalents (path-list syntax, `:` on Unix / `;` on Windows):
 
 Notes that save debugging time:
 
+- **Built-in (GH #1228):** Claude Code / CodeBuddy auto memory under
+  `~/.claude/projects/<slug>/memory/` (and the CodeBuddy twin) is allowed by
+  PathJail without config. Session transcripts next to that folder stay jailed.
+  Replace mode also keeps native `Read` available so auto memory and the edit
+  gate work; do not use MCP `resources/read` with `file://` URIs for those files.
 - **`~`, `$VAR` and `${VAR}` are expanded** in `allow_paths` / `extra_roots` /
   the env vars (since v3.8.1). On older versions `"$HOME/code"` was matched
   literally and silently never applied.

--- a/rust/src/core/pathjail.rs
+++ b/rust/src/core/pathjail.rs
@@ -370,6 +370,40 @@ fn is_under_prefix(path: &Path, prefix: &Path) -> bool {
     path.starts_with(prefix)
 }
 
+/// True for Claude Code / CodeBuddy auto-memory files under
+/// `~/.claude/projects/<slug>/memory/` (and the CodeBuddy twin).
+///
+/// Auto memory uses the host's native Read/Edit/Write on these paths
+/// (code.claude.com/docs/en/memory). Replace-mode PathJail must not force
+/// agents to shell out or hit MCP `resources/read` with file URIs (GH #1228).
+/// Scoped to the `memory/` subdirectory only — session transcripts and
+/// credentials under `projects/<slug>/` stay jailed.
+pub fn is_harness_auto_memory_path(path: &Path) -> bool {
+    let lower = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    for marker in ["/.claude/projects/", "/.codebuddy/projects/"] {
+        if let Some(idx) = lower.find(marker) {
+            let after = &lower[idx + marker.len()..];
+            let mut parts = after.split('/');
+            let Some(_slug) = parts.next() else {
+                continue;
+            };
+            if parts.next() == Some("memory") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn path_allowed_by_jail(base: &Path, root: &Path, allow: &[PathBuf]) -> bool {
+    let allowed = is_under_prefix(base, root)
+        || allow.iter().any(|p| is_under_prefix(base, p))
+        || is_harness_auto_memory_path(base);
+    #[cfg(windows)]
+    let allowed = allowed || is_under_prefix_windows(base, root);
+    allowed
+}
+
 /// Heuristic canonicalize — honours the #356 TCC guard. Used by the
 /// jail-disabled bypass and by external callers (session/startup/server roots)
 /// that must not pop a privacy prompt on their own initiative.
@@ -539,11 +573,7 @@ pub fn jail_path_with_roots(
             }
         })?;
 
-        let allowed =
-            is_under_prefix(&base, &root) || allow.iter().any(|p| is_under_prefix(&base, p));
-
-        #[cfg(windows)]
-        let allowed = allowed || is_under_prefix_windows(&base, &root);
+        let allowed = path_allowed_by_jail(&base, &root, &allow);
 
         if !allowed {
             let mut hint = if crate::core::protocol::meta_visible() {
@@ -604,10 +634,7 @@ pub fn jail_path_with_roots(
         // and re-check to close TOCTOU window (symlink created between check and use).
         if out.exists() {
             let final_canon = canonicalize_secure(&out);
-            let final_ok = is_under_prefix(&final_canon, &root)
-                || allow.iter().any(|p| is_under_prefix(&final_canon, p));
-            #[cfg(windows)]
-            let final_ok = final_ok || is_under_prefix_windows(&final_canon, &root);
+            let final_ok = path_allowed_by_jail(&final_canon, &root, &allow);
             if !final_ok {
                 return Err(PathJailError::PostCanonicalizeEscape {
                     path: candidate.to_path_buf(),
@@ -1156,6 +1183,41 @@ mod tests {
 
         // Empty entries are ignored (no accidental allow-all).
         assert!(jail_path_with_roots(&outside, &root, &[String::new()]).is_err());
+    }
+
+    /// GH #1228: Claude Code auto-memory under `…/.claude/projects/<slug>/memory/`
+    /// must be readable/writable via ctx_* without a manual extra_roots edit.
+    #[cfg(not(feature = "no-jail"))]
+    #[test]
+    fn harness_auto_memory_path_is_allowed_without_extra_roots() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let memory = tmp
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-tmp-project")
+            .join("memory");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&memory).unwrap();
+        let mem_file = memory.join("MEMORY.md");
+        std::fs::write(&mem_file, "# index\n").unwrap();
+
+        assert!(is_harness_auto_memory_path(&mem_file));
+        assert!(is_harness_auto_memory_path(&memory));
+        assert!(!is_harness_auto_memory_path(
+            &tmp.path()
+                .join(".claude")
+                .join("projects")
+                .join("-tmp-project")
+                .join("session.jsonl")
+        ));
+
+        assert!(
+            jail_path_with_roots(&mem_file, &root, &[]).is_ok(),
+            "auto-memory file must pass PathJail without extra_roots"
+        );
     }
 
     /// #820: lean-ctx state dir (tee files) is implicitly allowed by the jail.

--- a/rust/src/hook_handlers/deny.rs
+++ b/rust/src/hook_handlers/deny.rs
@@ -52,6 +52,14 @@ fn should_allow(tool_name: &str, file_path: Option<&str>) -> bool {
         return true;
     }
 
+    // GH #1228: Claude/CodeBuddy auto memory must use native Read/Edit even
+    // when Replace-mode deny hooks are installed.
+    if file_path.is_some_and(|p| {
+        crate::core::pathjail::is_harness_auto_memory_path(std::path::Path::new(p))
+    }) {
+        return true;
+    }
+
     if is_replace_mode_disabled() {
         return true;
     }
@@ -415,5 +423,17 @@ mod tests {
     fn extract_write_content_no_content_returns_none() {
         let payload = r#"{"tool_name":"Write","input":{"path":"test.md"}}"#;
         assert!(extract_write_content(payload).is_none());
+    }
+
+    #[test]
+    fn should_allow_claude_auto_memory_paths() {
+        assert!(should_allow(
+            "Read",
+            Some("/home/jules/.claude/projects/-slug/memory/MEMORY.md")
+        ));
+        assert!(
+            !should_allow("Read", Some("/home/jules/project/src/main.rs")),
+            "ordinary project files stay denied under replace deny hooks"
+        );
     }
 }

--- a/rust/src/hook_handlers/redirect.rs
+++ b/rust/src/hook_handlers/redirect.rs
@@ -631,6 +631,12 @@ pub(super) fn should_passthrough(path: &str) -> bool {
         return true;
     }
 
+    // GH #1228: Claude Code / CodeBuddy auto-memory must stay on native Read
+    // (edit gate + memory index). Never redirect these into a ctx_read temp.
+    if crate::core::pathjail::is_harness_auto_memory_path(std::path::Path::new(path)) {
+        return true;
+    }
+
     std::path::Path::new(&p)
         .extension()
         .and_then(|ext| ext.to_str())

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -382,6 +382,20 @@ fn should_passthrough_rules_files() {
 }
 
 #[test]
+fn should_passthrough_claude_auto_memory() {
+    assert!(should_passthrough(
+        "/home/jules/.claude/projects/-home-jules-Projects-blockposters/memory/MEMORY.md"
+    ));
+    assert!(should_passthrough(
+        "/home/jules/.claude/projects/-home-jules-Projects-blockposters/memory/debugging.md"
+    ));
+    assert!(
+        !should_passthrough("/home/jules/.claude/projects/-home-jules-Projects-blockposters/abc.jsonl"),
+        "session transcripts must not passthrough as memory"
+    );
+}
+
+#[test]
 fn wrap_single() {
     let r = wrap_single_command("git status", "lean-ctx");
     assert_eq!(r, expect_wrapped("git status", "lean-ctx"));

--- a/rust/src/hooks/agents/claude.rs
+++ b/rust/src/hooks/agents/claude.rs
@@ -89,8 +89,13 @@ fn install_claude_mcp_server(home: &std::path::Path) {
     }
 }
 
-/// In Replace mode, add Read/Grep/Glob/Bash to Claude Code's `permissions.deny`
-/// so native tools are completely unavailable and the agent must use ctx_* MCP tools.
+/// In Replace mode, deny Grep/Glob via Claude Code's `permissions.deny` so
+/// search/listing go through `ctx_*`. Native `Read` is intentionally NOT denied:
+/// Claude Code's read-before-write edit gate and auto memory
+/// (`~/.claude/projects/<slug>/memory/`) both require native Read (GH #637,
+/// #1091, #1228). Deny always wins over allow, so a bare `Read` deny cannot
+/// carve out memory paths — remove it instead and steer exploration via
+/// CLAUDE.md + hooks.
 pub(crate) fn install_claude_permissions_deny_replace(home: &std::path::Path) {
     let settings_path = home.join(".claude").join("settings.json");
 
@@ -125,7 +130,8 @@ pub(crate) fn install_claude_permissions_deny_replace(home: &std::path::Path) {
 
     // Bash intentionally NOT denied: permissions.deny blocks globally including
     // plugin commands (codex-companion etc.). PreToolUse hook handles agent Bash. (GH #799)
-    let deny_tools = ["Read", "Grep", "Glob"];
+    // Read intentionally NOT denied: auto memory + edit gate need native Read (#1228).
+    let deny_tools = ["Grep", "Glob"];
     let mut changed = false;
     for tool in deny_tools {
         let val = serde_json::Value::String(tool.to_string());
@@ -135,11 +141,14 @@ pub(crate) fn install_claude_permissions_deny_replace(home: &std::path::Path) {
         }
     }
 
-    // Remove stale "Bash" entry left by older versions (GH #799).
-    let bash_val = serde_json::Value::String("Bash".to_string());
-    if let Some(pos) = arr.iter().position(|v| v == &bash_val) {
-        arr.remove(pos);
-        changed = true;
+    // Remove stale bare "Read" / "Bash" entries left by older versions
+    // (GH #799 Bash; GH #1228 Read).
+    for stale in ["Read", "Bash"] {
+        let stale_val = serde_json::Value::String(stale.to_string());
+        if let Some(pos) = arr.iter().position(|v| v == &stale_val) {
+            arr.remove(pos);
+            changed = true;
+        }
     }
 
     if changed {
@@ -148,7 +157,7 @@ pub(crate) fn install_claude_permissions_deny_replace(home: &std::path::Path) {
         }
         if !mcp_server_quiet_mode() {
             eprintln!(
-                "  \x1b[32m✓\x1b[0m Claude Code: denied native Read/Grep/Glob (Replace mode)"
+                "  \x1b[32m✓\x1b[0m Claude Code: denied native Grep/Glob (Replace mode; Read kept for edit gate + auto memory)"
             );
         }
     }
@@ -165,7 +174,7 @@ pub(crate) fn install_claude_permissions_deny_replace(home: &std::path::Path) {
 /// appended a duplicate (GH #549).
 pub(crate) const CLAUDE_MD_BLOCK_START: &str = crate::core::rules_canonical::AGENTS_BLOCK_START;
 const CLAUDE_MD_BLOCK_END: &str = crate::core::rules_canonical::AGENTS_BLOCK_END;
-const CLAUDE_MD_BLOCK_VERSION: &str = "lean-ctx-claude-v7";
+const CLAUDE_MD_BLOCK_VERSION: &str = "lean-ctx-claude-v8";
 
 // v3 (GL #555): self-contained, no `@rules/lean-ctx.md` import. Claude Code
 // expands `@` imports inline at launch ("imports do not reduce context usage"
@@ -190,9 +199,14 @@ const CLAUDE_MD_BLOCK_VERSION: &str = "lean-ctx-claude-v7";
 // a prior native `Read` (denied), and native `Write` only succeeds for
 // brand-new files, so `ctx_patch` is the actual edit path. The MCP block is
 // unchanged; the shared version tag bumps so existing blocks get rewritten.
+//
+// v8 (#1228): stop denying native Read in Replace mode. Auto memory under
+// `~/.claude/projects/<slug>/memory/` and the edit gate both need native Read;
+// a bare permissions.deny Read cannot carve out exceptions (deny wins). Grep/
+// Glob stay denied. Agents must not use MCP resources/read with file:// URIs.
 const CLAUDE_MD_BLOCK_CONTENT_MCP: &str = "\
 <!-- lean-ctx -->
-<!-- lean-ctx-claude-v7 -->
+<!-- lean-ctx-claude-v8 -->
 ## lean-ctx — Context Runtime
 
 When the `ctx_*` MCP tools are listed in this session, prefer them over native equivalents:
@@ -203,7 +217,9 @@ When the `ctx_*` MCP tools are listed in this session, prefer them over native e
 - Edits: `ctx_read(mode=\"anchored\")` → `ctx_patch` (line+hash anchors, never echo old text; `op=create` for new files). `ctx_edit` (str_replace) is the legacy power-profile fallback.
 
 Native `Read` → `Edit`/`StrReplace` stays fully supported — the edit gate requires a
-prior native Read of the same file path. Write, Delete, Glob — use normally.
+prior native Read of the same file path. Auto memory under
+`~/.claude/projects/<slug>/memory/` also uses native Read/Edit (not MCP resources).
+Write, Delete, Glob — use normally.
 If no `ctx_*` tools are listed in this session, use the native tools throughout.
 
 Read modes: anchored (edit), full (verbatim), map (overview), signatures (API), diff (post-edit), lines:N-M (range), auto.
@@ -212,19 +228,21 @@ Details live in the `lean-ctx` skill (loads on demand — keep this file lean).
 
 const CLAUDE_MD_BLOCK_CONTENT_REPLACE: &str = "\
 <!-- lean-ctx -->
-<!-- lean-ctx-claude-v7 -->
-## lean-ctx — Replace Mode (native tools denied)
+<!-- lean-ctx-claude-v8 -->
+## lean-ctx — Replace Mode (native Grep/Glob denied by policy)
 
-Native Read/Grep/Glob/Bash are denied by policy. Use ONLY `ctx_*` MCP tools:
-- `ctx_read` for ALL file reads (cached, 10 modes, re-reads ~13 tokens)
-- `ctx_shell` for ALL shell commands (95+ compression patterns)
+Native Grep/Glob are denied by policy. Prefer `ctx_*` MCP tools for project work:
+- `ctx_read` for exploration reads (cached, 10 modes, re-reads ~13 tokens)
+- `ctx_shell` for shell commands (95+ compression patterns)
 - `ctx_search` instead of Grep/rg (compact results)
 - `ctx_tree` instead of ls/find (compact directory maps)
 - `ctx_glob` instead of Glob (file pattern matching)
-- Edits: `ctx_read(mode=\"anchored\")` → `ctx_patch` (line+hash anchors, never echo old text; `op=create` for new files).
+- Project edits: `ctx_read(mode=\"anchored\")` → `ctx_patch` (line+hash anchors; `op=create` for new files).
 
-`ctx_patch` is the edit path: native `Edit` needs a prior native `Read` (denied), and native `Write` only succeeds for brand-new files. Use `op=create` for new files; native Delete is fine.
-Do NOT attempt native Read, Grep, Glob, or Bash — they will be denied.
+Native `Read` stays available for the edit gate and for Claude auto memory
+(`~/.claude/projects/<slug>/memory/` — MEMORY.md and topic files). Use native
+Read/Edit there; do NOT call MCP `resources/read` with file:// URIs (lean-ctx
+resources are `lean-ctx://context/*` only). Native Delete is fine.
 
 Read modes: anchored (edit), full (verbatim), map (overview), signatures (API), diff (post-edit), lines:N-M (range), auto.
 Details live in the `lean-ctx` skill (loads on demand — keep this file lean).
@@ -1055,7 +1073,8 @@ mod tests {
             .and_then(|d| d.as_array())
             .unwrap();
 
-        assert!(deny.contains(&serde_json::json!("Read")));
+        // GH #1228: bare Read must not be denied (auto memory + edit gate).
+        assert!(!deny.contains(&serde_json::json!("Read")));
         assert!(deny.contains(&serde_json::json!("Grep")));
         assert!(deny.contains(&serde_json::json!("Glob")));
         // Bash must NOT be in permissions.deny — it blocks plugins (GH #799)
@@ -1084,12 +1103,17 @@ mod tests {
             .unwrap();
 
         // Each tool should appear exactly once
-        let read_count = deny.iter().filter(|v| v.as_str() == Some("Read")).count();
-        assert_eq!(read_count, 1, "idempotent: Read must appear exactly once");
+        let grep_count = deny.iter().filter(|v| v.as_str() == Some("Grep")).count();
+        assert_eq!(grep_count, 1, "idempotent: Grep must appear exactly once");
+        assert_eq!(
+            deny.iter().filter(|v| v.as_str() == Some("Read")).count(),
+            0,
+            "Read must stay off the deny list"
+        );
     }
 
     #[test]
-    fn replace_mode_removes_stale_bash_deny() {
+    fn replace_mode_removes_stale_read_and_bash_deny() {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
         std::fs::create_dir_all(home.join(".claude")).unwrap();
@@ -1111,7 +1135,10 @@ mod tests {
             .and_then(|d| d.as_array())
             .unwrap();
 
-        assert!(deny.contains(&serde_json::json!("Read")));
+        assert!(
+            !deny.contains(&serde_json::json!("Read")),
+            "stale Read must be removed (GH #1228)"
+        );
         assert!(deny.contains(&serde_json::json!("Grep")));
         assert!(deny.contains(&serde_json::json!("Glob")));
         assert!(

--- a/rust/src/hooks/agents/codebuddy.rs
+++ b/rust/src/hooks/agents/codebuddy.rs
@@ -38,7 +38,9 @@ pub(crate) fn install_codebuddy_permissions_deny_replace(home: &std::path::Path)
         return;
     };
 
-    let deny_tools = ["Read", "Grep", "Glob", "Bash"];
+    // Read kept available for edit gate + auto memory (shared Claude hook
+    // contract, GH #1228). Grep/Glob/Bash stay denied in Replace mode.
+    let deny_tools = ["Grep", "Glob", "Bash"];
     let mut changed = false;
     for tool in deny_tools {
         let val = serde_json::Value::String(tool.to_string());
@@ -48,12 +50,20 @@ pub(crate) fn install_codebuddy_permissions_deny_replace(home: &std::path::Path)
         }
     }
 
+    let read_val = serde_json::Value::String("Read".to_string());
+    if let Some(pos) = arr.iter().position(|v| v == &read_val) {
+        arr.remove(pos);
+        changed = true;
+    }
+
     if changed {
         if let Ok(out) = serde_json::to_string_pretty(&json) {
             let _ = std::fs::write(&settings_path, out);
         }
         if !mcp_server_quiet_mode() {
-            eprintln!("  \x1b[32m✓\x1b[0m CodeBuddy permissions.deny installed (Replace mode)");
+            eprintln!(
+                "  \x1b[32m✓\x1b[0m CodeBuddy permissions.deny installed (Replace mode; Read kept for auto memory)"
+            );
         }
     }
 }
@@ -144,7 +154,7 @@ fn install_codebuddy_mcp_server(home: &std::path::Path) {
 /// markers broke detection and caused duplicate blocks (GH #549).
 pub(crate) const CODEBUDDY_MD_BLOCK_START: &str = crate::core::rules_canonical::AGENTS_BLOCK_START;
 const CODEBUDDY_MD_BLOCK_END: &str = crate::core::rules_canonical::AGENTS_BLOCK_END;
-const CODEBUDDY_MD_BLOCK_VERSION: &str = "lean-ctx-codebuddy-v3";
+const CODEBUDDY_MD_BLOCK_VERSION: &str = "lean-ctx-codebuddy-v4";
 
 // v2 (GH #637 / GL #1138): MCP-aware guidance, mirroring the Claude v4 block.
 // CodeBuddy is a Claude Code fork with the same path-keyed read-before-write
@@ -154,21 +164,24 @@ const CODEBUDDY_MD_BLOCK_VERSION: &str = "lean-ctx-codebuddy-v3";
 // v3 (#1008 / GL #1144): anchored editing routes to `ctx_patch` (now advertised
 // in the lazy core for CodeBuddy); `ctx_edit` demoted to a legacy power-profile
 // mention. Native Read → Edit stays fully supported (v2 guard semantics).
+//
+// v4 (#1228): stop denying native Read — auto memory + edit gate need it.
 const CODEBUDDY_MD_BLOCK_CONTENT_REPLACE: &str = "\
 <!-- lean-ctx -->
-<!-- lean-ctx-codebuddy-v3 -->
-## lean-ctx — Replace Mode (native tools denied)
+<!-- lean-ctx-codebuddy-v4 -->
+## lean-ctx — Replace Mode (native Grep/Glob/Bash denied by policy)
 
-Native Read/Grep/Glob/Bash are denied by policy. Use ONLY `ctx_*` MCP tools:
-- `ctx_read` for ALL file reads (cached, 10 modes, re-reads ~13 tokens)
-- `ctx_shell` for ALL shell commands (95+ compression patterns)
+Native Grep/Glob/Bash are denied by policy. Prefer `ctx_*` MCP tools for project work:
+- `ctx_read` for exploration reads (cached, 10 modes, re-reads ~13 tokens)
+- `ctx_shell` for shell commands (95+ compression patterns)
 - `ctx_search` instead of Grep/rg (compact results)
 - `ctx_tree` instead of ls/find (compact directory maps)
 - `ctx_glob` instead of Glob (file pattern matching)
-- Edits: `ctx_read(mode=\"anchored\")` → `ctx_patch` (line+hash anchors, never echo old text; `op=create` for new files).
+- Project edits: `ctx_read(mode=\"anchored\")` → `ctx_patch` (line+hash anchors; `op=create` for new files).
 
-Write and Delete — use native tools normally.
-Do NOT attempt native Read, Grep, Glob, or Bash — they will be denied.
+Native `Read` stays available for the edit gate and for auto memory under
+`~/.claude/projects/<slug>/memory/`. Use native Read/Edit there; do NOT call
+MCP `resources/read` with file:// URIs. Write and Delete — use native tools normally.
 
 Read modes: anchored (edit), full (verbatim), map (overview), signatures (API), diff (post-edit), lines:N-M (range), auto.
 Details live in the `lean-ctx` skill (loads on demand — keep this file lean).
@@ -176,7 +189,7 @@ Details live in the `lean-ctx` skill (loads on demand — keep this file lean).
 
 const CODEBUDDY_MD_BLOCK_CONTENT_MCP: &str = "\
 <!-- lean-ctx -->
-<!-- lean-ctx-codebuddy-v3 -->
+<!-- lean-ctx-codebuddy-v4 -->
 ## lean-ctx — Context Runtime
 
 When the `ctx_*` MCP tools are listed in this session, prefer them over native equivalents:
@@ -187,7 +200,9 @@ When the `ctx_*` MCP tools are listed in this session, prefer them over native e
 - Edits: `ctx_read(mode=\"anchored\")` → `ctx_patch` (line+hash anchors, never echo old text; `op=create` for new files). `ctx_edit` (str_replace) is the legacy power-profile fallback.
 
 Native `Read` → `Edit`/`StrReplace` stays fully supported — the edit gate requires a
-prior native Read of the same file path. Write, Delete, Glob — use normally.
+prior native Read of the same file path. Auto memory under
+`~/.claude/projects/<slug>/memory/` also uses native Read/Edit (not MCP resources).
+Write, Delete, Glob — use normally.
 If no `ctx_*` tools are listed in this session, use the native tools throughout.
 
 Read modes: anchored (edit), full (verbatim), map (overview), signatures (API), diff (post-edit), lines:N-M (range), auto.

--- a/rust/src/server/resources.rs
+++ b/rust/src/server/resources.rs
@@ -50,6 +50,31 @@ pub fn read_resource(
     }
 }
 
+/// Agent-facing explanation when `resources/read` is called with an unknown URI.
+///
+/// GH #1228: agents denied native Read for auto memory often retry via MCP
+/// `resources/read` with `file://…/memory/MEMORY.md` and get a bare
+/// "Unknown resource". Point them at the real surfaces instead.
+pub fn unknown_resource_message(uri: &str) -> String {
+    let looks_like_file = uri.starts_with("file:")
+        || uri.starts_with('/')
+        || (uri.len() > 2 && uri.as_bytes()[1] == b':' && uri.as_bytes()[0].is_ascii_alphabetic())
+        || uri.contains("/.claude/projects/")
+        || uri.contains("\\memory\\")
+        || uri.contains("/memory/");
+
+    if looks_like_file {
+        format!(
+            "Unknown resource: {uri}. lean-ctx MCP resources are lean-ctx://context/* only \
+             (summary/pinned/pressure/plan/bounce) — not arbitrary files. \
+             For project files use ctx_read / ctx_patch. \
+             For Claude auto memory (~/.claude/projects/<slug>/memory/) use native Read/Edit."
+        )
+    } else {
+        format!("Unknown resource: {uri}")
+    }
+}
+
 fn make_resource(uri: &str, name: &str, desc: &str) -> Resource {
     Resource::new(uri, name)
         .with_description(desc)
@@ -182,5 +207,22 @@ mod tests {
         let ledger = crate::core::context_ledger::ContextLedger::new();
         let result = read_resource(URI_BOUNCE, &ledger);
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn unknown_file_uri_message_guides_to_ctx_read_and_native_memory() {
+        let msg = unknown_resource_message(
+            "file:///home/jules/.claude/projects/-home-jules-Projects-blockposters/memory/MEMORY.md",
+        );
+        assert!(msg.contains("lean-ctx://context/*"), "{msg}");
+        assert!(msg.contains("ctx_read"), "{msg}");
+        assert!(msg.contains("native Read/Edit"), "{msg}");
+        assert!(msg.contains("auto memory"), "{msg}");
+    }
+
+    #[test]
+    fn unknown_lean_ctx_uri_stays_short() {
+        let msg = unknown_resource_message("lean-ctx://unknown");
+        assert_eq!(msg, "Unknown resource: lean-ctx://unknown");
     }
 }

--- a/rust/src/server/server_handler.rs
+++ b/rust/src/server/server_handler.rs
@@ -539,7 +539,7 @@ impl ServerHandler for LeanCtxServer {
         match resources::read_resource(&request.uri, &ledger) {
             Some(contents) => Ok(rmcp::model::ReadResourceResult::new(contents)),
             None => Err(rmcp::ErrorData::resource_not_found(
-                format!("Unknown resource: {}", request.uri),
+                resources::unknown_resource_message(&request.uri),
                 None,
             )),
         }

--- a/rust/tests/suite/setup_ci_smoke.rs
+++ b/rust/tests/suite/setup_ci_smoke.rs
@@ -425,9 +425,10 @@ fn init_claude_installs_dedicated_rules_file_without_claude_md() {
     // is a legacy power-profile mention; v4's guard semantics stay documented.
     // v6: block content updated; version bump propagated here.
     // v7 (#1091): Replace-mode write guidance corrected; shared tag bumped.
+    // v8 (#1228): auto memory + edit gate keep native Read; file:// MCP resources guided away.
     assert!(
-        claude_md.contains("lean-ctx-claude-v7"),
-        "CLAUDE.md must carry the v7 block version"
+        claude_md.contains("lean-ctx-claude-v8"),
+        "CLAUDE.md must carry the v8 block version"
     );
     assert!(
         claude_md.contains("ctx_patch"),


### PR DESCRIPTION
## Summary

Fixes #1228.

Claude Code Replace mode put bare `Read` in `permissions.deny`. Deny always wins over allow, so auto memory under `~/.claude/projects/<slug>/memory/` could not use native Read/Edit. Agents then called lean-ctx `resources/read` with `file://…/MEMORY.md` and got a bare `Unknown resource`.

This PR:

- Stops denying bare `Read` in Claude/CodeBuddy Replace mode (keeps Grep/Glob; strips stale Read on reinstall). Native Read stays available for the edit gate and auto memory.
- Auto-allows harness auto-memory paths in PathJail (memory/ only; session transcripts stay jailed) so `ctx_read` / `ctx_patch` work without a manual `extra_roots` edit.
- Passthrough + deny-hook exceptions for the same memory paths.
- Guides `file://` / absolute-path MCP resource reads to `ctx_read` / native Read instead of a cryptic Unknown resource.
- Bumps CLAUDE.md / CODEBUDDY.md instruction blocks (v8 / v4) to match.

#1216 (cryptic missing hash on ctx_patch) is a different root; left alone.

## Test plan

- [x] `cargo test --lib -- --test-threads=1` filtered to the new cases (8 passed): PathJail auto-memory allow, redirect passthrough, deny-hook allow, Replace permissions (no Read / stale Read stripped), Unknown resource guidance
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (not re-run here; disk was tight after cold build)
- [ ] `cargo fmt --check`
- [ ] After merge: run `lean-ctx setup` (or re-init Claude) so settings.json drops stale `Read` deny and CLAUDE.md rewrites to v8

## Evidence

Product path (what the screenshot showed):

```
resources/read file:///…/.claude/projects/…/memory/MEMORY.md
# before: MCP error -32002: Unknown resource: file://…
# after:  Unknown resource: file://…. lean-ctx MCP resources are lean-ctx://context/* only
#         … For Claude auto memory … use native Read/Edit.
```

Unit repro of the permissions fix (Replace reinstall):

```
replace_mode_removes_stale_read_and_bash_deny … ok
replace_mode_adds_permissions_deny … ok   # deny has Grep/Glob, not Read
harness_auto_memory_path_is_allowed_without_extra_roots … ok
```

What was not tested: live Claude Code click-through on this Windows box (no Claude Code session wired here). Logic matches the reported `file://` MEMORY.md + Replace deny path.

## AI assistance

Assisted by Cursor/Grok. Human author: Stan Shih (@stantheman0128). Reviewed before submit.