### PR TITLE
fix(vscode): expose effective cache usage

### DIFF
--- a/rust/src/cli/config_cmd.rs
+++ b/rust/src/cli/config_cmd.rs
@@ -771,6 +771,67 @@ fn parse_flag_value(args: &[String], flag: &str) -> Option<String> {
         .cloned()
 }
 
+fn load_mcp_live_stats() -> Option<serde_json::Value> {
+    let path = crate::core::paths::state_dir().ok()?.join("mcp-live.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn stats_json_value(
+    store: &crate::core::stats::StatsStore,
+    mcp_cache: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut value = serde_json::to_value(store).unwrap_or_else(|_| serde_json::json!({}));
+    if let (Some(object), Some(mcp_cache)) = (value.as_object_mut(), mcp_cache) {
+        object.insert("mcp_cache".to_string(), mcp_cache);
+    }
+    value
+}
+
+fn mcp_cache_stats_lines(value: &serde_json::Value) -> Vec<String> {
+    let metric = |key| {
+        value
+            .get(key)
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0)
+    };
+    let mcp_reads = metric("total_reads");
+    let mcp_hits = metric("cache_hits");
+    let mcp_rate = if mcp_reads > 0 {
+        (mcp_hits as f64 / mcp_reads as f64 * 100.0).round() as u32
+    } else {
+        0
+    };
+    let updated = value
+        .get("updated_at")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let mut lines = vec![
+        "MCP Session Cache (ctx_read via AI editor):".to_string(),
+        format!("  Reads:         {mcp_reads}"),
+        format!("  Hits:          {mcp_hits}"),
+        format!("  Hit Rate:      {mcp_rate}%"),
+        format!("  Tokens Saved:  {}", metric("tokens_saved")),
+        format!("  Last Updated:  {updated}"),
+    ];
+
+    let dedup_reads = metric("dedup_reads");
+    if dedup_reads > 0 {
+        let dedup_hits = metric("dedup_hits");
+        let dedup_rate = dedup_hits as f64 / dedup_reads as f64 * 100.0;
+        lines.extend([
+            String::new(),
+            "Content Dedup (repeated ctx_read output):".to_string(),
+            format!("  Reads Checked: {dedup_reads}"),
+            format!("  Hits:          {dedup_hits}"),
+            format!("  Hit Rate:      {dedup_rate:.1}%"),
+            format!("  Tokens Saved:  {}", metric("dedup_tokens_saved")),
+        ]);
+    }
+
+    lines
+}
+
 pub fn cmd_stats(args: &[String]) {
     match args.first().map(std::string::String::as_str) {
         Some("reset-cep") => {
@@ -779,9 +840,10 @@ pub fn cmd_stats(args: &[String]) {
         }
         Some("json") => {
             let store = crate::core::stats::load();
+            let value = stats_json_value(&store, load_mcp_live_stats());
             println!(
                 "{}",
-                serde_json::to_string_pretty(&store).unwrap_or_else(|_| "{}".to_string())
+                serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
             );
         }
         _ => {
@@ -847,45 +909,14 @@ pub fn cmd_cache(args: &[String]) {
             println!("  Hits:      {hits}");
             println!("  Hit Rate:  {rate}%");
 
-            if let Ok(dir) = crate::core::paths::state_dir() {
-                let live_path = dir.join("mcp-live.json");
-                if let Ok(content) = std::fs::read_to_string(&live_path) {
-                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
-                        let mcp_reads = val
-                            .get("total_reads")
-                            .and_then(serde_json::Value::as_u64)
-                            .unwrap_or(0);
-                        let mcp_hits = val
-                            .get("cache_hits")
-                            .and_then(serde_json::Value::as_u64)
-                            .unwrap_or(0);
-                        let mcp_saved = val
-                            .get("tokens_saved")
-                            .and_then(serde_json::Value::as_u64)
-                            .unwrap_or(0);
-                        let mcp_rate = if mcp_reads > 0 {
-                            (mcp_hits as f64 / mcp_reads as f64 * 100.0).round() as u32
-                        } else {
-                            0
-                        };
-                        let updated = val
-                            .get("updated_at")
-                            .and_then(serde_json::Value::as_str)
-                            .unwrap_or("unknown");
-                        println!();
-                        println!("MCP Session Cache (ctx_read via AI editor):");
-                        println!("  Reads:         {mcp_reads}");
-                        println!("  Hits:          {mcp_hits}");
-                        println!("  Hit Rate:      {mcp_rate}%");
-                        println!("  Tokens Saved:  {mcp_saved}");
-                        println!("  Last Updated:  {updated}");
-                    }
-                } else {
-                    println!();
-                    println!(
-                        "MCP Session Cache: no data yet (start a session with your AI editor)"
-                    );
+            if let Some(value) = load_mcp_live_stats() {
+                println!();
+                for line in mcp_cache_stats_lines(&value) {
+                    println!("{line}");
                 }
+            } else {
+                println!();
+                println!("MCP Session Cache: no data yet (start a session with your AI editor)");
             }
         }
         Some("invalidate") => {
@@ -1290,6 +1321,47 @@ fn dir_size(path: &std::path::Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mcp_cache_stats_distinguish_session_cache_and_content_dedup() {
+        let current = serde_json::json!({
+            "total_reads": 55,
+            "cache_hits": 2,
+            "tokens_saved": 178_015,
+            "dedup_reads": 10,
+            "dedup_hits": 8,
+            "dedup_tokens_saved": 12_345,
+            "updated_at": "2026-07-24T14:17:30+02:00"
+        });
+        let lines = mcp_cache_stats_lines(&current);
+        assert!(lines.iter().any(|line| line == "  Hit Rate:      4%"));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "Content Dedup (repeated ctx_read output):")
+        );
+        assert!(lines.iter().any(|line| line == "  Hit Rate:      80.0%"));
+        assert!(lines.iter().any(|line| line == "  Tokens Saved:  12345"));
+
+        let legacy = serde_json::json!({"total_reads": 3, "cache_hits": 1});
+        let legacy_lines = mcp_cache_stats_lines(&legacy);
+        assert!(
+            legacy_lines
+                .iter()
+                .all(|line| !line.contains("Content Dedup"))
+        );
+    }
+
+    #[test]
+    fn stats_json_embeds_mcp_cache_snapshot() {
+        let store = crate::core::stats::StatsStore::default();
+        let cache = serde_json::json!({"cache_hits": 2, "dedup_hits": 8});
+        let value = stats_json_value(&store, Some(cache));
+
+        assert_eq!(value["mcp_cache"]["cache_hits"], 2);
+        assert_eq!(value["mcp_cache"]["dedup_hits"], 8);
+        assert!(stats_json_value(&store, None).get("mcp_cache").is_none());
+    }
 
     #[test]
     fn show_box_borders_line_up() {

--- a/rust/src/tools/registered/ctx_cache.rs
+++ b/rust/src/tools/registered/ctx_cache.rs
@@ -7,6 +7,19 @@ use crate::tool_defs::tool_def;
 
 pub struct CtxCacheTool;
 
+fn append_content_dedup_stats(lines: &mut Vec<String>) {
+    let dedup = crate::tools::ctx_read::dedup_hook::summary();
+    if dedup.total_reads > 0 {
+        lines.push(format!(
+            "content dedup: {} hit(s)/{} read(s) ({:.1}%), {} tokens saved",
+            dedup.dedup_hits,
+            dedup.total_reads,
+            dedup.hit_rate * 100.0,
+            dedup.tokens_saved
+        ));
+    }
+}
+
 impl McpTool for CtxCacheTool {
     fn name(&self) -> &'static str {
         "ctx_cache"
@@ -93,6 +106,7 @@ impl McpTool for CtxCacheTool {
                     }
                     lines
                 };
+                append_content_dedup_stats(&mut lines);
                 // Re-delivery telemetry: forced full re-sends grouped by cause
                 // (diagnostic only — never enters a cacheable body, #498).
                 let t = crate::core::cache_telemetry::snapshot();

--- a/rust/src/tools/server_metrics.rs
+++ b/rust/src/tools/server_metrics.rs
@@ -465,6 +465,7 @@ impl LeanCtxServer {
         let calls = self.tool_calls.read().await;
         let stats = cache.get_stats();
         let complexity = crate::core::adaptive::classify_from_context(&cache);
+        let dedup = crate::tools::ctx_read::dedup_hook::summary();
 
         let cs = Self::compute_cep_stats(&calls, stats, &complexity);
         let started_at = calls
@@ -500,6 +501,9 @@ impl LeanCtxServer {
             "files_cached": cs.total_reads,
             "total_reads": cs.total_reads,
             "cache_hits": cs.cache_hits,
+            "dedup_reads": dedup.total_reads,
+            "dedup_hits": dedup.dedup_hits,
+            "dedup_tokens_saved": dedup.tokens_saved,
             "tokens_saved": cs.total_saved,
             "tokens_original": cs.total_original,
             "tool_calls": cs.tool_call_count,

--- a/specs/1253-vscode-cache-observability/plan.md
+++ b/specs/1253-vscode-cache-observability/plan.md
@@ -1,0 +1,38 @@
+# Plan: VS Code Cache Observability  (refs #1253)
+
+> Implementation plan for `./spec.md`.
+
+**Goal:** Expose MCP SessionCache and Content Dedup as separate, backward-compatible metrics in runtime diagnostics and VS Code.
+**Architecture:** Sample the existing process-local dedup summary when the MCP live snapshot is written. Preserve existing fields and add three dedup fields; embed that snapshot under `mcp_cache` in `stats json`. Keep rendering consumers tolerant of missing fields.
+**Tech Stack:** Rust, serde_json, TypeScript, VS Code webview HTML/JavaScript.
+
+## Global Constraints
+- Do not change SessionCache, Content Dedup, compression, or provider-cache behavior.
+- Keep all JSON additions optional and additive for older runtime/extension combinations.
+- Never merge the two cache rates; their denominators and semantics differ.
+- No mock data, no placeholders, no stubs.
+- Output determinism: no new timestamps, counters, or randomness in cacheable tool bodies (#498).
+
+## File Structure
+| File | Responsibility | New/Modify |
+|------|----------------|------------|
+| `rust/src/tools/server_metrics.rs` | Persist dedup counters in `mcp-live.json` | modify |
+| `rust/src/cli/config_cmd.rs` | Embed snapshot in `stats json`; render separate CLI sections; unit tests | modify |
+| `rust/src/tools/registered/ctx_cache.rs` | Show process-local dedup summary in cache status | modify |
+| `vscode-extension/src/leanctx.ts` | Parse optional cache metrics with zero fallback | modify |
+| `vscode-extension/src/sidebar/panel.html` | Display both rates and exact counts | modify |
+| `vscode-extension/src/statusbar.ts` | Add both cache layers to tooltip | modify |
+| `specs/1253-vscode-cache-observability/*` | Intent, plan, and task traceability | new |
+
+## Impact (run impact analysis first)
+- `server_metrics.rs`: 8 dependents through server modules, updater, library/main, and `ctx_session`.
+- `config_cmd.rs`: 2 dependents through CLI dispatch and library.
+- `leanctx.ts`: 9 dependents, including commands, extension activation, sidebar provider, status bar, editor signals, dashboard, and URI handling.
+- Affected tests: CLI cache rendering, stats JSON embedding, existing ctx_read dedup hook tests, TypeScript compilation, webview script syntax.
+- Affected modules: MCP live metrics, CLI stats/cache diagnostics, registered cache tool, VS Code data adapter and stats UI.
+
+## Self-Review (fill before implementing)
+- Spec coverage: every EARS criterion maps to T1-T4 in `tasks.md`.
+- Placeholder scan: no TODO, TBD, mock, or guessed provider metrics.
+- Determinism: snapshot fields are numeric state; no new dynamic data enters cached read bodies.
+- Cleanup: generated `node_modules` remains ignored; no scratch files committed.

--- a/specs/1253-vscode-cache-observability/spec.md
+++ b/specs/1253-vscode-cache-observability/spec.md
@@ -1,0 +1,47 @@
+# Spec: VS Code Cache Observability  (refs #1253)
+
+> SDD spec-anchored: this file is the source of truth for **intent**.
+> Code + tests enforce it. When requirements change, update the spec first.
+
+## Problem / Why
+VS Code uses lean-ctx through MCP, but the extension and cache diagnostics expose only
+`SessionCache` hits. Context Kernel content deduplication can independently collapse a
+repeated `ctx_read` to an `already in context` stub, so the displayed hit rate can imply
+that caching is unused even while effective re-read elimination is working.
+
+Provider prompt-cache savings are a separate metric. Copilot model requests that do not
+traverse the lean-ctx proxy cannot be observed or credited as provider cache reads.
+
+## Goal
+Expose MCP SessionCache and Content Dedup as separate, backward-compatible metrics in the
+runtime diagnostics and VS Code extension.
+
+## Acceptance Criteria (EARS)
+- WHEN an MCP live snapshot is written, THE runtime SHALL persist content-dedup reads, hits, and tokens saved separately from SessionCache metrics.
+- WHEN `lean-ctx stats json` is requested, THE CLI SHALL expose the MCP live snapshot under an additive `mcp_cache` object without removing or renaming existing fields.
+- WHEN `lean-ctx cache stats` is requested, THE CLI SHALL display SessionCache and Content Dedup as separate layers.
+- WHEN `ctx_cache status` is requested after deduplication activity, THE tool SHALL display content-dedup reads, hits, hit rate, and tokens saved.
+- WHEN the VS Code dashboard receives cache metrics, THE extension SHALL display both hit rates and exact hit/read counts.
+- IF an older runtime omits `mcp_cache` or its deduplication fields, THEN THE extension SHALL render zero or unavailable values without failing.
+- THE implementation SHALL preserve existing SessionCache hit semantics and provider-cache accounting.
+
+## Out of Scope
+- Proxying GitHub Copilot model traffic through lean-ctx.
+- Estimating provider prompt-cache hits when no provider turn was observed.
+- Combining SessionCache and Content Dedup into one ambiguous hit rate.
+- Changing cache eviction, invalidation, or compression behavior.
+
+## Verification (deterministic first)
+- `cargo test --lib mcp_cache_stats_distinguish_session_cache_and_content_dedup`
+- `cargo test --lib stats_json_embeds_mcp_cache_snapshot`
+- `cargo test --lib tools::ctx_read::dedup_hook::tests`
+- `cargo fmt --check`
+- `cargo clippy --all-features -- -D warnings`
+- `npm ci && npm run compile`
+- Extract the webview script and run `node --check`.
+- `scripts/preflight.sh fast`
+
+## Links
+- Tracking issue: #1253
+- Plan: ./plan.md · Tasks: ./tasks.md
+- Contracts touched: additive fields in local `mcp-live.json` and `stats json`

--- a/specs/1253-vscode-cache-observability/tasks.md
+++ b/specs/1253-vscode-cache-observability/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: VS Code Cache Observability  (refs #1253)
+
+> Atomic, individually testable. Each task pairs a change with its verification.
+> Commit reference: `fix(vscode): expose effective cache usage refs specs/1253-vscode-cache-observability`.
+
+- [x] **T1 — Persist effective MCP cache metrics**
+  - Files: `rust/src/tools/server_metrics.rs`
+  - Do: add content-dedup reads, hits, and tokens saved to the additive MCP live snapshot.
+  - Verify: focused Rust compilation and `cargo test --lib tools::ctx_read::dedup_hook::tests`.
+- [x] **T2 — Expose separate runtime diagnostics**
+  - Files: `rust/src/cli/config_cmd.rs`, `rust/src/tools/registered/ctx_cache.rs`
+  - Do: embed `mcp_cache` in stats JSON and render SessionCache/Content Dedup separately.
+  - Verify: `cargo test --lib mcp_cache_stats_distinguish_session_cache_and_content_dedup` and `cargo test --lib stats_json_embeds_mcp_cache_snapshot`.
+- [x] **T3 — Surface metrics in VS Code**
+  - Files: `vscode-extension/src/leanctx.ts`, `vscode-extension/src/sidebar/panel.html`, `vscode-extension/src/statusbar.ts`
+  - Do: parse optional metrics, show both rates, and expose exact counts in tooltips.
+  - Verify: `npm run compile` and extracted webview script through `node --check`.
+- [x] **T4 — Preserve compatibility and semantics**
+  - Files: all touched runtime and extension files.
+  - Do: retain existing fields, zero-fallback absent fields, and avoid provider-cache estimation.
+  - Verify: legacy snapshot assertions, existing dedup tests, and diff review.
+
+## Done gate
+- [x] All EARS criteria covered by a task.
+- [x] `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` green.
+- [x] Fast preflight-equivalent gates green; Windows cross-check skipped because target is not installed.
+- [ ] Full local lib suite: 9,044 passed; 15 unrelated HOME/env-lock failures in unchanged modules.
+- [x] Tracking issue #1253 updated; spec referenced in commit and PR #1290.

--- a/vscode-extension/src/leanctx.ts
+++ b/vscode-extension/src/leanctx.ts
@@ -14,6 +14,11 @@ export interface SessionStats {
   tokensSaved: number;
   sessionDuration: string;
   filesTouched: number;
+  cacheReads: number;
+  cacheHits: number;
+  dedupReads: number;
+  dedupHits: number;
+  dedupTokensSaved: number;
 }
 
 export interface RepoMapEntry {
@@ -192,6 +197,7 @@ export async function getSessionStats(): Promise<SessionStats> {
 
     const inputTokens: number = data.total_input_tokens ?? 0;
     const outputTokens: number = data.total_output_tokens ?? 0;
+    const mcpCache = (data.mcp_cache ?? {}) as Record<string, number>;
 
     return {
       totalReads: count("ctx_read"),
@@ -200,6 +206,11 @@ export async function getSessionStats(): Promise<SessionStats> {
       tokensSaved: Math.max(0, inputTokens - outputTokens),
       sessionDuration: formatSpan(data.first_use, data.last_use),
       filesTouched: 0,
+      cacheReads: mcpCache.total_reads ?? 0,
+      cacheHits: mcpCache.cache_hits ?? 0,
+      dedupReads: mcpCache.dedup_reads ?? 0,
+      dedupHits: mcpCache.dedup_hits ?? 0,
+      dedupTokensSaved: mcpCache.dedup_tokens_saved ?? 0,
     };
   } catch {
     return {
@@ -209,6 +220,11 @@ export async function getSessionStats(): Promise<SessionStats> {
       tokensSaved: 0,
       sessionDuration: "—",
       filesTouched: 0,
+      cacheReads: 0,
+      cacheHits: 0,
+      dedupReads: 0,
+      dedupHits: 0,
+      dedupTokensSaved: 0,
     };
   }
 }

--- a/vscode-extension/src/sidebar/panel.html
+++ b/vscode-extension/src/sidebar/panel.html
@@ -376,6 +376,14 @@
         <div class="stat-value" id="files-touched">—</div>
         <div class="stat-label">Files</div>
       </div>
+      <div class="stat-card">
+        <div class="stat-value" id="read-cache-rate">—</div>
+        <div class="stat-label">Read Cache</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value" id="content-dedup-rate">—</div>
+        <div class="stat-label">Content Dedup</div>
+      </div>
     </div>
     <div class="version-badge" id="version-info">lean-ctx</div>
   </div>
@@ -458,6 +466,11 @@
       return String(n);
     }
 
+    function formatRate(hits, reads) {
+      if (!reads) return "—";
+      return Math.round((hits / reads) * 100) + "%";
+    }
+
     /* ── Render functions ── */
     function renderStats(data) {
       document.getElementById("tokens-saved").textContent = formatNumber(
@@ -475,6 +488,12 @@
       document.getElementById("files-touched").textContent = formatNumber(
         data.filesTouched
       );
+      const readCache = document.getElementById("read-cache-rate");
+      readCache.textContent = formatRate(data.cacheHits, data.cacheReads);
+      readCache.title = `${data.cacheHits} hits / ${data.cacheReads} reads`;
+      const contentDedup = document.getElementById("content-dedup-rate");
+      contentDedup.textContent = formatRate(data.dedupHits, data.dedupReads);
+      contentDedup.title = `${data.dedupHits} hits / ${data.dedupReads} reads · ${formatNumber(data.dedupTokensSaved)} tokens saved`;
     }
 
     function renderKnowledge(facts) {

--- a/vscode-extension/src/statusbar.ts
+++ b/vscode-extension/src/statusbar.ts
@@ -40,6 +40,8 @@ export class StatusBarManager {
         `Searches: ${stats.totalSearches}`,
         `Shells: ${stats.totalShells}`,
         `Files: ${stats.filesTouched}`,
+        `Read Cache: ${stats.cacheHits}/${stats.cacheReads}`,
+        `Content Dedup: ${stats.dedupHits}/${stats.dedupReads} (${this.formatTokens(stats.dedupTokensSaved)} tokens saved)`,
         `Session: ${stats.sessionDuration}`,
       ].join("\n");
     } catch {


### PR DESCRIPTION
## Summary

- persist Context Kernel content-dedup reads, hits, and saved tokens beside MCP SessionCache metrics
- expose the additive `mcp_cache` snapshot through `stats json` and separate both cache layers in CLI/MCP diagnostics
- show Read Cache and Content Dedup rates and exact counts in the VS Code sidebar/status tooltip, with backward-compatible zero fallbacks

Closes #1253

Spec: `specs/1253-vscode-cache-observability/spec.md`

## Test plan

- [x] `cd rust && cargo test -- --test-threads=1` (local lib run: 9,044 passed; 15 unrelated HOME/env-lock failures in unchanged dashboard/root modules)
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [x] `cd vscode-extension && npm ci && npm run compile`
- [x] extracted webview script passes `node --check`
- [x] focused Rust cache/JSON/dedup tests: 6 passed
- [x] fast preflight-equivalent rustdoc/generated-docs/registry gates passed; Windows cross-check skipped because the target is not installed

## Notes for reviewers

- Risk areas / edge cases: older runtimes omit `mcp_cache`; the extension falls back to zero/unavailable values. SessionCache and Content Dedup remain separate because their denominators differ.
- Backwards compatibility: all JSON fields are additive; existing SessionCache and provider-cache semantics are unchanged.
- Docs updated: `specs/1253-vscode-cache-observability/spec.md`, `plan.md`, and `tasks.md`.

## Contributor License Agreement

The repository CLA is already associated with this contributor account.