### PR TITLE
fix(allowlist): apply multi-word entry matching to delegation wrapper check

### DIFF
--- a/rust/src/core/shell_allowlist/enforcement.rs
+++ b/rust/src/core/shell_allowlist/enforcement.rs
@@ -220,9 +220,11 @@ fn check_interpreter_inner(
         let rest_tokens = delegated_command_tokens(&tokens[1..]);
         if let Some(&delegated_tok) = rest_tokens.first() {
             // In restricted mode, the delegated command must be in the allowlist.
+            // #1419: use matches_allowlist_entry so multi-word entries like
+            // "terraform plan *" match the delegated base "terraform".
             if let Some(al) = allowlist {
                 let delegated = delegated_tok.rsplit('/').next().unwrap_or(delegated_tok);
-                if !delegated.is_empty() && !al.iter().any(|a| a == delegated) {
+                if !delegated.is_empty() && !matches_allowlist_entry(delegated, al) {
                     return Err(format!(
                         "[BLOCKED — DO NOT RETRY] '{base}' delegates to '{delegated}' which is not \
                          in the shell allowlist. This is a permanent restriction."

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -1480,3 +1480,41 @@ fn allowlist_multi_word_does_not_false_positive() {
         "unrelated base must not match 'terraform plan *'"
     );
 }
+
+// GH #1419: end-to-end integration tests via enforce_shell_allowlist.
+// These exercise the full allowlist pipeline (not just matches_allowlist_entry)
+// so a regression in check_all_segments or check_interpreter_inner is caught.
+
+#[test]
+fn issue_1419_multiword_extra_allows_direct_command() {
+    // Exact repro from the issue: "terraform plan *" in shell_allowlist_extra
+    // must allow "terraform plan -no-color -lock=false" through ctx_shell.
+    let list = allow(&["git", "ls", "terraform plan *"]);
+    assert!(
+        check_all_segments("terraform plan -no-color -lock=false", &list).is_ok(),
+        "terraform plan with multi-word allowlist entry must be allowed"
+    );
+}
+
+#[test]
+fn issue_1419_multiword_extra_blocks_unlisted_binary() {
+    // "terraform plan *" must NOT accidentally permit an unrelated binary.
+    let list = allow(&["terraform plan *"]);
+    let result = check_all_segments("kubectl get pods", &list);
+    assert!(result.is_err(), "kubectl must still be blocked");
+    assert!(result.unwrap_err().contains("kubectl"));
+}
+
+#[test]
+fn issue_1419_multiword_entry_via_delegation_wrapper() {
+    // GH #1419: timeout wrapping terraform must work when the allowlist
+    // only has a multi-word entry like "terraform plan *".
+    let list = allow(&["timeout", "terraform plan *"]);
+    // check_all_segments validates the "timeout" base against the allowlist,
+    // then check_interpreter_abuse validates the delegated "terraform" base.
+    // Both must now use matches_allowlist_entry (not exact match).
+    assert!(
+        check_all_segments("timeout 120 terraform plan -no-color -lock=false", &list).is_ok(),
+        "timeout wrapping terraform must be allowed with multi-word entry"
+    );
+}


### PR DESCRIPTION
## Summary

- The earlier commit (5a73b02) fixed `check_all_segments` to use `matches_allowlist_entry` for multi-word entries like `"terraform plan *"`, but left `check_interpreter_inner` with exact matching for the **delegation wrapper** case
- When a delegation command (`timeout`, `sudo`, `nice`, etc.) precedes a binary whose allowlist entry is multi-word, the inner check compared the delegated binary name against each full entry string -- so `"terraform"` did not match `"terraform plan *"` and commands like `timeout 120 terraform plan ...` were still blocked
- This PR extends the fix to the delegation path by using `matches_allowlist_entry` in `check_interpreter_inner`
- Also adds end-to-end integration tests via `check_all_segments` for: (1) the exact direct-invocation repro from the issue, (2) delegation wrapper wrapping a multi-word-entry binary, and (3) unrelated binary still blocked

Fixes #1419

## Test plan

- [x] New test `issue_1419_multiword_extra_allows_direct_command`: verifies `terraform plan -no-color -lock=false` passes when `"terraform plan *"` is in the allowlist
- [x] New test `issue_1419_multiword_entry_via_delegation_wrapper`: verifies `timeout 120 terraform plan ...` passes with multi-word allowlist entry
- [x] New test `issue_1419_multiword_extra_blocks_unlisted_binary`: verifies unrelated binaries are still blocked
- [x] Full `shell_allowlist` test suite: 222 tests pass (`cargo test --lib -- shell_allowlist`)