### PR TITLE
fix(ci): refresh OCLA contract pack digest

### DIFF
--- a/docs/contracts/ocla-contract-pack-v1.json
+++ b/docs/contracts/ocla-contract-pack-v1.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "docs/contracts/capabilities-contract-v1.md",
-      "sha256": "3070de7f9b5556101acc5d86be7a13b08875c28e9220b2ff3bc5cfd3c3dd57eb"
+      "sha256": "334e6b25f1700d35d8b4319965d30db3a25b2ac4e01658b99b782a123d967571"
     },
     {
       "path": "docs/contracts/certification-levels-v1.md",


### PR DESCRIPTION
## Summary
- refresh the checksum for the updated capabilities contract in the OCLA contract pack
- restore wheel verifier contract-suite execution

## Validation
- cd clients/python && python3 -m pytest tests/test_ocla_package.py -v
- python3 scripts/verify-ocla-contract-suite.py --verifier /tmp/test-ocla-venv/bin/leanctx-ocla-verify
- python3 scripts/verify-ocla-contract-suite.py --check-version
- cd rust && RUSTFLAGS="-Dwarnings -Aunreachable-pub" cargo check
- cd rust && cargo test --lib ocla