### PR TITLE
fix: classify governance contract docs

### DIFF
--- a/rust/src/core/contracts.rs
+++ b/rust/src/core/contracts.rs
@@ -166,6 +166,12 @@ pub fn contract_docs() -> Vec<ContractDoc> {
         doc("degradation-policy", "degradation-policy-v1.md", 1, Stable),
         doc("extension-trust", "extension-trust-v1.md", 1, Stable),
         doc("extractors", "extractors-v1.md", 1, Stable),
+        doc("contracts-readme", "README.md", 1, Stable),
+        doc("deprecation-policy", "DEPRECATION.md", 1, Stable),
+        doc("audit-schedule", "audit-schedule-v1.md", 1, Stable),
+        doc("branch-protection", "branch-protection-v1.md", 1, Stable),
+        doc("certification-levels", "certification-levels-v1.md", 1, Stable),
+        doc("release-integrity", "release-integrity-v1.md", 1, Stable),
         doc(
             "gotchas-reminders",
             "gotchas-reminders-contract-v1.md",


### PR DESCRIPTION
Fixes #1344\n\n## Summary\n\n- classify the six governance docs reported by the contracts_frozen CI gate\n- keep them Stable instead of Frozen to avoid introducing new frozen hash obligations\n- leave contract document contents unchanged\n\n## Validation\n\n- git diff --check\n- local cargo test --test main contracts_frozen was attempted, but the cold Rust build did not complete in the available agent window after build-lock contention from parallel agents\n