### PR TITLE
fix(triage): stop deriving filter level 2 from a rules profile (#1484)

### DIFF
--- a/rust/src/core/decision_loop.rs
+++ b/rust/src/core/decision_loop.rs
@@ -178,7 +178,10 @@ mod tests {
     fn test_unknown_query() {
         let result = DecisionLoop::default().execute_task("", "session", "agent");
 
-        assert_eq!(result.profile.confidence_milli, 300);
+        assert_eq!(
+            result.profile.confidence_milli,
+            crate::core::triage::confidence::RULES_FALLBACK_MILLI
+        );
         assert!(result.envelope_created);
     }
 

--- a/rust/src/core/decision_loop_integration_test.rs
+++ b/rust/src/core/decision_loop_integration_test.rs
@@ -151,6 +151,25 @@ async fn decision_loop_integration_simple_read() {
     .await;
     assert_completed_task(&server, &task_id, "ctx_read").await;
 
+    // #1484: `ctx_read` carries neither `query` nor `task`, so the ingress must
+    // hand the triage no task text at all. Classifying the tool name instead
+    // ("ctx_read: ctx_read") yields a confident SingleFile profile and filter
+    // level 2 — the regression this binds shut.
+    let session_id = server.session.read().await.id.clone();
+    let profile = DecisionLoopRuntime::get_or_init()
+        .profile_for_session(&session_id)
+        .expect("a tool call must record a triage profile for its session");
+    assert_eq!(
+        profile.confidence_milli,
+        crate::core::triage::confidence::RULES_FALLBACK_MILLI,
+        "a call without a task text must reach rules::fallback(), not a classification"
+    );
+    assert_eq!(
+        crate::server::context_gate::triage_filter_level(&profile),
+        0,
+        "a task-text-less profile must pass output through unfiltered"
+    );
+
     // SAFETY: test_env_lock serializes process-wide data directory changes.
     unsafe { std::env::remove_var("LEAN_CTX_DATA_DIR") };
 }

--- a/rust/src/core/decision_loop_runtime.rs
+++ b/rust/src/core/decision_loop_runtime.rs
@@ -62,7 +62,7 @@ impl DecisionLoopRuntime {
     pub fn on_tool_start(
         &self,
         tool_name: &str,
-        query: &str,
+        query: Option<&str>,
         session_id: &str,
         agent_id: &str,
     ) -> TaskContext {
@@ -83,20 +83,21 @@ impl DecisionLoopRuntime {
     fn on_tool_start_inner(
         &self,
         tool_name: &str,
-        query: &str,
+        query: Option<&str>,
         session_id: &str,
         agent_id: &str,
     ) -> TaskContext {
         let profile = self
             .triage
             .analyze(&TaskAnalysisInput {
-                query: format!("{tool_name}: {query}"),
+                query: query.map_or_else(String::new, |text| format!("{tool_name}: {text}")),
                 ..Default::default()
             })
             .map(|hypothesis| hypothesis.profile)
             .unwrap_or_default();
         self.remember_profile(session_id, profile.clone());
-        let mut envelope = TaskSpine::create_envelope(query, session_id, agent_id);
+        let mut envelope =
+            TaskSpine::create_envelope(query.unwrap_or(tool_name), session_id, agent_id);
         TaskSpine::enrich_from_triage(&mut envelope, &protocol_profile(&profile));
         TaskContext {
             task_id: envelope.task_id.as_str().to_owned(),

--- a/rust/src/core/decision_loop_runtime_tests.rs
+++ b/rust/src/core/decision_loop_runtime_tests.rs
@@ -28,7 +28,7 @@ fn test_runtime_init() {
 fn test_on_tool_start() {
     let context = DecisionLoopRuntime::get_or_init().on_tool_start(
         "ctx_read",
-        "read lib.rs",
+        Some("read lib.rs"),
         "runtime-test",
         "agent",
     );
@@ -39,7 +39,7 @@ fn test_on_tool_start() {
 #[test]
 fn test_on_tool_end_success() {
     let runtime = DecisionLoopRuntime::with_triage(TriageEngine::default());
-    let context = runtime.on_tool_start("ctx_read", "read", "runtime-test", "agent");
+    let context = runtime.on_tool_start("ctx_read", Some("read"), "runtime-test", "agent");
     runtime.on_tool_end(&context, 1, 1, "gpt-4o", true);
     assert_eq!(runtime.latest_assessment_accepted(), Some(true));
 }
@@ -47,7 +47,7 @@ fn test_on_tool_end_success() {
 #[test]
 fn test_on_tool_end_failure() {
     let runtime = DecisionLoopRuntime::with_triage(TriageEngine::default());
-    let context = runtime.on_tool_start("ctx_read", "read", "runtime-test", "agent");
+    let context = runtime.on_tool_start("ctx_read", Some("read"), "runtime-test", "agent");
     runtime.on_tool_end(&context, 1, 1, "gpt-4o", false);
     assert_eq!(runtime.latest_assessment_accepted(), Some(false));
 }
@@ -58,8 +58,22 @@ fn test_error_does_not_block() {
         DecisionLoopRuntime::with_triage(TriageEngine::new(vec![Box::new(FailingAnalyzer)]));
     assert!(
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            runtime.on_tool_start("ctx_read", "", "test", "agent")
+            runtime.on_tool_start("ctx_read", None, "test", "agent")
         }))
         .is_ok()
     );
+}
+
+#[test]
+fn missing_task_text_yields_passthrough_profile() {
+    use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+    use crate::server::context_gate::triage_filter_level;
+
+    let runtime = DecisionLoopRuntime::with_triage(TriageEngine::default());
+    let context = runtime.on_tool_start("ctx_read", None, "no-task-text", "agent");
+
+    assert_eq!(context.profile_intent, "explore");
+    let profile = runtime.profile_for_session("no-task-text").unwrap();
+    assert!(profile.confidence_milli < ACTIONABLE_FLOOR_MILLI);
+    assert_eq!(triage_filter_level(&profile), 0);
 }

--- a/rust/src/core/shell_allowlist/function_def_tests.rs
+++ b/rust/src/core/shell_allowlist/function_def_tests.rs
@@ -1,0 +1,72 @@
+//! Shell function definitions and inline-env error text (#1488, #1489).
+//! Split out of `tests.rs` to keep that file under the LOC gate.
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// #1488: shell function definitions must not be blocked by the allowlist.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gh1488_function_definition_not_blocked() {
+    let allowlist: Vec<String> = vec!["echo".into()];
+    let result = check_all_segments("greet() { echo hi; }; greet", &allowlist);
+    assert!(
+        result.is_ok(),
+        "function definition + call should not be blocked: {result:?}"
+    );
+}
+
+#[test]
+fn gh1488_function_with_disallowed_body_is_blocked() {
+    let allowlist: Vec<String> = vec!["echo".into(), "ls".into()];
+    let result = check_all_segments("bad() { evil_command; }; bad", &allowlist);
+    assert!(
+        result.is_err(),
+        "function with disallowed body command must be blocked"
+    );
+}
+
+#[test]
+fn gh1488_detect_function_def_forms() {
+    use super::super::tokenizer::detect_function_def;
+    assert_eq!(
+        detect_function_def("greet() { echo hi; }"),
+        Some("greet".into())
+    );
+    assert_eq!(
+        detect_function_def("function greet { echo hi; }"),
+        Some("greet".into())
+    );
+    assert_eq!(
+        detect_function_def("function greet() { echo hi; }"),
+        Some("greet".into())
+    );
+    assert_eq!(detect_function_def("echo hello"), None);
+    assert_eq!(detect_function_def("ls -la"), None);
+}
+
+#[test]
+fn gh1488_extract_function_body_commands() {
+    use super::super::tokenizer::extract_function_body_commands;
+    let cmds = extract_function_body_commands("greet() { echo hi; echo bye; }");
+    assert_eq!(cmds, vec!["echo hi", "echo bye"]);
+}
+
+// ---------------------------------------------------------------------------
+// #1489: inline env override error must mention the `env` parameter.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gh1489_inline_env_block_message_mentions_env_parameter() {
+    let result = check_all_segments("PATH=/evil/bin echo hi", &["echo".into()]);
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("env parameter"),
+        "error must mention `env` parameter: {err}"
+    );
+    assert!(
+        err.contains("ctx_shell"),
+        "error must mention ctx_shell: {err}"
+    );
+}

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -3,6 +3,8 @@
 
 #[path = "comment_strip_tests.rs"]
 mod comment_strip_tests;
+#[path = "function_def_tests.rs"]
+mod function_def_tests;
 #[path = "substitution_tests.rs"]
 mod substitution_tests;
 #[path = "tests_powershell.rs"]
@@ -1494,72 +1496,4 @@ fn extract_bash_interpreters_from_json() {
     let mut out = Vec::new();
     extract_bash_interpreters(&json, &mut out);
     assert_eq!(out, vec!["python3", "node", "ruby"]);
-}
-
-// ---------------------------------------------------------------------------
-// #1488: shell function definitions must not be blocked by the allowlist.
-// ---------------------------------------------------------------------------
-
-#[test]
-fn gh1488_function_definition_not_blocked() {
-    let allowlist: Vec<String> = vec!["echo".into()];
-    let result = check_all_segments("greet() { echo hi; }; greet", &allowlist);
-    assert!(
-        result.is_ok(),
-        "function definition + call should not be blocked: {result:?}"
-    );
-}
-
-#[test]
-fn gh1488_function_with_disallowed_body_is_blocked() {
-    let allowlist: Vec<String> = vec!["echo".into(), "ls".into()];
-    let result = check_all_segments("bad() { evil_command; }; bad", &allowlist);
-    assert!(
-        result.is_err(),
-        "function with disallowed body command must be blocked"
-    );
-}
-
-#[test]
-fn gh1488_detect_function_def_forms() {
-    use super::tokenizer::detect_function_def;
-    assert_eq!(
-        detect_function_def("greet() { echo hi; }"),
-        Some("greet".into())
-    );
-    assert_eq!(
-        detect_function_def("function greet { echo hi; }"),
-        Some("greet".into())
-    );
-    assert_eq!(
-        detect_function_def("function greet() { echo hi; }"),
-        Some("greet".into())
-    );
-    assert_eq!(detect_function_def("echo hello"), None);
-    assert_eq!(detect_function_def("ls -la"), None);
-}
-
-#[test]
-fn gh1488_extract_function_body_commands() {
-    use super::tokenizer::extract_function_body_commands;
-    let cmds = extract_function_body_commands("greet() { echo hi; echo bye; }");
-    assert_eq!(cmds, vec!["echo hi", "echo bye"]);
-}
-
-// ---------------------------------------------------------------------------
-// #1489: inline env override error must mention the `env` parameter.
-// ---------------------------------------------------------------------------
-
-#[test]
-fn gh1489_inline_env_block_message_mentions_env_parameter() {
-    let result = check_all_segments("PATH=/evil/bin echo hi", &["echo".into()]);
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("env parameter"),
-        "error must mention `env` parameter: {err}"
-    );
-    assert!(
-        err.contains("ctx_shell"),
-        "error must mention ctx_shell: {err}"
-    );
 }

--- a/rust/src/core/triage/confidence.rs
+++ b/rust/src/core/triage/confidence.rs
@@ -8,6 +8,13 @@ pub fn is_low_confidence(milli: u16) -> bool {
     milli < 500
 }
 
+/// Below this a profile is not actionable and output passes through unfiltered.
+pub const ACTIONABLE_FLOOR_MILLI: u16 = 300;
+
+/// Confidence reported by the rules fallback — deliberately below the floor:
+/// a rules-only profile without a task text is a guess, and says so.
+pub const RULES_FALLBACK_MILLI: u16 = 200;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -26,5 +33,9 @@ mod tests {
     #[test]
     fn low_is_exclusive() {
         assert!(!is_low_confidence(500));
+    }
+    #[test]
+    fn rules_fallback_stays_below_the_actionable_floor() {
+        assert!(RULES_FALLBACK_MILLI < ACTIONABLE_FLOOR_MILLI);
     }
 }

--- a/rust/src/core/triage/rules.rs
+++ b/rust/src/core/triage/rules.rs
@@ -1,6 +1,6 @@
 use super::{
     ProfileHypothesis, TaskAnalysisInput, TaskAnalyzer, TriageBackendLocal,
-    confidence::clamp_milli,
+    confidence::{RULES_FALLBACK_MILLI, clamp_milli},
     profile::{TaskProfileLocal, TaskScopeLocal},
 };
 use crate::core::{
@@ -60,12 +60,12 @@ fn fallback() -> ProfileHypothesis {
     let profile = TaskProfileLocal {
         task_class: "coding".into(),
         intent: "explore".into(),
-        confidence_milli: 300,
+        confidence_milli: RULES_FALLBACK_MILLI,
         ..Default::default()
     };
     ProfileHypothesis {
         profile,
-        confidence_milli: 300,
+        confidence_milli: RULES_FALLBACK_MILLI,
         backend: TriageBackendLocal::Rules,
     }
 }
@@ -134,7 +134,7 @@ mod tests {
                 .analyze(&TaskAnalysisInput::default())
                 .unwrap()
                 .confidence_milli,
-            300
+            RULES_FALLBACK_MILLI
         );
     }
 }

--- a/rust/src/core/triage/rules.rs
+++ b/rust/src/core/triage/rules.rs
@@ -73,7 +73,10 @@ fn milli(value: f64) -> u16 {
     if value.is_finite() {
         clamp_milli((value.clamp(0.0, 1.0) * 1000.0).round() as u16)
     } else {
-        300
+        // A non-finite confidence is an absent signal, not a middling one — it
+        // reports the same guess-level confidence as `fallback()` so it stays
+        // below `ACTIONABLE_FLOOR_MILLI` (#1484).
+        RULES_FALLBACK_MILLI
     }
 }
 fn intent_name(t: TaskType) -> &'static str {
@@ -136,5 +139,16 @@ mod tests {
                 .confidence_milli,
             RULES_FALLBACK_MILLI
         );
+    }
+    #[test]
+    fn non_finite_confidence_stays_below_the_actionable_floor() {
+        use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                milli(value) < ACTIONABLE_FLOOR_MILLI,
+                "a non-finite confidence is an absent signal, not an actionable one"
+            );
+        }
     }
 }

--- a/rust/src/server/call_tool/guarded.rs
+++ b/rust/src/server/call_tool/guarded.rs
@@ -127,8 +127,7 @@ impl LeanCtxServer {
             .and_then(|values| values.get("query").and_then(serde_json::Value::as_str))
             .or_else(|| {
                 args.and_then(|values| values.get("task").and_then(serde_json::Value::as_str))
-            })
-            .unwrap_or(name);
+            });
         let session_id = self.session.read().await.id.clone();
         let agent_id = match self.agent_id.read().await.clone() {
             Some(agent_id) => agent_id,

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -1170,7 +1170,7 @@ mod tests {
 
     #[test]
     fn no_model_installed_means_passthrough() {
-        use crate::core::triage::{rules::RuleTriageBackend, TaskAnalysisInput, TaskAnalyzer};
+        use crate::core::triage::{TaskAnalysisInput, TaskAnalyzer, rules::RuleTriageBackend};
 
         let profile = RuleTriageBackend
             .analyze(&TaskAnalysisInput::default())

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -523,13 +523,19 @@ fn try_load_graph(project_root: &str) -> Option<crate::core::graph_provider::Ope
 
 /// Determines the output-filtering aggressiveness from a task profile.
 pub fn triage_filter_level(profile: &crate::core::triage::profile::TaskProfileLocal) -> u8 {
-    if profile.confidence_milli < 300 {
-        0
-    } else if profile.context_need_milli < 300 {
-        2
-    } else {
-        u8::from(profile.context_need_milli < 600)
+    use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+    // An unset context need means "unknown", never "needs no context".
+    if profile.confidence_milli < ACTIONABLE_FLOOR_MILLI || profile.context_need_milli == 0 {
+        return 0;
     }
+    // Level 2 removes declarations and leaves output that parses but no longer
+    // means what it says (#1484). Nothing in a rules-derived profile is precise
+    // enough to justify that: `confidence_milli` measures how sure the intent
+    // classification is, not how much information loss the output tolerates.
+    // The level stays reachable through `apply_triage_filter` for callers that
+    // ask for it, and should return here again only once a model backend can
+    // supply the prediction.
+    u8::from(profile.context_need_milli < 600)
 }
 
 /// Filters output according to the task profile and selected triage level.
@@ -1148,14 +1154,29 @@ mod tests {
 
     #[test]
     fn triage_filter_level_selects_expected_level() {
-        for (confidence, context_need, expected) in
-            [(200, 200, 0), (500, 200, 2), (500, 450, 1), (500, 700, 0)]
-        {
+        for (confidence, context_need, expected) in [
+            (200, 200, 0),
+            (500, 200, 1),
+            (500, 450, 1),
+            (500, 700, 0),
+            (500, 0, 0),
+        ] {
             assert_eq!(
                 triage_filter_level(&test_profile(confidence, context_need)),
                 expected
             );
         }
+    }
+
+    #[test]
+    fn no_model_installed_means_passthrough() {
+        use crate::core::triage::{rules::RuleTriageBackend, TaskAnalysisInput, TaskAnalyzer};
+
+        let profile = RuleTriageBackend
+            .analyze(&TaskAnalysisInput::default())
+            .unwrap()
+            .profile;
+        assert_eq!(triage_filter_level(&profile), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1484.

`0f86871a` made the triage filter's line removal **visible** (elision markers) and **escapable** (lossless bypasses), but did not change the level itself. Every installation still filters at level 2 — the most aggressive setting — on practically every call. This PR stops level 2 from being *derived* at all. It stays implemented in `apply_triage_filter` for callers that pass it explicitly; nothing derives it from a profile until a model backend can supply that prediction.

Two defects each turn an *absent* signal into a decision to discard content, and a third leaves the thresholds unbound.

**1. The classified text is not a task text.** `guarded.rs` resolved it as `args["query"] ?? args["task"] ?? name`. Most `ctx_*` tools carry neither argument — `ctx_read` takes `path` — so the tool *name* was classified as the user's task. `decision_loop_runtime.rs` then built `format!("{tool_name}: {query}")`, yielding `"ctx_read: ctx_read"`, which classifies as mechanical/standard → SingleFile → `context_need_milli = 250` → level 2, deterministically, on nearly every call. Because that string is never empty, `rules::fallback()` was unreachable on this path — so analyses aiming at `fallback()` were aiming at a function the server never called.

**2. A low `context_need_milli` meant "discard the most".** It expresses how *broad* a task is, not how much information loss its output tolerates. `TaskProfileLocal::default()` leaves it at `0`, which means "unknown" — not "needs no context". The same inversion produced an off-by-one: `rules::fallback()` reported `confidence_milli: 300` while the passthrough guard tested `< 300`, so the fallback missed its own guard by one.

**3. Three unbound thresholds.** `is_high_confidence` (`>= 850`), `is_low_confidence` (`< 500`), and a literal `300` in `triage_filter_level`. Nothing tied them together.

Measured with `lean-ctx model status` reporting "No models installed" — the rules backend is the only reachable path, as `DEFAULT_TRIAGE_MODEL_URL` returns 404:

| scope | scope_base | level before |
|---|---|---|
| SingleFile | 250 | **2** |
| MultiFile | 500 | 1 |
| CrossModule | 750 | 0 |
| ProjectWide | 900 | 0 |

### Commits

| Commit | Change |
|---|---|
| `fix(triage): bind the rules fallback…` | `ACTIONABLE_FLOOR_MILLI = 300` and `RULES_FALLBACK_MILLI = 200` in `core::triage::confidence`; `rules::fallback()` reports the constant in both profile and hypothesis |
| `fix(triage): never derive filter level 2…` | `triage_filter_level` returns only 0 or 1; `context_need_milli == 0` forces passthrough |
| `style(triage): rustfmt…` | formatting of the guard test's import |
| `fix(triage): stop classifying the tool name…` | `on_tool_start`/`on_tool_start_inner` take `query: Option<&str>`; `None` reaches `rules::fallback()` with an empty query, while `TaskSpine::create_envelope` still receives the tool name so envelope identity is unaffected |
| `fix(triage): bind the non-finite confidence fallback…` | `milli()`'s NaN/infinity arm returned a literal `300` — exactly `ACTIONABLE_FLOOR_MILLI`, so an absent signal counted as actionable. Now `RULES_FALLBACK_MILLI` |
| `test(triage): bind the ingress task-text extraction…` | end-to-end regression test (see below) |
| `test(shell)` | one CI repair unrelated to #1484 — see *Notes for reviewers* |

Keying level 2 on high confidence was considered and rejected: `is_high_confidence` is `>= 850`, and `lean-ctx scenario triage` reports 950 for *"fix the authentication bug in src/auth.rs"* — a well-classified SingleFile task at `context_need = 250`. That variant would have preserved the harshest filter for precisely the calls that carry a real `query`.

Both fixes are needed. Change 1 alone would leave those same calls classifying as SingleFile → 250 → level 2; change 2 alone would keep feeding the classifier a tool name.

## Test plan

- [ ] `cd rust && cargo test -- --test-threads=1` (the suite shares process-global state; CI serializes it too)
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd rust && cargo fmt --check`
- [x] If cookbook/packages changed: relevant `npm test` / build steps — n/a, no cookbook or package changes

> **Every failing check on this PR also fails on `main` — see #1496 and #1497.** Both were verified on a clean checkout of `d2ffd9787` with no local changes, and none of the affected files appear in this diff.
>
> | Failing job | Cause |
> |---|---|
> | Clippy, Embed SDK | #1496 — ten Clippy errors from lints new in Rust 1.98.0 |
> | Test (ubuntu/windows), Coverage, Benchmarks | #1496 — `unused import: persistence::*` in `core/shadow/runtime_tests.rs`, now a hard error |
> | Python SDK, SDK Conformance | #1497 — both point at `clients/python`, archived in `106f90446` |
>
> The `main` run `32392749871` looked greener only because its test-profile cache still held a pre-1.98 artifact; any PR touching `rust/src` invalidates it and surfaces the error. This PR is blocked on #1496 and #1497, not on its own content.

Two boxes deserve a precise word rather than a tick, so here is exactly what was run.

**Tests.** `cargo test --lib` passes 10461/10462; the single failure is `cli::value_report::tests::test_cli_reads_disk`, a pre-existing parallel-isolation flake that passes on its own with `--test-threads=1`. On the rebased head the scoped suites were re-run and are green (`triage` 52 passed / 1 ignored, `decision_loop` 13 passed). The fully serialized run across all ~50 integration binaries takes far longer locally than in CI and was still going when this PR was opened — CI will settle it.

**Clippy.** `--all-targets` on the main crate reports pre-existing `clippy::unwrap_used` findings throughout the existing test code, none of them from this PR. What CI gates for this crate is `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines` (ci.yml:183) — and that job is currently red on `main` too, independently of this branch: Rust 1.98.0 (2026-08-18) added `manual_is_variant_and`, `map_or_identity` and `chunks_exact_to_as_chunks`, which fire ten times in existing code (`edit_snapshot.rs:175`, `relevance_tracker.rs:335`, `budget_tracker.rs:78`, `events.rs:251`, `response_optimizer.rs:423`, `html_crush.rs:798`, `embedding_quant.rs:90/91/117/118`). None are in this diff, and none are touched here — reported separately rather than folded into this PR. `cargo fmt --check` (ci.yml:231) and the LOC gate (ci.yml:187) are clean.

Beyond the checklist, the behaviour change was measured **on the installed binary**, since the level is applied inside the running server and the unit tests cannot observe it:

- `lean-ctx scenario triage` → confidences 950, 425, 450, 460, 425 — **unchanged**. This changes which level those profiles select, not how they are classified.
- Real MCP calls now return complete output with no `(level 2)` elision footer. Before the fix, a `ctx_context` call returned nothing but `[lean-ctx: 15 lines filtered by triage (level 2)]`; after it, the full body comes through.

## Notes for reviewers

**Relationship to `d2ffd97` (#1492/#1493).** Rebased on top of it; the two are complementary and there is no overlap in intent. #1493 makes `apply_triage_filter` return the original when the keep set comes out empty — a safety net for the case where level 2 is passed explicitly and removes everything. This PR works one layer earlier: no profile *derives* level 2 in the first place, so on the rules backend that net should not need to catch anything. #1492's `mode="full"` bypass is likewise orthogonal — it exempts one contract from filtering, while this changes which level every other call selects.

**Risk areas / edge cases.** `on_tool_start` changes signature (`&str` → `Option<&str>`), which surfaces every caller as a compile error; each was fixed by wrapping in `Some(…)`, never by reintroducing a tool-name fallback. `TaskSpine::create_envelope` deliberately keeps receiving the tool name in the `None` case, so envelope identity is unchanged. A model backend may legitimately report `context_need_milli == 0`, which now means "unknown" and yields passthrough — conservative, and moot while no model ships.

**The regression test is adversarially checked.** `decision_loop_integration_simple_read` previously asserted only that `intent` and `task_class` were non-empty — which the classified tool name satisfies too, so reinstating `.unwrap_or(name)` left the whole suite green. It now reads the recorded profile and asserts the rules-fallback confidence plus filter level 0. With the fallback reinstated it fails with `left: 300, right: 200`. `no_model_installed_means_passthrough` is the long-term guard: it fails if either constant moves to the wrong side of the other, which is exactly what happened here.

**One commit repairs CI breakage that predates this PR**, separable on request: `test(shell)` — `shell_allowlist/tests.rs` stood at 1565 lines against the LOC gate's 1500 (ci.yml:187). `08c391b7` had trimmed that file below the gate; `3aae8096` pushed it back over with the #1488/#1489 tests. Those move to `function_def_tests.rs`, following the `#[path]` submodule pattern the file already uses for `comment_strip` / `substitution` / `powershell`. No test content changed; all five still run.

**Backwards compatibility.** No public API changes. `on_tool_start` is crate-internal. Output filtering becomes *less* aggressive, never more: calls that filtered at level 2 now filter at level 1 — boilerplate goes, declarations stay — or pass through unfiltered when the profile carries no usable signal. Determinism (#498) is preserved: the change alters which lines survive, and adds no timestamp, counter or random element to any output body.

**Docs updated.** None in this PR. The design write-up backing it is kept out of the diff deliberately; happy to add it under `docs/specs/` if you would like it in-tree.

**Explicit non-goals.** The missing ONNX model (`DEFAULT_TRIAGE_MODEL_URL` → 404, no `models` release) is worth its own issue. So is the deeper question of whether output filtering should key off `context_need_milli` at all — it conflates task breadth with tolerance for information loss, but changing that is a redesign, not a fix.
