### PR TITLE
fix(ci): remove private rustdoc link suppression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Docs
         working-directory: clients/rust/lean-ctx-client
         env:
-          RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
+      RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps
 
   embed-sdk:
@@ -347,7 +347,7 @@ jobs:
       - name: Docs
         working-directory: rust
         env:
-          RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
+      RUSTDOCFLAGS: -D warnings
         run: cargo doc -p lean-ctx-sdk --no-deps
 
   python-sdk:
@@ -654,7 +654,7 @@ jobs:
       - name: Check docs compile
         working-directory: rust
         env:
-          RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
+      RUSTDOCFLAGS: -D warnings
         run: cargo doc --no-deps --all-features
       - name: Check generated reference docs are current
         working-directory: rust

--- a/rust/src/core/addons/runtime.rs
+++ b/rust/src/core/addons/runtime.rs
@@ -5,7 +5,7 @@
 //! secret it read) and a prompt-injection surface. Before the gateway hands a
 //! downstream result to the model ([`crate::core::mcp_catalog::proxy`]), it runs the
 //! output through the same redaction the shell layer uses (single source of
-//! truth: [`crate::core::redaction`] + [`crate::core::secret_detection`]) and
+//! truth: `crate::core::redaction` + `crate::core::secret_detection`) and
 //! records an audit line tagging the bytes as untrusted, attributed to the
 //! originating server.
 

--- a/rust/src/core/addons/signing.rs
+++ b/rust/src/core/addons/signing.rs
@@ -9,7 +9,7 @@
 //! sidecar `addon_registry.json.sig` carries a valid signature **by a trusted
 //! org key** — the same pinned-key trust anchor as the signed org-policy floor
 //! ([`crate::core::policy::org::trust`]). This reuses the engine's Ed25519
-//! primitives ([`crate::core::agent_identity`]); the signature covers the exact
+//! primitives (`crate::core::agent_identity`); the signature covers the exact
 //! file bytes, so any tampering invalidates it.
 
 use ed25519_dalek::SigningKey;

--- a/rust/src/core/archive.rs
+++ b/rust/src/core/archive.rs
@@ -373,7 +373,7 @@ pub fn remove_files(id: &str) {
 /// metadata, and FTS index are removed together so the two stores stay in sync.
 /// Returns the number of entries removed.
 ///
-/// Wired into MCP-start + periodic maintenance ([`super::storage_maintenance`])
+/// Wired into MCP-start + periodic maintenance (`super::storage_maintenance`)
 /// and `lean-ctx cache prune`; without an enforcer the archive grew unbounded on
 /// disk and starved the host of RAM via the page cache (#417).
 pub fn cleanup() -> u32 {

--- a/rust/src/core/cache/entry.rs
+++ b/rust/src/core/cache/entry.rs
@@ -82,7 +82,7 @@ pub struct CacheEntry {
     /// Prevents cache-stub loops when upgrading from compressed to full mode.
     pub full_content_delivered: bool,
     /// Conversation id that received the full content (see
-    /// [`crate::core::conversation`]). The `[unchanged]` stub is only valid for
+    /// `crate::core::conversation`). The `[unchanged]` stub is only valid for
     /// a re-read from this same conversation; `None` means delivered without a
     /// known conversation context (legacy / hooks absent).
     pub delivered_conversation: Option<String>,

--- a/rust/src/core/cache/session.rs
+++ b/rust/src/core/cache/session.rs
@@ -426,7 +426,7 @@ impl SessionCache {
     /// Marks that full (uncompressed) content was delivered for this file,
     /// tagging it with the current conversation so a later re-read only serves
     /// the `[unchanged]` stub to the same conversation (see
-    /// [`crate::core::conversation`]).
+    /// `crate::core::conversation`).
     pub fn mark_full_delivered(&mut self, path: &str) {
         let conversation = crate::core::conversation::current_conversation_id();
         let key = normalize_key(path);

--- a/rust/src/core/compliance_report/mod.rs
+++ b/rust/src/core/compliance_report/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! Composes the engine's existing evidence surfaces into one signed,
 //! exportable artifact over a date range:
-//! - **OWASP** Top-10-for-Agents alignment ([`crate::core::owasp_alignment`]);
+//! - **OWASP** Top-10-for-Agents alignment (`crate::core::owasp_alignment`);
 //! - **Framework** coverage — EU AI Act / ISO 42001 / SOC 2
 //!   ([`crate::core::compliance`]), verified live against a resolved pack;
 //! - **Enforcement** — what was *blocked* / *redacted* over the period, folded

--- a/rust/src/core/data_dir.rs
+++ b/rust/src/core/data_dir.rs
@@ -115,7 +115,7 @@ fn marker_has_data(path: &std::path::Path) -> bool {
 
 /// Returns all known data directories that contain stats data, in resolution
 /// priority order (legacy → mixed config → XDG data). Used by the dual-dir
-/// consolidation ([`crate::core::data_consolidate`]) and doctor diagnostics.
+/// consolidation (`crate::core::data_consolidate`) and doctor diagnostics.
 ///
 /// `$XDG_DATA_HOME/lean-ctx` is included (GH #414): after the #408 default flip
 /// a fresh install writes stats there, so a user who *also* has a legacy/mixed

--- a/rust/src/core/embeddings/mod.rs
+++ b/rust/src/core/embeddings/mod.rs
@@ -729,7 +729,7 @@ fn detect_dimensions(
 /// Compute cosine similarity between two L2-normalized vectors.
 /// Both vectors must be pre-normalized for correct results.
 ///
-/// Uses the chunked, autovectorizable dot product from [`crate::core::embedding_quant`]
+/// Uses the chunked, autovectorizable dot product from `crate::core::embedding_quant`
 /// (turbovec-derived) so every semantic-search hot path gets SIMD throughput.
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     debug_assert_eq!(a.len(), b.len(), "vectors must have equal dimensions");

--- a/rust/src/core/eval_ab/conditions.rs
+++ b/rust/src/core/eval_ab/conditions.rs
@@ -38,18 +38,18 @@ pub enum Condition {
     /// Treatment — "with lean-ctx".
     LeanCtx,
     /// Treatment variant that routes JSON/JSONL through the deduplicating
-    /// [`crate::core::json_crush`] core (lossless array crush) instead of the
+    /// `crate::core::json_crush` core (lossless array crush) instead of the
     /// whitespace-only compaction the generic [`aggressive_compress`] applies to
     /// structured data. Used to measure json_crush's token savings and its
     /// answer-preservation floor in isolation (#942).
     JsonCrush,
     /// Treatment variant that routes CSV/TSV through the columnar
-    /// [`crate::core::tabular_crush`] core (lossless constant-column hoisting)
+    /// `crate::core::tabular_crush` core (lossless constant-column hoisting)
     /// instead of the line-based compaction the generic [`aggressive_compress`]
     /// applies to delimited data. Measures tabular_crush's token savings and its
     /// answer-preservation floor in isolation (#982).
     TabularCrush,
-    /// Treatment variant that routes YAML through the [`crate::core::yaml_crush`]
+    /// Treatment variant that routes YAML through the `crate::core::yaml_crush`
     /// core (YAML → compact JSON + lossless array factoring) instead of the
     /// line-based compaction the generic [`aggressive_compress`] applies to YAML.
     /// Measures yaml_crush's token savings and its answer-preservation floor in

--- a/rust/src/core/eval_ab/routing_eval.rs
+++ b/rust/src/core/eval_ab/routing_eval.rs
@@ -6,13 +6,13 @@
 //!
 //! * **off-arm**: every task is served by the model the client requested.
 //! * **on-arm**: the task's last user query runs through the *production*
-//!   classifier ([`classify`] → [`route_intent`]) and the configured
+//!   classifier (`classify` → `route_intent`) and the configured
 //!   [`RoutingRules`] — exactly the logic the proxy applies in-flight — and is
 //!   priced at the model the router selects.
 //!
 //! The savings claim is a pure **rate-card delta**: `input_rate(requested) −
 //! input_rate(serving)` per routed task, priced from the shared
-//! [`ModelPricing`] table (real provider list prices; enterprise#14). No token
+//! `ModelPricing` table (real provider list prices; enterprise#14). No token
 //! counts are invented — absolute USD amounts come from the usage ledger
 //! (enterprise#19), which applies the same formula to *measured*
 //! `usage_events` rows (`routed_from` × real input tokens). This eval proves

--- a/rust/src/core/graph_provider.rs
+++ b/rust/src/core/graph_provider.rs
@@ -264,7 +264,7 @@ impl GraphProvider {
         }
     }
 
-    /// Resolve a stable [`SymbolHandle`](crate::core::handle::SymbolHandle) to
+    /// Resolve a stable `SymbolHandle` to
     /// its current [`SymbolInfo`], robust to line drift. Resolution order:
     ///
     /// 1. Exact `(path, name)` — the unique `{file}::{name}` index key, so the

--- a/rust/src/core/input_filters/injection.rs
+++ b/rust/src/core/input_filters/injection.rs
@@ -1,6 +1,6 @@
 //! Prompt-injection filtering (OWASP LLM01) for inbound content (GL #675).
 //!
-//! Reuses the conservative heuristic in [`crate::core::output_sanitizer`] (the
+//! Reuses the conservative heuristic in `crate::core::output_sanitizer` (the
 //! same patterns already trusted elsewhere) and adds policy actions: count the
 //! signals for a block decision, or redact the offending lines so the rest of
 //! the file still reaches the agent.

--- a/rust/src/core/memory_policy.rs
+++ b/rust/src/core/memory_policy.rs
@@ -574,7 +574,7 @@ pub struct AdmissionPolicy {
     /// High by default so only genuine near-duplicates collapse; `0.0` disables
     /// auto-merge.
     pub auto_merge_similarity: f32,
-    /// Facts whose content salience ([`crate::core::memory_salience::text_salience`])
+    /// Facts whose content salience (`crate::core::memory_salience::text_salience`)
     /// is below this floor are not admitted as normal facts. `0` (default)
     /// disables the floor — the lossless choice; raise it to curate a noisy store.
     pub min_salience: u32,

--- a/rust/src/core/policy/mod.rs
+++ b/rust/src/core/policy/mod.rs
@@ -147,7 +147,7 @@ impl FilterRules {
 
 /// The `[egress]` section — output/DLP enforcement on agent writes & actions
 /// (GL #676). Gates `ctx_edit` writes and `ctx_shell` actions before they
-/// execute. Compiled into a [`crate::core::egress::EgressConfig`] at load time.
+/// execute. Compiled into a `crate::core::egress::EgressConfig` at load time.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EgressRules {

--- a/rust/src/core/savings_ledger/push.rs
+++ b/rust/src/core/savings_ledger/push.rs
@@ -2,7 +2,7 @@
 //! server's ingest endpoint.
 //!
 //! Shared by the `lean-ctx savings push` CLI and the opt-in daemon auto-push
-//! ([`crate::core::savings_autopush`]) so there is exactly **one** push path.
+//! (`crate::core::savings_autopush`) so there is exactly **one** push path.
 //! The batch is a cumulative whole-ledger snapshot (`period = "all"`), so
 //! re-pushing is idempotent on the server (the summary takes each signer's
 //! latest batch). It carries only counts, model names, tool names and chain

--- a/rust/src/core/scorecard/dual_arm.rs
+++ b/rust/src/core/scorecard/dual_arm.rs
@@ -16,13 +16,13 @@
 //! ## Honesty contract
 //!
 //! * Token sizes are **measured**, not assumed: they come from
-//!   [`benchmark::run_project_benchmark`] over the deterministic scorecard corpus
+//!   `benchmark::run_project_benchmark` over the deterministic scorecard corpus
 //!   (the private `super::scenarios` matrix). No magic numbers, no mock data.
 //! * `output` tokens are identical across arms (same work), so they are set to 0:
 //!   this is a strict **input-side** comparison of exactly the dimension lean-ctx
 //!   affects. The headline therefore never borrows credit from output pricing.
-//! * Prices come from the shared embedded [`ModelPricing`] table via
-//!   [`ModelCost::estimate_usd`] — the same function that prices the user's real
+//! * Prices come from the shared embedded `ModelPricing` table via
+//!   `ModelCost::estimate_usd` — the same function that prices the user's real
 //!   proxy bill ([`crate::proxy::usage_meter`]).
 //! * The result is reproducible: every number is a deterministic function of the
 //!   corpus + pricing, captured in a BLAKE3 `determinism_digest` (#498).

--- a/rust/src/core/signatures.rs
+++ b/rust/src/core/signatures.rs
@@ -2,7 +2,7 @@
 //!
 //! IMPORTANT for readers skimming the repo: this file is the *fallback*, not the
 //! primary engine. The default build extracts signatures with **tree-sitter** via
-//! declarative per-language queries in [`crate::core::signatures_ts`] (real ASTs,
+//! declarative per-language queries in `crate::core::signatures_ts` (real ASTs,
 //! real multi-line spans, ~27 languages). [`extract_signatures`] tries that path
 //! first and only drops to the line-oriented regex extractors here when the
 //! `tree-sitter` feature is off or a parse yields nothing usable for a file.
@@ -264,7 +264,7 @@ pub fn signature_backend_stats() -> (u64, u64) {
 }
 
 /// Which extractor produced a signature set: the primary tree-sitter AST path
-/// ([`crate::core::signatures_ts`]) or the line-oriented regex fallback in this
+/// (`crate::core::signatures_ts`) or the line-oriented regex fallback in this
 /// module. Surfaced so navigation output (`ctx_outline`) can label its backend
 /// honestly and verifiably instead of merely *claiming* "via tree-sitter"
 /// (gitlab #981).

--- a/rust/src/core/web/distill.rs
+++ b/rust/src/core/web/distill.rs
@@ -46,7 +46,7 @@ const FILLER: &[&str] = &[
 
 /// Extract sentences carrying factual signals, ranked and de-duplicated. Each
 /// sentence carries a confidence (`[0.0, 1.0]`) so callers can build attributable
-/// [`crate::core::evidence::Claim`]s. Facts use an *absolute* mapping (more
+/// `crate::core::evidence::Claim`s. Facts use an *absolute* mapping (more
 /// factual signals → higher confidence) rather than min-max, so the score is
 /// meaningful even when the top sentences tie.
 pub fn facts_scored(text: &str, query: Option<&str>, max_items: usize) -> Vec<(String, f32)> {
@@ -111,7 +111,7 @@ fn quotes_ranked(text: &str, query: Option<&str>) -> Vec<(f64, usize, String)> {
 /// For inputs that already fit the budget this is exactly [`transcript_summary`]
 /// (filler-strip + adjacent-dedup, no truncation) — no behaviour change. For
 /// OVERSIZED inputs, where [`transcript_summary`] would FIFO-truncate to the
-/// prefix, it instead uses extractive ranking ([`crate::core::extractive`]) to
+/// prefix, it instead uses extractive ranking (`crate::core::extractive`) to
 /// keep the most query-relevant (or, without a query, the most central)
 /// sentences. Falls back to [`transcript_summary`] when the embedding engine is
 /// unavailable, so no build/OS regresses.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,7 +2,6 @@
 // Every `unsafe` block must carry a `// SAFETY:` comment justifying soundness.
 // Enforced so the (mostly libc/Win32 syscall) unsafe surface stays documented.
 #![warn(clippy::undocumented_unsafe_blocks)]
-#![allow(rustdoc::private_intra_doc_links)]
 
 #[cfg(all(feature = "jemalloc", not(windows)))]
 #[global_allocator]

--- a/rust/src/proxy/cache_aligner.rs
+++ b/rust/src/proxy/cache_aligner.rs
@@ -14,7 +14,7 @@
 //!    relocated values. The cacheable prefix then stays byte-stable turn-to-turn
 //!    and finally caches; only the small, reprocessed tail changes. Follows the
 //!    same stable-first ordering as
-//!    [`crate::core::neural::cache_alignment::CacheAlignedOutput`].
+//!    `crate::core::neural::cache_alignment::CacheAlignedOutput`.
 //!
 //! ## Determinism (#498) & cache-safety (#448)
 //! Both stages are pure functions of the text: matches come from the

--- a/rust/src/proxy/cache_policy.rs
+++ b/rust/src/proxy/cache_policy.rs
@@ -13,7 +13,7 @@
 //!   *before* compression, so it can only weigh the measurable precondition: is
 //!   the cacheable prefix even large enough to be worth re-seeding?
 //! - [`net_cost_decision`] / [`repack_saving_usd`] — the fully priced primitive
-//!   (before/after token counts × [`ModelCost`]) for callers that already know
+//!   (before/after token counts × `ModelCost`) for callers that already know
 //!   the compressed size (tests today, cache-edit batching later).
 //!
 //! Pure functions, no globals; gated behind the opt-in `proxy.cache_policy` at

--- a/rust/src/proxy/cost.rs
+++ b/rust/src/proxy/cost.rs
@@ -2,7 +2,7 @@
 //!
 //! Headroom's per-model cost breakdown was the one metric a tester found clearer
 //! than lean-ctx's single flat number. This module buckets request-side savings
-//! by model and prices them with the shared [`ModelPricing`] table so `/status`
+//! by model and prices them with the shared `ModelPricing` table so `/status`
 //! can report estimated USD avoided per model.
 //!
 //! Honesty contract: token counts here are request-side *estimates* (the bytes

--- a/rust/src/proxy/model_router.rs
+++ b/rust/src/proxy/model_router.rs
@@ -1,6 +1,6 @@
 //! Intent-based model routing (P8 / DIM 3 — Leistungsstufe).
 //!
-//! Classifies each request's last user message via [`crate::core::intent_engine`]
+//! Classifies each request's last user message via `crate::core::intent_engine`
 //! and resolves the resulting a model tier to a concrete routing target using
 //! `[proxy.routing.tiers]`. The forward path then rewrites the request body's
 //! `model` field (and optionally re-targets the upstream provider).

--- a/rust/src/proxy/prose_ranker.rs
+++ b/rust/src/proxy/prose_ranker.rs
@@ -3,7 +3,7 @@
 //! The proxy rewrites prose in the frozen request region and re-squeezes every
 //! tool result on each turn. Those rewrites MUST be byte-identical across turns
 //! or the provider prompt-cache prefix is invalidated (#448/#498). Extractive
-//! ranking ([`crate::core::extractive`]) depends on the embedding engine, whose
+//! ranking (`crate::core::extractive`) depends on the embedding engine, whose
 //! availability transitions cold→warm exactly once per process — so the naive
 //! "extractive when warm, truncate when cold" would flip an already-emitted
 //! frozen rewrite the first time it is recompressed after warmup.

--- a/rust/src/proxy/usage.rs
+++ b/rust/src/proxy/usage.rs
@@ -14,7 +14,7 @@
 //! - Gemini: every chunk carries `usageMetadata`; the last one has the totals.
 //!
 //! [`RealUsage`] normalizes every provider onto the four billable buckets that
-//! [`crate::core::gain::model_pricing::ModelCost::estimate_usd`] prices:
+//! `crate::core::gain::model_pricing::ModelCost::estimate_usd` prices:
 //! uncached input, output (incl. reasoning/thoughts), cache-read, cache-write.
 
 use futures::{Stream, StreamExt};

--- a/rust/src/proxy/usage_meter.rs
+++ b/rust/src/proxy/usage_meter.rs
@@ -2,7 +2,7 @@
 //!
 //! [`record`] aggregates the real provider usage extracted by [`super::usage`]
 //! into per-model token sums, prices them with the shared
-//! [`ModelPricing`] table, and
+//! `ModelPricing` table, and
 //! persists the totals to `proxy_usage.json` so the dashboard, CLI and the
 //! savings ledger (which run in *other* processes) can read the user's real
 //! provider bill.

--- a/rust/src/tools/ctx_edit/implementation.rs
+++ b/rust/src/tools/ctx_edit/implementation.rs
@@ -128,7 +128,7 @@ pub fn handle(cache: &mut SessionCache, params: &EditParams) -> String {
 }
 
 /// Quality loop (#494): classify the edit result and feed it into
-/// [`crate::core::edit_quality`]. Only two outcomes carry a compression
+/// `crate::core::edit_quality`. Only two outcomes carry a compression
 /// signal: a clean replacement (success) and an `old_string` miss
 /// (failure — the body the agent quoted wasn't what's on disk). Parameter
 /// mistakes (empty/identical strings, preimage mismatch, missing file) and

--- a/rust/src/tools/ctx_outline/mod.rs
+++ b/rust/src/tools/ctx_outline/mod.rs
@@ -1,6 +1,6 @@
 //! `ctx_outline` — fast, syntax-aware code outline (a "table of contents").
 //!
-//! Backed by tree-sitter (primary, via [`crate::core::signatures_ts`]) with a
+//! Backed by tree-sitter (primary, via `crate::core::signatures_ts`) with a
 //! conservative regex fallback. Three navigation questions, one primitive:
 //! - a single **file** → its shape,
 //! - a **directory** → the folder surface (per-file symbols),

--- a/rust/src/tools/ctx_quality.rs
+++ b/rust/src/tools/ctx_quality.rs
@@ -1,7 +1,7 @@
 //! `ctx_quality` — code-health surface for agents.
 //!
 //! The agent-facing twin of `lean-ctx health`: it reads the same engine
-//! ([`crate::core::code_health`]) and surfaces the navigability score,
+//! (`crate::core::code_health`) and surfaces the navigability score,
 //! cognitive-complexity hotspots, and the estimated token "quality tax".
 //!
 //! Actions:


### PR DESCRIPTION
## Summary
- Render all public-doc references to private items as code spans.
- Remove crate and CI private intra-doc-link suppressions.
- Enforce strict rustdoc warnings in CI.

## Validation
- RUSTFLAGS=-Dwarnings -Aunreachable-pub cargo check
- RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features
- cargo test --lib: 9,548 passed
- cargo fmt --check

Pre-push full clippy is blocked by 53 existing clippy unwrap-used errors in unrelated files; strict cargo check and relevant docs/tests pass.