### PR TITLE
Fix adaptive routing fallback recovery

### DIFF
--- a/rust/src/core/ocla/routing_experiment.rs
+++ b/rust/src/core/ocla/routing_experiment.rs
@@ -195,6 +195,7 @@ mod tests {
     fn outcome(quality_score: Option<f64>, tokens_saved: u64) -> RoutingOutcome {
         RoutingOutcome {
             decision: RoutingDecision {
+                decision_id: "experiment-decision".into(),
                 original_model: "baseline".into(),
                 routed_model: "candidate".into(),
                 reason: "experiment".into(),

--- a/rust/src/core/ocla/routing_quality.rs
+++ b/rust/src/core/ocla/routing_quality.rs
@@ -4,10 +4,12 @@ use std::collections::VecDeque;
 
 const MAX_DECISIONS: usize = 1_000;
 const QUALITY_THRESHOLD: f64 = 0.8;
+const MIN_SCORED_OUTCOMES: usize = 20;
 
 /// The model route selected for one request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RoutingDecision {
+    pub decision_id: String,
     pub original_model: String,
     pub routed_model: String,
     pub reason: String,
@@ -40,7 +42,10 @@ impl RoutingQualityTracker {
         if self.outcomes.len() == MAX_DECISIONS {
             self.outcomes.pop_front();
         }
-        self.outcomes.push_back(outcome);
+        self.outcomes.push_back(RoutingOutcome {
+            quality_score: sanitize_quality(outcome.quality_score),
+            ..outcome
+        });
 
         if self.should_fallback() {
             tracing::warn!(
@@ -52,15 +57,20 @@ impl RoutingQualityTracker {
 
     /// Returns the fraction of recorded outcomes meeting the quality threshold.
     pub fn success_rate(&self) -> f64 {
-        if self.outcomes.is_empty() {
+        let scored = self.scored_outcomes();
+        if scored == 0 {
             return 0.0;
         }
 
         self.outcomes
             .iter()
-            .filter(|outcome| outcome.quality_score.unwrap_or(0.0) >= QUALITY_THRESHOLD)
+            .filter(|outcome| {
+                outcome
+                    .quality_score
+                    .is_some_and(|score| score >= QUALITY_THRESHOLD)
+            })
             .count() as f64
-            / self.outcomes.len() as f64
+            / scored as f64
     }
 
     /// Returns the average token savings across recorded outcomes.
@@ -78,8 +88,19 @@ impl RoutingQualityTracker {
 
     /// Returns whether recent route quality should trigger a fallback.
     pub fn should_fallback(&self) -> bool {
-        !self.outcomes.is_empty() && self.success_rate() < QUALITY_THRESHOLD
+        self.scored_outcomes() >= MIN_SCORED_OUTCOMES && self.success_rate() < QUALITY_THRESHOLD
     }
+
+    fn scored_outcomes(&self) -> usize {
+        self.outcomes
+            .iter()
+            .filter(|outcome| outcome.quality_score.is_some())
+            .count()
+    }
+}
+
+fn sanitize_quality(score: Option<f64>) -> Option<f64> {
+    score.filter(|value| value.is_finite() && (0.0..=1.0).contains(value))
 }
 
 #[cfg(test)]
@@ -89,6 +110,7 @@ mod tests {
     fn outcome(score: Option<f64>, tokens_saved: u64) -> RoutingOutcome {
         RoutingOutcome {
             decision: RoutingDecision {
+                decision_id: "decision-test".into(),
                 original_model: "expensive".into(),
                 routed_model: "fast".into(),
                 reason: "quality test".into(),
@@ -117,9 +139,9 @@ mod tests {
         tracker.record(outcome(None, 0));
         tracker.record(outcome(Some(0.8), 40));
 
-        assert!((tracker.success_rate() - 0.5).abs() < f64::EPSILON);
+        assert!((tracker.success_rate() - (2.0 / 3.0)).abs() < f64::EPSILON);
         assert!((tracker.average_savings() - 40.0).abs() < f64::EPSILON);
-        assert!(tracker.should_fallback());
+        assert!(!tracker.should_fallback());
     }
 
     #[test]
@@ -132,6 +154,29 @@ mod tests {
 
         assert!((tracker.success_rate() - 1.0).abs() < f64::EPSILON);
         assert!((tracker.average_savings() - 100.0).abs() < f64::EPSILON);
+        assert!(!tracker.should_fallback());
+    }
+
+    #[test]
+    fn fallback_requires_minimum_scored_samples() {
+        let mut tracker = RoutingQualityTracker::new();
+        for _ in 0..(MIN_SCORED_OUTCOMES - 1) {
+            tracker.record(outcome(Some(0.0), 0));
+        }
+        assert!(!tracker.should_fallback());
+
+        tracker.record(outcome(Some(0.0), 0));
+        assert!(tracker.should_fallback());
+    }
+
+    #[test]
+    fn invalid_and_absent_quality_do_not_count_as_failure() {
+        let mut tracker = RoutingQualityTracker::new();
+        tracker.record(outcome(None, 10));
+        tracker.record(outcome(Some(f64::NAN), 10));
+        tracker.record(outcome(Some(1.5), 10));
+
+        assert_eq!(tracker.success_rate(), 0.0);
         assert!(!tracker.should_fallback());
     }
 }

--- a/rust/src/proxy/forward/mod.rs
+++ b/rust/src/proxy/forward/mod.rs
@@ -271,11 +271,9 @@ pub async fn forward_request(
         && let Some(cached) = cache.try_cache_hit(model, &cache_prompt_hash, 0.0, 0)
     {
         if let Some(route_decision) = &route {
-            let quality = if cached.status.is_success() { 1.0 } else { 0.0 };
-            crate::proxy::routing_feedback::global_feedback().record_outcome(
-                &route_decision.routed_from,
-                &route_decision.model,
-                quality,
+            crate::proxy::routing_feedback::global_feedback().record_outcome_for_decision(
+                &route_decision.decision_id,
+                None,
                 tokens_saved,
                 0,
             );
@@ -356,15 +354,9 @@ pub async fn forward_request(
     .await?;
 
     if let Some(route_decision) = &route {
-        let quality = if response.status().is_success() {
-            1.0
-        } else {
-            0.0
-        };
-        crate::proxy::routing_feedback::global_feedback().record_outcome(
-            &route_decision.routed_from,
-            &route_decision.model,
-            quality,
+        crate::proxy::routing_feedback::global_feedback().record_outcome_for_decision(
+            &route_decision.decision_id,
+            None,
             tokens_saved,
             0,
         );

--- a/rust/src/proxy/routing.rs
+++ b/rust/src/proxy/routing.rs
@@ -42,6 +42,8 @@ use std::sync::Arc;
 /// re-targets the upstream and injects the registry credential if set.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RouteDecision {
+    /// Feedback correlation id unique to this routed request.
+    pub decision_id: String,
     /// Model now in the body.
     pub model: String,
     /// Originally requested model (usage record `routed_from`).
@@ -158,7 +160,9 @@ pub fn route_request(
     } else {
         "intent_tier"
     };
+    let decision_id = global_feedback().record_decision(&requested, &new_model, route_reason);
     let decision = RouteDecision {
+        decision_id,
         model: new_model,
         routed_from: requested,
         provider_id: resolved.provider_id,
@@ -167,7 +171,6 @@ pub fn route_request(
         local: resolved.local,
         xlat: resolved.xlat,
     };
-    global_feedback().record_decision(&decision.routed_from, &decision.model, route_reason);
     Some(decision)
 }
 
@@ -688,7 +691,9 @@ mod tests {
     #[test]
     fn poor_feedback_triggers_fallback() {
         let feedback = crate::proxy::routing_feedback::RoutingFeedback::new();
-        feedback.record_outcome("expensive", "fast", 0.4, 0, 0);
+        for _ in 0..20 {
+            feedback.record_outcome("expensive", "fast", Some(0.4), 0, 0);
+        }
         assert!(feedback.should_use_fallback());
     }
 }

--- a/rust/src/proxy/routing_feedback.rs
+++ b/rust/src/proxy/routing_feedback.rs
@@ -1,12 +1,15 @@
 //! Adapter between proxy routing events and OCLA quality tracking.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::core::ocla::routing_quality::{RoutingDecision, RoutingOutcome, RoutingQualityTracker};
 
 const MAX_PENDING_DECISIONS: usize = 1_000;
-type PendingDecisions = HashMap<(String, String), VecDeque<RoutingDecision>>;
+type PendingDecisions = HashMap<String, RoutingDecision>;
+static NEXT_DECISION_ID: AtomicU64 = AtomicU64::new(1);
+const FALLBACK_PROBE_INTERVAL: u64 = 20;
 
 static GLOBAL_FEEDBACK: OnceLock<RoutingFeedback> = OnceLock::new();
 
@@ -20,6 +23,7 @@ pub fn global_feedback() -> &'static RoutingFeedback {
 pub struct RoutingFeedback {
     tracker: Arc<Mutex<RoutingQualityTracker>>,
     pending_decisions: Arc<Mutex<PendingDecisions>>,
+    fallback_checks: Arc<AtomicU64>,
 }
 
 impl RoutingFeedback {
@@ -28,38 +32,63 @@ impl RoutingFeedback {
         Self {
             tracker: Arc::new(Mutex::new(RoutingQualityTracker::new())),
             pending_decisions: Arc::new(Mutex::new(HashMap::new())),
+            fallback_checks: Arc::new(AtomicU64::new(1)),
         }
     }
 
     /// Records a route selection until its measured outcome arrives.
-    pub fn record_decision(&self, original: &str, routed: &str, reason: &str) {
+    pub fn record_decision(&self, original: &str, routed: &str, reason: &str) -> String {
+        let decision_id = format!("route-{}", NEXT_DECISION_ID.fetch_add(1, Ordering::Relaxed));
         let decision = RoutingDecision {
+            decision_id: decision_id.clone(),
             original_model: original.to_string(),
             routed_model: routed.to_string(),
             reason: reason.to_string(),
             timestamp: chrono::Utc::now().to_rfc3339(),
         };
-        let key = (original.to_string(), routed.to_string());
         let mut pending = self
             .pending_decisions
             .lock()
             .expect("routing feedback pending decision mutex poisoned");
-        let queue = pending.entry(key).or_default();
-        queue.push_back(decision);
-        while pending.values().map(VecDeque::len).sum::<usize>() > MAX_PENDING_DECISIONS {
+        pending.insert(decision_id.clone(), decision);
+        while pending.len() > MAX_PENDING_DECISIONS {
             let Some(evicted_key) = pending
                 .iter()
-                .find(|(_, decisions)| !decisions.is_empty())
+                .min_by_key(|(_, decision)| &decision.timestamp)
                 .map(|(key, _)| key.clone())
             else {
                 break;
             };
-            if let Some(decisions) = pending.get_mut(&evicted_key) {
-                decisions.pop_front();
-                if decisions.is_empty() {
-                    pending.remove(&evicted_key);
-                }
-            }
+            pending.remove(&evicted_key);
+        }
+        decision_id
+    }
+
+    /// Records measured quality for a route and forwards it to the tracker.
+    pub fn record_outcome_for_decision(
+        &self,
+        decision_id: &str,
+        quality: Option<f64>,
+        tokens_saved: u64,
+        latency_delta_ms: i64,
+    ) {
+        let decision = {
+            let mut pending = self
+                .pending_decisions
+                .lock()
+                .expect("routing feedback pending decision mutex poisoned");
+            pending.remove(decision_id)
+        };
+        if let Some(decision) = decision {
+            self.tracker
+                .lock()
+                .expect("routing feedback tracker mutex poisoned")
+                .record(RoutingOutcome {
+                    decision,
+                    quality_score: quality,
+                    tokens_saved,
+                    latency_delta_ms,
+                });
         }
     }
 
@@ -68,35 +97,27 @@ impl RoutingFeedback {
         &self,
         original: &str,
         routed: &str,
-        quality: f64,
+        quality: Option<f64>,
         tokens_saved: u64,
         latency_delta_ms: i64,
     ) {
-        let key = (original.to_string(), routed.to_string());
-        let decision = {
-            let mut pending = self
-                .pending_decisions
-                .lock()
-                .expect("routing feedback pending decision mutex poisoned");
-            let decision = pending.get_mut(&key).and_then(VecDeque::pop_front);
-            if pending.get(&key).is_some_and(VecDeque::is_empty) {
-                pending.remove(&key);
-            }
-            decision
-        };
-        let decision = decision.unwrap_or_else(|| RoutingDecision {
+        let decision = RoutingDecision {
+            decision_id: format!(
+                "unmatched-{}",
+                NEXT_DECISION_ID.fetch_add(1, Ordering::Relaxed)
+            ),
             original_model: original.to_string(),
             routed_model: routed.to_string(),
             reason: "outcome without recorded decision".to_string(),
             timestamp: chrono::Utc::now().to_rfc3339(),
-        });
+        };
 
         self.tracker
             .lock()
             .expect("routing feedback tracker mutex poisoned")
             .record(RoutingOutcome {
                 decision,
-                quality_score: Some(quality),
+                quality_score: quality,
                 tokens_saved,
                 latency_delta_ms,
             });
@@ -104,10 +125,16 @@ impl RoutingFeedback {
 
     /// Returns whether tracked route quality warrants fallback.
     pub fn should_use_fallback(&self) -> bool {
-        self.tracker
+        let should_fallback = self
+            .tracker
             .lock()
             .expect("routing feedback tracker mutex poisoned")
-            .should_fallback()
+            .should_fallback();
+        should_fallback
+            && !self
+                .fallback_checks
+                .fetch_add(1, Ordering::Relaxed)
+                .is_multiple_of(FALLBACK_PROBE_INTERVAL)
     }
 
     /// Returns tracked success rate and average token savings.
@@ -134,7 +161,7 @@ mod tests {
     fn records_decision_until_matching_outcome() {
         let feedback = RoutingFeedback::new();
 
-        feedback.record_decision("expensive", "fast", "token budget");
+        let decision_id = feedback.record_decision("expensive", "fast", "token budget");
         assert_eq!(feedback.stats(), (0.0, 0.0));
         assert!(!feedback.should_use_fallback());
 
@@ -142,8 +169,7 @@ mod tests {
             .pending_decisions
             .lock()
             .expect("test pending decision mutex poisoned");
-        let key = (String::from("expensive"), String::from("fast"));
-        let decision = &pending[&key][0];
+        let decision = &pending[&decision_id];
         assert_eq!(decision.reason, "token budget");
     }
 
@@ -151,8 +177,8 @@ mod tests {
     fn records_successful_outcome_and_statistics() {
         let feedback = RoutingFeedback::new();
 
-        feedback.record_decision("expensive", "fast", "token budget");
-        feedback.record_outcome("expensive", "fast", 0.95, 120, -10);
+        let decision_id = feedback.record_decision("expensive", "fast", "token budget");
+        feedback.record_outcome_for_decision(&decision_id, Some(0.95), 120, -10);
 
         assert_eq!(feedback.stats(), (1.0, 120.0));
         assert!(!feedback.should_use_fallback());
@@ -162,9 +188,43 @@ mod tests {
     fn poor_outcome_triggers_fallback() {
         let feedback = RoutingFeedback::new();
 
-        feedback.record_outcome("expensive", "fast", 0.4, 20, 15);
+        for _ in 0..20 {
+            feedback.record_outcome("expensive", "fast", Some(0.4), 20, 15);
+        }
 
         assert_eq!(feedback.stats(), (0.0, 20.0));
         assert!(feedback.should_use_fallback());
+    }
+
+    #[test]
+    fn concurrent_same_pair_outcomes_match_by_decision_id() {
+        let feedback = RoutingFeedback::new();
+        let first = feedback.record_decision("expensive", "fast", "first");
+        let second = feedback.record_decision("expensive", "fast", "second");
+
+        feedback.record_outcome_for_decision(&second, Some(1.0), 20, 0);
+
+        let pending = feedback
+            .pending_decisions
+            .lock()
+            .expect("test pending decision mutex poisoned");
+        assert!(pending.contains_key(&first));
+        assert!(!pending.contains_key(&second));
+        assert_eq!(feedback.stats(), (1.0, 20.0));
+    }
+
+    #[test]
+    fn fallback_allows_periodic_recovery_probe() {
+        let feedback = RoutingFeedback::new();
+        for _ in 0..20 {
+            feedback.record_outcome("expensive", "fast", Some(0.4), 20, 15);
+        }
+
+        let mut allowed_probe = false;
+        for _ in 0..FALLBACK_PROBE_INTERVAL {
+            allowed_probe |= !feedback.should_use_fallback();
+        }
+
+        assert!(allowed_probe);
     }
 }

--- a/rust/tests/ocla_integration_suite.rs
+++ b/rust/tests/ocla_integration_suite.rs
@@ -164,6 +164,7 @@ fn test_full_pipeline() {
     let mut routing = RoutingQualityTracker::new();
     routing.record(RoutingOutcome {
         decision: RoutingDecision {
+            decision_id: "integration-route".into(),
             original_model: "expensive-model".into(),
             routed_model: "integration-model".into(),
             reason: "integration route".into(),


### PR DESCRIPTION
Fixes #1333

## Summary
- correlate routed outcomes with a per-request decision id instead of model pairs
- stop treating HTTP status as model quality feedback
- ignore absent or invalid quality scores for fallback decisions
- require a minimum scored sample count before fallback activates
- allow periodic routed probes so fallback can recover

## Validation
- cargo fmt --check
- git diff --check
- cargo test routing_feedback --lib (local run timed out while compiling native jemalloc before Rust diagnostics; CI will run the full check)