### PR TITLE
fix(mcp): reply -32601 to unknown pre-init requests instead of exiting

### DIFF
--- a/rust/src/cli/dispatch/server.rs
+++ b/rust/src/cli/dispatch/server.rs
@@ -116,21 +116,47 @@ pub(super) fn run_mcp_server() -> Result<()> {
             crate::cli::wrapped_publish::maybe_auto_publish_background();
         });
 
-        let transport =
-            mcp_stdio::HybridStdioTransport::new_server(tokio::io::stdin(), tokio::io::stdout());
         let server_handle = server.clone();
-        let service = match server.serve(transport).await {
-            Ok(s) => s,
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("expect initialized")
-                    || msg.contains("context canceled")
-                    || msg.contains("broken pipe")
-                {
-                    tracing::debug!("Client disconnected before init: {msg}");
-                    return Ok(());
+
+        // GH #1454: the vendored rmcp handshake rejects ANY well-formed
+        // request that isn't `initialize` — its ClientRequest union has a
+        // CustomRequest catch-all, so unknown methods (e.g. `server/discover`
+        // from MCP Go SDK >= 1.7 clients like Antigravity) parse fine and
+        // never hit the #1434 deser-path handler in mcp_stdio.rs. The
+        // pre-init loop surfaces them as ExpectedInitializeRequest; before
+        // this fix the server treated that like a silent client disconnect
+        // (bare EOF), which breaks the client's fallback to initialize.
+        // Reply -32601 and RE-ENTER the handshake on the same stdio pair so
+        // the fallback initialize succeeds. Exit silently only for genuine
+        // disconnects ("context canceled" / "broken pipe" / "connection
+        // closed").
+        let service = loop {
+            let transport = mcp_stdio::HybridStdioTransport::new_server(
+                tokio::io::stdin(),
+                tokio::io::stdout(),
+            );
+            let wire_protocol = transport.protocol();
+            match server.clone().serve(transport).await {
+                Ok(s) => break s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("context canceled")
+                        || msg.contains("broken pipe")
+                        || msg.contains("connection closed")
+                    {
+                        tracing::debug!("Client disconnected before init: {msg}");
+                        return Ok(());
+                    }
+                    if let Some((id, method)) = extract_request_id_from_error(&e) {
+                        mcp_stdio::write_method_not_found_pre_init(&id, &method, &wire_protocol);
+                        tracing::debug!(
+                            "Replied -32601 for unrecognized pre-init request '{method}'"
+                        );
+                        // Client falls back to `initialize` on this connection.
+                        continue;
+                    }
+                    return Err(e.into());
                 }
-                return Err(e.into());
             }
         };
         // serve() resolves once the client's initialize/initialized handshake
@@ -200,6 +226,34 @@ pub(super) fn run_mcp_server() -> Result<()> {
 /// client-visible state at this point (transport closed, telemetry flushed).
 fn shutdown_runtime_bounded(rt: tokio::runtime::Runtime) {
     rt.shutdown_timeout(std::time::Duration::from_secs(2));
+}
+
+/// GH #1454: pull the request id and method out of rmcp's pre-init rejection
+/// (`ExpectedInitializeRequest`) so we can answer -32601 instead of exiting
+/// silently. Typed extraction (no error-string parsing), so id and method
+/// survive any Display-formatting change in the vendored rmcp.
+fn extract_request_id_from_error(
+    error: &rmcp::service::ServerInitializeError,
+) -> Option<(serde_json::Value, String)> {
+    match error {
+        rmcp::service::ServerInitializeError::ExpectedInitializeRequest(Some(message)) => {
+            extract_request_id_from_message(message)
+        }
+        _ => None,
+    }
+}
+
+fn extract_request_id_from_message(
+    message: &rmcp::model::ClientJsonRpcMessage,
+) -> Option<(serde_json::Value, String)> {
+    use rmcp::model::JsonRpcMessage;
+    let JsonRpcMessage::Request(request) = message else {
+        return None;
+    };
+    Some((
+        request.id.clone().into_json_value(),
+        request.request.method().to_string(),
+    ))
 }
 
 /// Kill orphan MCP server processes whose parent (IDE) has died.
@@ -372,6 +426,60 @@ mod tests {
         // zero-thread pool that rayon would reject.
         assert_eq!(herd_aware_index_threads(4, 32), 1);
         assert_eq!(herd_aware_index_threads(0, 0), 1);
+    }
+
+    /// GH #1454: an unrecognized pre-init request must yield its id + method
+    /// so the server can reply -32601 instead of dying silently.
+    #[test]
+    fn extract_request_id_recovers_numeric_id_and_method() {
+        use rmcp::model::{
+            ClientJsonRpcMessage, ClientRequest, CustomRequest, JsonRpcMessage, RequestId,
+        };
+
+        let request = ClientRequest::CustomRequest(CustomRequest::new(
+            "server/discover",
+            Some(serde_json::json!({})),
+        ));
+        let message: ClientJsonRpcMessage = JsonRpcMessage::request(request, RequestId::Number(7));
+
+        let (id, method) =
+            extract_request_id_from_message(&message).expect("request id extraction");
+        assert_eq!(id, serde_json::json!(7));
+        assert_eq!(method, "server/discover");
+    }
+
+    /// String ids are JSON-RPC-legal and must round-trip untouched.
+    #[test]
+    fn extract_request_id_recovers_string_id() {
+        use rmcp::model::{
+            ClientJsonRpcMessage, ClientRequest, CustomRequest, JsonRpcMessage, RequestId,
+        };
+        use std::sync::Arc;
+
+        let request = ClientRequest::CustomRequest(CustomRequest::new("foo/bar", None));
+        let message: ClientJsonRpcMessage =
+            JsonRpcMessage::request(request, RequestId::String(Arc::from("probe-42")));
+
+        let (id, method) =
+            extract_request_id_from_message(&message).expect("request id extraction");
+        assert_eq!(id, serde_json::json!("probe-42"));
+        assert_eq!(method, "foo/bar");
+    }
+
+    /// Notifications (no id) and non-request messages yield nothing, so the
+    /// caller falls through to its normal error path.
+    #[test]
+    fn extract_request_id_ignores_notifications() {
+        use rmcp::model::{
+            ClientJsonRpcMessage, ClientNotification, CustomNotification, JsonRpcMessage,
+        };
+
+        let message: ClientJsonRpcMessage =
+            JsonRpcMessage::notification(ClientNotification::CustomNotification(
+                CustomNotification::new("server/discover", Some(serde_json::json!({}))),
+            ));
+
+        assert!(extract_request_id_from_message(&message).is_none());
     }
 
     /// #733: after the transport closes, the server process must exit even if

--- a/rust/src/mcp_stdio.rs
+++ b/rust/src/mcp_stdio.rs
@@ -27,7 +27,7 @@ enum WireProtocol {
 }
 
 #[derive(Debug, Clone)]
-struct SharedProtocol(Arc<Mutex<Option<WireProtocol>>>);
+pub(crate) struct SharedProtocol(Arc<Mutex<Option<WireProtocol>>>);
 
 impl SharedProtocol {
     fn new() -> Self {
@@ -58,6 +58,7 @@ pub type TransportWriter<Role, W> =
 pub struct HybridStdioTransport<Role: ServiceRole, R: AsyncRead, W: AsyncWrite> {
     read: FramedRead<R, HybridJsonRpcMessageCodec<RxJsonRpcMessage<Role>>>,
     write: Arc<AsyncMutex<Option<TransportWriter<Role, W>>>>,
+    protocol: SharedProtocol,
 }
 
 impl<Role: ServiceRole, R, W> HybridStdioTransport<Role, R, W>
@@ -73,9 +74,19 @@ where
         );
         let write = Arc::new(AsyncMutex::new(Some(FramedWrite::new(
             write,
-            HybridJsonRpcMessageCodec::<TxJsonRpcMessage<Role>>::new(protocol),
+            HybridJsonRpcMessageCodec::<TxJsonRpcMessage<Role>>::new(protocol.clone()),
         ))));
-        Self { read, write }
+        Self {
+            read,
+            write,
+            protocol,
+        }
+    }
+
+    /// Clone of the framing-negotiation state (which wire protocol the client
+    /// used). Lets pre-init error replies mirror the client's framing.
+    pub(crate) fn protocol(&self) -> SharedProtocol {
+        self.protocol.clone()
     }
 }
 
@@ -240,6 +251,47 @@ fn write_method_not_found(id: &serde_json::Value, method: &str, protocol: Option
     };
     let _ = std::io::Write::flush(&mut out);
     tracing::debug!("Replied -32601 MethodNotFound for '{method}'");
+}
+
+/// GH #1454: a well-formed JSON-RPC request with an unrecognized method
+/// reached the pre-init handshake loop. rmcp's `ClientRequest` union has a
+/// `CustomRequest` catch-all, so the message deserialized fine — the #1434
+/// handler in `try_parse_with_compatibility` (deser-failure path) never
+/// fired — and the pre-init loop rejected it with
+/// `ServerInitializeError::ExpectedInitializeRequest`. Modern clients (MCP
+/// Go SDK >= 1.7, e.g. Antigravity) probe with `server/discover` first and
+/// fall back to the legacy `initialize` handshake ONLY after a spec-compliant
+/// -32601. Reply with the same framing the client established, and keep the
+/// process alive so the fallback `initialize` lands on this connection.
+///
+/// The message mirrors the legacy-handshake-only contract so dual-era
+/// clients can detect the server class and proceed.
+pub(crate) fn write_method_not_found_pre_init(
+    id: &serde_json::Value,
+    method: &str,
+    protocol: &SharedProtocol,
+) {
+    let response = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": -32601,
+            "message": concat!(
+                "Method not found. This server supports MCP protocol 2025-11-25 ",
+                "(legacy initialize handshake only)."
+            )
+        }
+    });
+    let body = serde_json::to_string(&response).unwrap_or_default();
+    let mut out = std::io::stdout().lock();
+    use std::io::Write;
+    let _ = if protocol.get() == Some(WireProtocol::ContentLength) {
+        write!(out, "Content-Length: {}\r\n\r\n{}", body.len(), body)
+    } else {
+        writeln!(out, "{body}")
+    };
+    let _ = std::io::Write::flush(&mut out);
+    tracing::debug!("Replied -32601 MethodNotFound for pre-init '{method}'");
 }
 
 fn try_parse_with_compatibility<T: DeserializeOwned>(

--- a/rust/tests/suite/mcp_preinit_method_not_found_1454.rs
+++ b/rust/tests/suite/mcp_preinit_method_not_found_1454.rs
@@ -1,0 +1,335 @@
+//! Pre-init MethodNotFound contract (GH #1454).
+//!
+//! Modern MCP clients (MCP Go SDK >= 1.7 — Antigravity) probe a legacy stdio
+//! server with `server/discover` BEFORE the `initialize` handshake. The
+//! vendored rmcp handshake parses that fine (its ClientRequest union has a
+//! CustomRequest catch-all, so the #1434 deser-path handler in mcp_stdio.rs
+//! never fires) and rejects it with `ExpectedInitializeRequest`. Before the
+//! fix the server treated that like a client disconnect and exited with a
+//! bare EOF — the client then saw `connection closed: calling "initialize"`
+//! and the MCP server failed to start.
+//!
+//! This test drives the REAL binary over REAL stdio JSON-RPC in an isolated
+//! HOME and asserts the full Antigravity-style sequence:
+//!   1. `server/discover` → -32601 with the request id echoed, and the
+//!      PROCESS MUST STAY ALIVE (the regression this guards),
+//!   2. the fallback `initialize` succeeds on the SAME connection,
+//!   3. a post-init tools/list works,
+//!   4. the same -32601 contract holds for Content-Length framing.
+
+use std::io::{BufReader, Read, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const RESPONSE_DEADLINE: Duration = Duration::from_secs(15);
+
+struct TestEnv {
+    _tmp: tempfile::TempDir,
+    home: std::path::PathBuf,
+    data: std::path::PathBuf,
+    project: std::path::PathBuf,
+}
+
+fn test_env() -> TestEnv {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let data = tmp.path().join("data");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+    std::fs::write(project.join("hello.txt"), "hello 1454\n").unwrap();
+    TestEnv {
+        _tmp: tmp,
+        home,
+        data,
+        project,
+    }
+}
+
+fn spawn_server(env: &TestEnv) -> Child {
+    let bin = env!("CARGO_BIN_EXE_lean-ctx");
+    Command::new(bin)
+        .arg("mcp")
+        .current_dir(&env.project)
+        .env("HOME", &env.home)
+        .env("LEAN_CTX_DATA_DIR", &env.data)
+        .env("CODEX_HOME", env.home.join(".codex"))
+        .env("LEAN_CTX_HEADLESS", "1")
+        // Root detection must derive from the temp project's cwd. When the
+        // suite itself runs inside an IDE/agent session these carry the HOST
+        // workspace and would hijack the project root (→ path-jail rejects
+        // the temp file).
+        .env_remove("LEAN_CTX_PROJECT_ROOT")
+        .env_remove("CLAUDE_PROJECT_DIR")
+        .env_remove("WORKSPACE_FOLDER_PATHS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("mcp server spawn")
+}
+
+/// Accumulates raw stdout bytes and extracts complete JSON-RPC messages from
+/// either wire protocol the server may use (JSON-lines or Content-Length).
+struct FrameAccumulator {
+    buf: Vec<u8>,
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+impl FrameAccumulator {
+    fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// Push a chunk and drain any complete frames, parsed as JSON values.
+    fn push(&mut self, chunk: &[u8]) -> Vec<serde_json::Value> {
+        self.buf.extend_from_slice(chunk);
+        let mut out = Vec::new();
+        loop {
+            if self.buf.starts_with(b"Content-Length:") || self.buf.starts_with(b"content-length:")
+            {
+                let Some(end) = find_subsequence(&self.buf, b"\r\n\r\n") else {
+                    break;
+                };
+                let header = String::from_utf8_lossy(&self.buf[..end]);
+                let Some(len) = header
+                    .split_once(':')
+                    .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+                else {
+                    break;
+                };
+                let body_start = end + 4;
+                if self.buf.len() < body_start + len {
+                    break;
+                }
+                let body = &self.buf[body_start..body_start + len];
+                if let Ok(value) = serde_json::from_slice(body) {
+                    out.push(value);
+                }
+                self.buf.drain(..body_start + len);
+            } else if let Some(nl) = self.buf.iter().position(|byte| *byte == b'\n') {
+                let line = &self.buf[..nl];
+                let line = line.strip_suffix(b"\r").unwrap_or(line);
+                if let Ok(value) = serde_json::from_slice(line) {
+                    out.push(value);
+                }
+                self.buf.drain(..nl + 1);
+            } else {
+                break;
+            }
+        }
+        out
+    }
+}
+
+/// Spawn the server and a reader thread feeding parsed responses into `rx`.
+struct ServerSession {
+    child: Child,
+    stdin: std::process::ChildStdin,
+    rx: mpsc::Receiver<serde_json::Value>,
+}
+
+fn start_session(env: &TestEnv) -> ServerSession {
+    let mut child = spawn_server(env);
+    let stdin = child.stdin.take().expect("child stdin");
+    let stdout = child.stdout.take().expect("child stdout");
+    let (tx, rx) = mpsc::channel::<serde_json::Value>();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut frames = FrameAccumulator::new();
+        loop {
+            let mut chunk = [0u8; 8192];
+            match reader.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    for value in frames.push(&chunk[..n]) {
+                        if tx.send(value).is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    });
+    ServerSession { child, stdin, rx }
+}
+
+impl ServerSession {
+    fn write_line(&mut self, body: &serde_json::Value) {
+        writeln!(self.stdin, "{body}").expect("write JSON-line");
+    }
+
+    fn write_content_length(&mut self, body: &serde_json::Value) {
+        let serialized = body.to_string();
+        write!(
+            self.stdin,
+            "Content-Length: {}\r\n\r\n{}",
+            serialized.len(),
+            serialized
+        )
+        .expect("write Content-Length frame");
+        self.stdin.flush().expect("flush stdin");
+    }
+
+    fn wait_for(
+        &self,
+        predicate: impl Fn(&serde_json::Value) -> bool,
+        label: &str,
+    ) -> serde_json::Value {
+        let until = Instant::now() + RESPONSE_DEADLINE;
+        loop {
+            let remaining = until
+                .checked_duration_since(Instant::now())
+                .unwrap_or_else(|| panic!("timeout waiting for {label}"));
+            let value = self
+                .rx
+                .recv_timeout(remaining)
+                .unwrap_or_else(|e| panic!("no {label} within deadline: {e}"));
+            if predicate(&value) {
+                return value;
+            }
+        }
+    }
+
+    fn assert_alive(&mut self, context: &str) {
+        match self.child.try_wait().expect("try_wait") {
+            None => {}
+            Some(status) => {
+                panic!("server EXITED after {context} (status {status}) — must stay alive")
+            }
+        }
+    }
+}
+
+fn discover_request(id: i64) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "server/discover",
+        "params": {}
+    })
+}
+
+fn initialize_request(id: i64) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "antigravity-1454-test", "version": "2.5.5" }
+        }
+    })
+}
+
+/// The exact Antigravity startup sequence, JSON-line framing: server/discover
+/// must answer -32601 (not EOF) and the process must stay alive so the
+/// fallback initialize lands on the same connection.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "HOME-override isolation is Unix-only (dirs::home_dir uses the Win32 API)"
+)]
+fn discover_gets_32601_then_initialize_succeeds_json_line() {
+    let env = test_env();
+    let mut session = start_session(&env);
+
+    session.write_line(&discover_request(1));
+    let discover = session.wait_for(
+        |v| v.get("id").and_then(serde_json::Value::as_i64) == Some(1),
+        "server/discover response",
+    );
+    assert_eq!(
+        discover["error"]["code"],
+        serde_json::json!(-32601),
+        "server/discover must answer -32601; got: {discover}"
+    );
+    let message = discover["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("legacy initialize handshake"),
+        "error message must flag the legacy handshake; got: {message}"
+    );
+    // THE regression: the process must not die after the -32601 reply.
+    session.assert_alive("server/discover -32601");
+
+    session.write_line(&initialize_request(2));
+    let init = session.wait_for(
+        |v| v.get("id").and_then(serde_json::Value::as_i64) == Some(2),
+        "initialize response",
+    );
+    assert_eq!(
+        init["result"]["serverInfo"]["name"],
+        serde_json::json!("lean-ctx"),
+        "fallback initialize must succeed; got: {init}"
+    );
+
+    session.write_line(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    }));
+    session.write_line(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/list",
+        "params": {}
+    }));
+    let tools = session.wait_for(
+        |v| v.get("id").and_then(serde_json::Value::as_i64) == Some(3),
+        "tools/list response",
+    );
+    assert!(
+        tools["result"]["tools"]
+            .as_array()
+            .map_or(false, |t| !t.is_empty()),
+        "tools/list after fallback must work; got: {tools}"
+    );
+
+    drop(session.stdin); // EOF → clean server shutdown
+    let _ = session.child.wait();
+}
+
+/// The same contract over Content-Length framing (the modern spec's other
+/// wire protocol — both must mirror, cf. GH #1434's dual-framing matrix).
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "HOME-override isolation is Unix-only (dirs::home_dir uses the Win32 API)"
+)]
+fn discover_gets_32601_then_initialize_succeeds_content_length() {
+    let env = test_env();
+    let mut session = start_session(&env);
+
+    session.write_content_length(&discover_request(1));
+    let discover = session.wait_for(
+        |v| v.get("id").and_then(serde_json::Value::as_i64) == Some(1),
+        "server/discover response",
+    );
+    assert_eq!(
+        discover["error"]["code"],
+        serde_json::json!(-32601),
+        "server/discover must answer -32601; got: {discover}"
+    );
+    session.assert_alive("server/discover -32601");
+
+    session.write_content_length(&initialize_request(2));
+    let init = session.wait_for(
+        |v| v.get("id").and_then(serde_json::Value::as_i64) == Some(2),
+        "initialize response",
+    );
+    assert_eq!(
+        init["result"]["serverInfo"]["name"],
+        serde_json::json!("lean-ctx"),
+        "fallback initialize must succeed; got: {init}"
+    );
+
+    drop(session.stdin); // EOF → clean server shutdown
+    let _ = session.child.wait();
+}

--- a/rust/tests/suite/mod.rs
+++ b/rust/tests/suite/mod.rs
@@ -53,6 +53,7 @@ mod lsp_integration;
 mod mcp_fast_initialize_669;
 mod mcp_manifest_up_to_date;
 mod mcp_optout_281;
+mod mcp_preinit_method_not_found_1454;
 mod metrics_contract;
 mod ocla_wire_contract_suite;
 mod onboard_doctor_clean;


### PR DESCRIPTION
## Summary

Fixes #1454: the stdio MCP server exited **silently** (bare EOF) when a well-formed pre-init request with an unknown method arrived — e.g. `server/discover` from clients built on the MCP Go SDK >= 1.7 (Antigravity). Those clients probe with `server/discover` first and only fall back to the legacy `initialize` handshake after receiving a spec-compliant `-32601`. Because the server died, the fallback never landed and the MCP server failed to start.

Why the #1434 fix doesn't cover this: `server/discover` deserializes fine into rmcp's `ClientRequest` union (`CustomRequest` catch-all), so the deser-failure handler in `mcp_stdio.rs` never fires. The message reaches the pre-init handshake loop, which rejects it as `ExpectedInitializeRequest` — previously treated like a client disconnect.

## The fix

- `rust/src/mcp_stdio.rs` — `write_method_not_found_pre_init(...)`: replies `-32601` echoing the request id, mirroring the client's framing (JSON-line or Content-Length, tracked via `SharedProtocol`).
- `rust/src/cli/dispatch/server.rs` — `serve()` is now a loop: on `ExpectedInitializeRequest` it extracts the request id + method **typed** from rmcp's error/message types (no Display-string parsing), replies `-32601`, then re-enters the handshake on the same stdio pair. Genuine disconnects (`context canceled` / `broken pipe` / `connection closed`) still exit silently.
- `rust/tests/suite/mcp_preinit_method_not_found_1454.rs` — e2e regression against the **real binary**: `server/discover` → `-32601` with the request id echoed, **process must stay alive** (the regression this guards), fallback `initialize` succeeds on the same connection, `tools/list` works post-init, asserted for both framings (JSON-line and Content-Length). `#[cfg_attr(windows, ignore)]` (HOME-override isolation is Unix-only).

## Test plan

All commands mirror `.github/workflows/ci.yml` exactly (including the global `RUSTFLAGS=-Dwarnings -Aunreachable-pub`):

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines`
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features`
- [x] `cargo run --example gen_docs --features dev-tools -- --check` (no drift)
- [x] `cargo run --example gen_registry --features dev-tools -- --check` (no drift)
- [x] Windows cross-check: `RUSTFLAGS="-Dwarnings -Aunreachable-pub" cargo check --target x86_64-pc-windows-gnu --lib --tests --no-default-features --features "tree-sitter,embeddings,http-server,secure-update"`
- [x] `cargo test --all-features` (`PROPTEST_CASES=64`): lib 10 102 passed / 6 failed — all pre-existing environmental (git permission + missing fixtures), verified **identical on base `8c9c8dd`** via a temp worktree. Integration: 59/60 binaries green; `--test main` 875 passed / 3 failed — the same 3 fail on base (git permission on this WSL box). New `mcp_preinit` e2e 2/2 passed inside `--test main`. **Zero new failures vs base.**
- [x] Targeted release run `cargo test --release --test main mcp_preinit` — completed in the rey-workbench fork CI (ubuntu-latest, release profile): 2/2 passed (see comment below).

## Notes for reviewers

- **Framing for the -32601 reply**: uses whatever framing the client established (JSON-line or Content-Length) — same code path as the existing post-init `write_method_not_found`.
- **Backwards compatibility**: unchanged for well-behaved clients; the -32601 path only triggers for requests that previously crashed the server (silent EOF).
- **Alternative to the in-flight fix**: I know #1454 is also being addressed on the v3.9.19 branch — this PR is an alternative implementation plus the e2e regression you asked for ("process stays alive after -32601"). Happy to cherry-pick just the test if your fix takes precedence.
- **Toolchain drift note**: on rustc 1.97.x the repo's own `scripts/preflight.sh` clippy step (`-Dwarnings` without `-Aunreachable-pub`) turns pre-existing `unreachable_pub` lints in `cloud_files.rs` / `sandbox_landlock.rs` into errors (main-only code, unrelated to this PR). CI stays green because its global RUSTFLAGS carries `-Aunreachable-pub`.
- **Spec loop**: treated as a bug fix (CONTRIBUTING.md allows skipping the spec dir for trivial fixes); happy to add `specs/1454-*/` if you want the full loop for CLI-surface changes.

## Contributor License Agreement

First-time contributor — will sign via the CLA bot when it asks.

