### PR TITLE
fix(mcp): treat secret HTTP headers case-insensitively

### DIFF
--- a/rust/src/core/mcp_catalog/config.rs
+++ b/rust/src/core/mcp_catalog/config.rs
@@ -204,7 +204,10 @@ fn redacted_values<'a>(
     values
         .iter()
         .map(|(name, value)| {
-            let value = if secret_fingerprints.contains_key(name) {
+            let value = if secret_fingerprints
+                .keys()
+                .any(|secret| secret.eq_ignore_ascii_case(name))
+            {
                 "<redacted>"
             } else {
                 value.as_str()
@@ -649,7 +652,7 @@ secret_headers = { Authorization = { id = "mcp/gitlab/toml", format = "Bearer {s
                 ("Accept".into(), "application/json".into()),
                 ("Authorization".into(), "private-value".into()),
             ]),
-            secret_fingerprints: BTreeMap::from([("Authorization".into(), "abc123".into())]),
+            secret_fingerprints: BTreeMap::from([("authorization".into(), "abc123".into())]),
         };
 
         let debug = format!("{transport:?}");

--- a/rust/src/core/mcp_catalog/pool.rs
+++ b/rust/src/core/mcp_catalog/pool.rs
@@ -68,20 +68,34 @@ fn pool_identity(transport: &ResolvedTransport) -> String {
             headers,
             secret_fingerprints,
         } => format!(
-            "http|url={url:?}|headers={:?}|secrets={secret_fingerprints:?}",
-            public_values(headers, secret_fingerprints)
+            "http|url={url:?}|headers={:?}|secrets={:?}",
+            public_values_case_insensitive(headers, secret_fingerprints),
+            normalized_secret_fingerprints(secret_fingerprints)
         ),
     }
 }
 
-fn public_values(
+fn public_values_case_insensitive(
     values: &BTreeMap<String, String>,
     secret_fingerprints: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     values
         .iter()
-        .filter(|(name, _)| !secret_fingerprints.contains_key(*name))
+        .filter(|(name, _)| {
+            !secret_fingerprints
+                .keys()
+                .any(|secret| secret.eq_ignore_ascii_case(name))
+        })
         .map(|(name, value)| (name.clone(), value.clone()))
+        .collect()
+}
+
+fn normalized_secret_fingerprints(
+    secret_fingerprints: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    secret_fingerprints
+        .iter()
+        .map(|(name, fingerprint)| (name.to_ascii_lowercase(), fingerprint.clone()))
         .collect()
 }
 
@@ -199,6 +213,23 @@ mod tests {
             secret_fingerprints: secrets,
         };
         assert_ne!(key(&first), key(&rotated));
+    }
+
+    #[test]
+    fn http_key_treats_secret_header_names_case_insensitively() {
+        let upper = ResolvedTransport::Http {
+            url: "https://example.com/mcp".into(),
+            headers: BTreeMap::from([("Authorization".into(), "private-token".into())]),
+            secret_fingerprints: BTreeMap::from([("Authorization".into(), "fingerprint".into())]),
+        };
+        let lower_fingerprint = ResolvedTransport::Http {
+            url: "https://example.com/mcp".into(),
+            headers: BTreeMap::from([("Authorization".into(), "private-token".into())]),
+            secret_fingerprints: BTreeMap::from([("authorization".into(), "fingerprint".into())]),
+        };
+
+        assert!(!pool_identity(&lower_fingerprint).contains("private-token"));
+        assert_eq!(key(&upper), key(&lower_fingerprint));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- match secret HTTP header names case-insensitively when redacting debug output
- filter secret HTTP headers case-insensitively from pool identity
- normalize HTTP secret fingerprint names before hashing pool keys

Fixes #1249

## Validation
- CARGO_BUILD_JOBS=1 cargo test --lib resolved_transport_debug_redacts_memento_values --quiet
- CARGO_BUILD_JOBS=1 cargo test --lib http_key_treats_secret_header_names_case_insensitively --quiet
- CARGO_BUILD_JOBS=1 cargo test --lib core::mcp_catalog --quiet

Note: these passed on the implementation branch before rebasing the clean PR branch onto latest main; a later clean-worktree rerun was blocked by concurrent local Cargo builds.