### PR TITLE
fix(cli): scope read cache hits to the current process (#1459)

### DIFF
--- a/rust/src/core/cli_cache.rs
+++ b/rust/src/core/cli_cache.rs
@@ -2,6 +2,7 @@ use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CACHE_TTL_SECS: u64 = 300;
@@ -15,6 +16,14 @@ pub(crate) struct CliCacheEntry {
     pub original_tokens: usize,
     pub timestamp: u64,
     pub read_count: u32,
+    /// Process-lifetime nonce scoping a hit to the process that actually
+    /// delivered the file's full content. A fresh process carries a different
+    /// nonce, so it always misses and receives content instead of a
+    /// `cached … [NL]` stub (#1459). `serde(default)` keeps older on-disk
+    /// entries (written before this field existed) parseable; they simply never
+    /// match and are overwritten on the next read.
+    #[serde(default)]
+    pub nonce: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -49,6 +58,23 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+/// A value unique to this process for its whole lifetime, generated once and
+/// reused. Scopes cache hits to the process that first delivered the content:
+/// a one-shot `lean-ctx read` invocation is its own process, so a subsequent
+/// invocation (new nonce) can never be served a stub from a previous run (#1459).
+fn process_nonce() -> &'static str {
+    static NONCE: OnceLock<String> = OnceLock::new();
+    NONCE
+        .get_or_init(|| {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            format!("{}-{}", std::process::id(), nanos)
+        })
+        .as_str()
 }
 
 fn compute_md5(content: &str) -> String {
@@ -105,6 +131,7 @@ pub(crate) fn check_and_read(path: &str) -> CacheResult {
 
     if let Some(entry) = store.entries.get_mut(&key)
         && entry.hash == hash
+        && entry.nonce == process_nonce()
         && (now - entry.timestamp) < CACHE_TTL_SECS
     {
         entry.read_count += 1;
@@ -128,6 +155,7 @@ pub(crate) fn check_and_read(path: &str) -> CacheResult {
         original_tokens,
         timestamp: now,
         read_count: 1,
+        nonce: process_nonce().to_string(),
     };
     store.entries.insert(key, entry);
 
@@ -223,6 +251,7 @@ mod tests {
                 original_tokens: 50,
                 timestamp: 1000,
                 read_count: 1,
+                nonce: "n1".into(),
             },
         );
         store.entries.insert(
@@ -234,6 +263,7 @@ mod tests {
                 original_tokens: 100,
                 timestamp: now_secs(),
                 read_count: 1,
+                nonce: "n2".into(),
             },
         );
 
@@ -256,6 +286,7 @@ mod tests {
                     original_tokens: 10,
                     timestamp: now - i as u64,
                     read_count: 1,
+                    nonce: format!("n{i}"),
                 },
             );
         }
@@ -273,6 +304,7 @@ mod tests {
             original_tokens: 500,
             timestamp: now_secs(),
             read_count: 3,
+            nonce: "n".into(),
         };
         crate::test_env::set_var("LEAN_CTX_SAVINGS_FOOTER", "never");
         let output = format_hit(&entry, "F1", "test.rs");
@@ -323,6 +355,54 @@ mod tests {
         invalidate(path_str);
         let result3 = check_and_read(path_str);
         assert!(matches!(result3, CacheResult::Miss { .. }));
+
+        crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
+        let _ = std::fs::remove_dir_all(&test_data_dir);
+    }
+
+    #[test]
+    fn cross_process_entry_is_not_served_as_hit() {
+        // #1459: a persistent entry written by a *different* process (a foreign
+        // nonce) must not be served as a `cached … [NL]` stub — the reader never
+        // received the content, so it must miss and get the real bytes.
+        let _lock = crate::core::data_dir::test_env_lock();
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let test_data_dir = std::env::temp_dir().join(format!("lean_ctx_cache_xproc_{nanos}"));
+        std::fs::create_dir_all(&test_data_dir).unwrap();
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", &test_data_dir);
+
+        let tmp = test_data_dir.join("test_file.txt");
+        let content = "fn main() {}\n";
+        std::fs::write(&tmp, content).unwrap();
+        let path_str = tmp.to_str().unwrap();
+        let key = normalize_key(path_str);
+
+        // Simulate a prior process that cached this path under its own nonce.
+        let mut store = load_store();
+        store.entries.insert(
+            key.clone(),
+            CliCacheEntry {
+                path: key,
+                hash: compute_md5(content),
+                line_count: 1,
+                original_tokens: 4,
+                timestamp: now_secs(),
+                read_count: 1,
+                nonce: "a-different-process".into(),
+            },
+        );
+        save_store(&store);
+
+        // A fresh process (different nonce) must miss and receive full content.
+        let result = check_and_read(path_str);
+        assert!(
+            matches!(&result, CacheResult::Miss { content } if content == "fn main() {}\n"),
+            "foreign-process cache entry must not be served as a hit"
+        );
 
         crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
         let _ = std::fs::remove_dir_all(&test_data_dir);


### PR DESCRIPTION
Fixes #1459.

## Problem

The one-shot CLI `read -m full` path caches `(path, content_hash)` in a user-scoped persistent store (`~/.local/share/lean-ctx/`). A second `lean-ctx read probe.txt -m full` invocation returns a `cached probe.txt [3L]` stub even though that process never received the file's content. The MCP path was already fixed in #1292 by scoping its cache to the session; the CLI path was missed.

## Fix

Scope each cache entry to the process that actually delivered the file (Option A from the issue thread): store a process-lifetime nonce on the entry and require it to match on a hit. A one-shot CLI invocation is its own process, so a subsequent invocation carries a different nonce and always misses, returning the real content. Repeated same-process reads still hit the cache, preserving the original purpose.

The nonce lives on the entry (not the map key), so `invalidate`, `clear_project`, `stats`, and `file_ref` keep their existing path-keyed behavior, and entries written by older binaries still parse (`#[serde(default)]`).

This also makes the `enableMcp: false` claim in `extensions/config.ts` ("the one-shot CLI path, which cannot cache across calls") accurate again.

## Verification

- `cargo test --lib cli_cache` — 7 passed (incl. new `cross_process_entry_is_not_served_as_hit`)
- `cargo test --lib 'read_cmd'` — 14 passed
- `cargo test --lib reformat_jetbrains_scope_invalidates_all_changed_paths` — 1 passed (invalidate/key alignment)
- `cargo fmt --check` — clean
- `cargo clippy --lib` — no new warnings

Reproduction (standalone path, `__LEAN_CTX_NO_DAEMON=1`):

- before: second `read` returns `cached probe.txt [3L]`
- after: every `read` returns the file content
