### PR TITLE
fix(cline): register the Cline CLI's real MCP settings path

### DIFF
--- a/rust/src/cli/completions/engine.rs
+++ b/rust/src/cli/completions/engine.rs
@@ -144,6 +144,7 @@ const AGENT_KEYS: &[&str] = &[
     "claude",
     "claude-code",
     "cline",
+    "cline-cli",
     "codebuddy",
     "codex",
     "commandcode",

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use super::paths::{
-    augment_cli_settings_path, augment_vscode_mcp_path, claude_mcp_json_path, cline_mcp_path,
-    codebuddy_mcp_json_path, detect_vibe_path, qoder_all_mcp_paths, qodercli_settings_path,
-    qoderwork_mcp_path, roo_mcp_path, vibe_config_path, vscode_insiders_mcp_path, vscode_mcp_path,
-    zed_config_dir, zed_settings_path,
+    augment_cli_settings_path, augment_vscode_mcp_path, claude_mcp_json_path,
+    cline_cli_mcp_settings_path, cline_mcp_path, codebuddy_mcp_json_path, detect_vibe_path,
+    qoder_all_mcp_paths, qodercli_settings_path, qoderwork_mcp_path, roo_mcp_path,
+    vibe_config_path, vscode_insiders_mcp_path, vscode_mcp_path, zed_config_dir, zed_settings_path,
 };
 use super::types::{ConfigType, EditorTarget};
 
@@ -177,6 +177,17 @@ pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
             config_path: cline_mcp_path(),
             detect_path: detect_cline_path(),
             config_type: ConfigType::McpJson,
+        },
+        EditorTarget {
+            name: "Cline CLI",
+            // Reuses the "cline" hook dispatch (`.clinerules` + the shared
+            // global `~/.cline/rules/lean-ctx.md`) so CLI-only machines (no
+            // VS Code extension) still get rules installed; idempotent when
+            // both Cline targets are detected together.
+            agent_key: "cline".to_string(),
+            config_path: cline_cli_mcp_settings_path(),
+            detect_path: detect_cline_cli_path(),
+            config_type: ConfigType::ClineCli,
         },
         EditorTarget {
             name: "Roo Code",
@@ -690,6 +701,22 @@ pub fn detect_jetbrains_path(home: &Path) -> PathBuf {
         return home.join(".jb-mcp.json");
     }
     PathBuf::from("/nonexistent")
+}
+
+/// Signals a Cline CLI/SDK install (as opposed to just the VS Code
+/// extension): the CLI creates `~/.cline/data/` on first run for
+/// providers/sessions/etc., while the extension's rules-only footprint
+/// (`~/.cline/rules/`, written by lean-ctx itself) never touches `data/`.
+pub fn detect_cline_cli_path() -> PathBuf {
+    let data_dir = std::env::var("CLINE_DATA_DIR")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cline")));
+    match data_dir {
+        Some(dir) => dir.join("data"),
+        None => PathBuf::from("/nonexistent"),
+    }
 }
 
 #[allow(unreachable_code)]

--- a/rust/src/core/editor_registry/paths.rs
+++ b/rust/src/core/editor_registry/paths.rs
@@ -94,6 +94,28 @@ pub fn qoder_mcp_paths(home: &Path) -> Vec<PathBuf> {
     vec![qoder_mcp_path(home)]
 }
 
+/// Cline CLI's MCP settings file. Unified across the Cline IDE extension,
+/// CLI, and SDK since 2026.7 (`~/.cline/data/settings/cline_mcp_settings.json`),
+/// separate from the VS Code extension's own globalStorage copy
+/// (`cline_mcp_path`, below) that predates the unification. Honors the same
+/// overrides as Cline's own `resolveMcpSettingsPath()`: `CLINE_MCP_SETTINGS_PATH`
+/// wins outright, otherwise `CLINE_DATA_DIR` replaces the `~/.cline` root.
+pub fn cline_cli_mcp_settings_path() -> PathBuf {
+    if let Ok(explicit) = std::env::var("CLINE_MCP_SETTINGS_PATH") {
+        let trimmed = explicit.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    let data_dir = std::env::var("CLINE_DATA_DIR")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cline")))
+        .unwrap_or_else(|| PathBuf::from("/nonexistent"));
+    data_dir.join("data/settings/cline_mcp_settings.json")
+}
+
 #[allow(unreachable_code)]
 pub fn cline_mcp_path() -> PathBuf {
     #[cfg(target_os = "windows")]

--- a/rust/src/core/editor_registry/types.rs
+++ b/rust/src/core/editor_registry/types.rs
@@ -37,4 +37,12 @@ pub enum ConfigType {
     /// Command Code (`~/.commandcode/mcp.json`): `mcpServers` root with a
     /// custom entry schema (`transport`/`enabled`/`command`/`instructions`).
     CommandCode,
+    /// Cline CLI (`~/.cline/data/settings/cline_mcp_settings.json`, unified
+    /// across the Cline IDE extension/CLI/SDK since 2026.7): `mcpServers`
+    /// root where each entry nests `command`/`args`/`env` under a
+    /// `transport` object (`{"type": "stdio", ...}`), unlike the flat
+    /// `command`/`args`/`env` shape the VS Code extension's own
+    /// `cline_mcp_settings.json` (under globalStorage, see `ConfigType::McpJson`
+    /// via `cline_mcp_path`) and most other MCP-JSON agents use.
+    ClineCli,
 }

--- a/rust/src/core/editor_registry/writers/install/cline_cli.rs
+++ b/rust/src/core/editor_registry/writers/install/cline_cli.rs
@@ -1,0 +1,84 @@
+use serde_json::Value;
+
+#[allow(clippy::wildcard_imports)]
+use super::super::shared::*;
+use super::super::{WriteAction, WriteOptions, WriteResult};
+use crate::core::editor_registry::types::EditorTarget;
+
+/// Cline CLI schema: unlike every other `mcpServers`-keyed agent lean-ctx
+/// wires up, Cline nests `command`/`args`/`env` under a `transport` object
+/// (`{"type": "stdio", "command": ..., "args": [...], "env": {...}}`).
+/// Verified against a live `cline` 3.0.55 install: its own
+/// `cline mcp install --yes --json` writes exactly this shape into
+/// `~/.cline/data/settings/cline_mcp_settings.json`, and a real CLI session
+/// picked up the registered tools.
+pub(crate) fn write_cline_cli_config(
+    target: &EditorTarget,
+    binary: &str,
+    opts: WriteOptions,
+) -> Result<WriteResult, String> {
+    let desired = serde_json::json!({
+        "transport": {
+            "type": "stdio",
+            "command": binary,
+            "args": [],
+            "env": crate::hooks::mcp_server_env_json()
+        }
+    });
+
+    if target.config_path.exists() {
+        let content = std::fs::read_to_string(&target.config_path).map_err(|e| e.to_string())?;
+        let mut json = match crate::core::jsonc::parse_jsonc(&content) {
+            Ok(v) => v,
+            Err(_e) => {
+                return handle_invalid_json_write(
+                    &target.config_path,
+                    &content,
+                    "mcpServers",
+                    "lean-ctx",
+                    &desired,
+                    opts.overwrite_invalid,
+                );
+            }
+        };
+        let obj = json
+            .as_object_mut()
+            .ok_or_else(|| "root JSON must be an object".to_string())?;
+        let servers = obj
+            .entry("mcpServers")
+            .or_insert_with(|| serde_json::json!({}));
+        let servers_obj = servers
+            .as_object_mut()
+            .ok_or_else(|| "\"mcpServers\" must be an object".to_string())?;
+
+        let existing = servers_obj.get("lean-ctx").cloned();
+        if existing.as_ref() == Some(&desired) {
+            return Ok(WriteResult {
+                action: WriteAction::Already,
+                note: None,
+            });
+        }
+        servers_obj.insert("lean-ctx".to_string(), desired);
+
+        let formatted = serde_json::to_string_pretty(&json).map_err(|e| e.to_string())?;
+        crate::config_io::write_atomic_with_backup(&target.config_path, &formatted)?;
+        return Ok(WriteResult {
+            action: WriteAction::Updated,
+            note: None,
+        });
+    }
+
+    write_cline_cli_fresh(&target.config_path, &desired)
+}
+
+fn write_cline_cli_fresh(path: &std::path::Path, desired: &Value) -> Result<WriteResult, String> {
+    let content = serde_json::to_string_pretty(&serde_json::json!({
+        "mcpServers": { "lean-ctx": desired }
+    }))
+    .map_err(|e| e.to_string())?;
+    crate::config_io::write_atomic_with_backup(path, &content)?;
+    Ok(WriteResult {
+        action: WriteAction::Created,
+        note: None,
+    })
+}

--- a/rust/src/core/editor_registry/writers/install/mod.rs
+++ b/rust/src/core/editor_registry/writers/install/mod.rs
@@ -6,6 +6,7 @@
 
 mod amp;
 mod claude;
+mod cline_cli;
 mod codex;
 mod commandcode;
 mod copilot;
@@ -27,6 +28,8 @@ mod zed;
 pub(crate) use amp::*;
 #[allow(clippy::wildcard_imports)]
 pub(crate) use claude::*;
+#[allow(clippy::wildcard_imports)]
+pub(crate) use cline_cli::*;
 #[allow(clippy::wildcard_imports)]
 pub(crate) use codex::*;
 #[allow(clippy::wildcard_imports)]

--- a/rust/src/core/editor_registry/writers/mod.rs
+++ b/rust/src/core/editor_registry/writers/mod.rs
@@ -64,6 +64,7 @@ pub fn write_config_with_options(
         ConfigType::OpenClaw => write_openclaw_config(target, binary, opts),
         ConfigType::VibeToml => write_vibe_toml(target, binary, opts),
         ConfigType::CommandCode => write_commandcode_config(target, binary, opts),
+        ConfigType::ClineCli => write_cline_cli_config(target, binary, opts),
     }
 }
 
@@ -76,7 +77,8 @@ pub fn remove_lean_ctx_server(
         | ConfigType::JetBrains
         | ConfigType::GeminiSettings
         | ConfigType::QoderSettings
-        | ConfigType::CommandCode => remove_lean_ctx_mcp_server(&target.config_path, opts),
+        | ConfigType::CommandCode
+        | ConfigType::ClineCli => remove_lean_ctx_mcp_server(&target.config_path, opts),
         ConfigType::VsCodeMcp | ConfigType::CopilotCli => {
             remove_lean_ctx_vscode_server(&target.config_path, opts)
         }

--- a/rust/src/core/editor_registry/writers/tests.rs
+++ b/rust/src/core/editor_registry/writers/tests.rs
@@ -117,6 +117,40 @@ fn commandcode_config_uses_command_code_schema() {
     assert_eq!(res.action, WriteAction::Already);
 }
 
+/// Cline CLI nests `command`/`args`/`env` under a `transport` object —
+/// verified against a live `cline mcp install --yes --json` (see
+/// `write_cline_cli_config`'s doc comment) — unlike every other
+/// `mcpServers`-keyed agent, which keeps them flat.
+#[test]
+fn cline_cli_config_nests_command_under_transport() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("cline_mcp_settings.json");
+    std::fs::write(
+        &path,
+        r#"{ "mcpServers": { "other": { "transport": { "type": "stdio", "command": "other-bin" } } } }"#,
+    )
+    .unwrap();
+
+    let t = target("test", path.clone(), ConfigType::ClineCli);
+    let res = write_cline_cli_config(&t, "/new/path/lean-ctx", WriteOptions::default()).unwrap();
+    assert_eq!(res.action, WriteAction::Updated);
+
+    let json: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        json["mcpServers"]["other"]["transport"]["command"],
+        "other-bin"
+    );
+    let transport = &json["mcpServers"]["lean-ctx"]["transport"];
+    assert_eq!(transport["type"], "stdio");
+    assert_eq!(transport["command"], "/new/path/lean-ctx");
+    assert_eq!(transport["args"], serde_json::json!([]));
+    assert!(json["mcpServers"]["lean-ctx"]["command"].is_null());
+
+    // Idempotent: second write reports Already.
+    let res = write_cline_cli_config(&t, "/new/path/lean-ctx", WriteOptions::default()).unwrap();
+    assert_eq!(res.action, WriteAction::Already);
+}
+
 #[test]
 fn codex_toml_upserts_existing_section() {
     let dir = tempfile::tempdir().unwrap();

--- a/rust/src/doctor/integrations/editors.rs
+++ b/rust/src/doctor/integrations/editors.rs
@@ -34,6 +34,13 @@ pub(crate) fn integration_generic(
                 checks.push(antigravity_cli_hooks_note());
             }
         }
+        crate::core::editor_registry::types::ConfigType::ClineCli => {
+            checks.push(check_cline_cli_config(
+                &target.config_path,
+                binary,
+                data_dir,
+            ));
+        }
         crate::core::editor_registry::types::ConfigType::JetBrains => {
             checks.push(check_jetbrains_snippet(
                 &target.config_path,

--- a/rust/src/doctor/integrations/wiring.rs
+++ b/rust/src/doctor/integrations/wiring.rs
@@ -79,6 +79,65 @@ pub(crate) fn check_mcp_json(path: &std::path::Path, binary: &str, data_dir: &st
     }
 }
 
+/// Cline CLI nests `command`/`env` under a `transport` object instead of at
+/// the top level of the server entry (see `ConfigType::ClineCli`'s doc
+/// comment) — `check_mcp_json` can't be reused as-is since it reads those
+/// fields flat.
+pub(crate) fn check_cline_cli_config(
+    path: &std::path::Path,
+    binary: &str,
+    data_dir: &str,
+) -> NamedCheck {
+    if !path.exists() {
+        return NamedCheck {
+            name: "MCP config".to_string(),
+            ok: false,
+            detail: format!("missing ({})", path.display()),
+        };
+    }
+    let content = std::fs::read_to_string(path).unwrap_or_default();
+    let parsed = crate::core::jsonc::parse_jsonc(&content).ok();
+
+    let Some(v) = parsed else {
+        return NamedCheck {
+            name: "MCP config".to_string(),
+            ok: false,
+            detail: format!("invalid JSON ({})", path.display()),
+        };
+    };
+
+    let transport = v
+        .get("mcpServers")
+        .and_then(|m| m.get("lean-ctx"))
+        .and_then(|e| e.get("transport"));
+
+    let Some(t) = transport else {
+        return NamedCheck {
+            name: "MCP config".to_string(),
+            ok: false,
+            detail: format!("lean-ctx missing ({})", path.display()),
+        };
+    };
+
+    let cmd_ok = t
+        .get("command")
+        .and_then(|c| c.as_str())
+        .is_some_and(|c| cmd_matches_expected(c, binary));
+    let env_ok = pinned_data_dir_ok(t.get("env"), data_dir);
+
+    let ok = cmd_ok && env_ok;
+    let detail = if ok {
+        format!("ok ({})", path.display())
+    } else {
+        format!("drift ({})", path.display())
+    };
+    NamedCheck {
+        name: "MCP config".to_string(),
+        ok,
+        detail,
+    }
+}
+
 /// JetBrains AI Assistant has no auto-wiring: lean-ctx writes a ready-to-paste
 /// snippet to `~/.jb-mcp.json`, which the user imports once via the IDE. The
 /// `doctor` verdict therefore verifies the snippet exists and is current, while
@@ -258,7 +317,7 @@ pub(crate) fn humanize_ago(d: chrono::Duration) -> String {
 pub(crate) fn rules_path_for(name: &str, home: &std::path::Path) -> Option<std::path::PathBuf> {
     match name {
         "Windsurf" => Some(home.join(".codeium/windsurf/rules/lean-ctx.md")),
-        "Cline" => Some(home.join(".cline/rules/lean-ctx.md")),
+        "Cline" | "Cline CLI" => Some(home.join(".cline/rules/lean-ctx.md")),
         "Roo Code" => Some(home.join(".roo/rules/lean-ctx.md")),
         "OpenCode" => Some(home.join(".config/opencode/AGENTS.md")),
         "AWS Kiro" => Some(home.join(".kiro/steering/lean-ctx.md")),

--- a/rust/src/setup/mcp.rs
+++ b/rust/src/setup/mcp.rs
@@ -258,6 +258,12 @@ pub(crate) fn agent_mcp_targets(
             crate::core::editor_registry::cline_mcp_path(),
             ConfigType::McpJson,
         ),
+        "cline-cli" => push(
+            &mut targets,
+            "Cline CLI",
+            crate::core::editor_registry::cline_cli_mcp_settings_path(),
+            ConfigType::ClineCli,
+        ),
         "roo" => push(
             &mut targets,
             "Roo Code",
@@ -531,6 +537,12 @@ pub fn disable_agent_mcp(agent: &str, overwrite_invalid: bool) -> Result<(), Str
             crate::core::editor_registry::cline_mcp_path(),
             ConfigType::McpJson,
         ),
+        "cline-cli" => push(
+            &mut targets,
+            "Cline CLI",
+            crate::core::editor_registry::cline_cli_mcp_settings_path(),
+            ConfigType::ClineCli,
+        ),
         "roo" => push(
             &mut targets,
             "Roo Code",
@@ -670,6 +682,16 @@ mod qodercli_tests {
         assert_eq!(targets[0].name, "Command Code");
         assert_eq!(targets[0].config_path, home.join(".commandcode/mcp.json"));
         assert_eq!(targets[0].config_type, ConfigType::CommandCode);
+    }
+
+    #[test]
+    fn cline_cli_agent_target_uses_cline_cli_schema() {
+        let home = std::path::Path::new("/home/tester");
+        let targets = agent_mcp_targets("cline-cli", home).unwrap();
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].name, "Cline CLI");
+        assert_eq!(targets[0].config_type, ConfigType::ClineCli);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

lean-ctx's Cline integration only ever wired MCP registration for the **Cline VS Code extension** (globalStorage `cline_mcp_settings.json`, plus VS Code's own native `mcp.json`). The standalone **Cline CLI/SDK** reads from a different, now-unified location and a different JSON schema, so `lean-ctx setup`/`doctor --fix`/`wrap cline` never actually reached CLI-only installs.

- Real path: `~/.cline/data/settings/cline_mcp_settings.json` (honors `CLINE_DATA_DIR` / `CLINE_MCP_SETTINGS_PATH`, matching Cline's own `resolveMcpSettingsPath()`). Cline's own docs still say `~/.cline/mcp.json` for the CLI — see the still-open upstream issue [cline/cline#11671](https://github.com/cline/cline/issues/11671).
- Real schema: `command`/`args`/`env` nest under a `transport` object (`{"type": "stdio", ...}`), unlike every other `mcpServers`-keyed agent lean-ctx wires up, which keeps them flat.

Both were verified empirically against a live `cline` 3.0.55 install — `cline mcp install --yes --json` writes exactly this shape, and a real `cline` CLI session picked up every `ctx_*` tool from a server registered this way.

## Changes

- New `ConfigType::ClineCli` + dedicated writer (`writers/install/cline_cli.rs`), modeled on the existing `CommandCode` writer (closest existing precedent for a non-flat schema).
- New `EditorTarget` ("Cline CLI") added to `editor_registry::build_targets()` — the single registry `setup`, `doctor --fix`, `status`, and `wrap` all already consume, so no changes were needed in those call sites.
- Reuses the existing `"cline"` hook dispatch (`agent_key: "cline"`) so `.clinerules` / the shared global `~/.cline/rules/lean-ctx.md` still install correctly on CLI-only machines with no VS Code extension present (rules were already correct — verified via a live CLI session that correctly enforced the project's `.clinerules` policy).
- New `doctor` drift-check (`check_cline_cli_config`) since the existing `check_mcp_json` reads `command`/`env` flat and would false-positive "drift" against the nested schema.
- `agent_key: "cline-cli"` wired into `setup::mcp::agent_mcp_targets` for direct single-agent setup, and added to shell completions.

## Test plan

- `cargo build --lib` — clean.
- `cargo test --lib cline` — 6/6 passing, including two new tests (`cline_cli_config_nests_command_under_transport`, `cline_cli_agent_target_uses_cline_cli_schema`).
- `cargo fmt --check` — clean.
- `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines` (CI's exact invocation) — my changes introduce no new diagnostics (clippy diagnoses the whole crate in one pass and reported nothing in any file this PR touches). **Note:** this command currently fails on a clean `main` checkout with 4 pre-existing `unreachable_pub` errors in `core/cloud_files.rs` and `core/sandbox_landlock.rs` — unrelated to this change, reproduces after `cargo clean -p lean-ctx`, likely a stable-toolchain drift issue. Flagging for visibility, left out of scope here to keep this PR focused.
- Manual end-to-end: registered lean-ctx via `cline mcp install --yes --json`, confirmed the real file/schema, then ran a live `cline -p "..." --json` session that listed and successfully called `ctx_session` on the registered `lean-ctx` MCP server.

## Note on the spec-driven workflow

This skips the full `specs/NNN-.../spec.md` → `plan.md` → `tasks.md` loop CONTRIBUTING.md asks for on "anything touching the tool/CLI surface." I judged this as a scoped bug fix following an exact existing pattern (mirrors `ConfigType::CommandCode` file-for-file) rather than a new feature — happy to backfill a spec if maintainers would rather have one for a change of this shape.