### PR TITLE
chore: scope dead-code lint exceptions

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -337,9 +337,6 @@ dashmap = "6.2.1"
 async-trait = "0.1.91"
 
 [lints.rust]
-# Temporarily allow dead_code: ~800 items made pub(crate) by M14 audit
-# but not yet used. Track cleanup in issue #1393.
-dead_code = "allow"
 unreachable_pub = "warn"
 # CI coverage (cargo-tarpaulin) injects `--cfg tarpaulin`; declare it to avoid
 # `-D unexpected_cfgs` failures when using `cfg_attr(tarpaulin, ...)`.

--- a/rust/src/core/agents/mod.rs
+++ b/rust/src/core/agents/mod.rs
@@ -1,8 +1,12 @@
 mod bridge;
+#[allow(dead_code)]
 mod diary;
 mod persistence;
+#[allow(dead_code)]
 mod reaper;
+#[allow(dead_code)]
 mod registry;
+#[allow(dead_code)]
 mod roles;
 mod shared;
 mod types;

--- a/rust/src/core/benchmark_study/datasets/mod.rs
+++ b/rust/src/core/benchmark_study/datasets/mod.rs
@@ -3,4 +3,5 @@
 pub(crate) mod download;
 pub(crate) mod humaneval;
 pub(crate) mod mbpp;
+#[allow(dead_code)]
 pub(crate) mod swebench;

--- a/rust/src/core/benchmark_study/metrics/mod.rs
+++ b/rust/src/core/benchmark_study/metrics/mod.rs
@@ -1,5 +1,8 @@
 //! Benchmark metrics: pass@1, cost per 1k, quality retained.
 
+#[allow(dead_code)]
 pub(crate) mod cost;
+#[allow(dead_code)]
 pub(crate) mod pass_rate;
+#[allow(dead_code)]
 pub(crate) mod quality;

--- a/rust/src/core/benchmark_study/mod.rs
+++ b/rust/src/core/benchmark_study/mod.rs
@@ -6,11 +6,13 @@
 
 pub(crate) mod analysis;
 pub(crate) mod datasets;
+#[allow(dead_code)]
 pub(crate) mod experiment;
 pub(crate) mod llm_client;
 pub(crate) mod metrics;
 pub(crate) mod report;
 pub(crate) mod runner;
+#[allow(dead_code)]
 pub(crate) mod sandbox;
 pub(crate) mod stats;
 

--- a/rust/src/core/benchmark_study/stats/mod.rs
+++ b/rust/src/core/benchmark_study/stats/mod.rs
@@ -1,4 +1,5 @@
 //! Statistical framework: bootstrap CIs, non-inferiority tests.
 
 pub(crate) mod bootstrap;
+#[allow(dead_code)]
 pub(crate) mod significance;

--- a/rust/src/core/buddy/mod.rs
+++ b/rust/src/core/buddy/mod.rs
@@ -1,10 +1,13 @@
 pub(crate) mod achievements;
 mod ascension;
+#[allow(dead_code)]
 pub(crate) mod evolution;
+#[allow(dead_code)]
 mod format;
 mod mascot_art;
 mod rpg;
 mod sprite;
+#[allow(dead_code)]
 mod types;
 
 pub(crate) use format::{format_buddy_block_at, format_buddy_full};

--- a/rust/src/core/code_health/mod.rs
+++ b/rust/src/core/code_health/mod.rs
@@ -12,7 +12,9 @@
 pub(crate) mod annotate;
 #[cfg(feature = "tree-sitter")]
 pub(crate) mod astutil;
+#[allow(dead_code)]
 pub(crate) mod cognitive;
+#[allow(dead_code)]
 pub(crate) mod coupling;
 pub(crate) mod delta;
 pub(crate) mod fabric;

--- a/rust/src/core/context_kernel/mod.rs
+++ b/rust/src/core/context_kernel/mod.rs
@@ -1,82 +1,139 @@
 //! Context Control Kernel — unified orchestration over all context stores.
 
+#[allow(dead_code)]
 pub(crate) mod a2a_fixes;
+#[allow(dead_code)]
 pub(crate) mod accounting_fix;
+#[allow(dead_code)]
 pub(crate) mod activation;
 pub(crate) mod activation_e2e;
+#[allow(dead_code)]
 pub(crate) mod adaptive_bridge;
+#[allow(dead_code)]
 pub(crate) mod adaptive_hook;
 pub(crate) mod airgap_e2e;
+#[allow(dead_code)]
 pub(crate) mod attribution;
 pub(crate) mod bench;
+#[allow(dead_code)]
 pub(crate) mod bounded;
+#[allow(dead_code)]
 pub(crate) mod bridge;
 pub(crate) mod bridge_e2e;
+#[allow(dead_code)]
 pub(crate) mod capsule_wire;
 pub(crate) mod client_e2e;
+#[allow(dead_code)]
 pub(crate) mod client_profile;
+#[allow(dead_code)]
 pub(crate) mod client_wiring;
+#[allow(dead_code)]
 pub(crate) mod config_bridge;
 pub(crate) mod conformance;
+#[allow(dead_code)]
 pub(crate) mod context_broker;
+#[allow(dead_code)]
 pub(crate) mod context_dedup;
+#[allow(dead_code)]
 pub(crate) mod coverage_class;
+#[allow(dead_code)]
 pub(crate) mod ctx_read_dedup;
+#[allow(dead_code)]
 pub(crate) mod dashboard_report;
+#[allow(dead_code)]
 pub(crate) mod dedup_wiring;
+#[allow(dead_code)]
 pub(crate) mod degradation;
+#[allow(dead_code)]
 pub(crate) mod enforce;
+#[allow(dead_code)]
 pub(crate) mod envelope_bridge;
 pub(crate) mod envelope_e2e;
 pub(crate) mod envelope_wiring;
+#[allow(dead_code)]
 pub(crate) mod etpao;
+#[allow(dead_code)]
 pub(crate) mod etpao_live;
+#[allow(dead_code)]
 pub(crate) mod evidence_hook;
+#[allow(dead_code)]
 pub(crate) mod evidence_wiring;
+#[allow(dead_code)]
 pub(crate) mod feedback;
 pub(crate) mod feedback_e2e;
+#[allow(dead_code)]
 pub(crate) mod health;
+#[allow(dead_code)]
 pub(crate) mod health_api;
+#[allow(dead_code)]
 pub(crate) mod hotpath_wiring;
+#[allow(dead_code)]
 pub(crate) mod identity;
 pub(crate) mod identity_resolver;
 pub(crate) mod integration_e2e;
+#[allow(dead_code)]
 pub(crate) mod invalidation;
 pub(crate) mod kernel_config;
+#[allow(dead_code)]
 pub(crate) mod knowledge_health;
+#[allow(dead_code)]
 pub(crate) mod learning;
+#[allow(dead_code)]
 pub(crate) mod list_tools_opt;
+#[allow(dead_code)]
 pub(crate) mod live_dashboard;
+#[allow(dead_code)]
 pub(crate) mod mcp_bridge;
+#[allow(dead_code)]
 pub(crate) mod mcp_coverage;
 pub(crate) mod mcp_e2e;
+#[allow(dead_code)]
 pub(crate) mod mcp_receipt;
+#[allow(dead_code)]
 pub(crate) mod mcp_schema_opt;
 pub(crate) mod multi_agent_e2e;
+#[allow(dead_code)]
 pub(crate) mod orchestrator;
+#[allow(dead_code)]
 pub(crate) mod outcome_signal;
 pub(crate) mod perf_benchmark;
+#[allow(dead_code)]
 pub(crate) mod policy;
+#[allow(dead_code)]
 pub(crate) mod policy_engine;
 pub(crate) mod production_e2e;
+#[allow(dead_code)]
 pub(crate) mod provider_display;
 pub(crate) mod provider_metrics_e2e;
+#[allow(dead_code)]
 pub(crate) mod provider_parity;
 pub(crate) mod provider_traces;
 pub(crate) mod providers;
+#[allow(dead_code)]
 pub(crate) mod proxy_bridge;
 pub(crate) mod quality_e2e;
+#[allow(dead_code)]
 pub(crate) mod receipt_chain;
+#[allow(dead_code)]
 pub(crate) mod recovery;
+#[allow(dead_code)]
 pub(crate) mod response_evidence;
+#[allow(dead_code)]
 pub(crate) mod result_fusion;
+#[allow(dead_code)]
 pub(crate) mod schema_wiring;
+#[allow(dead_code)]
 pub(crate) mod shadow;
 pub(crate) mod smoke_test;
+#[allow(dead_code)]
 pub(crate) mod startup;
+#[allow(dead_code)]
 pub(crate) mod stream_controller;
 pub(crate) mod token_envelope;
+#[allow(dead_code)]
 pub(crate) mod tool_surface;
+#[allow(dead_code)]
 pub(crate) mod types;
+#[allow(dead_code)]
 pub(crate) mod usage_normalizer;
 pub(crate) mod wiring_e2e;

--- a/rust/src/core/context_package/mod.rs
+++ b/rust/src/core/context_package/mod.rs
@@ -1,20 +1,26 @@
 pub(crate) mod auto_load;
+#[allow(dead_code)]
 pub(crate) mod builder;
 pub(crate) mod bundle;
 pub(crate) mod composition;
 pub(crate) mod content;
 pub(crate) mod deps;
 pub(crate) mod export;
+#[allow(dead_code)]
 pub(crate) mod graph_model;
 pub(crate) mod import;
 pub(crate) mod keys;
 pub(crate) mod loader;
 pub(crate) mod lockfile;
+#[allow(dead_code)]
 pub(crate) mod manifest;
+#[allow(dead_code)]
 pub(crate) mod registry;
 pub(crate) mod remote;
 pub(crate) mod signing;
+#[allow(dead_code)]
 pub(crate) mod skills;
+#[allow(dead_code)]
 pub(crate) mod verify;
 
 pub(crate) use auto_load::auto_load_packages;

--- a/rust/src/core/context_snapshot/mod.rs
+++ b/rust/src/core/context_snapshot/mod.rs
@@ -20,6 +20,7 @@
 
 pub(crate) mod builder;
 pub(crate) mod digest;
+#[allow(dead_code)]
 pub(crate) mod publish;
 pub(crate) mod restore;
 pub(crate) mod signing;

--- a/rust/src/core/deep_queries/mod.rs
+++ b/rust/src/core/deep_queries/mod.rs
@@ -11,6 +11,7 @@ mod ext_methods;
 mod imports;
 mod type_defs;
 mod type_uses;
+#[allow(dead_code)]
 mod types;
 
 pub(crate) use types::*;

--- a/rust/src/core/gain/mod.rs
+++ b/rust/src/core/gain/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod bridge_status;
+#[allow(dead_code)]
 pub(crate) mod gain_score;
+#[allow(dead_code)]
 pub(crate) mod live_pricing;
 pub(crate) mod model_pricing;
 pub(crate) mod stream_savings;

--- a/rust/src/core/graph_index/mod.rs
+++ b/rust/src/core/graph_index/mod.rs
@@ -16,6 +16,7 @@ use crate::core::signatures;
 mod edges;
 pub(crate) use edges::*;
 #[allow(unreachable_pub)]
+#[allow(dead_code)]
 pub(crate) mod file_id;
 #[cfg(test)]
 mod tests;

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -1,13 +1,16 @@
 // ---------------------------------------------------------------------------
 // Domain: Compression
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod adaptive_chunking;
+#[allow(dead_code)]
 pub(crate) mod adaptive_compression;
 pub mod addons;
 pub(crate) mod aggressiveness;
 pub mod attention_context;
 pub(crate) mod auto_capture;
 pub(crate) mod auto_findings;
+#[allow(dead_code)]
 pub(crate) mod codebook;
 #[cfg(target_os = "macos")]
 pub(crate) mod codesign;
@@ -18,71 +21,98 @@ pub mod compressor;
 pub(crate) mod context_budget;
 pub(crate) mod datadog_push;
 pub mod entropy;
+#[allow(dead_code)]
 pub(crate) mod etpao;
 pub mod eval_ab;
 pub mod eval_harness;
 pub(crate) mod extractive;
 pub mod finops_export;
+#[allow(dead_code)]
 pub(crate) mod html_crush;
+#[allow(dead_code)]
 pub(crate) mod information_bottleneck;
+#[allow(dead_code)]
 pub(crate) mod json_crush;
+#[allow(dead_code)]
 pub(crate) mod json_sample;
 pub(crate) mod markdown_compact;
+#[allow(dead_code)]
 pub(crate) mod output_sanitizer;
 pub mod policy;
+#[allow(dead_code)]
 pub(crate) mod pop_pruning;
 pub mod predictive_coding;
 pub mod predictive_prefetch;
+#[allow(dead_code)]
 pub(crate) mod preservation;
+#[allow(dead_code)]
 pub(crate) mod process_guard;
+#[allow(dead_code)]
 pub(crate) mod progressive_compression;
 pub(crate) mod protect;
+#[allow(dead_code)]
 pub(crate) mod rabin_karp;
+#[allow(dead_code)]
 pub(crate) mod relevance_tracker;
 pub mod rule_artifacts;
 pub(crate) mod rule_discovery;
+#[allow(dead_code)]
 pub(crate) mod rule_scorer;
 #[cfg(feature = "experimental")]
 pub(crate) mod rule_staleness;
 pub mod rules_canonical;
+#[allow(dead_code)]
 pub(crate) mod rules_channel;
 pub(crate) mod rules_overhead;
 pub(crate) mod rules_sections;
 pub(crate) mod rules_validation;
 pub(crate) mod runtime_flags;
+#[allow(dead_code)]
 pub(crate) mod structural_tokenizer;
 pub(crate) mod structured_read;
+#[allow(dead_code)]
 pub(crate) mod tabular_crush;
+#[allow(dead_code)]
 pub(crate) mod yaml_crush;
 
 // ---------------------------------------------------------------------------
 // Domain: Memory
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod episodic_memory;
+#[allow(dead_code)]
 pub(crate) mod interrupt;
+#[allow(dead_code)]
 pub(crate) mod memory_archive;
 pub(crate) mod memory_boundary;
 pub(crate) mod memory_capacity;
 pub(crate) mod memory_consolidation;
+#[allow(dead_code)]
 pub(crate) mod memory_guard;
+#[allow(dead_code)]
 pub(crate) mod memory_lifecycle;
 pub mod memory_policy;
 pub(crate) mod memory_salience;
 pub mod multiscale_index;
+#[allow(dead_code)]
 pub(crate) mod procedural_memory;
 pub(crate) mod prospective_memory;
 
 // ---------------------------------------------------------------------------
 // Domain: Graph
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod call_graph;
+#[allow(dead_code)]
 pub(crate) mod community;
+#[allow(dead_code)]
 pub(crate) mod gamma_cover;
 pub(crate) mod graph_analysis;
 pub mod graph_context;
 pub(crate) mod graph_coordinator;
 pub(crate) mod graph_enricher;
 pub mod graph_export;
+#[allow(dead_code)]
 pub(crate) mod graph_features;
 pub mod graph_index;
 pub(crate) mod graph_parity;
@@ -94,22 +124,27 @@ pub(crate) mod repomap;
 // ---------------------------------------------------------------------------
 // Domain: Context
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod context_artifacts;
 pub mod context_column;
 pub(crate) mod context_compiler;
+#[allow(dead_code)]
 pub(crate) mod context_deficit;
 pub mod context_field;
+#[allow(dead_code)]
 pub(crate) mod context_handles;
 pub mod context_ir;
 pub(crate) mod context_kernel;
 pub mod context_ledger;
 pub(crate) mod context_lint;
 pub mod context_os;
+#[allow(dead_code)]
 pub(crate) mod context_overhead;
 pub mod context_overlay;
 pub(crate) mod context_package;
 pub mod context_policies;
 pub(crate) mod context_proof;
+#[allow(dead_code)]
 pub(crate) mod context_proof_v2;
 pub mod context_radar;
 pub(crate) mod context_snapshot;
@@ -119,11 +154,13 @@ pub mod cross_source_hints;
 // ---------------------------------------------------------------------------
 // Domain: Knowledge
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod claim_extractor;
 pub(crate) mod cognition_loop;
 pub(crate) mod cognition_scheduler;
 pub mod knowledge;
 pub(crate) mod knowledge_bootstrap;
+#[allow(dead_code)]
 pub(crate) mod knowledge_bridge;
 pub mod knowledge_embedding;
 pub mod knowledge_provider_extract;
@@ -132,16 +169,22 @@ pub mod knowledge_relations;
 // ---------------------------------------------------------------------------
 // Domain: Search & Retrieval
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod bm25_cache;
 pub mod bm25_index;
+#[allow(dead_code)]
 pub(crate) mod content_cache;
 pub mod content_chunk;
 pub(crate) mod context_packing;
+#[allow(dead_code)]
 pub(crate) mod cooccurrence;
+#[allow(dead_code)]
 pub(crate) mod dense_backend;
+#[allow(dead_code)]
 pub(crate) mod embedding_index;
 pub(crate) mod embedding_quant;
 pub mod embeddings;
+#[allow(dead_code)]
 pub(crate) mod energy;
 pub mod hybrid_search;
 #[cfg(feature = "pgvector")]
@@ -149,7 +192,9 @@ pub(crate) mod pgvector_store;
 #[cfg(feature = "qdrant")]
 pub(crate) mod qdrant_store;
 pub mod search_reranking;
+#[allow(dead_code)]
 pub(crate) mod semantic_cache;
+#[allow(dead_code)]
 pub(crate) mod semantic_chunks;
 pub(crate) mod splade_retrieval;
 pub mod spreading_activation;
@@ -168,14 +213,18 @@ pub(crate) mod skillify;
 // ---------------------------------------------------------------------------
 // Domain: Attention & Placement
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod attention_layout_driver;
 pub mod attention_model;
+#[allow(dead_code)]
 pub(crate) mod attention_placement;
+#[allow(dead_code)]
 pub(crate) mod litm;
 
 // ---------------------------------------------------------------------------
 // Domain: Neural / ML
 // ---------------------------------------------------------------------------
+#[allow(dead_code)]
 pub(crate) mod neural;
 // ORT runtime glue links against the `ort` crate, which is only pulled in by the
 // `embeddings` or `neural` features. On platforms ORT does not support (e.g.
@@ -200,6 +249,7 @@ pub(crate) mod agent_identity;
 pub(crate) mod agent_runtime_env;
 pub(crate) mod agents;
 pub(crate) mod autonomy;
+#[allow(dead_code)]
 pub(crate) mod autonomy_drivers;
 
 // ---------------------------------------------------------------------------
@@ -207,13 +257,18 @@ pub(crate) mod autonomy_drivers;
 // ---------------------------------------------------------------------------
 pub(crate) mod adaptive;
 pub(crate) mod adaptive_mode_policy;
+#[allow(dead_code)]
 pub(crate) mod adaptive_thresholds;
 pub mod auto_mode_resolver;
+#[allow(dead_code)]
 pub(crate) mod bandit;
+#[allow(dead_code)]
 pub(crate) mod litm_calibration;
+#[allow(dead_code)]
 pub(crate) mod mode_predictor;
 pub(crate) mod model_registry;
 pub mod task_relevance;
+#[allow(dead_code)]
 pub(crate) mod token_calibration;
 
 // ---------------------------------------------------------------------------
@@ -226,7 +281,9 @@ pub(crate) mod benchmark_study;
 /// Commercial-plane billing substrate (`billing-plane-v1`): plans, entitlements,
 /// and usage metering derived from the signed savings ledger. Never gates local.
 pub mod billing;
+#[allow(dead_code)]
 pub(crate) mod code_health;
+#[allow(dead_code)]
 pub(crate) mod cognitive_load;
 pub mod conformance;
 pub mod contracts;
@@ -234,6 +291,7 @@ pub(crate) mod cyclomatic;
 pub mod degradation_policy;
 pub mod loop_detection;
 pub(crate) mod output_verification;
+#[allow(dead_code)]
 pub(crate) mod quality;
 pub(crate) mod quality_lab;
 pub(crate) mod safety_needles;
@@ -243,6 +301,7 @@ pub(crate) mod slo;
 pub(crate) mod slow_log;
 pub(crate) mod smells;
 pub(crate) mod subagent_contract;
+#[allow(dead_code)]
 pub(crate) mod surprise;
 pub(crate) mod verification_observability;
 
@@ -250,24 +309,33 @@ pub(crate) mod verification_observability;
 // Domain: Config & Infrastructure
 // ---------------------------------------------------------------------------
 pub mod active_inference;
+#[allow(dead_code)]
 pub(crate) mod agent_attribution;
+#[allow(dead_code)]
 pub(crate) mod agent_budget;
+#[allow(dead_code)]
 pub(crate) mod agent_lease;
 pub mod anchor;
 pub(crate) mod ann_cache;
 pub(crate) mod atomic_fs;
+#[allow(dead_code)]
 pub(crate) mod attribution;
 pub mod audit_trail;
 pub(crate) mod binary_detect;
+#[allow(dead_code)]
 pub(crate) mod bounce_tracker;
 pub(crate) mod budget;
+#[allow(dead_code)]
 pub(crate) mod budget_tracker;
+#[allow(dead_code)]
 pub(crate) mod budgets;
 pub mod cache;
+#[allow(dead_code)]
 pub(crate) mod cache_diagnostics;
 pub(crate) mod cache_telemetry;
 pub mod capabilities;
 pub mod capsule_transport;
+#[allow(dead_code)]
 pub(crate) mod chain_compression;
 pub(crate) mod cli_cache;
 pub(crate) mod client_capabilities;
@@ -276,7 +344,9 @@ pub(crate) mod cloud_files;
 pub mod config;
 pub(crate) mod config_heal;
 pub mod consolidation;
+#[allow(dead_code)]
 pub(crate) mod consolidation_engine;
+#[allow(dead_code)]
 pub(crate) mod content_handle;
 pub mod context_capsule;
 pub(crate) mod contextops;
@@ -287,46 +357,64 @@ pub mod data_dir;
 pub(crate) mod debug_log;
 #[allow(unused)]
 pub(crate) mod delivered_ranges;
+#[allow(dead_code)]
 pub(crate) mod delta_response;
+#[allow(dead_code)]
 pub(crate) mod diagnostics_store;
+#[allow(dead_code)]
 pub(crate) mod editor_signal;
 pub(crate) mod egress;
+#[allow(dead_code)]
 pub(crate) mod error;
 pub mod events;
 pub(crate) mod eviction_orchestrator;
 pub(crate) mod evidence;
+#[allow(dead_code)]
 pub(crate) mod evidence_classification;
+#[allow(dead_code)]
 pub(crate) mod evidence_ledger;
 pub mod extension_registry;
+#[allow(dead_code)]
 pub(crate) mod extractors;
 pub mod feedback;
 pub(crate) mod fep_prefetch;
 pub(crate) mod filters;
 pub mod free_energy_budget;
+#[allow(dead_code)]
 pub(crate) mod gain;
 pub(crate) mod git;
+#[allow(dead_code)]
 pub(crate) mod git_cache;
 pub(crate) mod git_signals;
 pub(crate) mod git_util;
 pub(crate) mod godot;
 pub mod gotcha_tracker;
+#[allow(dead_code)]
 pub(crate) mod handle;
 pub mod hasher;
+#[allow(dead_code)]
 pub(crate) mod heatmap;
 pub mod hebbian_cache;
 pub mod hnsw;
+#[allow(dead_code)]
 pub(crate) mod home;
 pub mod homeostasis;
 pub(crate) mod immune_detector;
+#[allow(dead_code)]
 pub(crate) mod marginal_gate;
 pub mod mcp_catalog;
+#[allow(dead_code)]
 pub(crate) mod negative_knowledge;
 pub mod ocla;
+#[allow(dead_code)]
 pub(crate) mod ocla_bus;
 pub(crate) mod quality_benchmark;
 pub(crate) mod qubo_select;
+#[allow(dead_code)]
 pub(crate) mod query_aware;
+#[allow(dead_code)]
 pub(crate) mod session_budget;
+#[allow(dead_code)]
 pub(crate) mod work_graph;
 
 pub(crate) mod agent_registry;
@@ -336,32 +424,44 @@ pub(crate) mod edit_metering;
 pub(crate) mod edit_quality;
 pub(crate) mod efficacy;
 pub mod evidence_bundle;
+#[allow(dead_code)]
 pub(crate) mod grammar_usage;
 pub(crate) mod graph_cache;
 pub(crate) mod http_client;
+#[allow(dead_code)]
 pub(crate) mod ide_permissions;
+#[allow(dead_code)]
 pub(crate) mod import_resolver;
+#[allow(dead_code)]
 pub(crate) mod index_admission;
+#[allow(dead_code)]
 pub(crate) mod index_bundle;
 pub(crate) mod index_filter;
 pub(crate) mod index_namespace;
 pub mod index_orchestrator;
 pub(crate) mod index_paths;
+#[allow(dead_code)]
 pub(crate) mod index_progress;
+#[allow(dead_code)]
 pub(crate) mod ingestion;
 pub mod input_filters;
 pub(crate) mod instruction_compiler;
 pub(crate) mod integrity;
+#[allow(dead_code)]
 pub(crate) mod intent_engine;
 pub(crate) mod intent_lang;
 pub mod intent_protocol;
 pub(crate) mod intent_router;
+#[allow(dead_code)]
 pub(crate) mod introspect;
+#[allow(dead_code)]
 pub(crate) mod io_boundary;
 pub mod io_health;
+#[allow(dead_code)]
 pub(crate) mod journal;
 pub mod jsonc;
 pub(crate) mod knowledge_vault;
+#[allow(dead_code)]
 pub(crate) mod language_capabilities;
 #[cfg(target_os = "macos")]
 pub(crate) mod launchd;
@@ -369,12 +469,15 @@ pub(crate) mod layout_pin;
 pub(crate) mod learning_sync;
 pub(crate) mod levenshtein;
 pub(crate) mod limits;
+#[allow(dead_code)]
 pub(crate) mod llm_enhance;
 pub(crate) mod llm_feedback;
 pub mod locomo;
 pub(crate) mod logging;
 pub mod mcp_manifest;
+#[allow(dead_code)]
 pub(crate) mod mdl_selector;
+#[allow(dead_code)]
 pub(crate) mod multi_repo;
 pub(crate) mod nc_compress;
 pub mod ocp;
@@ -386,7 +489,9 @@ pub(crate) mod path_mode_memory;
 pub mod path_resolve;
 pub mod paths;
 pub mod pathutil;
+#[allow(dead_code)]
 pub(crate) mod persona;
+#[allow(dead_code)]
 pub(crate) mod pipeline;
 pub mod plugins;
 pub(crate) mod portable_binary;
@@ -395,27 +500,34 @@ pub(crate) mod profiles;
 pub(crate) mod project_hash;
 pub mod protocol;
 pub mod provider_bandit;
+#[allow(dead_code)]
 pub(crate) mod provider_cache;
 pub mod providers;
 pub(crate) mod read_stub_index;
 pub(crate) mod recovery;
 pub(crate) mod redaction;
 pub mod reference_docs;
+#[allow(dead_code)]
 pub(crate) mod roles;
 pub(crate) mod route_extractor;
 pub mod saliency;
+#[allow(dead_code)]
 pub(crate) mod sandbox;
 #[cfg(target_os = "linux")]
 pub(crate) mod sandbox_landlock;
 pub(crate) mod sandbox_seatbelt;
 pub(crate) mod sanitize;
 pub(crate) mod savings_autopush;
+#[allow(dead_code)]
 pub(crate) mod savings_footer;
 pub mod savings_ledger;
+#[allow(dead_code)]
 pub(crate) mod scent_field;
 pub(crate) mod search_delta;
 pub mod search_index;
+#[allow(dead_code)]
 pub(crate) mod secret_detection;
+#[allow(dead_code)]
 pub(crate) mod security_posture;
 pub mod sensitivity;
 pub mod server_capabilities;
@@ -424,10 +536,12 @@ pub(crate) mod share;
 pub mod shell_allowlist;
 pub mod startup_guard;
 pub mod stats;
+#[allow(dead_code)]
 pub(crate) mod structural_diff;
 pub mod symbol_map;
 pub(crate) mod syntax_validate;
 pub(crate) mod task_benchmark;
+#[allow(dead_code)]
 pub(crate) mod task_briefing;
 /// macOS Seatbelt self-sandbox (#356): wraps launchd-owned daemon/proxy/updater
 /// in a `sandbox-exec` profile that denies `~/Documents`/`~/Desktop`/
@@ -437,8 +551,10 @@ pub mod tcc_guard_sandbox;
 pub mod tdd_schema;
 pub mod telemetry;
 pub mod terse;
+#[allow(dead_code)]
 pub(crate) mod theme;
 pub(crate) mod threshold_learning;
+#[allow(dead_code)]
 pub(crate) mod tokenizer_translation_driver;
 pub mod tokens;
 pub(crate) mod tool_health;
@@ -457,6 +573,7 @@ pub(crate) mod wasm_ext;
 pub mod web;
 pub mod workflow;
 pub(crate) mod workspace_config;
+#[allow(dead_code)]
 pub(crate) mod wrapped;
 pub(crate) mod wrapped_share;
 pub(crate) mod wrapped_svg;
@@ -466,6 +583,7 @@ pub(crate) mod xdg_migrate;
 // Feature-gated modules
 // ---------------------------------------------------------------------------
 pub mod archive;
+#[allow(dead_code)]
 pub(crate) mod archive_fts;
 pub(crate) mod artifact_index;
 pub(crate) mod artifacts;
@@ -481,6 +599,7 @@ pub mod pathjail;
 pub mod signatures;
 #[cfg(feature = "tree-sitter")]
 pub(crate) mod signatures_ts;
+#[allow(dead_code)]
 pub(crate) mod storage_maintenance;
 pub(crate) mod structured_compact;
 pub(crate) mod type_ref_edges;

--- a/rust/src/core/neural/mod.rs
+++ b/rust/src/core/neural/mod.rs
@@ -4,10 +4,15 @@
 //! When an ONNX model is present, switches from heuristic to neural scoring.
 //! Falls back gracefully to heuristic mode when no model is available.
 
+#[allow(dead_code)]
 pub(crate) mod attention_learned;
+#[allow(dead_code)]
 pub(crate) mod cache_alignment;
+#[allow(dead_code)]
 pub(crate) mod context_reorder;
+#[allow(dead_code)]
 pub(crate) mod line_scorer;
+#[allow(dead_code)]
 pub(crate) mod token_optimizer;
 
 use std::path::PathBuf;

--- a/rust/src/core/ocla/mod.rs
+++ b/rust/src/core/ocla/mod.rs
@@ -22,6 +22,7 @@ pub mod routing_quality;
 pub mod runtime;
 pub mod sidecar;
 pub mod tracing;
+#[allow(dead_code)]
 pub mod unified_ledger;
 pub mod wire;
 #[cfg(feature = "http-server")]

--- a/rust/src/core/profiles/mod.rs
+++ b/rust/src/core/profiles/mod.rs
@@ -11,6 +11,7 @@
 
 mod builtins;
 mod loading;
+#[allow(dead_code)]
 mod types;
 
 pub(crate) use loading::*;

--- a/rust/src/core/quality_lab/mod.rs
+++ b/rust/src/core/quality_lab/mod.rs
@@ -1,4 +1,6 @@
+#[allow(dead_code)]
 pub(crate) mod calibration;
+#[allow(dead_code)]
 pub(crate) mod fidelity;
 pub(crate) mod orchestrator;
 

--- a/rust/src/core/repomap/mod.rs
+++ b/rust/src/core/repomap/mod.rs
@@ -4,6 +4,7 @@
 //! personalized by session context (recent files, focus files).
 
 pub(crate) mod budget;
+#[allow(dead_code)]
 pub(crate) mod graph;
 pub(crate) mod ranking;
 

--- a/rust/src/core/task_benchmark/mod.rs
+++ b/rust/src/core/task_benchmark/mod.rs
@@ -5,7 +5,9 @@
 //! Measures both token savings AND output quality to ensure compression never
 //! degrades agent performance.
 
+#[allow(dead_code)]
 pub(crate) mod config;
+#[allow(dead_code)]
 pub(crate) mod fixtures;
 pub(crate) mod report;
 pub(crate) mod runner;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -43,6 +43,7 @@ pub mod tools;
 pub mod tui;
 
 #[cfg(feature = "http-server")]
+#[allow(dead_code)]
 pub mod proxy;
 pub mod proxy_autostart;
 pub mod proxy_setup;

--- a/rust/src/proxy/mod.rs
+++ b/rust/src/proxy/mod.rs
@@ -40,6 +40,7 @@ mod connector;
 pub(crate) mod conversation;
 pub mod cost;
 pub mod counterfactual;
+#[allow(dead_code)]
 pub mod dedup;
 pub mod effort;
 pub mod effort_routing;
@@ -70,17 +71,20 @@ pub mod prose_ranker;
 pub mod providers;
 pub mod quality_lab_api;
 pub mod response_optimizer;
+#[allow(dead_code)]
 pub(crate) mod response_shaper;
 pub mod routing;
 pub mod routing_feedback;
 #[cfg(feature = "shape-xlat")]
 pub mod shape_xlat;
+#[allow(dead_code)]
 pub(crate) mod shaping_hook;
 pub mod sse_keepalive;
 #[cfg(test)]
 mod stats_tests;
 pub mod sticky_tools;
 pub mod tool_kind;
+#[allow(dead_code)]
 pub mod tool_output;
 #[cfg(test)]
 mod upstream_tests;
@@ -92,6 +96,7 @@ pub mod usage_parity;
 pub mod usage_sink;
 pub mod verbosity;
 pub mod web_app;
+#[allow(dead_code)]
 pub(crate) mod web_app_middleware;
 
 use std::net::SocketAddr;

--- a/rust/src/proxy/web_app/mod.rs
+++ b/rust/src/proxy/web_app/mod.rs
@@ -1,4 +1,6 @@
+#[allow(dead_code)]
 pub(crate) mod conversation_tracker;
+#[allow(dead_code)]
 pub(crate) mod normalize;
 #[cfg(test)]
 mod proof_tests;

--- a/rust/src/shell/compress/mod.rs
+++ b/rust/src/shell/compress/mod.rs
@@ -1,5 +1,6 @@
 mod boundaries;
 mod classification;
+#[allow(dead_code)]
 pub(crate) mod engine;
 mod footer;
 mod passthrough;


### PR DESCRIPTION
## Summary
- remove workspace-wide dead_code = "allow"
- scope dead-code allowances to dormant feature module boundaries
- preserve public APIs and runtime behavior

## Validation
- RUSTFLAGS="-Dwarnings -Aunreachable-pub" cargo check
- cargo test --lib (9,548 passed)
- cargo fmt --check

## Note
The repository-wide all-features Clippy gate remains blocked by 53 pre-existing unwrap_used violations outside this diff.