### PR TITLE
fix(tool-call): convert INVALID_PARAMS to soft error for Devin/Windsu…

### DIFF
--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -28,6 +28,26 @@ pub(in crate::server) async fn dispatch_and_post_process(
                     detector.record_error_outcome(name, &args_fp);
                 }
                 crate::core::debug_log::log_mcp_error(name, args, &format!("{e:?}"));
+
+                // Fix: Devin Failed to connect to MCP server on tool call
+                // Convert INVALID_PARAMS (-32602) to a soft tool error
+                // (CallToolResult with isError=true) instead of a hard JSON-RPC
+                // error response. Some MCP clients (Devin/Windsurf) treat hard
+                // -32602 errors as transport failures, disconnect, respawn the
+                // server, and report "Failed to connect to MCP server" — hiding
+                // the actual parameter validation message from the agent.
+                // By returning a soft error, the agent sees the validation
+                // message and can fix the parameter names.
+                if e.code == rmcp::model::ErrorCode::INVALID_PARAMS {
+                    tracing::debug!(
+                        "converting INVALID_PARAMS to soft tool error for '{name}': {}",
+                        e.message
+                    );
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(
+                        e.message.to_string(),
+                    )]));
+                }
+
                 return Err(e);
             }
         };


### PR DESCRIPTION
# fix(tool-call): convert INVALID_PARAMS to soft error for Devin/Windsurf compatibility

## Summary

Some MCP clients (Devin/Windsurf) treat hard JSON-RPC -32602 errors as transport failures, disconnect and respawn the server, hiding the actual parameter validation message from the agent. Convert INVALID_PARAMS to CallToolResult with isError=true so agents see validation messages and can fix parameter names.

## Test plan

- [x] `cd rust && cargo test -- --test-threads=1` (the suite shares process-global state; CI serializes it too)
- [x] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [ ] If cookbook/packages changed: relevant `npm test` / build steps

## Notes for reviewers

Fixes Devin MCP connection reset issue on Devin local mode.

```
Failed to call ctx_patch from lean-ctx
Failed to connect to MCP server 'lean-ctx'. Please try again.
```

thus model stops using ctx_* because of continues failures and not reliable tools.
Resulting soft error, allows model to get response and understand issue, and MCP connection stays in tact.

## Contributor License Agreement

First-time contributors: a bot will ask you to sign our one-time
[CLA](https://github.com/yvgude/lean-ctx/blob/main/CLA.md) (it keeps lean-ctx
Apache-2.0 and free for individual developers — see §8). You sign **once** by
replying to this PR with: `I have read the CLA Document and I hereby sign the CLA`

I have read the CLA Document and I hereby sign the CLA
