### PR TITLE
fix(ctx_shell): pass dataset command output through verbatim

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -123,6 +123,7 @@ Settings for the zero-loss compression archive (large tool outputs saved to disk
 - `inline_max_bytes` (usize, default `32768`) — Maximum ctx_shell(inline=true) output size in bytes before archive/firewall handling. Env: LEAN_CTX_INLINE_MAX_BYTES
 - `max_age_hours` (u64, default `48`) — Maximum age of archived entries before cleanup
 - `max_disk_mb` (u64, default `500`) — Maximum total disk usage for the archive
+- `raw_commands` (Vec<String>, default `["sqlite3","psql","duckdb","jq"]`) — Programs whose ctx_shell output is a dataset (rows/JSON) and passes through verbatim at any size, never archived or elided. `gh` is included automatically when the command uses --json/--jq. Set to [] to disable
 - `threshold_chars` (usize, default `800`) — Minimum output size (chars) to trigger archiving
 
 ## `[autonomy]`

--- a/rust/src/core/config/merge.rs
+++ b/rust/src/core/config/merge.rs
@@ -215,6 +215,7 @@ impl Config {
             archive.ephemeral_min_tokens
         );
         override_if_ne!(default.archive.inline_max_bytes, archive.inline_max_bytes);
+        override_if_ne!(default.archive.raw_commands, archive.raw_commands);
         override_if_ne!(
             default.memory.knowledge.max_facts,
             memory.knowledge.max_facts

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -866,6 +866,10 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         "inline_max_bytes".into(),
         key("usize", serde_json::json!(cfg.archive.inline_max_bytes), "Maximum ctx_shell(inline=true) output size in bytes before archive/firewall handling. Env: LEAN_CTX_INLINE_MAX_BYTES"),
     );
+    archive.insert(
+        "raw_commands".into(),
+        key("Vec<String>", serde_json::json!(cfg.archive.raw_commands), "Programs whose ctx_shell output is a dataset (rows/JSON) and passes through verbatim at any size, never archived or elided. `gh` is included automatically when the command uses --json/--jq. Set to [] to disable"),
+    );
     sections.insert(
         "archive".into(),
         SectionSchema {

--- a/rust/src/core/config/sections.rs
+++ b/rust/src/core/config/sections.rs
@@ -141,6 +141,11 @@ pub struct ArchiveConfig {
     /// Maximum output size that `ctx_shell(inline=true)` returns verbatim before
     /// the archive/firewall path takes over.
     pub inline_max_bytes: usize,
+    /// Programs whose stdout *is* a dataset (#1260). Head+tail elision does not
+    /// compress those — it drops the interior rows that hold the answer — so a
+    /// `ctx_shell` command running one of these passes through verbatim at any
+    /// size. Set to `[]` to disable the passthrough.
+    pub raw_commands: Vec<String>,
 }
 
 /// Opt-in conversation-history compression settings (#1123).
@@ -190,6 +195,10 @@ impl Default for ArchiveConfig {
             ephemeral: true,
             ephemeral_min_tokens: 2000,
             inline_max_bytes: 32 * 1024,
+            raw_commands: crate::core::firewall::DEFAULT_RAW_COMMANDS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
         }
     }
 }

--- a/rust/src/core/firewall.rs
+++ b/rust/src/core/firewall.rs
@@ -47,6 +47,31 @@ pub fn should_firewall(tool: &str, output_tokens: usize, config: &Config) -> boo
         && output_tokens >= min_tokens(config)
 }
 
+/// Programs whose stdout *is* a dataset: rows or JSON the caller already
+/// narrowed with `where` / `limit` / `--json` / a filter expression. Head+tail
+/// elision does not compress those — it deletes the interior rows, which for
+/// sorted output is exactly where the answer lives (#1260). No size threshold
+/// makes that safe, so these bypass the firewall entirely.
+pub const DEFAULT_RAW_COMMANDS: &[&str] = &["sqlite3", "psql", "duckdb", "jq"];
+
+/// Whether `command` runs a dataset program in any of its pipeline segments.
+/// `gh` counts only with `--json`/`--jq` — plain `gh` output is prose and
+/// compresses fine.
+pub fn is_raw_command(command: &str, config: &Config) -> bool {
+    command
+        .split(['|', ';', '&', '\n'])
+        .any(|seg| match seg.split_whitespace().next() {
+            // ponytail: first word per segment, so `FOO=1 sqlite3 …` and
+            // `$(sqlite3 …)` are missed — pass raw=true for those.
+            Some(word) => {
+                let prog = word.rsplit('/').next().unwrap_or(word);
+                config.archive.raw_commands.iter().any(|r| r == prog)
+                    || (prog == "gh" && (seg.contains("--json") || seg.contains("--jq")))
+            }
+            None => false,
+        })
+}
+
 /// Whether an explicitly requested `ctx_shell(inline=true)` result fits the
 /// configured verbatim-delivery cap.
 pub fn should_inline_shell(inline_requested: bool, output_bytes: usize, config: &Config) -> bool {
@@ -155,6 +180,24 @@ mod tests {
         assert!(should_firewall("ctx_shell", 5000, &cfg));
         assert!(!should_firewall("ctx_shell", 1000, &cfg)); // below threshold
         assert!(!should_firewall("ctx_read", 5000, &cfg)); // not firewallable
+    }
+
+    #[test]
+    fn dataset_commands_bypass_the_firewall_but_prose_does_not() {
+        let cfg = Config::default();
+        assert!(is_raw_command("sqlite3 -header backup.db \"select 1\"", &cfg));
+        assert!(is_raw_command("/usr/bin/psql -c 'select 1'", &cfg));
+        assert!(is_raw_command("cat x.json | jq '.[]'", &cfg));
+        assert!(is_raw_command("gh issue list --json number,title", &cfg));
+        // Plain gh is prose; a mention of a dataset tool is not an invocation.
+        assert!(!is_raw_command("gh issue view 1260", &cfg));
+        assert!(!is_raw_command("grep -rn sqlite3 src/", &cfg));
+        assert!(!is_raw_command("cargo test", &cfg));
+
+        // Opt out.
+        let mut off = Config::default();
+        off.archive.raw_commands.clear();
+        assert!(!is_raw_command("sqlite3 backup.db 'select 1'", &off));
     }
 
     #[test]

--- a/rust/src/core/firewall.rs
+++ b/rust/src/core/firewall.rs
@@ -185,7 +185,10 @@ mod tests {
     #[test]
     fn dataset_commands_bypass_the_firewall_but_prose_does_not() {
         let cfg = Config::default();
-        assert!(is_raw_command("sqlite3 -header backup.db \"select 1\"", &cfg));
+        assert!(is_raw_command(
+            "sqlite3 -header backup.db \"select 1\"",
+            &cfg
+        ));
         assert!(is_raw_command("/usr/bin/psql -c 'select 1'", &cfg));
         assert!(is_raw_command("cat x.json | jq '.[]'", &cfg));
         assert!(is_raw_command("gh issue list --json number,title", &cfg));

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -57,6 +57,10 @@ pub(in crate::server) async fn dispatch_and_post_process(
             || std::env::var("LEAN_CTX_DISABLED").is_ok()
             || crate::core::runtime_flags::raw_enabled()
             || inline_shell
+            // #1260: dataset output (sqlite3/psql/jq/`gh --json`) is destroyed,
+            // not compressed, by middle elision — pass it through at any size.
+            || helpers::get_str(args, "command")
+                .is_some_and(|c| crate::core::firewall::is_raw_command(&c, &config))
     };
 
     let pre_terse_len = result_text.len();


### PR DESCRIPTION
Fixes #1260

For commands whose stdout *is* a dataset — `sqlite3`, `psql`, `duckdb`, `jq`, `gh --json` — head+tail elision does not compress the result, it destroys it. Rows are ordered by time or magnitude, so the interior is exactly where the answer lives. In the reported case a 60-row query came back as 19 rows of night-time zeros plus 8 tail rows, with every daylight row — the point of the query — dropped.

No size threshold fixes this (cf. #1129): a legitimate aggregation is *supposed* to be several thousand tokens and is still 100% signal. The agent already did the compression with `where` / `group by` / `limit` / `--json`.

## Change

`firewall::is_raw_command()` — a `ctx_shell` command running a dataset program in any pipeline segment skips archive, firewall and compression at any size. It feeds the existing `is_raw_shell` flag in `server/call_tool/pipeline.rs`, so it takes the same path as `raw=true`.

```toml
[archive]
raw_commands = ["sqlite3", "psql", "duckdb", "jq"]   # default; [] disables
```

- `gh` is matched only when the segment contains `--json`/`--jq` — plain `gh` output is prose and compresses fine.
- Matching is per pipeline segment on the first word, basename-normalized, so `cat x.json | jq '.[]'` and `/usr/bin/psql …` hit while `grep -rn sqlite3 src/` does not.
- Known ceiling, marked with a `ponytail:` comment: `FOO=1 sqlite3 …` and `$(sqlite3 …)` are missed — `raw=true` still covers those.
- `[archive] inline_max_bytes` (the other ask in the issue) was already schema-exposed and tunable; `raw_commands` joins it in the generated config-keys reference.

Not included: preferring tail-truncation over middle-elision for output that *is* archived. That is the issue's secondary suggestion and changes behavior for every firewalled tool, so it belongs in its own change.

## Test

`firewall::tests::dataset_commands_bypass_the_firewall_but_prose_does_not`

🤖 Generated with [Claude Code](https://claude.com/claude-code)