### PR TITLE
MES-1609 Preserve structured verdicts for auto-detached shell jobs

### DIFF
--- a/rust/src/core/archive.rs
+++ b/rust/src/core/archive.rs
@@ -91,10 +91,29 @@ pub fn should_archive(content: &str) -> bool {
 const MAX_ARCHIVE_SIZE: usize = 10 * 1024 * 1024; // 10 MB
 
 pub fn store(tool: &str, command: &str, content: &str, session_id: Option<&str>) -> Option<String> {
+    store_with_result(tool, command, content, session_id).map(|result| result.id)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchiveStoreResult {
+    pub id: String,
+    pub captured_chars: usize,
+    pub archived_chars: usize,
+    pub truncated: bool,
+}
+
+pub fn store_with_result(
+    tool: &str,
+    command: &str,
+    content: &str,
+    session_id: Option<&str>,
+) -> Option<ArchiveStoreResult> {
     if !is_enabled() || content.is_empty() {
         return None;
     }
 
+    let captured_chars = content.chars().count();
+    let truncated = content.len() > MAX_ARCHIVE_SIZE;
     let content = if content.len() > MAX_ARCHIVE_SIZE {
         &content[..content.floor_char_boundary(MAX_ARCHIVE_SIZE)]
     } else {
@@ -102,11 +121,17 @@ pub fn store(tool: &str, command: &str, content: &str, session_id: Option<&str>)
     };
 
     let id = compute_id(content);
+    let result = ArchiveStoreResult {
+        id: id.clone(),
+        captured_chars,
+        archived_chars: content.chars().count(),
+        truncated,
+    };
     let c_path = content_path(&id);
 
     // Fast path: content already archived (idempotent, no race)
     if c_path.exists() {
-        return Some(id);
+        return Some(result);
     }
 
     let dir = entry_dir(&id);
@@ -128,7 +153,7 @@ pub fn store(tool: &str, command: &str, content: &str, session_id: Option<&str>)
         let _ = std::fs::remove_file(&tmp_path);
         // Another process may have won the race — check if content is there now
         if c_path.exists() {
-            return Some(id);
+            return Some(result);
         }
         return None;
     }
@@ -158,7 +183,7 @@ pub fn store(tool: &str, command: &str, content: &str, session_id: Option<&str>)
 
     super::archive_fts::index_entry(&id, tool, command, content);
 
-    Some(id)
+    Some(result)
 }
 
 pub fn retrieve(id: &str) -> Option<String> {

--- a/rust/src/core/archive_fts.rs
+++ b/rust/src/core/archive_fts.rs
@@ -4,8 +4,30 @@ use std::sync::Mutex;
 
 use super::data_dir::lean_ctx_data_dir;
 
-static DB: std::sync::LazyLock<Mutex<Option<Connection>>> =
-    std::sync::LazyLock::new(|| Mutex::new(open_db()));
+struct CachedConnection {
+    path: PathBuf,
+    connection: Option<Connection>,
+}
+
+impl CachedConnection {
+    fn new() -> Self {
+        let path = db_path();
+        let connection = open_db_at(&path);
+        Self { path, connection }
+    }
+
+    fn current(&mut self) -> Option<&Connection> {
+        let path = db_path();
+        if path != self.path {
+            self.connection = open_db_at(&path);
+            self.path = path;
+        }
+        self.connection.as_ref()
+    }
+}
+
+static DB: std::sync::LazyLock<Mutex<CachedConnection>> =
+    std::sync::LazyLock::new(|| Mutex::new(CachedConnection::new()));
 
 /// Default maximum on-disk size for the archive FTS database. Overridable via
 /// `LEAN_CTX_ARCHIVE_DB_MAX_MB`. Without enforcement this DB grew unbounded
@@ -65,8 +87,13 @@ fn wal_bytes() -> u64 {
 /// Mirrors the retry strategy in `property_graph::CodeGraph::open` (#1409).
 const DB_OPEN_MAX_ATTEMPTS: u32 = 8;
 
+#[cfg(test)]
 fn open_db() -> Option<Connection> {
     let path = db_path();
+    open_db_at(&path)
+}
+
+fn open_db_at(path: &std::path::Path) -> Option<Connection> {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -135,8 +162,10 @@ fn is_transient_sqlite_error(e: &rusqlite::Error) -> bool {
 }
 
 pub fn index_entry(archive_id: &str, tool: &str, command: &str, content: &str) {
-    let guard = DB.lock().ok();
-    let Some(conn) = guard.as_ref().and_then(|g| g.as_ref()) else {
+    let Some(mut guard) = DB.lock().ok() else {
+        return;
+    };
+    let Some(conn) = guard.current() else {
         return;
     };
 
@@ -234,8 +263,8 @@ fn enforce_cap_locked(conn: &Connection) {
 /// Public entry point to enforce the archive DB size cap on demand (e.g. from
 /// idle maintenance or `doctor`). Returns the resulting size in bytes.
 pub fn enforce_cap() -> u64 {
-    if let Ok(guard) = DB.lock()
-        && let Some(conn) = guard.as_ref()
+    if let Ok(mut guard) = DB.lock()
+        && let Some(conn) = guard.current()
     {
         enforce_cap_locked(conn);
     }
@@ -243,8 +272,10 @@ pub fn enforce_cap() -> u64 {
 }
 
 pub fn remove_entry(archive_id: &str) {
-    let guard = DB.lock().ok();
-    let Some(conn) = guard.as_ref().and_then(|g| g.as_ref()) else {
+    let Some(mut guard) = DB.lock().ok() else {
+        return;
+    };
+    let Some(conn) = guard.current() else {
         return;
     };
     let _ = conn.execute(
@@ -267,8 +298,10 @@ pub struct FtsResult {
 }
 
 pub fn search(query: &str, limit: usize) -> Vec<FtsResult> {
-    let guard = DB.lock().ok();
-    let Some(conn) = guard.as_ref().and_then(|g| g.as_ref()) else {
+    let Some(mut guard) = DB.lock().ok() else {
+        return Vec::new();
+    };
+    let Some(conn) = guard.current() else {
         return Vec::new();
     };
 
@@ -297,8 +330,10 @@ pub fn search(query: &str, limit: usize) -> Vec<FtsResult> {
 }
 
 pub fn entry_count() -> usize {
-    let guard = DB.lock().ok();
-    let Some(conn) = guard.as_ref().and_then(|g| g.as_ref()) else {
+    let Some(mut guard) = DB.lock().ok() else {
+        return 0;
+    };
+    let Some(conn) = guard.current() else {
         return 0;
     };
     conn.query_row("SELECT COUNT(*) FROM archive_meta", [], |row| {
@@ -311,10 +346,23 @@ pub fn entry_count() -> usize {
 pub mod tests {
     use super::*;
 
+    struct EnvGuard(Option<std::ffi::OsString>);
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.0 {
+                crate::test_env::set_var("LEAN_CTX_DATA_DIR", previous);
+            } else {
+                crate::test_env::remove_var("LEAN_CTX_DATA_DIR");
+            }
+        }
+    }
+
     #[test]
     fn fts_roundtrip() {
         let _lock = crate::core::data_dir::test_env_lock();
         let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard(std::env::var_os("LEAN_CTX_DATA_DIR"));
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", tmp.path());
 
         // Force re-open by directly testing open_db
@@ -343,6 +391,7 @@ pub mod tests {
     fn open_db_bounds_the_wal() {
         let _lock = crate::core::data_dir::test_env_lock();
         let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard(std::env::var_os("LEAN_CTX_DATA_DIR"));
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", tmp.path());
 
         let conn = open_db().expect("should open");
@@ -359,5 +408,46 @@ pub mod tests {
             .query_row("PRAGMA wal_autocheckpoint;", [], |row| row.get(0))
             .unwrap();
         assert_eq!(autocheckpoint, 1000);
+    }
+
+    #[test]
+    fn cached_connection_tracks_the_active_data_dir() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let original_path = db_path();
+        let _env = EnvGuard(std::env::var_os("LEAN_CTX_DATA_DIR"));
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", first.path());
+        index_entry(
+            "mes1609_first",
+            "ctx_shell",
+            "first",
+            "mes1609_fts_first_only",
+        );
+        assert_eq!(
+            search("mes1609_fts_first_only", 10)[0].archive_id,
+            "mes1609_first"
+        );
+
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", second.path());
+        index_entry(
+            "mes1609_second",
+            "ctx_shell",
+            "second",
+            "mes1609_fts_second_only",
+        );
+        assert_eq!(
+            search("mes1609_fts_second_only", 10)[0].archive_id,
+            "mes1609_second"
+        );
+        assert!(search("mes1609_fts_first_only", 10).is_empty());
+
+        crate::test_env::set_var(
+            "LEAN_CTX_DATA_DIR",
+            original_path.parent().unwrap().parent().unwrap(),
+        );
+        assert!(search("mes1609_fts_first_only", 10).is_empty());
+        assert!(search("mes1609_fts_second_only", 10).is_empty());
     }
 }

--- a/rust/src/core/policy/runtime.rs
+++ b/rust/src/core/policy/runtime.rs
@@ -196,12 +196,42 @@ pub fn reload() {
     w.active = loaded;
 }
 
-/// Test hook: force the active policy without touching disk.
 #[cfg(test)]
-pub fn set_active_for_test(resolved: Option<ResolvedPolicy>) {
+fn set_active_for_test(resolved: Option<ResolvedPolicy>) {
     let mut w = cache().write().expect("policy cache poisoned");
     w.loaded = true;
     w.active = resolved.map(|r| Arc::new(ActivePolicy::from_resolved(r)));
+}
+
+/// Process-wide test override held under a shared lock for its whole lifetime.
+#[cfg(test)]
+pub struct TestPolicyOverride {
+    previous: Option<ResolvedPolicy>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl TestPolicyOverride {
+    pub fn set(resolved: Option<ResolvedPolicy>) -> Self {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        let lock = LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = active().map(|active| active.resolved.clone());
+        set_active_for_test(resolved);
+        Self {
+            previous,
+            _lock: lock,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestPolicyOverride {
+    fn drop(&mut self) {
+        set_active_for_test(self.previous.take());
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/server/background_shell.rs
+++ b/rust/src/server/background_shell.rs
@@ -241,6 +241,11 @@ fn remove(id: &str) {
         .remove(id);
 }
 
+#[cfg(all(test, not(windows)))]
+pub(crate) fn remove_for_test(id: &str) {
+    remove(id);
+}
+
 pub fn status(id: &str) -> Option<JobState> {
     let jobs = JOBS
         .lock()

--- a/rust/src/server/call_tool/outcome.rs
+++ b/rust/src/server/call_tool/outcome.rs
@@ -18,25 +18,36 @@ pub(in crate::server) fn roots_list_failure_is_permanent(e: &rmcp::ServiceError)
 /// (GitHub #389): a failing or blocked command sets `isError: true` and a
 /// `structuredContent` payload (`{"exitCode": N}` / `{"blocked": true}`), so
 /// clients no longer have to regex-parse the `[exit:N]` text footer. The text
-/// content is identical in both cases — only the metadata changes. A non-zero
-/// exit that is *not* a failure (#1090/#1086) carries neither, because some
-/// clients render `structuredContent` in place of the text (#1127).
+/// content is identical in both cases — only the metadata changes. Managed
+/// background jobs always carry structured state, code and a short summary;
+/// ordinary non-zero exits that are *not* failures (#1090/#1086) still carry
+/// neither, because some clients render `structuredContent` in place of text
+/// (#1127).
 pub(in crate::server) fn finalize_call_result(
     result_text: &str,
     shell_outcome: Option<crate::server::tool_trait::ShellOutcome>,
 ) -> CallToolResult {
     let mut result = CallToolResult::success(vec![ContentBlock::text(result_text.to_owned())]);
-    if let Some(outcome) = shell_outcome
-        && is_shell_error(outcome, result_text)
-    {
-        // #1127: clients that understand `structuredContent` render it *instead
-        // of* the text block on a non-error result, so attaching it to a benign
-        // non-zero exit (exit 1 with output per #1090, exit 124 with partial
-        // output per #1086) hid the command output completely — `ls /nope` came
-        // back as a bare `{"exitCode":1}`. Only errors, whose text the client
-        // surfaces separately, carry the structured payload.
-        result.is_error = Some(true);
-        result.structured_content = outcome.structured();
+    if let Some(outcome) = shell_outcome {
+        if matches!(
+            outcome,
+            crate::server::tool_trait::ShellOutcome::Background(_)
+                | crate::server::tool_trait::ShellOutcome::BackgroundLookupError(_)
+        ) {
+            result.structured_content = outcome.structured();
+            if outcome.is_error() {
+                result.is_error = Some(true);
+            }
+        } else if is_shell_error(&outcome, result_text) {
+            // #1127: clients that understand `structuredContent` render it *instead
+            // of* the text block on a non-error result, so attaching it to a benign
+            // non-zero exit (exit 1 with output per #1090, exit 124 with partial
+            // output per #1086) hid the command output completely — `ls /nope` came
+            // back as a bare `{"exitCode":1}`. Only errors, whose text the client
+            // surfaces separately, carry the structured payload.
+            result.is_error = Some(true);
+            result.structured_content = outcome.structured();
+        }
     }
     result
 }
@@ -46,7 +57,7 @@ pub(in crate::server) fn finalize_call_result(
 /// as a success with a timeout marker, not as an error. The partial output is
 /// often enough to answer the question; treating it as a failure causes the
 /// client to retry the entire pipeline.
-fn is_shell_error(outcome: crate::server::tool_trait::ShellOutcome, output: &str) -> bool {
+fn is_shell_error(outcome: &crate::server::tool_trait::ShellOutcome, output: &str) -> bool {
     match outcome {
         crate::server::tool_trait::ShellOutcome::Exit(0) => false,
         crate::server::tool_trait::ShellOutcome::Exit(1) => {
@@ -59,6 +70,8 @@ fn is_shell_error(outcome: crate::server::tool_trait::ShellOutcome, output: &str
             crate::server::execute::output_before_timeout_marker(output).is_none_or(str::is_empty)
         }
         crate::server::tool_trait::ShellOutcome::Exit(_)
-        | crate::server::tool_trait::ShellOutcome::Blocked => true,
+        | crate::server::tool_trait::ShellOutcome::Blocked
+        | crate::server::tool_trait::ShellOutcome::BackgroundLookupError(_) => true,
+        crate::server::tool_trait::ShellOutcome::Background(outcome) => outcome.is_error,
     }
 }

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -17,7 +17,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
 ) -> Result<CallToolResult, ErrorData> {
     let tool_start = std::time::Instant::now();
     let shadow_auto_record = config.shadow.enabled && config.shadow.auto_record;
-    let (mut result_text, tool_saved_tokens, mut shell_outcome, content_blocks) =
+    let (mut result_text, tool_saved_tokens, shell_outcome, content_blocks) =
         match server.dispatch_tool(name, args, minimal).await {
             Ok(tuple) => tuple,
             Err(e) => {
@@ -56,6 +56,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
                 return Err(e);
             }
         };
+    let mut shell_outcome = shell_outcome;
 
     let task_profile = {
         let session = server.session.read().await;
@@ -294,7 +295,9 @@ pub(in crate::server) async fn dispatch_and_post_process(
     // the firewall must NOT replace their content with a structural digest.
     // The output is still *archived* (so ctx_expand works), but stays inline.
     // `minimal` (no-overhead mode) skips even archiving.
-    let archive_hint = if background_status {
+    let archive_hint = if minimal {
+        None
+    } else if background_status {
         use crate::core::archive;
         let chars = result_text.chars().count();
         let lines = result_text.lines().count();
@@ -307,7 +310,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
             format!("{chars} chars, {lines} lines")
         };
         let mut stored_result = None;
-        if !minimal && archive::should_archive(&result_text) {
+        if archive::should_archive(&result_text) {
             let job_id = match shell_outcome.as_ref() {
                 Some(crate::server::tool_trait::ShellOutcome::Background(outcome)) => {
                     outcome.job_id.clone()
@@ -363,8 +366,6 @@ pub(in crate::server) async fn dispatch_and_post_process(
                 outcome.archived_chars = Some(stored.archived_chars);
             }
         }
-        None
-    } else if minimal {
         None
     } else {
         use crate::core::archive;

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -17,7 +17,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
 ) -> Result<CallToolResult, ErrorData> {
     let tool_start = std::time::Instant::now();
     let shadow_auto_record = config.shadow.enabled && config.shadow.auto_record;
-    let (mut result_text, tool_saved_tokens, shell_outcome, content_blocks) =
+    let (mut result_text, tool_saved_tokens, mut shell_outcome, content_blocks) =
         match server.dispatch_tool(name, args, minimal).await {
             Ok(tuple) => tuple,
             Err(e) => {
@@ -62,6 +62,9 @@ pub(in crate::server) async fn dispatch_and_post_process(
         crate::core::decision_loop_runtime::DecisionLoopRuntime::get_or_init()
             .profile_for_session(&session.id)
     };
+    let background_status = shell_outcome
+        .as_ref()
+        .is_some_and(crate::server::tool_trait::ShellOutcome::is_background_status);
     // #1484: respect lossless escape hatches — never triage when the caller
     // explicitly requested unfiltered output (raw, aggressiveness=0, fresh=true).
     // #1490: an explicit lines:N-M / anchored:N-M window is already an
@@ -87,7 +90,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false)
     });
-    if !triage_bypass {
+    if !background_status && !triage_bypass {
         result_text =
             apply_task_triage_filter(result_text, task_profile.as_ref(), &mut decision_context);
     }
@@ -105,7 +108,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
     // Image/binary content blocks: skip all post-processing, return directly.
     if let Some(blocks) = content_blocks {
         let mut result = CallToolResult::success(blocks);
-        if let Some(outcome) = shell_outcome
+        if let Some(outcome) = shell_outcome.as_ref()
             && outcome.is_error()
         {
             result.is_error = Some(true);
@@ -291,7 +294,77 @@ pub(in crate::server) async fn dispatch_and_post_process(
     // the firewall must NOT replace their content with a structural digest.
     // The output is still *archived* (so ctx_expand works), but stays inline.
     // `minimal` (no-overhead mode) skips even archiving.
-    let archive_hint = if minimal {
+    let archive_hint = if background_status {
+        use crate::core::archive;
+        let chars = result_text.chars().count();
+        let lines = result_text.lines().count();
+        let trimmed = result_text.trim();
+        let mut summary = if trimmed.is_empty() {
+            "no output".to_string()
+        } else if chars <= 512 {
+            trimmed.to_string()
+        } else {
+            format!("{chars} chars, {lines} lines")
+        };
+        let mut stored_result = None;
+        if !minimal && archive::should_archive(&result_text) {
+            let job_id = match shell_outcome.as_ref() {
+                Some(crate::server::tool_trait::ShellOutcome::Background(outcome)) => {
+                    outcome.job_id.clone()
+                }
+                _ => String::new(),
+            };
+            let session_id = server.session.read().await.id.clone();
+            let to_store = crate::core::redaction::redact_text_if_enabled(&result_text);
+            if let Some(stored) =
+                archive::store_with_result(name, &job_id, &to_store, Some(&session_id))
+            {
+                summary = if stored.truncated {
+                    format!(
+                        "{} captured chars, {} archived chars (archive truncated)",
+                        stored.captured_chars, stored.archived_chars
+                    )
+                } else {
+                    format!("{chars} chars, {lines} lines archived")
+                };
+                if !is_raw_shell {
+                    let archived = if stored.truncated {
+                        archive::retrieve(&stored.id).unwrap_or_default()
+                    } else {
+                        to_store.clone()
+                    };
+                    let tokens = crate::core::tokens::count_tokens(&archived);
+                    if crate::core::firewall::should_firewall(name, tokens, &config) {
+                        let digest = crate::core::firewall::summarize(
+                            &archived, &stored.id, name, tokens, &job_id,
+                        );
+                        result_text = if stored.truncated {
+                            format!(
+                                "[archive truncated: {} captured chars, {} archived chars; remainder unavailable]\n{digest}",
+                                stored.captured_chars, stored.archived_chars
+                            )
+                        } else {
+                            digest
+                        };
+                        firewalled = true;
+                    }
+                }
+                stored_result = Some(stored);
+            }
+        }
+        if let Some(crate::server::tool_trait::ShellOutcome::Background(outcome)) =
+            shell_outcome.as_mut()
+        {
+            outcome.summary = summary;
+            if let Some(stored) = stored_result {
+                outcome.archive_id = Some(stored.id);
+                outcome.archive_truncated = Some(stored.truncated);
+                outcome.captured_chars = Some(stored.captured_chars);
+                outcome.archived_chars = Some(stored.archived_chars);
+            }
+        }
+        None
+    } else if minimal {
         None
     } else {
         use crate::core::archive;
@@ -329,6 +402,11 @@ pub(in crate::server) async fn dispatch_and_post_process(
             None
         }
     };
+
+    if background_status && !triage_bypass && !is_raw_shell && !firewalled {
+        result_text =
+            apply_task_triage_filter(result_text, task_profile.as_ref(), &mut decision_context);
+    }
 
     let pre_compression = result_text.clone();
     // A firewalled result is already a compact digest — re-compressing it would mangle
@@ -838,6 +916,22 @@ pub(in crate::server) async fn dispatch_and_post_process(
     server
         .persist_shared_context_os(name, action.as_deref(), args)
         .await;
+
+    if let Some(crate::server::tool_trait::ShellOutcome::Background(outcome)) =
+        shell_outcome.as_ref()
+        && let Some(display) = &outcome.display
+    {
+        let mut rendered = display.header.clone();
+        if !result_text.trim().is_empty() {
+            rendered.push('\n');
+            rendered.push_str(&result_text);
+        }
+        if let Some(footer) = &display.footer {
+            rendered.push('\n');
+            rendered.push_str(footer);
+        }
+        result_text = rendered;
+    }
 
     let skip_checkpoint = minimal
         || matches!(

--- a/rust/src/server/call_tool/tests.rs
+++ b/rust/src/server/call_tool/tests.rs
@@ -4,7 +4,100 @@ use super::{finalize_call_result, roots_list_failure_is_permanent};
 
 mod shell_outcome_tests {
     use super::*;
-    use crate::server::tool_trait::ShellOutcome;
+    #[cfg(not(windows))]
+    use crate::server::call_tool::dispatch_and_post_process;
+    use crate::server::tool_trait::{McpTool, ShellOutcome, ToolContext};
+
+    #[cfg(not(windows))]
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    #[cfg(not(windows))]
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            crate::test_env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    #[cfg(not(windows))]
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                crate::test_env::set_var(self.key, previous);
+            } else {
+                crate::test_env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    struct ScopedPolicy {
+        _override: crate::core::policy::runtime::TestPolicyOverride,
+    }
+
+    #[cfg(not(windows))]
+    impl ScopedPolicy {
+        fn redacting(label: &str, pattern: &str) -> Self {
+            let mut redaction = std::collections::BTreeMap::new();
+            redaction.insert(label.to_string(), pattern.to_string());
+            Self {
+                _override: crate::core::policy::runtime::TestPolicyOverride::set(Some(
+                    crate::core::policy::ResolvedPolicy {
+                        name: "mes1609-test-policy".into(),
+                        version: "1.0.0".into(),
+                        description: "MES-1609 archive chokepoint regression".into(),
+                        chain: vec![],
+                        default_read_mode: None,
+                        allow_tools: None,
+                        deny_tools: vec![],
+                        max_context_tokens: None,
+                        audit_retention_days: None,
+                        redaction,
+                        filters: crate::core::policy::FilterRules {
+                            pii: Some("redact".into()),
+                            ..crate::core::policy::FilterRules::default()
+                        },
+                        egress: crate::core::policy::EgressRules::default(),
+                        routing: crate::core::policy::RoutingPolicyRules::default(),
+                        budgets: crate::core::policy::BudgetRules::default(),
+                    },
+                )),
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    struct BackgroundJobGuard {
+        job_id: String,
+    }
+
+    #[cfg(not(windows))]
+    impl BackgroundJobGuard {
+        fn new(job_id: String) -> Self {
+            Self { job_id }
+        }
+    }
+
+    #[cfg(not(windows))]
+    impl Drop for BackgroundJobGuard {
+        fn drop(&mut self) {
+            let _ = crate::server::background_shell::cancel(&self.job_id);
+            for _ in 0..120 {
+                if !matches!(
+                    crate::server::background_shell::status(&self.job_id),
+                    Some(crate::server::background_shell::JobState::Running { .. })
+                ) {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            crate::server::background_shell::remove_for_test(&self.job_id);
+        }
+    }
 
     fn text_of(result: &CallToolResult) -> String {
         result
@@ -13,6 +106,227 @@ mod shell_outcome_tests {
             .and_then(|c| c.as_text())
             .map(|t| t.text.clone())
             .unwrap_or_default()
+    }
+
+    #[cfg(not(windows))]
+    fn launched_job_guard(result: &CallToolResult) -> BackgroundJobGuard {
+        let structured_id = result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value["jobId"].as_str());
+        let text = text_of(result);
+        let text_id = text
+            .strip_prefix('[')
+            .and_then(|value| value.split_once(':'))
+            .and_then(|(_, value)| value.split_whitespace().next());
+        BackgroundJobGuard::new(
+            structured_id
+                .or(text_id)
+                .expect("background launch must expose a job id")
+                .to_string(),
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn auto_detached_result(command: &str) -> CallToolResult {
+        let detached = crate::server::background_shell::run_foreground_or_detach(
+            command.to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+            std::time::Duration::from_millis(10),
+            None,
+        );
+        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
+        else {
+            panic!("the reproduction must exercise the auto-detached path");
+        };
+        let _job = BackgroundJobGuard::new(job_id.clone());
+
+        let mut terminal = false;
+        for _ in 0..240 {
+            if matches!(
+                crate::server::background_shell::status(&job_id),
+                Some(
+                    crate::server::background_shell::JobState::Completed { .. }
+                        | crate::server::background_shell::JobState::Cancelled { .. }
+                )
+            ) {
+                terminal = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(
+            terminal,
+            "auto-detached child did not reach a terminal state"
+        );
+
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+        let output = crate::tools::registered::ctx_shell::CtxShellTool
+            .handle(&args, &ToolContext::default())
+            .expect("status must return a tool result");
+        finalize_call_result(&output.text, output.shell_outcome)
+    }
+
+    #[cfg(not(windows))]
+    async fn auto_detached_pipeline_result(command: &str) -> (CallToolResult, BackgroundJobGuard) {
+        let detached = crate::server::background_shell::run_foreground_or_detach(
+            command.to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(30_000),
+            std::time::Duration::from_millis(10),
+            None,
+        );
+        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
+        else {
+            panic!("the reproduction must exercise the auto-detached path");
+        };
+        let job = BackgroundJobGuard::new(job_id.clone());
+        for _ in 0..400 {
+            if matches!(
+                crate::server::background_shell::status(&job_id),
+                Some(crate::server::background_shell::JobState::Completed { .. })
+            ) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(matches!(
+            crate::server::background_shell::status(&job_id),
+            Some(crate::server::background_shell::JobState::Completed { .. })
+        ));
+        (
+            pipeline_background_status(&job_id, false, false, false).await,
+            job,
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn structured_of(result: &CallToolResult) -> &serde_json::Value {
+        result
+            .structured_content
+            .as_ref()
+            .expect("background status must expose structuredContent")
+    }
+
+    #[cfg(not(windows))]
+    fn auto_detached_running_result() -> CallToolResult {
+        let detached = crate::server::background_shell::run_foreground_or_detach(
+            "sleep 2 # MES1609_RUNNING_STATUS".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+            std::time::Duration::from_millis(10),
+            None,
+        );
+        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
+        else {
+            panic!("the reproduction must exercise the auto-detached path");
+        };
+        let _job = BackgroundJobGuard::new(job_id.clone());
+
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+        let output = crate::tools::registered::ctx_shell::CtxShellTool
+            .handle(&args, &ToolContext::default())
+            .expect("status must return a tool result");
+        finalize_call_result(&output.text, output.shell_outcome)
+    }
+
+    #[cfg(not(windows))]
+    fn shell_context() -> ToolContext {
+        let cwd = std::env::current_dir()
+            .expect("current directory")
+            .to_string_lossy()
+            .into_owned();
+        let mut session = crate::core::session::SessionState::new();
+        session.project_root = Some(cwd.clone());
+        session.shell_cwd = Some(cwd.clone());
+        ToolContext {
+            project_root: cwd,
+            session: Some(std::sync::Arc::new(tokio::sync::RwLock::new(session))),
+            ..ToolContext::default()
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn completed_background_job(command: &str) -> (String, BackgroundJobGuard) {
+        let job_id = crate::server::background_shell::start(
+            command.to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(30_000),
+        );
+        let job = BackgroundJobGuard::new(job_id.clone());
+        for _ in 0..400 {
+            if matches!(
+                crate::server::background_shell::status(&job_id),
+                Some(
+                    crate::server::background_shell::JobState::Completed { .. }
+                        | crate::server::background_shell::JobState::Cancelled { .. }
+                )
+            ) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(matches!(
+            crate::server::background_shell::status(&job_id),
+            Some(crate::server::background_shell::JobState::Completed { .. })
+        ));
+        (job_id, job)
+    }
+
+    #[cfg(not(windows))]
+    async fn pipeline_background_status(
+        job_id: &str,
+        minimal: bool,
+        raw: bool,
+        inline: bool,
+    ) -> CallToolResult {
+        let root = std::env::current_dir()
+            .expect("current directory")
+            .to_string_lossy()
+            .into_owned();
+        let server = crate::tools::LeanCtxServer::new_with_project_root(Some(&root));
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+        if raw {
+            args.insert("raw".to_string(), serde_json::json!(true));
+        }
+        if inline {
+            args.insert("inline".to_string(), serde_json::json!(true));
+        }
+        dispatch_and_post_process(
+            &server,
+            "ctx_shell",
+            Some(&args),
+            minimal,
+            crate::core::config::Config::load_arc(),
+            false,
+            None,
+            None,
+            format!("mes1609_pipeline_{job_id}"),
+            None,
+        )
+        .await
+        .expect("background status pipeline must succeed")
+    }
+
+    fn call_shell(
+        args: serde_json::Map<String, serde_json::Value>,
+        ctx: &ToolContext,
+    ) -> CallToolResult {
+        let output = crate::tools::registered::ctx_shell::CtxShellTool
+            .handle(&args, ctx)
+            .expect("ctx_shell must return a tool result");
+        finalize_call_result(&output.text, output.shell_outcome)
     }
 
     #[test]
@@ -75,6 +389,614 @@ mod shell_outcome_tests {
             r.is_error,
             Some(true),
             "exit 1 with no command output must set isError"
+        );
+    }
+
+    /// MES-1609: once a foreground command auto-detaches, its terminal
+    /// failure is a job verdict, not grep-like output that may use exit 1 as
+    /// data. The MCP result must therefore keep both state and exit code.
+    #[test]
+    #[cfg(not(windows))]
+    fn auto_detached_exit_1_is_a_structured_failed_job() {
+        let result = auto_detached_result("sleep 0.1; printf TAP_FAILURE; exit 1");
+
+        assert_eq!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("failed"));
+        assert_eq!(structured["exitCode"], serde_json::json!(1));
+        assert!(structured["jobId"].as_str().is_some());
+        assert!(
+            structured["summary"]
+                .as_str()
+                .is_some_and(|s| s.contains("TAP_FAILURE"))
+        );
+        assert!(text_of(&result).contains("TAP_FAILURE"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn auto_detached_exit_7_is_a_structured_failed_job() {
+        let result = auto_detached_result("sleep 0.1; exit 7");
+
+        assert_eq!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("failed"));
+        assert_eq!(structured["exitCode"], serde_json::json!(7));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn auto_detached_running_job_has_no_exit_code() {
+        let result = auto_detached_running_result();
+
+        assert_ne!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("running"));
+        assert!(structured["jobId"].as_str().is_some());
+        assert!(structured.get("exitCode").is_none());
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn auto_detached_cancel_returns_cancelled_exit_130_without_error() {
+        let detached = crate::server::background_shell::run_foreground_or_detach(
+            "sleep 2 # MES1609_CANCEL_STATUS".to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+            std::time::Duration::from_millis(10),
+            None,
+        );
+        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
+        else {
+            panic!("the reproduction must exercise the auto-detached path");
+        };
+        let _job = BackgroundJobGuard::new(job_id.clone());
+
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("cancel"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+        let output = crate::tools::registered::ctx_shell::CtxShellTool
+            .handle(&args, &ToolContext::default())
+            .expect("cancel must return a tool result");
+        let cancel_result = finalize_call_result(&output.text, output.shell_outcome);
+
+        assert_ne!(cancel_result.is_error, Some(true));
+        let mut cancelled = false;
+        for _ in 0..80 {
+            if matches!(
+                crate::server::background_shell::status(&job_id),
+                Some(crate::server::background_shell::JobState::Cancelled { .. })
+            ) {
+                cancelled = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(cancelled, "cancelled job did not reach a terminal state");
+
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        let output = crate::tools::registered::ctx_shell::CtxShellTool
+            .handle(&args, &ToolContext::default())
+            .expect("status must return a tool result");
+        let result = finalize_call_result(&output.text, output.shell_outcome);
+
+        assert_ne!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("cancelled"));
+        assert_eq!(structured["exitCode"], serde_json::json!(130));
+    }
+
+    #[test]
+    fn missing_cancel_is_a_success_ack_without_a_fabricated_terminal_state() {
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("cancel"));
+        args.insert(
+            "job_id".to_string(),
+            serde_json::json!("shell_mes1609_missing_cancel"),
+        );
+
+        let result = call_shell(args, &ToolContext::default());
+
+        assert_ne!(result.is_error, Some(true));
+        assert!(
+            result.structured_content.is_none(),
+            "an unknown terminal must not be fabricated: {:?}",
+            result.structured_content
+        );
+        assert!(text_of(&result).contains("already finished or cancelled"));
+    }
+
+    #[test]
+    fn missing_status_is_a_lookup_error_without_a_fabricated_lifecycle_state() {
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert(
+            "job_id".to_string(),
+            serde_json::json!("shell_mes1609_missing_status"),
+        );
+
+        let result = call_shell(args, &ToolContext::default());
+
+        assert_eq!(result.is_error, Some(true));
+        let structured = result
+            .structured_content
+            .as_ref()
+            .expect("missing status must expose a structured lookup error");
+        assert_eq!(
+            structured["jobId"],
+            serde_json::json!("shell_mes1609_missing_status")
+        );
+        assert_eq!(
+            structured["errorCode"],
+            serde_json::json!("background_job_not_found_or_expired")
+        );
+        assert!(structured["reason"].as_str().is_some());
+        assert!(structured.get("state").is_none());
+        assert!(structured.get("exitCode").is_none());
+        assert!(text_of(&result).contains("not found or expired"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn explicit_background_launch_ack_is_structured_running() {
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "command".to_string(),
+            serde_json::json!("sleep 2 # MES1609_EXPLICIT_LAUNCH"),
+        );
+        args.insert("run_in_background".to_string(), serde_json::json!(true));
+
+        let result = call_shell(args, &shell_context());
+
+        let _job = launched_job_guard(&result);
+        assert_ne!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("running"));
+        assert!(structured["jobId"].as_str().is_some());
+        assert!(structured.get("exitCode").is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn soft_cap_auto_detach_ack_is_structured_running() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _soft_cap = ScopedEnvVar::set("LEAN_CTX_SHELL_FG_CAP_MS", "10");
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "command".to_string(),
+            serde_json::json!("sleep 2 # MES1609_SOFT_CAP_LAUNCH"),
+        );
+
+        let result = call_shell(args, &shell_context());
+
+        let _job = launched_job_guard(&result);
+        assert_ne!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("running"));
+        assert!(structured["jobId"].as_str().is_some());
+        assert!(structured.get("exitCode").is_none());
+    }
+
+    /// MES-1609: a successful auto-detached child remains queryable after
+    /// the OS process exits and exposes an explicit terminal code 0.
+    #[test]
+    #[cfg(not(windows))]
+    fn auto_detached_exit_0_remains_queryable_as_completed() {
+        let result = auto_detached_result("sleep 0.1; printf LONG_OK");
+
+        assert_ne!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("completed"));
+        assert_eq!(structured["exitCode"], serde_json::json!(0));
+        assert!(structured["jobId"].as_str().is_some());
+        assert!(
+            structured["summary"]
+                .as_str()
+                .is_some_and(|s| s.contains("LONG_OK"))
+        );
+        assert!(text_of(&result).contains("LONG_OK"));
+    }
+
+    /// MES-1609: terminal output too large for an inline response is archived
+    /// before generic filtering can erase both the verdict and retrieval id.
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn auto_detached_large_output_keeps_summary_and_archive_id_inline() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let (result, _job) = auto_detached_pipeline_result("sleep 0.1; seq 1 50000").await;
+
+        assert_ne!(result.is_error, Some(true));
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("completed"));
+        assert_eq!(structured["exitCode"], serde_json::json!(0));
+        let archive_id = structured["archiveId"]
+            .as_str()
+            .expect("large terminal output must expose its archive id");
+        assert!(
+            structured["summary"]
+                .as_str()
+                .is_some_and(|s| s.contains("50000 lines"))
+        );
+        let text = text_of(&result);
+        assert!(text.contains(&format!("ctx_expand(id=\"{archive_id}\")")));
+        assert!(text.len() < 20_000, "large output was returned inline");
+        let archived = crate::core::archive::retrieve(archive_id)
+            .expect("archive id must resolve to the terminal output");
+        assert!(archived.starts_with("1\n2\n"));
+        assert!(archived.ends_with("49999\n50000\n"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn auto_detached_private_key_block_is_fully_redacted_before_archive() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let begin_marker = ["-----BEGIN ", "PRIVATE", " KEY-----"].concat();
+        let end_marker = ["-----END ", "PRIVATE", " KEY-----"].concat();
+        let command = format!(
+            "sleep 0.1; printf '%s\\n' '{begin_marker}'; \
+             yes MES1609_FAKE_KEY_BODY_0123456789 | head -n 2000; \
+             printf '%s\\n' '{end_marker}'; \
+             yes MES1609_SAFE_OUTPUT | head -n 2000"
+        );
+        let (result, _job) = auto_detached_pipeline_result(&command).await;
+
+        let archive_id = structured_of(&result)["archiveId"]
+            .as_str()
+            .expect("large redacted output must be archived");
+        let archived = crate::core::archive::retrieve(archive_id)
+            .expect("archive id must resolve to redacted output");
+        assert!(!archived.contains("BEGIN PRIVATE KEY"));
+        assert!(!archived.contains("END PRIVATE KEY"));
+        assert!(!archived.contains("MES1609_FAKE_KEY_BODY_0123456789"));
+        assert!(archived.contains("[REDACTED:Private key block]"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn oversized_background_archive_reports_truncation_and_exact_sizes() {
+        const ARCHIVE_LIMIT: usize = 10 * 1024 * 1024;
+        const CAPTURED: usize = ARCHIVE_LIMIT + 4096;
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _shell_cap = ScopedEnvVar::set("LCTX_MAX_SHELL_BYTES", (CAPTURED + 1024).to_string());
+        let (result, _job) = auto_detached_pipeline_result(&format!(
+            "sleep 0.1; head -c {CAPTURED} /dev/zero | tr '\\0' X"
+        ))
+        .await;
+
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("completed"));
+        assert_eq!(structured["exitCode"], serde_json::json!(0));
+        assert_eq!(structured["archiveTruncated"], serde_json::json!(true));
+        assert_eq!(structured["capturedChars"], serde_json::json!(CAPTURED));
+        assert_eq!(
+            structured["archivedChars"],
+            serde_json::json!(ARCHIVE_LIMIT)
+        );
+        let archive_id = structured["archiveId"]
+            .as_str()
+            .expect("oversized output must expose archiveId");
+        let archived = crate::core::archive::retrieve(archive_id)
+            .expect("truncated archive must remain retrievable");
+        assert_eq!(archived.len(), ARCHIVE_LIMIT);
+        assert!(text_of(&result).contains("archive truncated"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn background_status_pipeline_keeps_single_archive_and_structured_metadata() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let job_id = crate::server::background_shell::start(
+            "sleep 0.1; printf MES1609_PIPELINE; head -c 50000 /dev/zero | tr '\\000' P"
+                .to_string(),
+            ".".to_string(),
+            std::collections::HashMap::default(),
+            Some(10_000),
+        );
+        let _job = BackgroundJobGuard::new(job_id.clone());
+        for _ in 0..240 {
+            if matches!(
+                crate::server::background_shell::status(&job_id),
+                Some(crate::server::background_shell::JobState::Completed { .. })
+            ) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(matches!(
+            crate::server::background_shell::status(&job_id),
+            Some(crate::server::background_shell::JobState::Completed { .. })
+        ));
+
+        let root = std::env::current_dir()
+            .expect("current directory")
+            .to_string_lossy()
+            .into_owned();
+        let server = crate::tools::LeanCtxServer::new_with_project_root(Some(&root));
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+        let result = dispatch_and_post_process(
+            &server,
+            "ctx_shell",
+            Some(&args),
+            false,
+            crate::core::config::Config::load_arc(),
+            false,
+            None,
+            None,
+            "mes1609_pipeline".to_string(),
+            None,
+        )
+        .await
+        .expect("background status pipeline must succeed");
+
+        let structured = structured_of(&result);
+        assert_eq!(structured["state"], serde_json::json!("completed"));
+        assert_eq!(structured["exitCode"], serde_json::json!(0));
+        let archive_id = structured["archiveId"]
+            .as_str()
+            .expect("pipeline must retain archiveId");
+        assert_eq!(crate::core::archive::list_entries(None).len(), 1);
+        assert_eq!(
+            text_of(&result)
+                .matches(&format!("ctx_expand(id=\"{archive_id}\")"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn background_status_triage_filters_display_after_preserving_complete_archive() {
+        const KEEP: &str = "MES1609_TRIAGE_KEEP";
+        const DROP: &str = "MES1609_TRIAGE_DROP";
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _archive_threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let _firewall_threshold = ScopedEnvVar::set("LEAN_CTX_EPHEMERAL_MIN_TOKENS", "100000");
+        let (job_id, _job) = completed_background_job(&format!(
+            "printf 'coding coding_fix {KEEP}\\n'; yes '// unrelated {DROP}' | head -n 80"
+        ));
+
+        let root = std::env::current_dir()
+            .expect("current directory")
+            .to_string_lossy()
+            .into_owned();
+        let server = crate::tools::LeanCtxServer::new_with_project_root(Some(&root));
+        let session_id = server.session.read().await.id.clone();
+        let context = crate::core::decision_loop_runtime::DecisionLoopRuntime::get_or_init()
+            .on_tool_start(
+                "ctx_shell",
+                "fix a coding bug in one file",
+                &session_id,
+                "mes1609-triage-test",
+            );
+        let profile = crate::core::decision_loop_runtime::DecisionLoopRuntime::get_or_init()
+            .profile_for_session(&session_id)
+            .expect("task profile must be remembered for the pipeline session");
+        assert!(crate::server::context_gate::triage_filter_level(&profile) > 0);
+
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+        let result = dispatch_and_post_process(
+            &server,
+            "ctx_shell",
+            Some(&args),
+            false,
+            crate::core::config::Config::load_arc(),
+            false,
+            None,
+            None,
+            "mes1609_triage_pipeline".to_string(),
+            Some(context),
+        )
+        .await
+        .expect("background status pipeline must succeed");
+
+        let structured = structured_of(&result);
+        let archive_id = structured["archiveId"]
+            .as_str()
+            .expect("normal background status must retain its complete archive");
+        let archived = crate::core::archive::retrieve(archive_id)
+            .expect("structured archiveId must remain retrievable");
+        assert!(archived.contains(KEEP));
+        assert!(archived.contains(DROP));
+        let displayed = text_of(&result);
+        assert!(displayed.contains(KEEP));
+        assert!(!displayed.contains(DROP));
+        assert!(!displayed.contains("ctx_expand"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn background_archive_is_created_after_policy_and_input_filters() {
+        const POLICY_PATTERN: &str = "MES1609_POLICY_PII_7F3A9C2E";
+        const TEST_CARD: &str = "4111111111111111";
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let _policy = ScopedPolicy::redacting("mes1609_policy", POLICY_PATTERN);
+        let (job_id, _job) = completed_background_job(&format!(
+            "printf '%s\\n%s\\n' '{POLICY_PATTERN}' '{TEST_CARD}'; \
+             yes MES1609_POLICY_SAFE | head -n 3000"
+        ));
+
+        let result = pipeline_background_status(&job_id, false, false, false).await;
+
+        let structured = structured_of(&result);
+        let archive_id = structured["archiveId"]
+            .as_str()
+            .expect("secured background output must be archived");
+        assert_eq!(crate::core::archive::list_entries(None).len(), 1);
+        assert_eq!(structured["archiveTruncated"], serde_json::json!(false));
+        let archived = crate::core::archive::retrieve(archive_id)
+            .expect("structured archiveId must remain retrievable");
+        assert!(!archived.contains(POLICY_PATTERN));
+        assert!(!archived.contains(TEST_CARD));
+        assert!(archived.contains("[REDACTED:mes1609_policy]"));
+        assert!(archived.contains("[REDACTED:card]"));
+        assert!(!text_of(&result).contains(POLICY_PATTERN));
+        assert!(
+            crate::core::audit_trail::load_recent(10)
+                .iter()
+                .any(|entry| {
+                    entry.tool == "ctx_shell"
+                        && entry.role == "mes1609-test-policy"
+                        && matches!(
+                            entry.event_type,
+                            crate::core::audit_trail::AuditEventType::SecretDetected
+                        )
+                })
+        );
+        assert!(
+            result.meta.is_some(),
+            "finalize metadata must still be present"
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn scoped_policy_overrides_serialize_parallel_mutation() {
+        let (first_ready_tx, first_ready_rx) = std::sync::mpsc::channel();
+        let (release_first_tx, release_first_rx) = std::sync::mpsc::channel();
+        let first = std::thread::spawn(move || {
+            let _policy = ScopedPolicy::redacting("mes1609_first", "MES1609_FIRST");
+            first_ready_tx.send(()).expect("signal first override");
+            release_first_rx.recv().expect("release first override");
+        });
+        first_ready_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("first override must become active");
+
+        let (second_started_tx, second_started_rx) = std::sync::mpsc::channel();
+        let (second_acquired_tx, second_acquired_rx) = std::sync::mpsc::channel();
+        let (release_second_tx, release_second_rx) = std::sync::mpsc::channel();
+        let second = std::thread::spawn(move || {
+            second_started_tx.send(()).expect("signal second thread");
+            let _policy = ScopedPolicy::redacting("mes1609_second", "MES1609_SECOND");
+            second_acquired_tx.send(()).expect("signal second override");
+            release_second_rx.recv().expect("release second override");
+        });
+        second_started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("second thread must start");
+        let overlapped = second_acquired_rx
+            .recv_timeout(std::time::Duration::from_millis(500))
+            .is_ok();
+
+        release_first_tx.send(()).expect("release first thread");
+        first.join().expect("first policy thread");
+        if !overlapped {
+            second_acquired_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("second override must acquire after first drops");
+        }
+        release_second_tx.send(()).expect("release second thread");
+        second.join().expect("second policy thread");
+
+        assert!(!overlapped, "policy test overrides must not overlap");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn raw_background_status_keeps_secured_output_inline_without_digest() {
+        const RAW_SIZE: usize = 50_000;
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let _turn_limit = ScopedEnvVar::set("LEAN_CTX_TURN_FRESH_LIMIT", "0");
+        let (job_id, _job) = completed_background_job(&format!(
+            "printf MES1609_RAW_HEAD; head -c {RAW_SIZE} /dev/zero | tr '\\000' R; printf MES1609_RAW_TAIL"
+        ));
+
+        let result = pipeline_background_status(&job_id, false, true, false).await;
+
+        let text = text_of(&result);
+        assert!(text.len() >= RAW_SIZE);
+        assert!(text.contains("MES1609_RAW_HEAD"));
+        assert!(text.contains("MES1609_RAW_TAIL"));
+        assert!(!text.contains("ctx_expand"));
+        assert!(!text.contains("[Archived:"));
+        assert!(structured_of(&result)["archiveId"].as_str().is_some());
+        assert_eq!(crate::core::archive::list_entries(None).len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn minimal_background_status_does_not_archive_or_digest() {
+        const MINIMAL_SIZE: usize = 50_000;
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let (job_id, _job) = completed_background_job(&format!(
+            "printf MES1609_MINIMAL_HEAD; head -c {MINIMAL_SIZE} /dev/zero | tr '\\000' M; printf MES1609_MINIMAL_TAIL"
+        ));
+
+        let result = pipeline_background_status(&job_id, true, false, false).await;
+
+        let structured = structured_of(&result);
+        assert!(structured.get("archiveId").is_none());
+        assert_eq!(crate::core::archive::list_entries(None).len(), 0);
+        let text = text_of(&result);
+        assert!(!text.contains("ctx_expand"));
+        assert!(!text.contains("[Archived:"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(not(windows))]
+    async fn inline_background_status_under_limit_stays_inline_without_digest() {
+        const INLINE_SIZE: usize = 5_000;
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let _turn_limit = ScopedEnvVar::set("LEAN_CTX_TURN_FRESH_LIMIT", "0");
+        let (job_id, _job) = completed_background_job(&format!(
+            "printf MES1609_INLINE_HEAD; head -c {INLINE_SIZE} /dev/zero | tr '\\000' I; printf MES1609_INLINE_TAIL"
+        ));
+
+        let result = pipeline_background_status(&job_id, false, false, true).await;
+
+        let text = text_of(&result);
+        assert!(text.len() >= INLINE_SIZE);
+        assert!(text.contains("MES1609_INLINE_HEAD"));
+        assert!(text.contains("MES1609_INLINE_TAIL"));
+        assert!(!text.contains("ctx_expand"));
+        assert!(!text.contains("[Archived:"));
+        assert!(structured_of(&result)["archiveId"].as_str().is_some());
+        assert_eq!(crate::core::archive::list_entries(None).len(), 1);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn background_status_handler_does_not_write_archives_before_pipeline() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let _archive = ScopedEnvVar::set("LEAN_CTX_ARCHIVE", "1");
+        let _threshold = ScopedEnvVar::set("LEAN_CTX_ARCHIVE_THRESHOLD", "1");
+        let (job_id, _job) = completed_background_job(
+            "printf MES1609_HANDLER_ONLY; head -c 50000 /dev/zero | tr '\\000' H",
+        );
+        let mut args = serde_json::Map::new();
+        args.insert("background_action".to_string(), serde_json::json!("status"));
+        args.insert("job_id".to_string(), serde_json::json!(job_id));
+
+        let output = crate::tools::registered::ctx_shell::CtxShellTool
+            .handle(&args, &ToolContext::default())
+            .expect("status handler must succeed without pipeline I/O");
+
+        assert_eq!(crate::core::archive::list_entries(None).len(), 0);
+        assert!(
+            output
+                .shell_outcome
+                .and_then(|outcome| outcome.structured())
+                .is_some_and(|structured| structured.get("archiveId").is_none())
         );
     }
 

--- a/rust/src/server/policy_guard.rs
+++ b/rust/src/server/policy_guard.rs
@@ -243,30 +243,30 @@ mod tests {
     fn global_active_drives_allow_and_redaction() {
         let mut redaction = BTreeMap::new();
         redaction.insert("employee_id".to_string(), r"EMP-\d{4}".to_string());
-        runtime::set_active_for_test(Some(ResolvedPolicy {
-            name: "itest".into(),
-            version: "1.0.0".into(),
-            description: "t".into(),
-            chain: vec![],
-            default_read_mode: Some("map".into()),
-            allow_tools: None,
-            deny_tools: vec!["ctx_url_read".into()],
-            max_context_tokens: Some(5_000),
-            audit_retention_days: None,
-            redaction,
-            filters: crate::core::policy::FilterRules::default(),
-            egress: crate::core::policy::EgressRules::default(),
-            routing: crate::core::policy::RoutingPolicyRules::default(),
-            budgets: crate::core::policy::BudgetRules::default(),
-        }));
+        {
+            let _policy = runtime::TestPolicyOverride::set(Some(ResolvedPolicy {
+                name: "itest".into(),
+                version: "1.0.0".into(),
+                description: "t".into(),
+                chain: vec![],
+                default_read_mode: Some("map".into()),
+                allow_tools: None,
+                deny_tools: vec!["ctx_url_read".into()],
+                max_context_tokens: Some(5_000),
+                audit_retention_days: None,
+                redaction,
+                filters: crate::core::policy::FilterRules::default(),
+                egress: crate::core::policy::EgressRules::default(),
+                routing: crate::core::policy::RoutingPolicyRules::default(),
+                budgets: crate::core::policy::BudgetRules::default(),
+            }));
 
-        assert!(!check_tool_access("ctx_read").blocked);
-        assert!(!check_tool_access("ctx_session").blocked, "exempt tool");
-        let (out, hits) = redact_result("contact EMP-1234 today");
-        assert_eq!(hits, 1);
-        assert!(out.contains("[REDACTED:employee_id]"));
-
-        runtime::set_active_for_test(None);
+            assert!(!check_tool_access("ctx_read").blocked);
+            assert!(!check_tool_access("ctx_session").blocked, "exempt tool");
+            let (out, hits) = redact_result("contact EMP-1234 today");
+            assert_eq!(hits, 1);
+            assert!(out.contains("[REDACTED:employee_id]"));
+        }
         assert!(
             !check_tool_access("ctx_url_read").blocked,
             "no pack → allow"

--- a/rust/src/server/tool_trait.rs
+++ b/rust/src/server/tool_trait.rs
@@ -2,38 +2,144 @@ use rmcp::ErrorData;
 use rmcp::model::{ContentBlock, Tool};
 use serde_json::{Map, Value};
 
+/// Stable states exposed by `ctx_shell(background_action="status")`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundJobState {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl BackgroundJobState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundDisplay {
+    pub header: String,
+    pub footer: Option<String>,
+}
+
+/// Protocol metadata that must survive output compression and archiving.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundShellOutcome {
+    pub state: BackgroundJobState,
+    pub exit_code: Option<i32>,
+    pub job_id: String,
+    pub archive_id: Option<String>,
+    pub archive_truncated: Option<bool>,
+    pub captured_chars: Option<usize>,
+    pub archived_chars: Option<usize>,
+    pub summary: String,
+    pub is_error: bool,
+    pub display: Option<BackgroundDisplay>,
+}
+
+/// A background job lookup failed without evidence of a lifecycle state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundLookupError {
+    pub job_id: String,
+    pub code: String,
+    pub reason: String,
+}
+
 /// Outcome of a shell execution, carried alongside the rendered text so the
 /// MCP dispatch layer can surface failures in protocol metadata instead of
 /// only as an `[exit:N]` text footer (GitHub #389: clients had no programmatic
 /// way to detect ctx_shell failures and resorted to fragile regex matching).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ShellOutcome {
     /// The command ran; carries its real exit code (0 = success).
     Exit(i32),
     /// The command never ran (allowlist/validation rejection, or a
     /// precondition failure such as an unreadable/oversized input file).
     Blocked,
+    /// A managed background job status. Unlike a foreground `Exit(1)`, a
+    /// terminal failed job is never reclassified as grep-like result data.
+    Background(BackgroundShellOutcome),
+    /// The requested background job is unknown or its retained verdict expired.
+    BackgroundLookupError(BackgroundLookupError),
 }
 
 impl ShellOutcome {
     /// Whether this outcome must be reported as a tool error (`isError: true`).
-    pub fn is_error(self) -> bool {
+    pub fn is_error(&self) -> bool {
         match self {
-            ShellOutcome::Exit(code) => code != 0,
-            ShellOutcome::Blocked => true,
+            ShellOutcome::Exit(code) => *code != 0,
+            ShellOutcome::Blocked | ShellOutcome::BackgroundLookupError(_) => true,
+            ShellOutcome::Background(outcome) => outcome.is_error,
         }
     }
 
     /// Structured payload for `CallToolResult.structuredContent`, so guards
-    /// can read `exitCode`/`blocked` instead of parsing output text. Success
-    /// (exit 0) intentionally returns `None` — the happy path stays
-    /// token-neutral for clients that render structured content.
-    pub fn structured(self) -> Option<serde_json::Value> {
+    /// can read state/exit/archive data instead of parsing output text.
+    /// Ordinary foreground success (exit 0) stays token-neutral; background
+    /// status always remains structured because clients may filter its text.
+    pub fn structured(&self) -> Option<serde_json::Value> {
         match self {
             ShellOutcome::Exit(0) => None,
             ShellOutcome::Exit(code) => Some(serde_json::json!({ "exitCode": code })),
             ShellOutcome::Blocked => Some(serde_json::json!({ "blocked": true })),
+            ShellOutcome::Background(outcome) => {
+                let mut fields = serde_json::Map::new();
+                fields.insert(
+                    "state".to_string(),
+                    serde_json::json!(outcome.state.as_str()),
+                );
+                fields.insert("jobId".to_string(), serde_json::json!(outcome.job_id));
+                fields.insert("summary".to_string(), serde_json::json!(outcome.summary));
+                if let Some(exit_code) = outcome.exit_code {
+                    fields.insert("exitCode".to_string(), serde_json::json!(exit_code));
+                }
+                if let Some(archive_id) = &outcome.archive_id {
+                    fields.insert("archiveId".to_string(), serde_json::json!(archive_id));
+                }
+                if let Some(archive_truncated) = outcome.archive_truncated {
+                    fields.insert(
+                        "archiveTruncated".to_string(),
+                        serde_json::json!(archive_truncated),
+                    );
+                }
+                if let Some(captured_chars) = outcome.captured_chars {
+                    fields.insert(
+                        "capturedChars".to_string(),
+                        serde_json::json!(captured_chars),
+                    );
+                }
+                if let Some(archived_chars) = outcome.archived_chars {
+                    fields.insert(
+                        "archivedChars".to_string(),
+                        serde_json::json!(archived_chars),
+                    );
+                }
+                Some(serde_json::Value::Object(fields))
+            }
+            ShellOutcome::BackgroundLookupError(error) => Some(serde_json::json!({
+                "jobId": error.job_id,
+                "errorCode": error.code,
+                "reason": error.reason,
+            })),
         }
+    }
+
+    /// Whether this is a status body that the common pipeline must secure,
+    /// archive and render before delivery.
+    pub fn is_background_status(&self) -> bool {
+        matches!(
+            self,
+            ShellOutcome::Background(BackgroundShellOutcome {
+                display: Some(_),
+                ..
+            })
+        )
     }
 }
 

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -5,9 +5,12 @@ use serde_json::{Map, Value, json};
 use crate::core::ocla::cache_types::{CacheKeyBuilder, ShellCommandKey};
 
 use crate::server::tool_trait::{
-    McpTool, ShellOutcome, ToolContext, ToolOutput, get_bool, get_int, get_str,
+    BackgroundJobState, BackgroundShellOutcome, McpTool, ShellOutcome, ToolContext, ToolOutput,
+    get_bool, get_int, get_str,
 };
 use crate::tool_defs::tool_def;
+
+use super::ctx_shell_background::{format_background_state, redact_shell_output_secrets};
 
 pub struct CtxShellTool;
 
@@ -35,7 +38,7 @@ impl McpTool for CtxShellTool {
                     "timeout_ms": { "type": "integer", "description": "Job lifetime in ms (max 3600000) — NOT the inline wait. A command still running at the ~110s foreground cap detaches to a pollable shell_* job and keeps running up to timeout_ms. Overridden by LEAN_CTX_SHELL_TIMEOUT_MS." },
                     "env": { "type": "object", "description": "Extra env vars", "additionalProperties": { "type": "string" } },
                     "run_in_background": { "type": "boolean", "description": "Detach immediately and return a job id. The command keeps timeout_ms; poll or cancel with background_action and job_id." },
-                    "background_action": { "type": "string", "enum": ["status", "cancel"], "description": "Inspect or cancel a background ctx_shell job." },
+                    "background_action": { "type": "string", "enum": ["status", "cancel"], "description": "Inspect or cancel a background ctx_shell job. During the documented 5-minute retention window, status exposes the real terminal state and exit code; bounded retention may evict older jobs under pressure, after which status returns a structured lookup error." },
                     "job_id": { "type": "string", "description": "Job id returned by run_in_background." }
                 }
             }),
@@ -70,9 +73,9 @@ impl McpTool for CtxShellTool {
                     ));
                 }
             };
-            let (text, exit_code) = format_background_state(&id, is_cancel, state);
+            let (text, outcome) = format_background_state(&id, is_cancel, state);
             return Ok(ToolOutput {
-                shell_outcome: Some(ShellOutcome::Exit(exit_code)),
+                shell_outcome: Some(outcome),
                 content_blocks: None,
                 ..ToolOutput::simple(text)
             });
@@ -325,7 +328,18 @@ impl McpTool for CtxShellTool {
                     "background"
                 };
                 return Ok(ToolOutput {
-                    shell_outcome: Some(ShellOutcome::Exit(0)),
+                    shell_outcome: Some(ShellOutcome::Background(BackgroundShellOutcome {
+                        state: BackgroundJobState::Running,
+                        exit_code: None,
+                        job_id: job_id.clone(),
+                        archive_id: None,
+                        archive_truncated: None,
+                        captured_chars: None,
+                        archived_chars: None,
+                        summary: format!("{mode} job started"),
+                        is_error: false,
+                        display: None,
+                    })),
                     content_blocks: None,
                     ..ToolOutput::simple(format!(
                         "[{mode}:{job_id} started — use ctx_shell(background_action=\"status\", job_id=\"{job_id}\") to poll or background_action=\"cancel\" to stop it]"
@@ -380,7 +394,18 @@ impl McpTool for CtxShellTool {
                     } => (output, exit_code),
                     crate::server::background_shell::ForegroundResult::Detached { job_id } => {
                         return Ok(ToolOutput {
-                            shell_outcome: Some(ShellOutcome::Exit(0)),
+                            shell_outcome: Some(ShellOutcome::Background(BackgroundShellOutcome {
+                                state: BackgroundJobState::Running,
+                                exit_code: None,
+                                job_id: job_id.clone(),
+                                archive_id: None,
+                                archive_truncated: None,
+                                captured_chars: None,
+                                archived_chars: None,
+                                summary: "auto-detached job is still running".to_string(),
+                                is_error: false,
+                                display: None,
+                            })),
                             content_blocks: None,
                             // #1173: a detach is not a failure — the command is
                             // alive and its output is recoverable, so say so
@@ -743,90 +768,6 @@ fn warn_shell_secret_paths(command: &str) {
             }
         }
     }
-}
-
-/// Render a `background_action` result.
-///
-/// #1246: a caller-requested cancel is a success, not a tool failure. The
-/// process's own SIGINT exit (130) used to be reported as the tool's exit code,
-/// which tripped the client's failure hook and told the agent to fix something
-/// it had deliberately done. A cancel therefore never reports a non-zero exit,
-/// and is idempotent: cancelling an already-cancelled, already-finished or
-/// already-pruned job is equally benign. The first cancel also gets its own
-/// wording so it cannot be mistaken for a status poll that did nothing.
-fn format_background_state(
-    id: &str,
-    is_cancel: bool,
-    state: Option<crate::server::background_shell::JobState>,
-) -> (String, i32) {
-    use crate::server::background_shell::JobState;
-    let Some(state) = state else {
-        return if is_cancel {
-            (
-                format!("[background:{id} not found — already finished or cancelled]"),
-                0,
-            )
-        } else {
-            (format!("[background:{id} not found]"), 1)
-        };
-    };
-    match state {
-        JobState::Running { output } => {
-            // #1217: show the captured-so-far output so a poll of a
-            // long-running job reflects progress instead of a bare
-            // "running" with no signal of whether it is advancing.
-            let body = redact_shell_output_secrets(&output);
-            let head = if is_cancel {
-                format!(
-                    "[background:{id} cancel requested — job is stopping; poll status for the final output]"
-                )
-            } else {
-                format!("[background:{id} running]")
-            };
-            if body.trim().is_empty() {
-                (head, 0)
-            } else {
-                (format!("{head}\n{body}"), 0)
-            }
-        }
-        JobState::Completed { output, exit_code } => (
-            format!(
-                "[background:{id} completed]\n{}{}",
-                redact_shell_output_secrets(&output),
-                if exit_code == 0 {
-                    String::new()
-                } else {
-                    format!("\n[exit:{exit_code}]")
-                }
-            ),
-            if is_cancel { 0 } else { exit_code },
-        ),
-        JobState::Cancelled { output } => (
-            format!(
-                "[background:{id} cancelled]\n{}\n[cancelled: {id}, exit 130]",
-                redact_shell_output_secrets(&output)
-            ),
-            0,
-        ),
-    }
-}
-
-fn redact_shell_output_secrets(output: &str) -> String {
-    let cfg = crate::core::config::Config::load();
-    if !cfg.secret_detection.enabled {
-        return output.to_string();
-    }
-    let (redacted, matches) =
-        crate::core::secret_detection::scan_and_redact(output, &cfg.secret_detection);
-    if !matches.is_empty() {
-        let names: Vec<&str> = matches.iter().map(|m| m.pattern_name).collect();
-        tracing::warn!(
-            "[SHELL SECRET REDACTION] {} secret(s) redacted from shell output: {}",
-            matches.len(),
-            names.join(", ")
-        );
-    }
-    redacted
 }
 
 /// The Codex MCP client abandons a tool call after five minutes. A Cargo test
@@ -1198,7 +1139,16 @@ mod tests {
         resolve_effective_cwd, shell_access_denial, should_auto_background,
     };
     use crate::server::background_shell::JobState;
-    use crate::server::tool_trait::{McpTool, ShellOutcome, ToolContext};
+    use crate::server::tool_trait::{
+        BackgroundJobState, BackgroundShellOutcome, McpTool, ShellOutcome, ToolContext,
+    };
+
+    fn background(outcome: ShellOutcome) -> BackgroundShellOutcome {
+        let ShellOutcome::Background(outcome) = outcome else {
+            panic!("expected a background outcome");
+        };
+        outcome
+    }
 
     /// #1246: a cancel must never come back as a tool error, and must not read
     /// like a status poll that did nothing.
@@ -1207,41 +1157,81 @@ mod tests {
         let running = JobState::Running {
             output: String::new(),
         };
-        let (text, exit) = format_background_state("shell_x", true, Some(running.clone()));
-        assert_eq!(exit, 0);
-        assert!(text.contains("cancel requested"), "{text}");
+        let (text, outcome) = format_background_state("shell_x", true, Some(running.clone()));
+        let outcome = background(outcome);
+        assert!(!outcome.is_error);
+        assert_eq!(outcome.state, BackgroundJobState::Running);
+        assert_eq!(outcome.exit_code, None);
+        assert!(text.is_empty());
+        assert!(
+            outcome
+                .display
+                .as_ref()
+                .is_some_and(|display| display.header.contains("cancel requested"))
+        );
 
         // A status poll of the same state keeps the old wording.
-        let (text, exit) = format_background_state("shell_x", false, Some(running));
-        assert_eq!(exit, 0);
-        assert!(text.contains("[background:shell_x running]"), "{text}");
+        let (text, outcome) = format_background_state("shell_x", false, Some(running));
+        let outcome = background(outcome);
+        assert!(!outcome.is_error);
+        assert_eq!(outcome.state, BackgroundJobState::Running);
+        assert!(text.is_empty());
+        assert!(
+            outcome
+                .display
+                .as_ref()
+                .is_some_and(|display| display.header == "[background:shell_x running]")
+        );
 
-        // The terminal state is data, not an error — no exit 130 leaks out.
-        let (text, exit) = format_background_state(
+        // The terminal child code is data; the requested cancel remains a
+        // successful tool action even though structuredContent keeps 130.
+        let (text, outcome) = format_background_state(
             "shell_x",
             true,
             Some(JobState::Cancelled {
                 output: "[cancelled: command stopped on request]".to_string(),
             }),
         );
-        assert_eq!(exit, 0);
-        assert!(text.contains("[cancelled: shell_x, exit 130]"), "{text}");
+        let outcome = background(outcome);
+        assert!(!outcome.is_error);
+        assert_eq!(outcome.state, BackgroundJobState::Cancelled);
+        assert_eq!(outcome.exit_code, Some(130));
+        assert!(text.contains("[cancelled: command stopped on request]"));
+        assert!(
+            outcome
+                .display
+                .as_ref()
+                .and_then(|display| display.footer.as_deref())
+                .is_some_and(|footer| footer == "[cancelled: shell_x, exit 130]")
+        );
 
         // Idempotent: already finished, or finished and pruned.
         let finished = JobState::Completed {
             output: "boom".to_string(),
             exit_code: 1,
         };
-        assert_eq!(
-            format_background_state("shell_x", true, Some(finished.clone())).1,
-            0
-        );
-        assert_eq!(
-            format_background_state("shell_x", false, Some(finished)).1,
-            1
-        );
-        assert_eq!(format_background_state("shell_x", true, None).1, 0);
-        assert_eq!(format_background_state("shell_x", false, None).1, 1);
+        let cancelled_finished =
+            background(format_background_state("shell_x", true, Some(finished.clone())).1);
+        assert!(!cancelled_finished.is_error);
+        assert_eq!(cancelled_finished.state, BackgroundJobState::Failed);
+        assert_eq!(cancelled_finished.exit_code, Some(1));
+
+        let polled_finished =
+            background(format_background_state("shell_x", false, Some(finished)).1);
+        assert!(polled_finished.is_error);
+        assert_eq!(polled_finished.state, BackgroundJobState::Failed);
+        assert_eq!(polled_finished.exit_code, Some(1));
+
+        let missing_cancel = format_background_state("shell_x", true, None).1;
+        assert!(!missing_cancel.is_error());
+        assert_eq!(missing_cancel, ShellOutcome::Exit(0));
+
+        let missing_status = format_background_state("shell_x", false, None).1;
+        assert!(missing_status.is_error());
+        assert!(matches!(
+            missing_status,
+            ShellOutcome::BackgroundLookupError(_)
+        ));
     }
 
     #[test]

--- a/rust/src/tools/registered/ctx_shell_background.rs
+++ b/rust/src/tools/registered/ctx_shell_background.rs
@@ -1,0 +1,152 @@
+use crate::server::background_shell::JobState;
+use crate::server::tool_trait::{
+    BackgroundDisplay, BackgroundJobState, BackgroundLookupError, BackgroundShellOutcome,
+    ShellOutcome,
+};
+
+/// Render a `background_action` result.
+///
+/// #1246: a caller-requested cancel is a success, not a tool failure. The
+/// process's own SIGINT exit (130) used to be reported as the tool's exit code,
+/// which tripped the client's failure hook and told the agent to fix something
+/// it had deliberately done. A cancel therefore never reports a non-zero exit,
+/// and is idempotent: cancelling an already-cancelled, already-finished or
+/// already-pruned job is equally benign. The first cancel also gets its own
+/// wording so it cannot be mistaken for a status poll that did nothing.
+pub(super) fn format_background_state(
+    id: &str,
+    is_cancel: bool,
+    state: Option<JobState>,
+) -> (String, ShellOutcome) {
+    let Some(state) = state else {
+        return if is_cancel {
+            (
+                format!("[background:{id} not found — already finished or cancelled]"),
+                ShellOutcome::Exit(0),
+            )
+        } else {
+            (
+                format!("[background:{id} not found or expired]"),
+                ShellOutcome::BackgroundLookupError(BackgroundLookupError {
+                    job_id: id.to_string(),
+                    code: "background_job_not_found_or_expired".to_string(),
+                    reason: "job not found or retained terminal verdict expired".to_string(),
+                }),
+            )
+        };
+    };
+    match state {
+        JobState::Running { output } => {
+            // #1217: show the captured-so-far output so a poll of a
+            // long-running job reflects progress instead of a bare
+            // "running" with no signal of whether it is advancing.
+            let output = redact_shell_output_secrets(&output);
+            let head = if is_cancel {
+                format!(
+                    "[background:{id} cancel requested — job is stopping; poll status for the final output]"
+                )
+            } else {
+                format!("[background:{id} running]")
+            };
+            (
+                output.clone(),
+                ShellOutcome::Background(BackgroundShellOutcome {
+                    state: BackgroundJobState::Running,
+                    exit_code: None,
+                    job_id: id.to_string(),
+                    archive_id: None,
+                    archive_truncated: None,
+                    captured_chars: None,
+                    archived_chars: None,
+                    summary: summarize_background_output(&output),
+                    is_error: false,
+                    display: Some(BackgroundDisplay {
+                        header: head,
+                        footer: None,
+                    }),
+                }),
+            )
+        }
+        JobState::Completed { output, exit_code } => {
+            let output = redact_shell_output_secrets(&output);
+            let state = if exit_code == 0 {
+                BackgroundJobState::Completed
+            } else {
+                BackgroundJobState::Failed
+            };
+            let head = format!("[background:{id} {}, exit {exit_code}]", state.as_str());
+            let footer = (exit_code != 0).then(|| format!("[exit:{exit_code}]"));
+            (
+                output.clone(),
+                ShellOutcome::Background(BackgroundShellOutcome {
+                    state,
+                    exit_code: Some(exit_code),
+                    job_id: id.to_string(),
+                    archive_id: None,
+                    archive_truncated: None,
+                    captured_chars: None,
+                    archived_chars: None,
+                    summary: summarize_background_output(&output),
+                    is_error: !is_cancel && exit_code != 0,
+                    display: Some(BackgroundDisplay {
+                        header: head,
+                        footer,
+                    }),
+                }),
+            )
+        }
+        JobState::Cancelled { output } => {
+            let output = redact_shell_output_secrets(&output);
+            (
+                output.clone(),
+                ShellOutcome::Background(BackgroundShellOutcome {
+                    state: BackgroundJobState::Cancelled,
+                    exit_code: Some(130),
+                    job_id: id.to_string(),
+                    archive_id: None,
+                    archive_truncated: None,
+                    captured_chars: None,
+                    archived_chars: None,
+                    summary: summarize_background_output(&output),
+                    is_error: false,
+                    display: Some(BackgroundDisplay {
+                        header: format!("[background:{id} cancelled, exit 130]"),
+                        footer: Some(format!("[cancelled: {id}, exit 130]")),
+                    }),
+                }),
+            )
+        }
+    }
+}
+
+fn summarize_background_output(output: &str) -> String {
+    let chars = output.chars().count();
+    let lines = output.lines().count();
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        "no output".to_string()
+    } else if chars <= 512 {
+        trimmed.to_string()
+    } else {
+        format!("{chars} chars, {lines} lines")
+    }
+}
+
+pub(super) fn redact_shell_output_secrets(output: &str) -> String {
+    let output = crate::core::redaction::redact_text_if_enabled(output);
+    let cfg = crate::core::config::Config::load();
+    if !cfg.secret_detection.enabled {
+        return output;
+    }
+    let (redacted, matches) =
+        crate::core::secret_detection::scan_and_redact(&output, &cfg.secret_detection);
+    if !matches.is_empty() {
+        let names: Vec<&str> = matches.iter().map(|m| m.pattern_name).collect();
+        tracing::warn!(
+            "[SHELL SECRET REDACTION] {} secret(s) redacted from shell output: {}",
+            matches.len(),
+            names.join(", ")
+        );
+    }
+    redacted
+}

--- a/rust/src/tools/registered/mod.rs
+++ b/rust/src/tools/registered/mod.rs
@@ -71,6 +71,7 @@ pub mod ctx_semantic_search;
 pub mod ctx_session;
 pub mod ctx_share;
 pub mod ctx_shell;
+mod ctx_shell_background;
 pub mod ctx_skillify;
 pub mod ctx_smart_read;
 pub mod ctx_smells;

--- a/rust/tests/solution_integration.rs
+++ b/rust/tests/solution_integration.rs
@@ -16,6 +16,16 @@ use lean_ctx::core::solution_types::{SolutionDecisionKind, SolutionStatus};
 use lean_ctx::instructions::solution::solution_ladder_text;
 use serde_json::{Value, json};
 
+// These tests mutate the same process-global tracker and its persisted store.
+// Keep their baseline/delta assertions isolated from the parallel test runner.
+static SOLUTION_TRACKER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock_solution_tracker() -> std::sync::MutexGuard<'static, ()> {
+    SOLUTION_TRACKER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[test]
 fn solution_config_defaults_are_sane() {
     let config = SolutionConfig::default();
@@ -80,6 +90,7 @@ fn solution_ladder_text_covers_all_intensities() {
 
 #[test]
 fn solution_tracker_lifecycle() {
+    let _tracker_guard = lock_solution_tracker();
     solution_tracker::reset();
 
     let baseline = solution_tracker::snapshot();
@@ -424,6 +435,7 @@ fn auto_capture_ignores_existing_imports_and_ordinary_comments() {
     ignore = "Edit-tool path resolution uses Unix path conventions"
 )]
 fn native_edit_via_observe_hook_triggers_solution_capture() {
+    let _tracker_guard = lock_solution_tracker();
     let tmp = std::env::temp_dir().join("native_capture_test");
     let tmp_str = tmp.to_string_lossy().replace('\\', "/");
     let path = format!("{tmp_str}/src/main.rs");
@@ -455,6 +467,7 @@ fn native_edit_via_observe_hook_triggers_solution_capture() {
 
 #[test]
 fn native_write_tool_records_loc_addition() {
+    let _tracker_guard = lock_solution_tracker();
     let tmp = std::env::temp_dir().join("native_write_test");
     let tmp_str = tmp.to_string_lossy().replace('\\', "/");
     let path = format!("{tmp_str}/new_file.rs");


### PR DESCRIPTION
## Summary

- Preserve typed lifecycle state and exact terminal exit codes for auto-detached ctx_shell jobs without removing the intentional auto-detach behavior.
- Return structured running, completed, failed, and cancelled verdicts at the MCP boundary; failed background jobs now set isError and cancelled jobs report exit code 130.
- Secure and archive the full background result before firewall compression and deferred task triage, with explicit 10 MiB truncation metadata.
- Keep foreground exit-1 heuristics and raw, bypass, inline, and minimal mode behavior unchanged.
- Move background verdict rendering into a private submodule so ctx_shell.rs remains below the 1,500-line maintainability gate.

This supersedes #1509. The contributor branch was recreated without a force-push after the history security gate rejected a secret-like synthetic fixture literal in an intermediate commit. The final fixture assembles the marker only at runtime; the local history gate reports zero new findings.

## Test plan

- [ ] cd rust && cargo test -- --test-threads=1
  - Final feature commit 3c003693: 10,202 passed; 3 failed; 22 ignored.
  - Clean base da0ed554: 10,181 passed; the same 3 tests failed; 22 ignored.
  - The delta is exactly 21 added passing tests. The shared local failures are dashboard::tests::api_context_overlay_evict_removes_ledger_entry, server::roots::tests::best_root_prefers_safe_dir_over_home, and server::roots::tests::best_root_rejects_home_without_marker; all resolve the host home directory as project state.
- [x] cd rust && cargo clippy --all-features -- -D warnings -A clippy::too_many_lines
- [x] cd rust && cargo fmt --check
- [x] ./scripts/loc-gate.sh
- [x] python3 scripts/history-policy-gate.py gate --root . --policy security/history-policy-v1.json: zero new findings
- [x] 11 ctx_shell unit tests and the private-key archive-redaction integration test pass after the module split.
- [x] scripts/preflight.sh fast: six gates pass. The Windows cross-compile reaches only the pre-existing core/cloud_files.rs unreachable_pub diagnostic on both branch and base; the MES-1609 delta is clean.

## Notes for reviewers

- Risk areas / edge cases: background pipeline ordering, archive redaction, cancellation, retention, and exact exit-code propagation.
- Backwards compatibility: auto-detach thresholds remain intentional; foreground exit-1 text heuristics and raw, bypass, inline, and minimal modes remain unchanged.
- Docs updated: none; this repairs the existing runtime contract and adds regression coverage.

## Contributor License Agreement

The repository CLA bot may verify the contributor signature on this PR.