### PR TITLE
fix(ctx_read): preserve explicit line windows

### DIFF
--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -1207,12 +1207,14 @@ fn anchored_lines_mode(start: i64, limit: Option<i64>) -> String {
 }
 
 /// Apply a resolved line window to `mode`/`fresh`. An explicit non-lines mode
-/// (map/signatures/…) is never clobbered (#259), and `start_line=1` with no
-/// limit is a no-op so it cannot disturb an auto/explicit read (#253). An
-/// explicit `anchored` mode is windowed in place (`anchored:N-M`, #811)
-/// instead of being collapsed to `lines:N-M` — that would silently drop the
-/// hash anchors the caller asked for, and previously let a bounded anchored
-/// read fall through to rendering (and erroring on) the whole file.
+/// (map/signatures/...) is never clobbered (#259), and `start_line=1` with no
+/// limit is a no-op so it cannot disturb an auto/explicit read (#253). A bare
+/// `limit` must not replace an already explicit `lines:`/`anchored:N-M` window;
+/// it only exists as shorthand for `lines:1-N` when no window was supplied. An
+/// explicit `anchored` mode is windowed in place (`anchored:N-M`, #811) instead
+/// of being collapsed to `lines:N-M` -- that would silently drop the hash anchors
+/// the caller asked for, and previously let a bounded anchored read fall through
+/// to rendering (and erroring on) the whole file.
 fn apply_line_window(
     mode: &mut String,
     fresh: &mut bool,
@@ -1224,6 +1226,13 @@ fn apply_line_window(
     let Some((start, limit)) = resolve_line_window(start_line, offset, limit) else {
         return;
     };
+    if start_line.is_none()
+        && offset.is_none()
+        && limit.is_some()
+        && (mode.starts_with("lines:") || mode.starts_with("anchored:"))
+    {
+        return;
+    }
     if start <= 1 && limit.is_none() {
         return;
     }

--- a/rust/src/tools/registered/ctx_read_inline_tests.rs
+++ b/rust/src/tools/registered/ctx_read_inline_tests.rs
@@ -270,6 +270,21 @@ fn limit_alone_reads_from_first_line() {
 }
 
 #[test]
+fn limit_alone_preserves_explicit_line_windows() {
+    let mut mode = "lines:90-100".to_string();
+    let mut fresh = false;
+    super::apply_line_window(&mut mode, &mut fresh, true, None, None, Some(5));
+    assert_eq!(mode, "lines:90-100");
+    assert!(!fresh);
+
+    let mut mode = "anchored:90-100".to_string();
+    let mut fresh = false;
+    super::apply_line_window(&mut mode, &mut fresh, true, None, None, Some(5));
+    assert_eq!(mode, "anchored:90-100");
+    assert!(!fresh);
+}
+
+#[test]
 fn start_line_wins_over_offset_when_both_present() {
     assert_eq!(
         super::resolve_line_window(Some(10), Some(99), None),


### PR DESCRIPTION
Closes #1255

## Summary
- preserve explicit `lines:N-M` and `anchored:N-M` modes when `limit` is the only line-window alias
- keep `start_line`/`offset` override behavior for bounded reads
- add inline regression coverage for explicit line windows

## Tests
- `CARGO_TARGET_DIR=/tmp/lean-ctx-target-pr1255 cargo test --jobs 1 --lib limit_alone_preserves_explicit_line_windows -- --nocapture` (running locally; CI will validate)

No co-authored-by trailer.