### PR TITLE
fix(pi-lean-ctx): resolve config.json directly under PI_CODING_AGENT_DIR

### DIFF
--- a/packages/pi-lean-ctx/extensions/config.ts
+++ b/packages/pi-lean-ctx/extensions/config.ts
@@ -102,8 +102,25 @@ export interface ResolvedPiConfig {
 /** Absolute path to the Pi override file (Pi's per-extension config convention).
  *  Respects `PI_CODING_AGENT_DIR` when set (#930). */
 export function piConfigPath(): string {
-  const piHome = process.env.PI_CODING_AGENT_DIR || resolve(homedir(), ".pi");
-  return resolve(piHome, "agent", "extensions", "pi-lean-ctx", "config.json");
+  if (process.env.PI_CODING_AGENT_DIR) {
+    const primary = resolve(
+      process.env.PI_CODING_AGENT_DIR,
+      "extensions",
+      "pi-lean-ctx",
+      "config.json",
+    );
+    if (existsSync(primary)) return primary;
+    const fallback = resolve(
+      process.env.PI_CODING_AGENT_DIR,
+      "agent",
+      "extensions",
+      "pi-lean-ctx",
+      "config.json",
+    );
+    if (existsSync(fallback)) return fallback;
+    return primary;
+  }
+  return resolve(homedir(), ".pi", "agent", "extensions", "pi-lean-ctx", "config.json");
 }
 
 function envFlag(name: string): boolean {

--- a/packages/pi-lean-ctx/test/config.test.ts
+++ b/packages/pi-lean-ctx/test/config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   loadPiConfig,
+  piConfigPath,
   REPLACEABLE_BUILTIN_TOOLS,
   resolveRouteShell,
   resolveSuppressedBuiltins,
@@ -125,5 +126,23 @@ describe("loadPiConfig tool-profile mapping", () => {
     expect(cfg.toolProfile).toBe("power");
     // …but the pre-existing engine env var is left untouched.
     expect(cfg.forwardedEnv.LEAN_CTX_TOOL_PROFILE).toBeUndefined();
+  });
+});
+
+describe("piConfigPath", () => {
+  const AGENT_DIR_KEY = "PI_CODING_AGENT_DIR";
+
+  afterEach(() => {
+    delete process.env[AGENT_DIR_KEY];
+  });
+
+  it("resolves under ~/.pi/agent/extensions when PI_CODING_AGENT_DIR is unset", () => {
+    delete process.env[AGENT_DIR_KEY];
+    expect(piConfigPath()).toContain(".pi/agent/extensions/pi-lean-ctx/config.json");
+  });
+
+  it("resolves directly under PI_CODING_AGENT_DIR/extensions when set", () => {
+    process.env[AGENT_DIR_KEY] = "/tmp/custom-pi-agent";
+    expect(piConfigPath()).toBe("/tmp/custom-pi-agent/extensions/pi-lean-ctx/config.json");
   });
 });


### PR DESCRIPTION
Fixes #1506

### Summary of Changes

1. **Fix `piConfigPath` resolution with `PI_CODING_AGENT_DIR`:** Under Pi's specification, `PI_CODING_AGENT_DIR` defines the agent directory itself (equivalent to `~/.pi/agent`), not the parent `.pi` folder. Appending `/agent` causes `pi-lean-ctx` to search `<PI_CODING_AGENT_DIR>/agent/extensions/pi-lean-ctx/config.json` instead of `<PI_CODING_AGENT_DIR>/extensions/pi-lean-ctx/config.json`.
2. **Backward Compatibility Fallback:** Primary lookup resolves directly under `extensions/pi-lean-ctx/config.json`, with a fallback checking `agent/extensions/pi-lean-ctx/config.json` if present.
3. **Unit Tests:** Adds test coverage in `packages/pi-lean-ctx/test/config.test.ts` for both default and custom `PI_CODING_AGENT_DIR` paths.