### PR TITLE
fix(readme): restore broken star history chart via star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,11 +711,11 @@ pi uninstall npm:pi-lean-ctx   # Pi Coding Agent
 
 ## Star History
 
-<a href="https://star-history.com/#yvgude/lean-ctx&Date">
+<a href="https://star-history.dera.page/#yvgude/lean-ctx&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=yvgude/lean-ctx&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=yvgude/lean-ctx&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=yvgude/lean-ctx&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=yvgude/lean-ctx&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=yvgude/lean-ctx&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=yvgude/lean-ctx&type=Date" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the README is currently broken because GitHub's stargazer API restrictions prevent the previous provider from rendering the graph. This PR migrates the chart to star-history.dera.page, which uses a fork that reads from an alternative data source requiring no API token. This restores a working star history chart.