### PR TITLE
fix(pi-lean-ctx): propagate AbortSignal to enable ESC key tool cancellation

### DIFF
--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -1,6 +1,7 @@
 import type {
   AgentToolResult,
   BashToolDetails,
+  ExecOptions,
   ExtensionAPI,
   ReadToolDetails,
 } from "@earendil-works/pi-coding-agent";
@@ -319,9 +320,15 @@ function isMcpAdapterConfigured(): boolean {
   return false;
 }
 
-async function execLeanCtx(pi: ExtensionAPI, args: string[]) {
+async function execLeanCtx(pi: ExtensionAPI, args: string[], options?: ExecOptions) {
+  if (options?.signal?.aborted) {
+    throw new Error("lean-ctx command interrupted by host.");
+  }
   const bin = resolveBinary();
-  const result = await pi.exec(bin, args);
+  const result = await pi.exec(bin, args, options);
+  if (options?.signal?.aborted || result.killed) {
+    throw new Error("lean-ctx command interrupted by host.");
+  }
   if (result.code !== 0) {
     const msg = (result.stderr || result.stdout || `lean-ctx failed: ${args.join(" ")}`).trim();
     throw new Error(msg);
@@ -595,7 +602,7 @@ export default async function (pi: ExtensionAPI) {
         }
         const args = ["read", absolutePath, "-m", mode, ...(forceFresh ? ["--fresh"] : [])];
         try {
-          const output = await execLeanCtx(pi, args);
+          const output = await execLeanCtx(pi, args, { signal });
           const originalSlice = await readSlice(absolutePath, startOffset, params.limit);
           const decorated = withFooter(output, { originalText: originalSlice.text, always: true, preferEstimate: true, suppressIfNoSaving: true });
           return {
@@ -646,7 +653,7 @@ export default async function (pi: ExtensionAPI) {
       }
 
       const args = ["read", absolutePath, "-m", mode, ...(wantsFresh ? ["--fresh"] : [])];
-      const output = await execLeanCtx(pi, args);
+      const output = await execLeanCtx(pi, args, { signal });
       const originalText = await readFile(absolutePath, "utf8");
       const decorated = withFooter(output, { originalText, always: true, preferEstimate: true, suppressIfNoSaving: true });
 
@@ -677,10 +684,10 @@ export default async function (pi: ExtensionAPI) {
         ? nativeLsTool.renderCall(args, theme, context)
         : (context.lastComponent ?? new Text("", 0, 0));
     },
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path);
       const absolutePath = resolve(ctx.cwd, requestedPath);
-      const output = await execLeanCtx(pi, ["ls", absolutePath]);
+      const output = await execLeanCtx(pi, ["ls", absolutePath], { signal });
       const decorated = withFooter(output, { limit: params.limit, always: true });
       return {
         content: [{ type: "text", text: decorated.text }],
@@ -701,10 +708,10 @@ export default async function (pi: ExtensionAPI) {
         ? nativeFindTool.renderCall(args, theme, context)
         : (context.lastComponent ?? new Text("", 0, 0));
     },
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const requestedPath = normalizePathArg(params.path);
       const absolutePath = resolve(ctx.cwd, requestedPath);
-      const output = await execLeanCtx(pi, ["find", params.pattern, absolutePath]);
+      const output = await execLeanCtx(pi, ["find", params.pattern, absolutePath], { signal });
       const decorated = withFooter(output, { limit: params.limit, always: true });
       return {
         content: [{ type: "text", text: decorated.text }],
@@ -725,7 +732,10 @@ export default async function (pi: ExtensionAPI) {
         ? nativeGrepTool.renderCall(args, theme, context)
         : (context.lastComponent ?? new Text("", 0, 0));
     },
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      if (signal?.aborted) {
+        throw new Error("lean-ctx grep interrupted by host.");
+      }
       const requestedPath = normalizePathArg(params.path);
       const absolutePath = resolve(ctx.cwd, requestedPath);
       const searchArgs = ["rg", "--line-number", "--color=never"];
@@ -738,7 +748,10 @@ export default async function (pi: ExtensionAPI) {
       searchArgs.push(params.pattern, absolutePath);
 
       const bin = resolveBinary();
-      const result = await pi.exec(bin, ["-c", ...searchArgs]);
+      const result = await pi.exec(bin, ["-c", ...searchArgs], { signal });
+      if (signal?.aborted || result.killed) {
+        throw new Error("lean-ctx grep interrupted by host.");
+      }
       if (result.code >= 2) {
         const msg = (result.stderr || result.stdout || `lean-ctx grep failed: ${params.pattern}`).trim();
         throw new Error(msg);
@@ -765,8 +778,8 @@ export default async function (pi: ExtensionAPI) {
       + "Use this for advanced commands like session/knowledge/overview/gain/stats/index/pack.",
     promptSnippet: "Run lean-ctx CLI directly",
     parameters: leanCtxSchema,
-    async execute(_toolCallId, params) {
-      const output = await execLeanCtx(pi, params.args);
+    async execute(_toolCallId, params, signal) {
+      const output = await execLeanCtx(pi, params.args, { signal });
       return {
         content: [{ type: "text", text: output.trimEnd() }],
         details: { source: "lean-ctx", args: params.args },
@@ -804,13 +817,13 @@ export default async function (pi: ExtensionAPI) {
       "Use ctx_edit when cache coherence matters or for race-condition protection.",
     ],
     parameters: editSchema,
-    async execute(_toolCallId, params) {
+    async execute(_toolCallId, params, signal) {
       if (!mcpBridge?.isConnected()) {
         throw new Error(
           "lean-ctx MCP bridge not connected. Use Pi's native edit tool instead.",
         );
       }
-      const result = await mcpBridge.callTool("ctx_edit", params as Record<string, unknown>);
+      const result = await mcpBridge.callTool("ctx_edit", params as Record<string, unknown>, signal);
       const text = result.content.map((b) => b.text).join("");
       return {
         content: [{ type: "text", text }],

--- a/packages/pi-lean-ctx/extensions/mcp-bridge.ts
+++ b/packages/pi-lean-ctx/extensions/mcp-bridge.ts
@@ -374,7 +374,11 @@ export class McpBridge {
     args: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<McpCallResult> {
-    const call = this.client?.callTool({ name, arguments: args });
+    if (signal?.aborted) {
+      throw new Error(`lean-ctx MCP tool "${name}" interrupted by host.`);
+    }
+
+    const call = this.client?.callTool({ name, arguments: args }, undefined, { signal });
     if (!call) {
       throw new Error(`lean-ctx MCP bridge not connected. Tool "${name}" unavailable.`);
     }


### PR DESCRIPTION
### Summary

This PR fixes an issue where pressing the ESC key in Pi did not interrupt running tool calls or background lean-ctx subprocesses.

### Root Cause
1. In packages/pi-lean-ctx/extensions/index.ts, execLeanCtx invoked pi.exec(bin, args) without passing ExecOptions ({ signal }).
2. Without signal, Pi's execCommand runner never attached an abort listener, leaving spawned lean-ctx / ripgrep processes running even after the user requested cancellation via ESC.
3. Tool definitions for ctx_ls, ctx_find, ctx_grep, lean_ctx, and ctx_edit ignored or discarded their signal parameters.
4. McpBridge.callToolWithTimeout did not pass signal as RequestOptions into Client.callTool().

### Changes
- Updated execLeanCtx to accept ExecOptions and pass them to pi.exec().
- Check signal.aborted before and after execution to throw an immediate cancellation error.
- Pass signal into ctx_read, ctx_ls, ctx_find, ctx_grep, lean_ctx, and ctx_edit.
- Pass signal as RequestOptions in McpBridge.callToolWithTimeout for MCP tool calls.