### PR TITLE
fix: price gain estimates from resolved model

### DIFF
--- a/rust/src/core/stats/format/dashboard.rs
+++ b/rust/src/core/stats/format/dashboard.rs
@@ -443,8 +443,11 @@ fn gain_dashboard(t: &Theme, tick: Option<u64>, with_footer: bool) -> String {
 
     // -- COST BREAKDOWN section --
     let price_label = format!(
-        "@ ${:.2}/M input · ${:.2}/M output",
-        cost_model.input_price_per_m, cost_model.output_price_per_m,
+        "{} · @ ${:.2}/M input · ${:.2}/M output · {}",
+        cost_model.model_key,
+        cost_model.input_price_per_m,
+        cost_model.output_price_per_m,
+        pricing_match_label(cost_model.pricing_match_kind),
     );
     let cost_label = format!("COST BREAKDOWN ──── {price_label}");
     out.push(format!("  {}", t.box_top_labeled(w, &cost_label)));
@@ -799,6 +802,31 @@ fn trend_string(store: &StatsStore, up_color: &str, down_color: &str, rst: &str)
         format!("{up_color}+{change:.0}%{rst} vs last week")
     } else {
         format!("{down_color}{change:.0}%{rst} vs last week")
+    }
+}
+
+fn pricing_match_label(kind: crate::core::gain::model_pricing::PricingMatchKind) -> &'static str {
+    match kind {
+        crate::core::gain::model_pricing::PricingMatchKind::Exact => "exact price",
+        crate::core::gain::model_pricing::PricingMatchKind::Live => "live price",
+        crate::core::gain::model_pricing::PricingMatchKind::Alias => "alias price",
+        crate::core::gain::model_pricing::PricingMatchKind::Heuristic => "estimated price",
+        crate::core::gain::model_pricing::PricingMatchKind::Fallback => "fallback estimate",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pricing_match_label;
+    use crate::core::gain::model_pricing::PricingMatchKind;
+
+    #[test]
+    fn pricing_match_labels_surface_estimates() {
+        assert_eq!(pricing_match_label(PricingMatchKind::Exact), "exact price");
+        assert_eq!(
+            pricing_match_label(PricingMatchKind::Fallback),
+            "fallback estimate"
+        );
     }
 }
 

--- a/rust/src/core/stats/format/util.rs
+++ b/rust/src/core/stats/format/util.rs
@@ -18,12 +18,8 @@ pub(super) fn format_usd(amount: f64) -> String {
 }
 
 pub(super) fn usd_estimate(tokens: u64) -> String {
-    let env_model = std::env::var("LEAN_CTX_MODEL")
-        .or_else(|_| std::env::var("LCTX_MODEL"))
-        .ok();
-    let pricing = crate::core::gain::model_pricing::ModelPricing::load();
-    let quote = pricing.quote(env_model.as_deref());
-    let cost = tokens as f64 * quote.cost.input_per_m / 1_000_000.0;
+    let model = CostModel::default();
+    let cost = tokens as f64 * model.input_price_per_m / 1_000_000.0;
     format_usd(cost)
 }
 

--- a/rust/src/core/stats/model.rs
+++ b/rust/src/core/stats/model.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::core::gain::model_pricing::{ModelQuote, PricingMatchKind};
+
 /// Persistent store for all-time token savings, command stats, and daily history.
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct StatsStore {
@@ -225,6 +227,8 @@ pub const DEFAULT_OUTPUT_PRICE_PER_M: f64 = 10.0;
 
 /// LLM pricing model for estimating dollar savings from token compression.
 pub struct CostModel {
+    pub model_key: String,
+    pub pricing_match_kind: PricingMatchKind,
     pub input_price_per_m: f64,
     pub output_price_per_m: f64,
     pub avg_verbose_output_per_call: u64,
@@ -233,12 +237,30 @@ pub struct CostModel {
 
 impl Default for CostModel {
     fn default() -> Self {
-        let env_model = std::env::var("LEAN_CTX_MODEL")
-            .or_else(|_| std::env::var("LCTX_MODEL"))
-            .ok();
         let pricing = crate::core::gain::model_pricing::ModelPricing::load();
-        let quote = pricing.quote(env_model.as_deref());
+        let quote = pricing.quote(resolved_gain_model().as_deref());
+        Self::from_quote(quote)
+    }
+}
+
+fn resolved_gain_model() -> Option<String> {
+    std::env::var("LEAN_CTX_MODEL")
+        .or_else(|_| std::env::var("LCTX_MODEL"))
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            crate::core::config::Config::load()
+                .cost
+                .model_for_client("cli")
+        })
+        .or_else(crate::proxy::usage_meter::persisted_dominant_model)
+}
+
+impl CostModel {
+    fn from_quote(quote: ModelQuote) -> Self {
         Self {
+            model_key: quote.model_key,
+            pricing_match_kind: quote.match_kind,
             input_price_per_m: quote.cost.input_per_m,
             output_price_per_m: quote.cost.output_per_m,
             avg_verbose_output_per_call: 180,
@@ -308,7 +330,8 @@ impl CostModel {
 
 #[cfg(test)]
 mod tests {
-    use super::{CompressionTotals, StatsStore, TrafficClass, classify_command};
+    use super::{CompressionTotals, CostModel, StatsStore, TrafficClass, classify_command};
+    use crate::core::gain::model_pricing::PricingMatchKind;
 
     #[test]
     fn known_tools_are_classified_by_delivery_contract() {
@@ -318,6 +341,35 @@ mod tests {
         assert_eq!(classify_command("ctx_compose"), TrafficClass::Passthrough);
         assert_eq!(classify_command("ctx_glob"), TrafficClass::Passthrough);
         assert_eq!(classify_command("cli_full"), TrafficClass::Passthrough);
+    }
+
+    #[test]
+    fn cost_model_uses_resolved_model_pricing() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let old_lean_ctx_model = std::env::var("LEAN_CTX_MODEL").ok();
+        let old_lctx_model = std::env::var("LCTX_MODEL").ok();
+        unsafe {
+            std::env::set_var("LEAN_CTX_MODEL", "claude-opus-4.5");
+            std::env::remove_var("LCTX_MODEL");
+        }
+
+        let model = CostModel::default();
+
+        assert_eq!(model.model_key, "claude-opus-4.5");
+        assert_eq!(model.pricing_match_kind, PricingMatchKind::Exact);
+        assert_eq!(model.input_price_per_m, 5.0);
+        assert_eq!(model.output_price_per_m, 25.0);
+
+        unsafe {
+            match old_lean_ctx_model {
+                Some(value) => std::env::set_var("LEAN_CTX_MODEL", value),
+                None => std::env::remove_var("LEAN_CTX_MODEL"),
+            }
+            match old_lctx_model {
+                Some(value) => std::env::set_var("LCTX_MODEL", value),
+                None => std::env::remove_var("LCTX_MODEL"),
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1243.

lean-ctx gain --deep now prices cost estimates from the best available model signal instead of falling straight back to blended pricing when env vars are absent.

This PR:
- carries the resolved model_key and pricing match kind through CostModel
- resolves gain pricing from env/config/proxy dominant model before fallback
- shows the resolved model and whether the price is exact/live/estimated/fallback in the cost breakdown
- makes usd_estimate reuse the same CostModel pricing path

## Test plan

- [x] cd rust && cargo test --lib pricing -- --nocapture
- [x] cd rust && cargo fmt --check
- [x] cd rust && cargo clippy --all-features -- -D warnings
- [ ] cd rust && cargo test -- --test-threads=1 (the suite shares process-global state; CI serializes it too)

## Notes for reviewers

- Risk areas / edge cases: StatsStore remains aggregate, so this improves the dashboard estimate using the best current model signal; it does not reconstruct exact historical per-call model costs.
- Backwards compatibility: fallback blended pricing remains the final fallback when no model signal exists.
- Docs updated (links/files): no docs file changed; the cost breakdown label now surfaces the pricing source.

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time CLA.
