### PR TITLE
Fix Go SDK conformance routes

### DIFF
--- a/scripts/sdk-conformance.sh
+++ b/scripts/sdk-conformance.sh
@@ -68,9 +68,13 @@ echo "==> TypeScript SDK conformance"
 echo "==> Go SDK conformance"
 (
   cd go-sdk
+  set +e
+  set -o pipefail
   LEANCTX_CONFORMANCE_URL="$URL" go test -run TestConformanceLive -v ./... 2>&1 | tee "$MATRIX_DIR/go.log"
-  echo $? > "$MATRIX_DIR/go.exit"
-)
+  GO_EXIT=$?
+  echo "$GO_EXIT" > "$MATRIX_DIR/go.exit"
+  exit "$GO_EXIT"
+) || FAIL=1
 echo "==> Rust SDK conformance"
 (cd clients/rust/lean-ctx-client && cargo test --test conformance_live) || FAIL=1
 


### PR DESCRIPTION
## Summary
- align Go SDK HTTP paths with the main conformance server routes
- update Go endpoint tests for /health and /v1 APIs
- preserve the Go conformance exit code while allowing the SDK matrix to continue

Fixes #1332

## Validation
- go test ./...
- gofmt on touched Go files
- git diff --check -- go-sdk/client.go go-sdk/client_test.go scripts/sdk-conformance.sh