### PR TITLE
feat(engine): complete P1 runtime acceptance spine

### DIFF
--- a/docs/contracts/engine-interface/v1/rejected-receipt.json
+++ b/docs/contracts/engine-interface/v1/rejected-receipt.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "invocation": {
+    "schema_version": 1,
+    "invocation_id": "engine-invocation-fixture-v1",
+    "engine": {
+      "engine_id": "lean-ctx-local",
+      "engine_version": "1.0.0"
+    },
+    "operation": {
+      "capability_id": "capability://leanctx/context-optimization",
+      "capability_version": "1.0.0"
+    },
+    "input_ref": "input:fixture",
+    "input_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "source_refs": [
+      "input:fixture",
+      "source:fixture"
+    ],
+    "policy_admission": {
+      "policy_ref": "policy:fixture",
+      "decision": "rejected"
+    }
+  },
+  "observation": {
+    "schema_version": 1,
+    "invocation_id": "engine-invocation-fixture-v1",
+    "status": "rejected",
+    "source_lineage": [
+      "input:fixture",
+      "source:fixture"
+    ],
+    "measurements": [],
+    "failure": {
+      "code": "policy_rejected",
+      "retryable_by_host": false
+    }
+  }
+}

--- a/docs/contracts/native-engine-context-proof-v1.md
+++ b/docs/contracts/native-engine-context-proof-v1.md
@@ -40,15 +40,26 @@ engine-interface/v1/receipts/<sha256>.json
 engine-interface/v1/recovery/<sha256>.json
 ```
 
-- Directories are private on Unix; artifacts are atomically written with mode
-  `0600`.
+- Directories are private on Unix. Every relative directory component is
+  rejected when it is a symlink/reparse point or resolves outside the canonical
+  data root. New content-addressed artifacts are opened with exclusive-create
+  and no-follow semantics; the opened file handle is bound back to that root
+  before bytes are written and is synchronized before success. Unix artifacts
+  use mode `0600`.
 - Existing artifact paths must be regular, non-symlink files whose contents
   match their address.
+- P1 rejects pre-existing symlink/reparse escape and never writes payload bytes
+  outside the resolved data root. Malicious same-user relocation after artifact
+  handle validation is outside this boundary; that excluded race can leave an
+  empty external leaf, but cannot produce an external payload write.
 - Receipt JSON is canonical and contains references, digests, status and
   measurements only. It intentionally excludes raw source and output bytes.
 - The production source reference binds the canonical resolved path by SHA-256;
   the input reference binds the raw worker snapshot, while `input_digest` binds
   the redacted bytes actually consumed by the Engine.
+- A rejected invocation that cannot safely resolve its source instead binds a
+  SHA-256 identity of the requested absolute path under the distinct
+  `source:requested-path-sha256` namespace; raw path bytes are never persisted.
 - If receipt persistence fails, a separate canonical recovery artifact records
   the invocation and terminal observation without source or output payload.
 
@@ -69,9 +80,13 @@ remain untouched when Engine v1 is omitted. Explicit Engine v1 forces a fresh
 bounded worker snapshot; identical calls reuse the same content-addressed
 output and receipt identities rather than silently accepting a legacy cache hit.
 
-The production source is revalidated against the Engine root before dispatch.
-Materialized compression runs in a dedicated worker behind a real 30-second
-host deadline; timed-out computation cannot persist an Engine output or receipt.
+The production worker opens the source through the Engine root one component at
+a time without following links. The Engine receives that descriptor-backed raw
+snapshot and canonical identity; it does not resolve or read the caller path a
+second time. Materialized compression runs in a dedicated worker behind a real
+30-second host deadline. A timed-out worker cannot persist an artifact and late
+completion cannot publish output. The receiving Engine records the terminal
+`failed` / `resource_limit` observation and receipt itself.
 Invocation identity includes Engine ID/version, capability ID/version in
 addition to source, input, policy, mode and deadline identities.
 
@@ -90,7 +105,8 @@ Operational traces also record successful receipt references.
 | Condition | Engine record | Recovery |
 | --- | --- | --- |
 | Pre-admission rejected | `rejected` / `policy_rejected` | none |
-| Jailed source cannot be read | `failed` / `source_unavailable` | supplied input reference |
+| Production source admission cannot complete safely | `rejected` / `policy_rejected` | requested-path hash only |
+| Standalone native source cannot be read | `failed` / `source_unavailable` | supplied input reference |
 | Read bytes differ from supplied identity | `failed` / `source_integrity_mismatch` | supplied input reference |
 | Native input/output/timeout limit | `failed` / `resource_limit` | host decides |
 | Native request shape invalid | `failed` / `internal` | host decides |
@@ -107,7 +123,8 @@ deterministic version-scoped receipt identity across repeated calls, real gate
 admission,
 single-snapshot production dispatch, raw/redacted identity separation, durable
 and visible receipt-write failure plus successful retry, rooted-source refusal,
-hard host deadline, permission re-hardening, no adapter invocation on rejection,
+artifact-directory symlink containment, hard host deadline with no late output,
+permission re-hardening, no adapter invocation on rejection,
 structured source recovery, source-integrity mismatch, redaction non-disclosure,
 tamper/symlink refusal and the versioned rejected-receipt golden fixture at
 `engine-interface/v1/rejected-receipt.json`. Run:
@@ -117,6 +134,11 @@ cd rust
 cargo test --lib core::engine_interface::tests
 cargo test --lib tools::registered::ctx_read::engine::tests
 cargo test --lib mcp_aggressive_read_
+cargo test --lib engine_v1_rejects_
+cargo test --lib engine_v1_rooted_read_failure_never_falls_back_to_outside_content
+cargo test --lib omitted_engine_interface_preserves_legacy_image_and_binary_paths
+cargo test --lib tools::ctx_read::file_io::tests
+cargo test --lib tools::registered::ctx_read::image::tests
 ```
 
 Volatile latency remains runtime telemetry and is deliberately absent from the

--- a/docs/contracts/native-engine-context-proof-v1.md
+++ b/docs/contracts/native-engine-context-proof-v1.md
@@ -11,13 +11,18 @@ v1 implementation: `capability://leanctx/context-optimization@1.0.0`.
 The implementation in `core::engine_interface` binds exactly one rooted local
 context operation to the versioned records in `lean-ctx-protocol`:
 
-1. The caller supplies a bounded input reference, its expected SHA-256 digest,
-   source references and an admission decision.
+1. Generic internal callers supply a bounded input identity and admission
+   decision. The production `ctx_read` entry point accepts only the canonical
+   path, raw authorized snapshot and actual gate admission; it derives every
+   Engine identity internally.
 2. A rejected decision produces `rejected` / `policy_rejected` and does not
    invoke the native adapter.
-3. An admitted decision reads and transforms the source once through the
-   existing jailed native adapter. The exact input digest is checked before a
-   successful observation is emitted.
+3. A standalone admitted decision reads and transforms the source once through
+   the existing jailed native adapter. The production `ctx_read` bridge instead
+   supplies the already authorized, bounded, no-follow worker snapshot, so the
+   Engine cannot race a second disk read. The raw snapshot SHA-256 becomes the
+   input reference; redaction occurs inside the request factory and the exact
+   post-policy Engine-input digest is checked before success is emitted.
 4. The derived bytes are written locally under their SHA-256 identity. The
    observation contains only `output:<digest>` and measurements, never payload
    bytes.
@@ -32,6 +37,7 @@ Artifacts live under the resolved local data directory:
 ```text
 engine-interface/v1/outputs/<sha256>.txt
 engine-interface/v1/receipts/<sha256>.json
+engine-interface/v1/recovery/<sha256>.json
 ```
 
 - Directories are private on Unix; artifacts are atomically written with mode
@@ -40,6 +46,44 @@ engine-interface/v1/receipts/<sha256>.json
   match their address.
 - Receipt JSON is canonical and contains references, digests, status and
   measurements only. It intentionally excludes raw source and output bytes.
+- The production source reference binds the canonical resolved path by SHA-256;
+  the input reference binds the raw worker snapshot, while `input_digest` binds
+  the redacted bytes actually consumed by the Engine.
+- If receipt persistence fails, a separate canonical recovery artifact records
+  the invocation and terminal observation without source or output payload.
+
+## Production runtime path
+
+An effective cold single-path `ctx_read` with `mode="aggressive"` and explicit
+`engine_interface="v1"` invokes this Engine bridge after the context gate and
+before the response is assembled. Omission preserves the exact legacy path,
+including no Engine artifact side effects. The v1 boundary rejects implicit or
+non-aggressive modes, every `paths` value, line windows, raw mode,
+aggressiveness tuning and symbol protection; these inputs cannot silently alter
+an invocation whose fixed shape is not represented in its identity. Its
+admission reference is the SHA-256 identity of the actual gate decision, including the
+requested/overridden mode and bounded policy signals. Budget blocks, pressure
+downgrades, mode overrides and triage filtering produce a deterministic
+`rejected` receipt without entering the native adapter. Existing warm-cache reads
+remain untouched when Engine v1 is omitted. Explicit Engine v1 forces a fresh
+bounded worker snapshot; identical calls reuse the same content-addressed
+output and receipt identities rather than silently accepting a legacy cache hit.
+
+The production source is revalidated against the Engine root before dispatch.
+Materialized compression runs in a dedicated worker behind a real 30-second
+host deadline; timed-out computation cannot persist an Engine output or receipt.
+Invocation identity includes Engine ID/version, capability ID/version in
+addition to source, input, policy, mode and deadline identities.
+
+The existing `ctx_read` renderer remains authoritative until measured parity:
+successful response bytes do not include Engine metadata. A receipt-recording
+failure is prefixed with the stable
+`[ENGINE RECEIPT WARNING] code=engine_record_unavailable` marker while legacy
+content stays available; a terminal Engine failure includes its receipt and
+recovery reference in that warning. Receipt-write failures include their durable
+recovery reference; a later cold/fresh read retries normal output and receipt
+persistence.
+Operational traces also record successful receipt references.
 
 ## Failure mapping
 
@@ -50,20 +94,31 @@ engine-interface/v1/receipts/<sha256>.json
 | Read bytes differ from supplied identity | `failed` / `source_integrity_mismatch` | supplied input reference |
 | Native input/output/timeout limit | `failed` / `resource_limit` | host decides |
 | Native request shape invalid | `failed` / `internal` | host decides |
+| Output artifact cannot persist | `failed` / `internal`, retryable | receipt plus input reference |
+| Receipt cannot persist | visible caller warning | content-addressed recovery artifact |
 
 The bridge maps typed native failures; it does not classify errors by parsing
 human-readable strings.
 
 ## Verification
 
-The unit proof covers admitted execution, source and output integrity,
-deterministic identity/output across repeated calls, no adapter invocation on
-rejection, structured source recovery and source-integrity mismatch. Run:
+The proof covers admitted execution, canonical source and output integrity,
+deterministic version-scoped receipt identity across repeated calls, real gate
+admission,
+single-snapshot production dispatch, raw/redacted identity separation, durable
+and visible receipt-write failure plus successful retry, rooted-source refusal,
+hard host deadline, permission re-hardening, no adapter invocation on rejection,
+structured source recovery, source-integrity mismatch, redaction non-disclosure,
+tamper/symlink refusal and the versioned rejected-receipt golden fixture at
+`engine-interface/v1/rejected-receipt.json`. Run:
 
 ```sh
 cd rust
 cargo test --lib core::engine_interface::tests
+cargo test --lib tools::registered::ctx_read::engine::tests
+cargo test --lib mcp_aggressive_read_
 ```
 
-The measured latency may differ between executions; identity, source lineage,
-input digest and output digest must not.
+Volatile latency remains runtime telemetry and is deliberately absent from the
+content-addressed Engine receipt; identical admitted inputs, policy decisions
+and canonical sources produce the same invocation, output and receipt identity.

--- a/docs/contracts/native-engine-context-proof-v1.md
+++ b/docs/contracts/native-engine-context-proof-v1.md
@@ -42,10 +42,12 @@ engine-interface/v1/recovery/<sha256>.json
 
 - Directories are private on Unix. Every relative directory component is
   rejected when it is a symlink/reparse point or resolves outside the canonical
-  data root. New content-addressed artifacts are opened with exclusive-create
-  and no-follow semantics; the opened file handle is bound back to that root
-  before bytes are written and is synchronized before success. Unix artifacts
-  use mode `0600`.
+  data root. New content-addressed artifacts are written to an exclusive,
+  no-follow temporary leaf in the validated final directory. Only a fully
+  written, permission-hardened and synchronized temporary artifact may be
+  published under its digest by an atomic no-replace operation; an existing
+  digest path is never overwritten. Any failure before publication leaves the
+  final digest path absent and retryable. Unix artifacts use mode `0600`.
 - Existing artifact paths must be regular, non-symlink files whose contents
   match their address.
 - P1 rejects pre-existing symlink/reparse escape and never writes payload bytes

--- a/docs/contracts/native-engine-context-proof-v1.md
+++ b/docs/contracts/native-engine-context-proof-v1.md
@@ -124,7 +124,8 @@ The proof covers admitted execution, canonical source and output integrity,
 deterministic version-scoped receipt identity across repeated calls, real gate
 admission,
 single-snapshot production dispatch, raw/redacted identity separation, durable
-and visible receipt-write failure plus successful retry, rooted-source refusal,
+and visible receipt-write failure plus successful retry, exact legacy omission
+even when Engine artifact storage is unavailable, rooted-source refusal,
 artifact-directory symlink containment, hard host deadline with no late output,
 permission re-hardening, no adapter invocation on rejection,
 structured source recovery, source-integrity mismatch, redaction non-disclosure,

--- a/docs/internal/execution/MASTER-EXECUTION-PLAN.md
+++ b/docs/internal/execution/MASTER-EXECUTION-PLAN.md
@@ -11,10 +11,10 @@
 ## Workstreams (parallel)
 
 ```text
-WS-1: CODEBASE CLEANUP          ██████████  Cleanup done; P0 implementation complete; CI rehearsal and admin policy apply remain
+WS-1: CODEBASE CLEANUP          ██████████  Cleanup and P0 operational delivery/security gate complete
 WS-2: SDK V1 + EVIDENCE         ██████████  Phase-A substrate complete; public SDK remains Preview
 WS-3: WEBSITE REBUILD           ████████░░  v2 live, Nav/Footer/SEO/Docs pending
-WS-4: OCLA + COMPOSABLE (B)     ██████████  P1 runtime Engine caller and evidence boundary complete
+WS-4: OCLA + COMPOSABLE (B)     █████████░  P1 runtime wired; security remediation and acceptance gates active
 WS-5: PARTNERSHIP (C)           —— DEFERRED (no near-term partner execution)
 WS-6: BENCHMARK + CALIBRATOR    ██████████  Technical v0 complete; P2 evidence gate remains open
 WS-7: REPRODUCIBLE EVIDENCE (C) ██████░░░░  Manifest and signed-bundle foundations exist; provenance replay and independent verification remain
@@ -36,16 +36,16 @@ This file schedules approved work; it does not supersede those authorities.
 
 | Roadmap phase | Current state | Next exit |
 | --- | --- | --- |
-| **P0 — delivery/security** | Code complete: exact-tag, OCLA conformance, signed manifest, evidence, rehearsal, delivery/security/history suites, and the audited history delta now gate `CI Green`; release/publishing remains transitively blocked. The branch-protection declaration requires `CI Green` plus the independent `Security Scan`. | Run the clean regular-CI rehearsal on `main`, then apply and verify the declared GitHub branch-protection rule with repository-admin authority. |
-| **P1 — Engine runtime spine** | Code and local evidence complete: explicit single-path `ctx_read` `engine_interface="v1"` dispatches aggressive compression through `NativeContextEngine`; omission remains legacy-compatible. Actual gate admission, raw/redacted input identity, canonical source, deterministic output/receipt, durable recovery and retry are covered by real-path fixtures. | Feed this invocation and receipt into the P2 canonical identity chain; promotion still obeys the independent P0 operational gate. |
+| **P0 — delivery/security** | **Operational exit complete (2026-08-23):** regular `main` CI run `32639983816`, Security Check `32639983788`, and CodeQL `32639983823` passed; declared GitHub `main` protection was applied and independently verified drift-free with required `CI Green` and `Security Scan`, admin enforcement, and force-push/deletion disabled. | Keep the declarative policy and drift verification green; release/publishing remains transitively gated by these checks. |
+| **P1 — Engine runtime spine** | Integration in acceptance: explicit single-path `ctx_read` `engine_interface="v1"` dispatches aggressive compression through `NativeContextEngine`; omission remains legacy-compatible. Post-admission non-text/mode rejection, descriptor-rooted source capture, artifact hardening and a positive deadline test are being closed against adversarial review. | Pass focused legacy/v1 integration tests, full Rust gates and GitHub cross-platform CI; only then feed the accepted invocation/receipt into P2. |
 | **P2 — canonical evidence** | Partial: receipt, ledger and verifier substrates exist but have no single producer-to-ledger-to-independent-verifier chain. | Canonical Task → Plan → Invocation → Receipt → Outcome projection and replay/tamper verification. |
 | **P3 — Python Preview** | Blocked on P1/P2: the wrapper is fixture-backed; Rust session/Kit/receipt routes are absent. | Live-runtime parity or an explicitly narrowed facade with migration tests. |
 | **P4 — production SDK repo** | Not entered: all four repository/license/release/security approvals remain pending. | Approved decision record plus P3 evidence, then separate SDK repo and five-primitive contract. |
 | **P5–P7 — Workspace, package, handoff** | Research queue: target architecture only. | Start only after P4; never promote legacy stores/artifacts as the new truth. |
 | **P8–P9 — Cloud/optimization** | Private and blocked. | Separate private repository only after local proof, trusted evidence and designated owners. |
 
-**Execution order:** P0 operational CI/branch-protection verification → P1 runtime Engine caller
-(local exit met) → P2 canonical evidence → P3 live Python Preview parity → P4 SDK repository.
+**Execution order:** P0 operational CI/branch-protection verification (**met**) → P1 runtime Engine caller
+(acceptance active) → P2 canonical evidence → P3 live Python Preview parity → P4 SDK repository.
 No later workstream may bypass an earlier exit.
 
 ---

--- a/docs/internal/execution/MASTER-EXECUTION-PLAN.md
+++ b/docs/internal/execution/MASTER-EXECUTION-PLAN.md
@@ -14,7 +14,7 @@
 WS-1: CODEBASE CLEANUP          ██████████  Cleanup done; P0 implementation complete; CI rehearsal and admin policy apply remain
 WS-2: SDK V1 + EVIDENCE         ██████████  Phase-A substrate complete; public SDK remains Preview
 WS-3: WEBSITE REBUILD           ████████░░  v2 live, Nav/Footer/SEO/Docs pending
-WS-4: OCLA + COMPOSABLE (B)     ██████████  Substrate complete; P1 runtime caller remains open
+WS-4: OCLA + COMPOSABLE (B)     ██████████  P1 runtime Engine caller and evidence boundary complete
 WS-5: PARTNERSHIP (C)           —— DEFERRED (no near-term partner execution)
 WS-6: BENCHMARK + CALIBRATOR    ██████████  Technical v0 complete; P2 evidence gate remains open
 WS-7: REPRODUCIBLE EVIDENCE (C) ██████░░░░  Manifest and signed-bundle foundations exist; provenance replay and independent verification remain
@@ -37,15 +37,15 @@ This file schedules approved work; it does not supersede those authorities.
 | Roadmap phase | Current state | Next exit |
 | --- | --- | --- |
 | **P0 — delivery/security** | Code complete: exact-tag, OCLA conformance, signed manifest, evidence, rehearsal, delivery/security/history suites, and the audited history delta now gate `CI Green`; release/publishing remains transitively blocked. The branch-protection declaration requires `CI Green` plus the independent `Security Scan`. | Run the clean regular-CI rehearsal on `main`, then apply and verify the declared GitHub branch-protection rule with repository-admin authority. |
-| **P1 — Engine runtime spine** | Pending: Engine interface and native adapter proofs exist, but no canonical `ctx_read`/daemon caller invokes `NativeContextEngine`. | One bounded compression caller with policy/identity/digest/receipt linkage and a real-path fixture. |
+| **P1 — Engine runtime spine** | Code and local evidence complete: explicit single-path `ctx_read` `engine_interface="v1"` dispatches aggressive compression through `NativeContextEngine`; omission remains legacy-compatible. Actual gate admission, raw/redacted input identity, canonical source, deterministic output/receipt, durable recovery and retry are covered by real-path fixtures. | Feed this invocation and receipt into the P2 canonical identity chain; promotion still obeys the independent P0 operational gate. |
 | **P2 — canonical evidence** | Partial: receipt, ledger and verifier substrates exist but have no single producer-to-ledger-to-independent-verifier chain. | Canonical Task → Plan → Invocation → Receipt → Outcome projection and replay/tamper verification. |
 | **P3 — Python Preview** | Blocked on P1/P2: the wrapper is fixture-backed; Rust session/Kit/receipt routes are absent. | Live-runtime parity or an explicitly narrowed facade with migration tests. |
 | **P4 — production SDK repo** | Not entered: all four repository/license/release/security approvals remain pending. | Approved decision record plus P3 evidence, then separate SDK repo and five-primitive contract. |
 | **P5–P7 — Workspace, package, handoff** | Research queue: target architecture only. | Start only after P4; never promote legacy stores/artifacts as the new truth. |
 | **P8–P9 — Cloud/optimization** | Private and blocked. | Separate private repository only after local proof, trusted evidence and designated owners. |
 
-**Execution order:** P0 operational CI/branch-protection verification → P1 runtime Engine caller →
-P2 canonical evidence → P3 live Python Preview parity → P4 SDK repository.
+**Execution order:** P0 operational CI/branch-protection verification → P1 runtime Engine caller
+(local exit met) → P2 canonical evidence → P3 live Python Preview parity → P4 SDK repository.
 No later workstream may bypass an earlier exit.
 
 ---

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -522,7 +522,7 @@ Read source files. mode recommended — choose by intent (see `mode` below); def
 To UNDERSTAND code run ctx_compose FIRST; ctx_read after it identified files.
 anchored → edit by reference via ctx_patch (no exact-recall).
 
-Parameters: `aggressiveness`, `fresh`, `limit`, `mode`, `offset`, `path`, `paths`, `protect`, `raw`, `start_line`
+Parameters: `aggressiveness`, `engine_interface`, `fresh`, `limit`, `mode`, `offset`, `path`, `paths`, `protect`, `raw`, `start_line`
 
 ## `ctx_refactor`
 

--- a/rust/src/core/binary_detect.rs
+++ b/rust/src/core/binary_detect.rs
@@ -129,7 +129,7 @@ const LLM_VIEWABLE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp"];
 pub(crate) const IMAGE_MAX_BYTES: u64 = 20 * 1024 * 1024;
 
 /// Fast extension-based binary detection (zero I/O).
-fn has_binary_extension(path: &str) -> bool {
+pub(crate) fn has_binary_extension(path: &str) -> bool {
     Path::new(path)
         .extension()
         .and_then(|e| e.to_str())

--- a/rust/src/core/engine_artifact.rs
+++ b/rust/src/core/engine_artifact.rs
@@ -1,0 +1,286 @@
+//! Contained, immutable storage for local Engine Interface artifacts.
+
+use std::io::{Read, Seek, Write};
+use std::path::{Component, Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::core::data_dir;
+
+pub(super) fn persist_content(
+    directory: &str,
+    digest: &str,
+    extension: &str,
+    bytes: &[u8],
+) -> Result<std::fs::File, String> {
+    validate_artifact_name(digest, extension)?;
+    if hex_sha256(bytes) != digest {
+        return Err(
+            "engine_artifact_digest_mismatch: supplied bytes do not match digest".to_owned(),
+        );
+    }
+
+    let configured_root = data_dir::lean_ctx_data_dir()?;
+    std::fs::create_dir_all(&configured_root)
+        .map_err(|error| format!("create Engine data directory: {error}"))?;
+    let root = crate::core::pathutil::canonicalize_secure(&configured_root)
+        .map_err(|error| format!("resolve Engine data directory: {error}"))?;
+    let directory = prepare_directory(&root, directory)?;
+    let path = directory.join(format!("{digest}.{extension}"));
+
+    match create_artifact(&path, &root) {
+        Ok(mut artifact) => {
+            if let Some(permissions) = artifact_permissions() {
+                artifact
+                    .set_permissions(permissions)
+                    .map_err(|error| format!("harden Engine artifact permissions: {error}"))?;
+            }
+            artifact
+                .write_all(bytes)
+                .map_err(|error| format!("write Engine artifact: {error}"))?;
+            artifact
+                .sync_all()
+                .map_err(|error| format!("sync Engine artifact: {error}"))?;
+            artifact
+                .rewind()
+                .map_err(|error| format!("rewind Engine artifact: {error}"))?;
+            Ok(artifact)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            verify_existing_artifact(&path, &root, digest)
+        }
+        Err(error) => Err(format!("create Engine artifact exclusively: {error}")),
+    }
+}
+
+fn validate_artifact_name(digest: &str, extension: &str) -> Result<(), String> {
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("Engine artifact digest must be 64 hexadecimal characters".to_owned());
+    }
+    if !matches!(extension, "json" | "txt") {
+        return Err("Engine artifact extension is not allowed".to_owned());
+    }
+    Ok(())
+}
+
+fn prepare_directory(root: &Path, relative: &str) -> Result<PathBuf, String> {
+    let mut current = root.to_path_buf();
+    for component in Path::new(relative).components() {
+        let Component::Normal(component) = component else {
+            return Err("Engine artifact directory must be a relative normal path".to_owned());
+        };
+        let next = current.join(component);
+        match std::fs::symlink_metadata(&next) {
+            Ok(metadata) => validate_directory_metadata(&metadata)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::create_dir(&next) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                    Err(error) => {
+                        return Err(format!("create Engine artifact directory: {error}"));
+                    }
+                }
+                let metadata = std::fs::symlink_metadata(&next)
+                    .map_err(|error| format!("inspect Engine artifact directory: {error}"))?;
+                validate_directory_metadata(&metadata)?;
+            }
+            Err(error) => {
+                return Err(format!("inspect Engine artifact directory: {error}"));
+            }
+        }
+        let resolved = crate::core::pathutil::canonicalize_secure(&next)
+            .map_err(|error| format!("resolve Engine artifact directory: {error}"))?;
+        if !resolved.starts_with(root) {
+            return Err(
+                "engine_artifact_boundary_rejected: directory escaped data root".to_owned(),
+            );
+        }
+        data_dir::ensure_dir_permissions(&resolved);
+        current = resolved;
+    }
+    Ok(current)
+}
+
+fn validate_directory_metadata(metadata: &std::fs::Metadata) -> Result<(), String> {
+    if crate::core::pathutil::is_symlink_or_reparse(metadata) || !metadata.is_dir() {
+        return Err(
+            "engine_artifact_boundary_rejected: directory must be real and non-symlink".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn create_artifact(path: &Path, root: &Path) -> Result<std::fs::File, std::io::Error> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create_new(true);
+    apply_nofollow_flags(&mut options);
+    let artifact = options.open(path)?;
+    verify_open_artifact(&artifact, path, root)?;
+    Ok(artifact)
+}
+
+fn verify_existing_artifact(
+    path: &Path,
+    root: &Path,
+    digest: &str,
+) -> Result<std::fs::File, String> {
+    if std::fs::symlink_metadata(path)
+        .is_ok_and(|metadata| crate::core::pathutil::is_symlink_or_reparse(&metadata))
+    {
+        return Err(
+            "engine_artifact_leaf_untrusted: artifact must be regular and non-symlink".to_owned(),
+        );
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    apply_nofollow_flags(&mut options);
+    let mut artifact = options
+        .open(path)
+        .map_err(|error| format!("open Engine artifact without following links: {error}"))?;
+    verify_open_artifact(&artifact, path, root).map_err(|_| {
+        "engine_artifact_boundary_rejected: opened file escaped data root".to_owned()
+    })?;
+    let mut bytes = Vec::new();
+    artifact
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("read Engine artifact: {error}"))?;
+    if hex_sha256(&bytes) != digest {
+        return Err(
+            "engine_artifact_digest_mismatch: content differs from addressed digest".to_owned(),
+        );
+    }
+    if let Some(permissions) = artifact_permissions() {
+        artifact
+            .set_permissions(permissions)
+            .map_err(|error| format!("harden Engine artifact permissions: {error}"))?;
+    }
+    artifact
+        .rewind()
+        .map_err(|error| format!("rewind Engine artifact: {error}"))?;
+    Ok(artifact)
+}
+
+fn apply_nofollow_flags(options: &mut std::fs::OpenOptions) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+}
+
+fn verify_open_artifact(
+    artifact: &std::fs::File,
+    path: &Path,
+    root: &Path,
+) -> Result<(), std::io::Error> {
+    let metadata = artifact.metadata()?;
+    if crate::core::pathutil::is_symlink_or_reparse(&metadata) || !metadata.is_file() {
+        return Err(std::io::Error::other(
+            "Engine artifact must be a regular non-symlink file",
+        ));
+    }
+    verify_handle_path(artifact, path, root, &metadata)
+}
+
+#[cfg(unix)]
+fn verify_handle_path(
+    _artifact: &std::fs::File,
+    path: &Path,
+    root: &Path,
+    metadata: &std::fs::Metadata,
+) -> Result<(), std::io::Error> {
+    use std::os::unix::fs::MetadataExt;
+
+    let resolved = crate::core::pathutil::canonicalize_secure(path)?;
+    let resolved_metadata = std::fs::metadata(&resolved)?;
+    if !resolved.starts_with(root)
+        || metadata.dev() != resolved_metadata.dev()
+        || metadata.ino() != resolved_metadata.ino()
+    {
+        return Err(std::io::Error::other(
+            "opened Engine artifact escaped the data root",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn verify_handle_path(
+    artifact: &std::fs::File,
+    _path: &Path,
+    root: &Path,
+    _metadata: &std::fs::Metadata,
+) -> Result<(), std::io::Error> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_DOS,
+    };
+
+    let mut buffer = vec![0u16; 32_768];
+    // SAFETY: the handle is live and buffer is writable for its full length.
+    let length = unsafe {
+        GetFinalPathNameByHandleW(
+            artifact.as_raw_handle() as _,
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+            FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
+        )
+    };
+    if length == 0 || length as usize >= buffer.len() {
+        return Err(std::io::Error::last_os_error());
+    }
+    buffer.truncate(length as usize);
+    let opened = crate::core::pathutil::strip_verbatim(PathBuf::from(OsString::from_wide(&buffer)));
+    let opened = opened.to_string_lossy().to_ascii_lowercase();
+    let root = root.to_string_lossy().to_ascii_lowercase();
+    if opened != root
+        && !opened
+            .strip_prefix(&root)
+            .is_some_and(|suffix| suffix.starts_with('\\') || suffix.starts_with('/'))
+    {
+        return Err(std::io::Error::other(
+            "opened Engine artifact escaped the data root",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn verify_handle_path(
+    _artifact: &std::fs::File,
+    path: &Path,
+    root: &Path,
+    _metadata: &std::fs::Metadata,
+) -> Result<(), std::io::Error> {
+    let resolved = crate::core::pathutil::canonicalize_secure(path)?;
+    if !resolved.starts_with(root) {
+        return Err(std::io::Error::other(
+            "opened Engine artifact escaped the data root",
+        ));
+    }
+    Ok(())
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    crate::core::agent_identity::hex_encode(&Sha256::digest(bytes))
+}
+
+fn artifact_permissions() -> Option<std::fs::Permissions> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        Some(std::fs::Permissions::from_mode(0o600))
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}

--- a/rust/src/core/engine_artifact.rs
+++ b/rust/src/core/engine_artifact.rs
@@ -3,9 +3,50 @@
 use std::io::{Read, Seek, Write};
 use std::path::{Component, Path, PathBuf};
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use sha2::{Digest, Sha256};
 
 use crate::core::data_dir;
+
+#[cfg(test)]
+thread_local! {
+    static TEST_FAIL_BEFORE_PUBLISH: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(super) fn inject_test_pre_publish_failure() {
+    TEST_FAIL_BEFORE_PUBLISH.with(|failpoint| failpoint.set(true));
+}
+
+fn test_pre_publish_failure() -> bool {
+    #[cfg(test)]
+    {
+        TEST_FAIL_BEFORE_PUBLISH.with(|failpoint| failpoint.replace(false))
+    }
+    #[cfg(not(test))]
+    {
+        false
+    }
+}
+
+struct TempArtifact {
+    file: Option<std::fs::File>,
+    path: PathBuf,
+    published: bool,
+}
+
+impl Drop for TempArtifact {
+    fn drop(&mut self) {
+        // Closing before unlinking is required on Windows. A failed operation
+        // may leave only this private, same-directory temporary leaf behind.
+        self.file.take();
+        if !self.published {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
 
 pub(super) fn persist_content(
     directory: &str,
@@ -27,29 +68,20 @@ pub(super) fn persist_content(
         .map_err(|error| format!("resolve Engine data directory: {error}"))?;
     let directory = prepare_directory(&root, directory)?;
     let path = directory.join(format!("{digest}.{extension}"));
+    let mut temp = create_temp_artifact(&path, &root)
+        .map_err(|_| "engine_artifact_temp_create_failed".to_owned())?;
+    write_temp_artifact(&mut temp, bytes)?;
 
-    match create_artifact(&path, &root) {
-        Ok(mut artifact) => {
-            if let Some(permissions) = artifact_permissions() {
-                artifact
-                    .set_permissions(permissions)
-                    .map_err(|error| format!("harden Engine artifact permissions: {error}"))?;
-            }
-            artifact
-                .write_all(bytes)
-                .map_err(|error| format!("write Engine artifact: {error}"))?;
-            artifact
-                .sync_all()
-                .map_err(|error| format!("sync Engine artifact: {error}"))?;
-            artifact
-                .rewind()
-                .map_err(|error| format!("rewind Engine artifact: {error}"))?;
-            Ok(artifact)
-        }
+    if test_pre_publish_failure() {
+        return Err("engine_artifact_test_pre_publish_failure".to_owned());
+    }
+
+    match publish_temp_artifact(&mut temp, &path) {
+        Ok(()) => open_published_artifact(&path, &root, digest),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             verify_existing_artifact(&path, &root, digest)
         }
-        Err(error) => Err(format!("create Engine artifact exclusively: {error}")),
+        Err(_) => Err("engine_artifact_publish_failed".to_owned()),
     }
 }
 
@@ -110,12 +142,147 @@ fn validate_directory_metadata(metadata: &std::fs::Metadata) -> Result<(), Strin
     Ok(())
 }
 
-fn create_artifact(path: &Path, root: &Path) -> Result<std::fs::File, std::io::Error> {
+fn create_temp_artifact(path: &Path, root: &Path) -> Result<TempArtifact, std::io::Error> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("Engine artifact path has no parent"))?;
+    let filename = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("Engine artifact path has no filename"))?
+        .to_string_lossy();
+
+    // The bounded suffix loop handles concurrent writers and a temp left by a
+    // process crash without putting a random name into any persisted record.
+    for suffix in 0..128u16 {
+        let temp_name = if suffix == 0 {
+            format!(".{filename}.tmp")
+        } else {
+            format!(".{filename}.tmp.{suffix}")
+        };
+        let temp_path = parent.join(temp_name);
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create_new(true);
+        apply_nofollow_flags(&mut options);
+        let file = match options.open(&temp_path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+        if let Err(error) = verify_open_artifact(&file, &temp_path, root) {
+            drop(file);
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(error);
+        }
+        return Ok(TempArtifact {
+            file: Some(file),
+            path: temp_path,
+            published: false,
+        });
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "Engine artifact temporary namespace is occupied",
+    ))
+}
+
+fn write_temp_artifact(temp: &mut TempArtifact, bytes: &[u8]) -> Result<(), String> {
+    let artifact = temp
+        .file
+        .as_mut()
+        .ok_or_else(|| "engine_artifact_temp_closed".to_owned())?;
+    if let Some(permissions) = artifact_permissions() {
+        artifact
+            .set_permissions(permissions)
+            .map_err(|_| "engine_artifact_temp_permissions_failed".to_owned())?;
+    }
+    artifact
+        .write_all(bytes)
+        .map_err(|_| "engine_artifact_temp_write_failed".to_owned())?;
+    artifact
+        .sync_all()
+        .map_err(|_| "engine_artifact_temp_sync_failed".to_owned())?;
+    Ok(())
+}
+
+fn publish_temp_artifact(temp: &mut TempArtifact, path: &Path) -> Result<(), std::io::Error> {
+    // The file is fully written and synchronized before it becomes visible at
+    // its content address. Closing also makes the publication portable.
+    temp.file.take();
+
+    #[cfg(windows)]
+    windows_publish_no_replace(&temp.path, path)?;
+
+    #[cfg(not(windows))]
+    {
+        // hard_link is an atomic create-without-replacement primitive: unlike
+        // rename, it cannot replace an existing addressed artifact.
+        std::fs::hard_link(&temp.path, path)?;
+        #[cfg(unix)]
+        sync_directory(path.parent());
+        std::fs::remove_file(&temp.path)?;
+    }
+
+    temp.published = true;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_publish_no_replace(temp: &Path, path: &Path) -> Result<(), std::io::Error> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_WRITE_THROUGH, MoveFileExW};
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let temp = wide(temp);
+    let path = wide(path);
+    // Omitting MOVEFILE_REPLACE_EXISTING makes an existing final path a
+    // deterministic AlreadyExists failure; the move stays same-volume because
+    // the temp was created in the final directory.
+    let ok = unsafe { MoveFileExW(temp.as_ptr(), path.as_ptr(), MOVEFILE_WRITE_THROUGH) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_directory(parent: Option<&Path>) {
+    if let Some(parent) = parent
+        && let Ok(directory) = std::fs::File::open(parent)
+    {
+        let _ = directory.sync_all();
+    }
+}
+
+fn open_published_artifact(
+    path: &Path,
+    root: &Path,
+    digest: &str,
+) -> Result<std::fs::File, String> {
     let mut options = std::fs::OpenOptions::new();
-    options.read(true).write(true).create_new(true);
+    options.read(true);
     apply_nofollow_flags(&mut options);
-    let artifact = options.open(path)?;
-    verify_open_artifact(&artifact, path, root)?;
+    let mut artifact = options
+        .open(path)
+        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
+    verify_open_artifact(&artifact, path, root)
+        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
+    let mut bytes = Vec::new();
+    artifact
+        .read_to_end(&mut bytes)
+        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
+    if hex_sha256(&bytes) != digest {
+        return Err("engine_artifact_publish_verification_failed".to_owned());
+    }
+    artifact
+        .rewind()
+        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
     Ok(artifact)
 }
 

--- a/rust/src/core/engine_interface.rs
+++ b/rust/src/core/engine_interface.rs
@@ -15,8 +15,8 @@ use lean_ctx_protocol::{
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::core::atomic_fs;
 use crate::core::canonical;
+#[cfg(test)]
 use crate::core::data_dir;
 use crate::core::ocla::adapters::native_context::{
     NativeContextAdapter, NativeContextInvocationFailure,
@@ -29,6 +29,9 @@ const CAPABILITY_VERSION: &str = "1.0.0";
 const RECEIPT_DIRECTORY: &str = "engine-interface/v1/receipts";
 const OUTPUT_DIRECTORY: &str = "engine-interface/v1/outputs";
 const RECOVERY_DIRECTORY: &str = "engine-interface/v1/recovery";
+
+#[path = "engine_artifact.rs"]
+mod artifact_store;
 
 /// Inputs intentionally retained inside the local Engine proof boundary.
 ///
@@ -55,6 +58,54 @@ impl NativeContextEngineRequest {
         timeout_ms: u64,
         policy_admission: EnginePolicyAdmissionV1,
     ) -> Result<(Self, String), String> {
+        let canonical_path = std::fs::canonicalize(path)
+            .map_err(|error| format!("resolve ctx_read Engine source: {error}"))?;
+        Self::ctx_read_snapshot_canonical(&canonical_path, raw_input, timeout_ms, policy_admission)
+    }
+
+    fn ctx_read_snapshot_canonical(
+        canonical_path: &Path,
+        raw_input: &str,
+        timeout_ms: u64,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(Self, String), String> {
+        if !canonical_path.is_absolute() {
+            return Err("ctx_read Engine canonical source must be absolute".to_owned());
+        }
+        Self::ctx_read_identified(
+            canonical_path.to_string_lossy().into_owned(),
+            "source:canonical-path-sha256",
+            raw_input,
+            timeout_ms,
+            policy_admission,
+        )
+    }
+
+    fn ctx_read_rejection(
+        requested_path: &str,
+        timeout_ms: u64,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<Self, String> {
+        if !Path::new(requested_path).is_absolute() {
+            return Err("ctx_read Engine requested source must be absolute".to_owned());
+        }
+        Self::ctx_read_identified(
+            requested_path.to_owned(),
+            "source:requested-path-sha256",
+            "",
+            timeout_ms,
+            policy_admission,
+        )
+        .map(|(request, _)| request)
+    }
+
+    fn ctx_read_identified(
+        path_identity: String,
+        source_prefix: &str,
+        raw_input: &str,
+        timeout_ms: u64,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(Self, String), String> {
         let input = crate::core::redaction::redact_text_if_enabled(raw_input);
         let raw_input_digest = sha256_digest(raw_input.as_bytes())?;
         let input_digest = sha256_digest(input.as_bytes())?;
@@ -63,15 +114,9 @@ impl NativeContextEngineRequest {
             raw_input_digest.hex()
         ))
         .map_err(|error| error.to_string())?;
-        let canonical_path = std::fs::canonicalize(path)
-            .map_err(|error| format!("resolve ctx_read Engine source: {error}"))?;
-        let canonical_path = canonical_path.to_string_lossy().into_owned();
-        let path_digest = sha256_digest(canonical_path.as_bytes())?;
-        let source_ref = ProtocolReference::new(format!(
-            "source:canonical-path-sha256:{}",
-            path_digest.hex()
-        ))
-        .map_err(|error| error.to_string())?;
+        let path_digest = sha256_digest(path_identity.as_bytes())?;
+        let source_ref = ProtocolReference::new(format!("{source_prefix}:{}", path_digest.hex()))
+            .map_err(|error| error.to_string())?;
         let invocation_seed = canonical::canonical_serialize(&CtxReadInvocationIdentityV1 {
             engine_id: ENGINE_ID,
             engine_version: env!("CARGO_PKG_VERSION"),
@@ -96,7 +141,7 @@ impl NativeContextEngineRequest {
             input_digest,
             source_refs: vec![input_ref, source_ref],
             policy_admission,
-            paths: vec![canonical_path],
+            paths: vec![path_identity],
             mode: "aggressive".to_owned(),
             budget_tokens: None,
             timeout_ms,
@@ -146,6 +191,8 @@ struct EngineRecoveryArtifactV1 {
 impl NativeContextEngine {
     #[must_use]
     pub(crate) fn with_root(root: impl AsRef<Path>) -> Self {
+        let root = crate::core::pathutil::canonicalize_secure(root.as_ref())
+            .unwrap_or_else(|_| root.as_ref().to_path_buf());
         Self {
             adapter: NativeContextAdapter::with_root(root),
         }
@@ -195,9 +242,26 @@ impl NativeContextEngine {
     ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
         let rooted_path = crate::core::pathjail::jail_path(Path::new(path), self.adapter.root())
             .map_err(|_| "ctx_read Engine source is outside its rooted boundary".to_owned())?;
-        let rooted_path = rooted_path.to_string_lossy().into_owned();
-        let (request, input) = NativeContextEngineRequest::ctx_read_snapshot(
-            &rooted_path,
+        self.execute_ctx_read_rooted_snapshot(
+            &rooted_path.to_string_lossy(),
+            raw_input,
+            policy_admission,
+        )
+    }
+
+    pub(crate) fn execute_ctx_read_rooted_snapshot(
+        &self,
+        rooted_path: &str,
+        raw_input: &str,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
+        let root = self.adapter.root();
+        let rooted_path = Path::new(rooted_path);
+        if !rooted_path.is_absolute() || !rooted_path.starts_with(root) {
+            return Err("ctx_read Engine source is outside its rooted boundary".to_owned());
+        }
+        let (request, input) = NativeContextEngineRequest::ctx_read_snapshot_canonical(
+            rooted_path,
             raw_input,
             30_000,
             policy_admission,
@@ -213,14 +277,8 @@ impl NativeContextEngine {
         if policy_admission.decision != EnginePolicyDecisionV1::Rejected {
             return Err("ctx_read rejection requires a rejected policy admission".to_owned());
         }
-        let rooted_path = crate::core::pathjail::jail_path(Path::new(path), self.adapter.root())
-            .map_err(|_| "ctx_read Engine source is outside its rooted boundary".to_owned())?;
-        let (request, _) = NativeContextEngineRequest::ctx_read_snapshot(
-            &rooted_path.to_string_lossy(),
-            "",
-            30_000,
-            policy_admission,
-        )?;
+        let request =
+            NativeContextEngineRequest::ctx_read_rejection(path, 30_000, policy_admission)?;
         self.execute(request)
     }
 
@@ -511,38 +569,7 @@ fn persist_content(
     extension: &str,
     bytes: &[u8],
 ) -> Result<(), String> {
-    let data_dir = data_dir::lean_ctx_data_dir()?;
-    let directory = data_dir.join(directory);
-    std::fs::create_dir_all(&directory)
-        .map_err(|error| format!("create Engine artifact directory: {error}"))?;
-    data_dir::ensure_dir_permissions(&directory);
-    let path = directory.join(format!("{digest}.{extension}"));
-    if path.exists() {
-        verify_existing_artifact(&path, digest)?;
-        if let Some(permissions) = artifact_permissions() {
-            std::fs::set_permissions(&path, permissions)
-                .map_err(|error| format!("harden Engine artifact permissions: {error}"))?;
-        }
-        return Ok(());
-    }
-
-    let permissions = artifact_permissions();
-    atomic_fs::write_bytes_with_fallback(&path, bytes, permissions.as_ref())?;
-    verify_existing_artifact(&path, digest)
-}
-
-fn verify_existing_artifact(path: &Path, digest: &str) -> Result<(), String> {
-    let metadata = std::fs::symlink_metadata(path)
-        .map_err(|error| format!("read Engine artifact metadata: {error}"))?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err("Engine artifact path must be a regular non-symlink file".to_owned());
-    }
-    let bytes = std::fs::read(path).map_err(|error| format!("read Engine artifact: {error}"))?;
-    let actual = sha256_digest(&bytes)?;
-    if actual.hex() != digest {
-        return Err("Engine artifact digest does not match its content-addressed path".to_owned());
-    }
-    Ok(())
+    artifact_store::persist_content(directory, digest, extension, bytes).map(|_| ())
 }
 
 fn sha256_digest(bytes: &[u8]) -> Result<Sha256Digest, String> {
@@ -551,18 +578,6 @@ fn sha256_digest(bytes: &[u8]) -> Result<Sha256Digest, String> {
         crate::core::agent_identity::hex_encode(&Sha256::digest(bytes))
     ))
     .map_err(|error| error.to_string())
-}
-
-fn artifact_permissions() -> Option<std::fs::Permissions> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        Some(std::fs::Permissions::from_mode(0o600))
-    }
-    #[cfg(not(unix))]
-    {
-        None
-    }
 }
 
 #[cfg(test)]
@@ -802,7 +817,13 @@ mod tests {
         let root = tempfile::tempdir().expect("native adapter root");
         let source = root.path().join("fixture.md");
         std::fs::write(&source, "deadline fixture").expect("fixture write");
-        let engine = NativeContextEngine::with_root(root.path());
+        let control = std::sync::Arc::new(
+            crate::core::ocla::adapters::native_context::MaterializedTestControl::new(),
+        );
+        let engine = NativeContextEngine {
+            adapter: NativeContextAdapter::with_root(root.path())
+                .with_materialized_test_control(control.clone()),
+        };
         let admission = EnginePolicyAdmissionV1 {
             policy_ref: ProtocolReference::new("policy:ctx-read-context-gate-v1:fixture")
                 .expect("policy ref"),
@@ -811,19 +832,29 @@ mod tests {
         let (request, input) = NativeContextEngineRequest::ctx_read_snapshot(
             &source.to_string_lossy(),
             "deadline fixture",
-            0,
+            25,
             admission,
         )
         .expect("bounded request");
 
+        let started = std::time::Instant::now();
         let (_, observation) = engine
             .execute_materialized(request, &input)
             .expect("deadline failure receipt");
+        assert!(started.elapsed() < std::time::Duration::from_secs(1));
         assert_eq!(observation.status, EngineObservationStatusV1::Failed);
         assert_eq!(
-            observation.failure.expect("deadline failure").code,
+            observation.failure.as_ref().expect("deadline failure").code,
             EngineFailureCodeV1::ResourceLimit
         );
+        assert!(observation.receipt_link.is_some());
+        let output_dir = data_dir::lean_ctx_data_dir()
+            .expect("isolated data dir")
+            .join(OUTPUT_DIRECTORY);
+        assert!(!output_dir.exists());
+        control.release.wait();
+        control.completed.wait();
+        assert!(!output_dir.exists());
     }
 
     #[cfg(unix)]
@@ -879,7 +910,32 @@ mod tests {
         assert!(
             persist_output(digest.hex(), bytes)
                 .unwrap_err()
-                .contains("regular non-symlink")
+                .contains("engine_artifact_leaf_untrusted")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_engine_artifact_directory_is_rejected_before_any_write() {
+        use std::os::unix::fs::symlink;
+
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_dir = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let engine_dir = data_dir.join("engine-interface/v1");
+        std::fs::create_dir_all(&engine_dir).expect("Engine directory");
+        let outside = tempfile::tempdir().expect("outside directory");
+        symlink(outside.path(), engine_dir.join("outputs")).expect("artifact directory symlink");
+        let bytes = b"must remain inside the Engine data root";
+        let digest = digest(bytes);
+
+        let error = persist_output(digest.hex(), bytes).expect_err("symlinked directory rejected");
+
+        assert!(error.contains("engine_artifact_boundary_rejected"));
+        assert_eq!(
+            std::fs::read_dir(outside.path())
+                .expect("outside directory")
+                .count(),
+            0
         );
     }
 

--- a/rust/src/core/engine_interface.rs
+++ b/rust/src/core/engine_interface.rs
@@ -28,6 +28,7 @@ const CAPABILITY_ID: &str = "capability://leanctx/context-optimization";
 const CAPABILITY_VERSION: &str = "1.0.0";
 const RECEIPT_DIRECTORY: &str = "engine-interface/v1/receipts";
 const OUTPUT_DIRECTORY: &str = "engine-interface/v1/outputs";
+const RECOVERY_DIRECTORY: &str = "engine-interface/v1/recovery";
 
 /// Inputs intentionally retained inside the local Engine proof boundary.
 ///
@@ -35,16 +36,88 @@ const OUTPUT_DIRECTORY: &str = "engine-interface/v1/outputs";
 /// verifies the expected input digest against the bytes read through the native
 /// rooted adapter, so an observation can never claim a different source input.
 #[derive(Clone, Debug)]
-pub(crate) struct NativeContextEngineRequest {
-    pub invocation_id: EngineInvocationIdV1,
-    pub input_ref: ProtocolReference,
-    pub input_digest: Sha256Digest,
-    pub source_refs: Vec<ProtocolReference>,
-    pub policy_admission: EnginePolicyAdmissionV1,
-    pub paths: Vec<String>,
-    pub mode: String,
-    pub budget_tokens: Option<u64>,
-    pub timeout_ms: u64,
+struct NativeContextEngineRequest {
+    invocation_id: EngineInvocationIdV1,
+    input_ref: ProtocolReference,
+    input_digest: Sha256Digest,
+    source_refs: Vec<ProtocolReference>,
+    policy_admission: EnginePolicyAdmissionV1,
+    paths: Vec<String>,
+    mode: String,
+    budget_tokens: Option<u64>,
+    timeout_ms: u64,
+}
+
+impl NativeContextEngineRequest {
+    fn ctx_read_snapshot(
+        path: &str,
+        raw_input: &str,
+        timeout_ms: u64,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(Self, String), String> {
+        let input = crate::core::redaction::redact_text_if_enabled(raw_input);
+        let raw_input_digest = sha256_digest(raw_input.as_bytes())?;
+        let input_digest = sha256_digest(input.as_bytes())?;
+        let input_ref = ProtocolReference::new(format!(
+            "input:ctx-read-snapshot-sha256:{}",
+            raw_input_digest.hex()
+        ))
+        .map_err(|error| error.to_string())?;
+        let canonical_path = std::fs::canonicalize(path)
+            .map_err(|error| format!("resolve ctx_read Engine source: {error}"))?;
+        let canonical_path = canonical_path.to_string_lossy().into_owned();
+        let path_digest = sha256_digest(canonical_path.as_bytes())?;
+        let source_ref = ProtocolReference::new(format!(
+            "source:canonical-path-sha256:{}",
+            path_digest.hex()
+        ))
+        .map_err(|error| error.to_string())?;
+        let invocation_seed = canonical::canonical_serialize(&CtxReadInvocationIdentityV1 {
+            engine_id: ENGINE_ID,
+            engine_version: env!("CARGO_PKG_VERSION"),
+            capability_id: CAPABILITY_ID,
+            capability_version: CAPABILITY_VERSION,
+            input_ref: input_ref.as_str(),
+            source_ref: source_ref.as_str(),
+            input_digest: input_digest.as_str(),
+            policy_ref: policy_admission.policy_ref.as_str(),
+            policy_decision: policy_admission.decision,
+            mode: "aggressive",
+            timeout_ms,
+        });
+        let invocation_digest = sha256_digest(&invocation_seed)?;
+        let request = Self {
+            invocation_id: EngineInvocationIdV1::new(format!(
+                "engine-invocation-{}",
+                &invocation_digest.hex()[..32]
+            ))
+            .map_err(|error| error.to_string())?,
+            input_ref: input_ref.clone(),
+            input_digest,
+            source_refs: vec![input_ref, source_ref],
+            policy_admission,
+            paths: vec![canonical_path],
+            mode: "aggressive".to_owned(),
+            budget_tokens: None,
+            timeout_ms,
+        };
+        Ok((request, input))
+    }
+}
+
+#[derive(Serialize)]
+struct CtxReadInvocationIdentityV1<'a> {
+    engine_id: &'a str,
+    engine_version: &'a str,
+    capability_id: &'a str,
+    capability_version: &'a str,
+    input_ref: &'a str,
+    source_ref: &'a str,
+    input_digest: &'a str,
+    policy_ref: &'a str,
+    policy_decision: EnginePolicyDecisionV1,
+    mode: &'a str,
+    timeout_ms: u64,
 }
 
 /// One strictly local implementation of the published Engine records.
@@ -61,6 +134,15 @@ struct EngineReceiptArtifactV1 {
     observation: EngineObservationV1,
 }
 
+#[derive(Serialize)]
+#[serde(deny_unknown_fields)]
+struct EngineRecoveryArtifactV1 {
+    schema_version: u32,
+    invocation: EngineInvocationV1,
+    observation: EngineObservationV1,
+    failure_class: &'static str,
+}
+
 impl NativeContextEngine {
     #[must_use]
     pub(crate) fn with_root(root: impl AsRef<Path>) -> Self {
@@ -69,7 +151,7 @@ impl NativeContextEngine {
         }
     }
 
-    pub(crate) fn interface(&self) -> Result<EngineInterfaceV1, String> {
+    fn interface(&self) -> Result<EngineInterfaceV1, String> {
         let interface = EngineInterfaceV1 {
             schema_version: V1_SCHEMA_VERSION,
             interface_version: SemanticVersion::new("1.0.0").map_err(|error| error.to_string())?,
@@ -85,9 +167,67 @@ impl NativeContextEngine {
     /// Rejections never enter the adapter. Successful output is persisted only
     /// as a local integrity-addressed artifact; the observation exposes its
     /// reference and SHA-256, never the payload.
-    pub(crate) fn execute(
+    fn execute(
         &self,
         request: NativeContextEngineRequest,
+    ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
+        self.execute_inner(request, None)
+    }
+
+    /// Execute against a caller-owned immutable source snapshot.
+    ///
+    /// The digest is still verified by the adapter; the only difference from
+    /// `execute` is that no second disk read can race the production caller.
+    fn execute_materialized(
+        &self,
+        request: NativeContextEngineRequest,
+        input: &str,
+    ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
+        self.execute_inner(request, Some(input))
+    }
+
+    /// Bind and execute the production `ctx_read` snapshot as one operation.
+    pub(crate) fn execute_ctx_read_snapshot(
+        &self,
+        path: &str,
+        raw_input: &str,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
+        let rooted_path = crate::core::pathjail::jail_path(Path::new(path), self.adapter.root())
+            .map_err(|_| "ctx_read Engine source is outside its rooted boundary".to_owned())?;
+        let rooted_path = rooted_path.to_string_lossy().into_owned();
+        let (request, input) = NativeContextEngineRequest::ctx_read_snapshot(
+            &rooted_path,
+            raw_input,
+            30_000,
+            policy_admission,
+        )?;
+        self.execute_materialized(request, &input)
+    }
+
+    pub(crate) fn execute_ctx_read_rejection(
+        &self,
+        path: &str,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
+        if policy_admission.decision != EnginePolicyDecisionV1::Rejected {
+            return Err("ctx_read rejection requires a rejected policy admission".to_owned());
+        }
+        let rooted_path = crate::core::pathjail::jail_path(Path::new(path), self.adapter.root())
+            .map_err(|_| "ctx_read Engine source is outside its rooted boundary".to_owned())?;
+        let (request, _) = NativeContextEngineRequest::ctx_read_snapshot(
+            &rooted_path.to_string_lossy(),
+            "",
+            30_000,
+            policy_admission,
+        )?;
+        self.execute(request)
+    }
+
+    fn execute_inner(
+        &self,
+        request: NativeContextEngineRequest,
+        materialized_input: Option<&str>,
     ) -> Result<(EngineInvocationV1, EngineObservationV1), String> {
         let invocation = self.invocation_for(&request)?;
         if request.policy_admission.decision == EnginePolicyDecisionV1::Rejected {
@@ -122,23 +262,34 @@ impl NativeContextEngine {
             timeout_ms: request.timeout_ms,
         };
 
-        let observation = match self.adapter.invoke_with_output_identity(&native_invocation) {
+        let native_result = match materialized_input {
+            Some(input) => self
+                .adapter
+                .invoke_materialized_bounded(native_invocation, input.to_owned()),
+            None => self.adapter.invoke_with_output_identity(&native_invocation),
+        };
+        let observation = match native_result {
             Ok(result) if result.input_digest == request.input_digest.as_str() => {
                 let output_digest = Sha256Digest::new(result.output_digest)
                     .map_err(|error| format!("native output digest is invalid: {error}"))?;
                 let output_ref = ProtocolReference::new(format!("output:{}", output_digest.hex()))
                     .map_err(|error| error.to_string())?;
-                persist_output(output_digest.hex(), &result.output)?;
-                EngineObservationV1 {
-                    schema_version: V1_SCHEMA_VERSION,
-                    invocation_id: invocation.invocation_id.clone(),
-                    status: EngineObservationStatusV1::Succeeded,
-                    output_ref: Some(output_ref),
-                    output_digest: Some(output_digest),
-                    source_lineage: invocation.source_refs.clone(),
-                    measurements: measured_observations(&result.result),
-                    failure: None,
-                    receipt_link: None,
+                match persist_output(output_digest.hex(), &result.output) {
+                    Ok(()) => EngineObservationV1 {
+                        schema_version: V1_SCHEMA_VERSION,
+                        invocation_id: invocation.invocation_id.clone(),
+                        status: EngineObservationStatusV1::Succeeded,
+                        output_ref: Some(output_ref),
+                        output_digest: Some(output_digest),
+                        source_lineage: invocation.source_refs.clone(),
+                        measurements: measured_observations(&result.result),
+                        failure: None,
+                        receipt_link: None,
+                    },
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to persist Engine output artifact");
+                        storage_failure_observation(&invocation)
+                    }
                 }
             }
             Ok(_) => source_integrity_failure(&invocation),
@@ -173,7 +324,25 @@ impl NativeContextEngine {
         observation
             .validate_for(&invocation)
             .map_err(|error| format!("invalid Engine observation: {error}"))?;
-        let receipt_link = persist_receipt(&invocation, &observation)?;
+        let receipt_link = match persist_receipt(&invocation, &observation) {
+            Ok(receipt_link) => receipt_link,
+            Err(error) => {
+                let recovery_ref = persist_recovery(
+                    &invocation,
+                    &observation,
+                    "receipt-persistence-failed",
+                )
+                .map_err(|recovery_error| {
+                    format!(
+                        "persist Engine receipt: {error}; persist Engine recovery artifact: {recovery_error}"
+                    )
+                })?;
+                return Err(format!(
+                    "persist Engine receipt: {error}; recovery_ref={}",
+                    recovery_ref.as_str()
+                ));
+            }
+        };
         let mut observation = observation;
         observation.receipt_link = Some(receipt_link);
         observation
@@ -207,7 +376,6 @@ fn measured_observations(
     let mut measurements = vec![
         measured("input_tokens", "token", result.observation.input_tokens),
         measured("output_tokens", "token", result.output_tokens),
-        measured("latency_ms", "millisecond", result.latency_ms),
     ];
     for name in ["compression_saved_tokens", "compression_rate_milli"] {
         if let Some(value) = result.observation.metrics.get(name) {
@@ -280,6 +448,18 @@ fn failed_observation(
     }
 }
 
+fn storage_failure_observation(invocation: &EngineInvocationV1) -> EngineObservationV1 {
+    let mut observation = failed_observation(
+        invocation,
+        EngineFailureCodeV1::Internal,
+        Some(invocation.input_ref.clone()),
+    );
+    if let Some(failure) = observation.failure.as_mut() {
+        failure.retryable_by_host = true;
+    }
+    observation
+}
+
 fn persist_output(digest: &str, bytes: &[u8]) -> Result<(), String> {
     persist_content(OUTPUT_DIRECTORY, digest, "txt", bytes)
 }
@@ -307,6 +487,24 @@ fn persist_receipt(
     })
 }
 
+fn persist_recovery(
+    invocation: &EngineInvocationV1,
+    observation: &EngineObservationV1,
+    failure_class: &'static str,
+) -> Result<ProtocolReference, String> {
+    let artifact = EngineRecoveryArtifactV1 {
+        schema_version: V1_SCHEMA_VERSION,
+        invocation: invocation.clone(),
+        observation: observation.clone(),
+        failure_class,
+    };
+    let bytes = canonical::canonical_serialize(&artifact);
+    let digest = sha256_digest(&bytes)?;
+    persist_content(RECOVERY_DIRECTORY, digest.hex(), "json", &bytes)?;
+    ProtocolReference::new(format!("recovery:sha256:{}", digest.hex()))
+        .map_err(|error| error.to_string())
+}
+
 fn persist_content(
     directory: &str,
     digest: &str,
@@ -321,6 +519,10 @@ fn persist_content(
     let path = directory.join(format!("{digest}.{extension}"));
     if path.exists() {
         verify_existing_artifact(&path, digest)?;
+        if let Some(permissions) = artifact_permissions() {
+            std::fs::set_permissions(&path, permissions)
+                .map_err(|error| format!("harden Engine artifact permissions: {error}"))?;
+        }
         return Ok(());
     }
 
@@ -399,6 +601,60 @@ mod tests {
     }
 
     #[test]
+    fn rejected_receipt_matches_the_versioned_golden_fixture() {
+        let input_ref = ProtocolReference::new("input:fixture").expect("input ref");
+        let source_ref = ProtocolReference::new("source:fixture").expect("source ref");
+        let invocation = EngineInvocationV1 {
+            schema_version: V1_SCHEMA_VERSION,
+            invocation_id: EngineInvocationIdV1::new("engine-invocation-fixture-v1")
+                .expect("invocation id"),
+            engine: ResolvedLocalEngineIdentityV1 {
+                engine_id: ENGINE_ID.to_owned(),
+                engine_version: SemanticVersion::new("1.0.0").expect("engine version"),
+            },
+            operation: native_operation().expect("operation"),
+            input_ref: input_ref.clone(),
+            input_digest: Sha256Digest::new(format!("sha256:{}", "0".repeat(64)))
+                .expect("input digest"),
+            source_refs: vec![input_ref, source_ref],
+            policy_admission: EnginePolicyAdmissionV1 {
+                policy_ref: ProtocolReference::new("policy:fixture").expect("policy ref"),
+                decision: EnginePolicyDecisionV1::Rejected,
+            },
+        };
+        let observation = EngineObservationV1 {
+            schema_version: V1_SCHEMA_VERSION,
+            invocation_id: invocation.invocation_id.clone(),
+            status: EngineObservationStatusV1::Rejected,
+            output_ref: None,
+            output_digest: None,
+            source_lineage: invocation.source_refs.clone(),
+            measurements: Vec::new(),
+            failure: Some(EngineFailureV1 {
+                code: EngineFailureCodeV1::PolicyRejected,
+                retryable_by_host: false,
+                recovery_ref: None,
+            }),
+            receipt_link: None,
+        };
+        let artifact = EngineReceiptArtifactV1 {
+            schema_version: V1_SCHEMA_VERSION,
+            invocation,
+            observation,
+        };
+        let fixture: serde_json::Value = serde_json::from_slice(include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../docs/contracts/engine-interface/v1/rejected-receipt.json"
+        )))
+        .expect("golden receipt fixture");
+
+        assert_eq!(
+            canonical::canonical_serialize(&artifact),
+            canonical::canonical_serialize(&fixture)
+        );
+    }
+
+    #[test]
     fn admitted_native_operation_persists_integrity_addressed_output_and_receipt() {
         let _data_dir = data_dir::isolated_data_dir();
         let root = tempfile::tempdir().expect("native adapter root");
@@ -456,6 +712,239 @@ mod tests {
         );
         assert_eq!(first_invocation.source_refs, second_invocation.source_refs);
         assert_eq!(first.output_digest, second.output_digest);
+        assert_eq!(first.receipt_link, second.receipt_link);
+    }
+
+    #[test]
+    fn materialized_execution_binds_receipt_to_the_callers_exact_snapshot() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let root = tempfile::tempdir().expect("native adapter root");
+        std::fs::write(root.path().join("fixture.md"), "different disk bytes")
+            .expect("fixture write");
+        std::fs::create_dir(root.path().join("alias-parent")).expect("alias directory");
+        let input = "caller snapshot\nwith stable context";
+        let engine = NativeContextEngine::with_root(root.path());
+        let policy_ref = "policy:ctx-read-context-gate-v1:fixture";
+        let policy_admission = EnginePolicyAdmissionV1 {
+            policy_ref: ProtocolReference::new(policy_ref).expect("policy ref"),
+            decision: EnginePolicyDecisionV1::Admitted,
+        };
+        let source_path = root.path().join("fixture.md");
+        let (request, prepared_input) = NativeContextEngineRequest::ctx_read_snapshot(
+            &source_path.to_string_lossy(),
+            input,
+            30_000,
+            policy_admission.clone(),
+        )
+        .expect("production request");
+        let (alias_request, alias_prepared_input) = NativeContextEngineRequest::ctx_read_snapshot(
+            &root
+                .path()
+                .join("alias-parent/../fixture.md")
+                .to_string_lossy(),
+            input,
+            30_000,
+            policy_admission,
+        )
+        .expect("canonical alias request");
+        assert_eq!(request.invocation_id, alias_request.invocation_id);
+        assert_eq!(request.source_refs, alias_request.source_refs);
+        assert_eq!(prepared_input, alias_prepared_input);
+        assert!(
+            request
+                .input_ref
+                .as_str()
+                .starts_with("input:ctx-read-snapshot-sha256:")
+        );
+
+        let (invocation, observation) = engine
+            .execute_materialized(request, &prepared_input)
+            .expect("materialized Engine invocation");
+
+        assert_eq!(invocation.input_digest, digest(prepared_input.as_bytes()));
+        assert_eq!(invocation.policy_admission.policy_ref.as_str(), policy_ref);
+        assert_eq!(observation.status, EngineObservationStatusV1::Succeeded);
+        assert!(observation.receipt_link.is_some());
+        assert!(
+            observation
+                .measurements
+                .iter()
+                .all(|measurement| measurement.name != "latency_ms")
+        );
+    }
+
+    #[test]
+    fn production_snapshot_refuses_a_source_outside_the_engine_root() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let root = tempfile::tempdir().expect("native adapter root");
+        let outside = tempfile::tempdir().expect("outside root");
+        let source = outside.path().join("escape.md");
+        std::fs::write(&source, "outside").expect("outside fixture");
+        let engine = NativeContextEngine::with_root(root.path());
+        let admission = EnginePolicyAdmissionV1 {
+            policy_ref: ProtocolReference::new("policy:ctx-read-context-gate-v1:fixture")
+                .expect("policy ref"),
+            decision: EnginePolicyDecisionV1::Admitted,
+        };
+
+        let error = engine
+            .execute_ctx_read_snapshot(&source.to_string_lossy(), "outside", admission)
+            .unwrap_err();
+        assert_eq!(
+            error,
+            "ctx_read Engine source is outside its rooted boundary"
+        );
+    }
+
+    #[test]
+    fn materialized_execution_enforces_a_real_host_deadline() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let root = tempfile::tempdir().expect("native adapter root");
+        let source = root.path().join("fixture.md");
+        std::fs::write(&source, "deadline fixture").expect("fixture write");
+        let engine = NativeContextEngine::with_root(root.path());
+        let admission = EnginePolicyAdmissionV1 {
+            policy_ref: ProtocolReference::new("policy:ctx-read-context-gate-v1:fixture")
+                .expect("policy ref"),
+            decision: EnginePolicyDecisionV1::Admitted,
+        };
+        let (request, input) = NativeContextEngineRequest::ctx_read_snapshot(
+            &source.to_string_lossy(),
+            "deadline fixture",
+            0,
+            admission,
+        )
+        .expect("bounded request");
+
+        let (_, observation) = engine
+            .execute_materialized(request, &input)
+            .expect("deadline failure receipt");
+        assert_eq!(observation.status, EngineObservationStatusV1::Failed);
+        assert_eq!(
+            observation.failure.expect("deadline failure").code,
+            EngineFailureCodeV1::ResourceLimit
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_engine_artifact_permissions_are_rehardened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _data_dir = data_dir::isolated_data_dir();
+        let bytes = b"permission fixture";
+        let digest = digest(bytes);
+        persist_output(digest.hex(), bytes).expect("initial artifact");
+        let path = data_dir::lean_ctx_data_dir()
+            .expect("isolated data dir")
+            .join(OUTPUT_DIRECTORY)
+            .join(format!("{}.txt", digest.hex()));
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen fixture permissions");
+
+        persist_output(digest.hex(), bytes).expect("reharden existing artifact");
+        assert_eq!(
+            std::fs::metadata(path)
+                .expect("artifact metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_engine_artifact_rejects_tampering_and_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_dir = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let output_dir = data_dir.join(OUTPUT_DIRECTORY);
+        std::fs::create_dir_all(&output_dir).expect("output directory");
+        let bytes = b"expected output";
+        let digest = digest(bytes);
+        let path = output_dir.join(format!("{}.txt", digest.hex()));
+        std::fs::write(&path, b"tampered output").expect("tampered artifact");
+        assert!(
+            persist_output(digest.hex(), bytes)
+                .unwrap_err()
+                .contains("digest")
+        );
+
+        std::fs::remove_file(&path).expect("remove tampered artifact");
+        let target = output_dir.join("target.txt");
+        std::fs::write(&target, bytes).expect("symlink target");
+        symlink(&target, &path).expect("artifact symlink");
+        assert!(
+            persist_output(digest.hex(), bytes)
+                .unwrap_err()
+                .contains("regular non-symlink")
+        );
+    }
+
+    #[test]
+    fn ctx_read_identity_is_bound_to_raw_snapshot_bytes() {
+        let root = tempfile::tempdir().expect("native adapter root");
+        let path = root.path().join("fixture.md");
+        std::fs::write(&path, "fixture").expect("fixture write");
+        let admission = EnginePolicyAdmissionV1 {
+            policy_ref: ProtocolReference::new("policy:ctx-read-context-gate-v1:fixture")
+                .expect("policy ref"),
+            decision: EnginePolicyDecisionV1::Admitted,
+        };
+        let (first, _) = NativeContextEngineRequest::ctx_read_snapshot(
+            &path.to_string_lossy(),
+            "raw snapshot A",
+            30_000,
+            admission.clone(),
+        )
+        .expect("first request");
+        let (second, _) = NativeContextEngineRequest::ctx_read_snapshot(
+            &path.to_string_lossy(),
+            "raw snapshot B",
+            30_000,
+            admission,
+        )
+        .expect("second request");
+
+        assert_ne!(first.input_ref, second.input_ref);
+        assert_ne!(first.invocation_id, second.invocation_id);
+    }
+
+    #[test]
+    fn production_snapshot_redacts_secret_before_output_and_recovery_persistence() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_dir = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let engine_dir = data_dir.join("engine-interface/v1");
+        std::fs::create_dir_all(&engine_dir).expect("Engine directory");
+        std::fs::write(engine_dir.join("receipts"), "blocks receipt directory")
+            .expect("receipt blocker");
+        let root = tempfile::tempdir().expect("native adapter root");
+        let path = root.path().join("secret.md");
+        std::fs::write(&path, "source placeholder").expect("fixture write");
+        let secret = format!(
+            "api_key={}",
+            ["not", "-a-real-secret-", "1234567890abcdef"].concat()
+        );
+        let admission = EnginePolicyAdmissionV1 {
+            policy_ref: ProtocolReference::new("policy:ctx-read-context-gate-v1:redaction")
+                .expect("policy ref"),
+            decision: EnginePolicyDecisionV1::Admitted,
+        };
+
+        let error = NativeContextEngine::with_root(root.path())
+            .execute_ctx_read_snapshot(&path.to_string_lossy(), &secret, admission)
+            .expect_err("blocked receipt must return a durable recovery error");
+        assert!(!error.contains(&secret));
+
+        for directory in [OUTPUT_DIRECTORY, RECOVERY_DIRECTORY] {
+            for entry in std::fs::read_dir(data_dir.join(directory)).expect("artifact directory") {
+                let bytes =
+                    std::fs::read(entry.expect("artifact entry").path()).expect("artifact bytes");
+                assert!(!String::from_utf8_lossy(&bytes).contains(&secret));
+            }
+        }
     }
 
     #[test]
@@ -516,6 +1005,34 @@ mod tests {
         let failure = observation.failure.expect("failure record");
         assert_eq!(failure.code, EngineFailureCodeV1::SourceIntegrityMismatch);
         assert!(failure.recovery_ref.is_some());
+    }
+
+    #[test]
+    fn output_persistence_failure_is_receipted_and_retryable() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_dir = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let engine_dir = data_dir.join("engine-interface/v1");
+        std::fs::create_dir_all(&engine_dir).expect("Engine directory");
+        std::fs::write(engine_dir.join("outputs"), "blocks output directory")
+            .expect("output blocker");
+        let root = tempfile::tempdir().expect("native adapter root");
+        let input = b"retryable native context";
+        std::fs::write(root.path().join("fixture.md"), input).expect("fixture write");
+        let engine = NativeContextEngine::with_root(root.path());
+        let request = request("fixture.md", input, EnginePolicyDecisionV1::Admitted);
+
+        let (_, failed) = engine.execute(request.clone()).expect("failed receipt");
+        assert_eq!(failed.status, EngineObservationStatusV1::Failed);
+        assert!(failed.receipt_link.is_some());
+        let failure = failed.failure.expect("failure record");
+        assert_eq!(failure.code, EngineFailureCodeV1::Internal);
+        assert!(failure.retryable_by_host);
+
+        std::fs::remove_file(engine_dir.join("outputs")).expect("remove output blocker");
+        std::fs::create_dir(engine_dir.join("outputs")).expect("output directory");
+        let (_, retried) = engine.execute(request).expect("successful retry");
+        assert_eq!(retried.status, EngineObservationStatusV1::Succeeded);
+        assert!(retried.receipt_link.is_some());
     }
 
     #[test]

--- a/rust/src/core/engine_interface.rs
+++ b/rust/src/core/engine_interface.rs
@@ -940,6 +940,47 @@ mod tests {
     }
 
     #[test]
+    fn failed_engine_artifact_publish_leaves_final_absent_and_retryable() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let bytes = b"failure-atomic artifact fixture";
+        let digest = digest(bytes);
+        let output_dir = data_dir::lean_ctx_data_dir()
+            .expect("isolated data dir")
+            .join(OUTPUT_DIRECTORY);
+        let final_path = output_dir.join(format!("{}.txt", digest.hex()));
+
+        artifact_store::inject_test_pre_publish_failure();
+        assert_eq!(
+            persist_output(digest.hex(), bytes).expect_err("injected publish failure"),
+            "engine_artifact_test_pre_publish_failure"
+        );
+        assert!(
+            !final_path.exists(),
+            "failed publish must not expose final path"
+        );
+        assert_eq!(
+            std::fs::read_dir(&output_dir)
+                .expect("output directory")
+                .count(),
+            0,
+            "failed publish must clean its temporary leaf"
+        );
+
+        persist_output(digest.hex(), bytes).expect("retry publishes complete artifact");
+        assert_eq!(
+            std::fs::read(&final_path).expect("published artifact"),
+            bytes
+        );
+        assert_eq!(
+            std::fs::read_dir(&output_dir)
+                .expect("output directory")
+                .count(),
+            1,
+            "successful retry leaves only the addressed artifact"
+        );
+    }
+
+    #[test]
     fn ctx_read_identity_is_bound_to_raw_snapshot_bytes() {
         let root = tempfile::tempdir().expect("native adapter root");
         let path = root.path().join("fixture.md");

--- a/rust/src/core/episodic_memory.rs
+++ b/rust/src/core/episodic_memory.rs
@@ -577,8 +577,7 @@ pub mod tests {
 
     #[test]
     fn record_session_episode_deduplicates_per_agent() {
-        let tmp = tempfile::tempdir().unwrap();
-        crate::test_env::set_var("LEAN_CTX_DATA_DIR", tmp.path());
+        let _isolated = crate::core::data_dir::isolated_data_dir();
         let policy = EpisodicPolicy::default();
         let project_hash = "episodic-agent-dedup";
         let mut session = super::super::session::SessionState::new();

--- a/rust/src/core/ocla/adapters/native_context.rs
+++ b/rust/src/core/ocla/adapters/native_context.rs
@@ -126,6 +126,18 @@ impl NativeContextAdapter {
         let input = read_context_paths(&self.root, paths).map_err(|error| {
             NativeContextInvocationFailure::SourceUnavailable(error.to_string())
         })?;
+        self.invoke_materialized_context(invocation, paths, mode, budget_tokens, start, &input)
+    }
+
+    fn invoke_materialized_context(
+        &self,
+        invocation: &CapabilityInvocation,
+        paths: &[String],
+        mode: &str,
+        budget_tokens: Option<u64>,
+        start: Instant,
+        input: &str,
+    ) -> Result<NativeContextInvocationResult, NativeContextInvocationFailure> {
         let input_tokens = tokens::count_tokens(&input) as u64;
         if let Some(max) = invocation.policy_constraints.max_input_tokens
             && input_tokens > max
@@ -200,16 +212,7 @@ impl NativeContextAdapter {
         &self,
         invocation: &CapabilityInvocation,
     ) -> Result<NativeContextInvocationResult, NativeContextInvocationFailure> {
-        invocation
-            .validate()
-            .map_err(|error| NativeContextInvocationFailure::InvalidRequest(error.to_string()))?;
-        if invocation.capability_id != self.manifest().capability_id.as_str()
-            || invocation.capability_version != self.manifest().version
-        {
-            return Err(NativeContextInvocationFailure::InvalidRequest(
-                "invocation capability identity does not match adapter manifest".into(),
-            ));
-        }
+        self.validate_engine_invocation(invocation)?;
         let start = Instant::now();
         match &invocation.input {
             CapabilityInput::ContextRequest {
@@ -221,6 +224,93 @@ impl NativeContextAdapter {
                 Err(NativeContextInvocationFailure::UnsupportedInput)
             }
         }
+    }
+
+    /// Execute against the exact source snapshot already acquired by a
+    /// production caller. This prevents a second file read and binds the
+    /// Engine digest to the same bytes the caller will render.
+    fn invoke_materialized_with_output_identity(
+        &self,
+        invocation: &CapabilityInvocation,
+        input: &str,
+    ) -> Result<NativeContextInvocationResult, NativeContextInvocationFailure> {
+        self.validate_engine_invocation(invocation)?;
+        let start = Instant::now();
+        match &invocation.input {
+            CapabilityInput::ContextRequest {
+                paths,
+                mode,
+                budget_tokens,
+            } => self.invoke_materialized_context(
+                invocation,
+                paths,
+                mode,
+                *budget_tokens,
+                start,
+                input,
+            ),
+            CapabilityInput::ShellCommand { .. } | CapabilityInput::ModelRequest { .. } => {
+                Err(NativeContextInvocationFailure::UnsupportedInput)
+            }
+        }
+    }
+
+    /// Execute a materialized invocation behind an actual host deadline.
+    /// Timed-out workers can finish computation, but cannot persist Engine
+    /// artifacts because persistence remains in the receiving Engine layer.
+    pub(crate) fn invoke_materialized_bounded(
+        &self,
+        invocation: CapabilityInvocation,
+        input: String,
+    ) -> Result<NativeContextInvocationResult, NativeContextInvocationFailure> {
+        if invocation.timeout_ms == 0 {
+            return Err(NativeContextInvocationFailure::ResourceLimit(
+                "native context deadline expired before dispatch".to_owned(),
+            ));
+        }
+        let timeout = std::time::Duration::from_millis(invocation.timeout_ms);
+        let adapter = Self::with_root(&self.root);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("native-context-engine".to_owned())
+            .spawn(move || {
+                let result = adapter.invoke_materialized_with_output_identity(&invocation, &input);
+                let _ = tx.send(result);
+            })
+            .map_err(|error| {
+                NativeContextInvocationFailure::InvalidRequest(format!(
+                    "start native context worker: {error}"
+                ))
+            })?;
+        rx.recv_timeout(timeout).map_err(|error| match error {
+            std::sync::mpsc::RecvTimeoutError::Timeout => {
+                NativeContextInvocationFailure::ResourceLimit(
+                    "native context execution exceeded its deadline".to_owned(),
+                )
+            }
+            std::sync::mpsc::RecvTimeoutError::Disconnected => {
+                NativeContextInvocationFailure::InvalidRequest(
+                    "native context worker disconnected".to_owned(),
+                )
+            }
+        })?
+    }
+
+    fn validate_engine_invocation(
+        &self,
+        invocation: &CapabilityInvocation,
+    ) -> Result<(), NativeContextInvocationFailure> {
+        invocation
+            .validate()
+            .map_err(|error| NativeContextInvocationFailure::InvalidRequest(error.to_string()))?;
+        if invocation.capability_id != self.manifest().capability_id.as_str()
+            || invocation.capability_version != self.manifest().version
+        {
+            return Err(NativeContextInvocationFailure::InvalidRequest(
+                "invocation capability identity does not match adapter manifest".into(),
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/rust/src/core/ocla/adapters/native_context.rs
+++ b/rust/src/core/ocla/adapters/native_context.rs
@@ -39,6 +39,24 @@ fn manifest() -> &'static CapabilityManifestV1 {
 /// Local adapter that combines existing file reads and compression primitives.
 pub struct NativeContextAdapter {
     root: PathBuf,
+    #[cfg(test)]
+    materialized_test_control: Option<std::sync::Arc<MaterializedTestControl>>,
+}
+
+#[cfg(test)]
+pub(crate) struct MaterializedTestControl {
+    pub(crate) release: std::sync::Barrier,
+    pub(crate) completed: std::sync::Barrier,
+}
+
+#[cfg(test)]
+impl MaterializedTestControl {
+    pub(crate) fn new() -> Self {
+        Self {
+            release: std::sync::Barrier::new(2),
+            completed: std::sync::Barrier::new(2),
+        }
+    }
 }
 
 /// Payload-free result used by the internal Engine proof path.
@@ -88,6 +106,8 @@ impl NativeContextAdapter {
     pub fn new() -> Self {
         Self {
             root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            #[cfg(test)]
+            materialized_test_control: None,
         }
     }
 
@@ -95,7 +115,18 @@ impl NativeContextAdapter {
     pub fn with_root(root: impl AsRef<Path>) -> Self {
         Self {
             root: root.as_ref().to_path_buf(),
+            #[cfg(test)]
+            materialized_test_control: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_materialized_test_control(
+        mut self,
+        control: std::sync::Arc<MaterializedTestControl>,
+    ) -> Self {
+        self.materialized_test_control = Some(control);
+        self
     }
 
     #[must_use]
@@ -270,11 +301,25 @@ impl NativeContextAdapter {
         }
         let timeout = std::time::Duration::from_millis(invocation.timeout_ms);
         let adapter = Self::with_root(&self.root);
+        #[cfg(test)]
+        let adapter = {
+            let mut adapter = adapter;
+            adapter.materialized_test_control = self.materialized_test_control.clone();
+            adapter
+        };
         let (tx, rx) = std::sync::mpsc::sync_channel(1);
         std::thread::Builder::new()
             .name("native-context-engine".to_owned())
             .spawn(move || {
+                #[cfg(test)]
+                if let Some(control) = adapter.materialized_test_control.as_ref() {
+                    control.release.wait();
+                }
                 let result = adapter.invoke_materialized_with_output_identity(&invocation, &input);
+                #[cfg(test)]
+                if let Some(control) = adapter.materialized_test_control.as_ref() {
+                    control.completed.wait();
+                }
                 let _ = tx.send(result);
             })
             .map_err(|error| {

--- a/rust/src/tools/ctx_read/file_io.rs
+++ b/rust/src/tools/ctx_read/file_io.rs
@@ -1,10 +1,16 @@
 use super::{ReadOutput, count_tokens, format_anchored_output_window};
 
+#[derive(Debug)]
+pub(crate) struct RootedRead {
+    pub(crate) content: String,
+    pub(crate) canonical_path: String,
+}
+
 /// Reads a file as UTF-8 with lossy fallback, enforcing binary detection and max read size limit.
 /// Defense-in-depth: verifies that the canonical path stays within the process's project root
 /// (if determinable) even though callers SHOULD have already jail-checked the path.
 pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
-    if crate::core::binary_detect::is_binary_file(path) {
+    if crate::core::binary_detect::has_binary_extension(path) {
         let msg = crate::core::binary_detect::binary_file_message(path);
         return Err(std::io::Error::other(msg));
     }
@@ -29,9 +35,26 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
         }
     }
 
-    let cap = crate::core::limits::max_read_bytes();
-
     let file = open_with_retry(path)?;
+    read_open_file_lossy(file, path)
+}
+
+pub(crate) fn read_file_lossy_rooted(path: &str, root: &str) -> Result<RootedRead, std::io::Error> {
+    if crate::core::binary_detect::has_binary_extension(path) {
+        return Err(std::io::Error::other(
+            crate::core::binary_detect::binary_file_message(path),
+        ));
+    }
+    let (file, canonical_path) =
+        open_rooted_nofollow(std::path::Path::new(path), std::path::Path::new(root))?;
+    Ok(RootedRead {
+        content: read_open_file_lossy(file, path)?,
+        canonical_path: canonical_path.to_string_lossy().into_owned(),
+    })
+}
+
+fn read_open_file_lossy(file: std::fs::File, path: &str) -> Result<String, std::io::Error> {
+    let cap = crate::core::limits::max_read_bytes();
     let meta = file
         .metadata()
         .map_err(|e| std::io::Error::other(format!("cannot stat open file descriptor: {e}")))?;
@@ -44,14 +67,147 @@ pub fn read_file_lossy(path: &str) -> Result<String, std::io::Error> {
         )));
     }
 
-    use std::io::Read;
+    use std::io::{BufRead, Read};
     let mut bytes = Vec::with_capacity(meta.len() as usize);
-    std::io::BufReader::new(file).read_to_end(&mut bytes)?;
+    let mut reader = std::io::BufReader::new(file);
+    if reader.fill_buf()?.iter().take(8192).any(|byte| *byte == 0) {
+        return Err(std::io::Error::other(
+            crate::core::binary_detect::binary_file_message(path),
+        ));
+    }
+    reader.read_to_end(&mut bytes)?;
     let s = match String::from_utf8(bytes) {
         Ok(s) => s,
         Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
     };
     Ok(crate::core::io_boundary::strip_utf8_bom(s))
+}
+
+#[cfg(unix)]
+fn open_rooted_nofollow(
+    path: &std::path::Path,
+    root: &std::path::Path,
+) -> Result<(std::fs::File, std::path::PathBuf), std::io::Error> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    let root = crate::core::pathutil::canonicalize_secure(root)?;
+    let target = crate::core::pathjail::jail_path(path, &root)
+        .map_err(|_| std::io::Error::other("file is outside the rooted read boundary"))?;
+    let relative = target
+        .strip_prefix(&root)
+        .map_err(|_| std::io::Error::other("file is outside the rooted read boundary"))?;
+    let components: Vec<_> = relative.components().collect();
+    if components.is_empty() {
+        return Err(std::io::Error::other(
+            "rooted read target must be a regular file",
+        ));
+    }
+    let root_name = CString::new(root.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::other("rooted read path contains a NUL byte"))?;
+    // SAFETY: root_name is NUL-terminated; File takes ownership immediately.
+    let root_fd = unsafe {
+        libc::open(
+            root_name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if root_fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: root_fd is a new successful descriptor owned by this scope.
+    let mut directory = unsafe { std::fs::File::from_raw_fd(root_fd) };
+    for (index, component) in components.iter().enumerate() {
+        let std::path::Component::Normal(name) = component else {
+            return Err(std::io::Error::other(
+                "rooted read path contains an invalid component",
+            ));
+        };
+        let name = CString::new(name.as_bytes())
+            .map_err(|_| std::io::Error::other("rooted read path contains a NUL byte"))?;
+        let last = index + 1 == components.len();
+        let flags = if last {
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK
+        } else {
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW
+        };
+        // SAFETY: directory is live and name is NUL-terminated. File owns success.
+        let fd = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: fd is a new successful descriptor owned by this scope.
+        let opened = unsafe { std::fs::File::from_raw_fd(fd) };
+        if last {
+            if !opened.metadata()?.is_file() {
+                return Err(std::io::Error::other(
+                    "rooted read target must be a regular file",
+                ));
+            }
+            return Ok((opened, target));
+        }
+        directory = opened;
+    }
+    unreachable!("non-empty rooted path must return from its final component")
+}
+
+#[cfg(windows)]
+fn open_rooted_nofollow(
+    path: &std::path::Path,
+    root: &std::path::Path,
+) -> Result<(std::fs::File, std::path::PathBuf), std::io::Error> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_DOS,
+    };
+
+    let root = crate::core::pathutil::canonicalize_secure(root)?;
+    crate::core::pathjail::jail_path(path, &root)
+        .map_err(|_| std::io::Error::other("file is outside the rooted read boundary"))?;
+    let file = std::fs::OpenOptions::new().read(true).open(path)?;
+    let mut buffer = vec![0u16; 32_768];
+    // SAFETY: the handle is live and buffer is writable for its full length.
+    let length = unsafe {
+        GetFinalPathNameByHandleW(
+            file.as_raw_handle() as _,
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+            FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
+        )
+    };
+    if length == 0 || length as usize >= buffer.len() {
+        return Err(std::io::Error::last_os_error());
+    }
+    buffer.truncate(length as usize);
+    let final_path = crate::core::pathutil::strip_verbatim(std::path::PathBuf::from(
+        OsString::from_wide(&buffer),
+    ));
+    if !final_path.starts_with(&root) || !file.metadata()?.is_file() {
+        return Err(std::io::Error::other(
+            "opened file escaped the rooted read boundary",
+        ));
+    }
+    Ok((file, final_path))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_rooted_nofollow(
+    path: &std::path::Path,
+    root: &std::path::Path,
+) -> Result<(std::fs::File, std::path::PathBuf), std::io::Error> {
+    let root = crate::core::pathutil::canonicalize_secure(root)?;
+    let target = crate::core::pathjail::jail_path(path, &root)
+        .map_err(|_| std::io::Error::other("file is outside the rooted read boundary"))?;
+    let file = std::fs::File::open(&target)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::other(
+            "rooted read target must be a regular file",
+        ));
+    }
+    Ok((file, target))
 }
 
 /// A streamed line-window read (#811): only the requested span's raw lines,
@@ -90,12 +246,21 @@ pub(super) fn parse_disk_anchor_range(payload: &str) -> Option<(usize, usize)> {
 /// the existing, more permissive `read_file_lossy` path — behaviour never
 /// regresses, it just doesn't always get the fast path.
 pub(super) fn read_line_window(path: &str, start: usize, end: usize) -> Option<LineWindow> {
-    if crate::core::binary_detect::is_binary_file(path) {
+    if crate::core::binary_detect::has_binary_extension(path) {
         return None;
     }
     use std::io::BufRead;
     let file = open_with_retry(path).ok()?;
-    let reader = std::io::BufReader::new(file);
+    let mut reader = std::io::BufReader::new(file);
+    if reader
+        .fill_buf()
+        .ok()?
+        .iter()
+        .take(8192)
+        .any(|byte| *byte == 0)
+    {
+        return None;
+    }
     let mut total = 0usize;
     let mut collected = Vec::new();
     for line in reader.lines() {
@@ -202,4 +367,78 @@ fn open_nofollow(path: &str) -> Result<std::fs::File, std::io::Error> {
 #[cfg(not(unix))]
 fn open_nofollow(path: &str) -> Result<std::fs::File, std::io::Error> {
     std::fs::File::open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_file_lossy_rooted;
+
+    #[test]
+    fn rooted_read_binds_content_to_canonical_in_root_source() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("source.txt");
+        std::fs::write(&path, "rooted content").unwrap();
+
+        let read = read_file_lossy_rooted(&path.to_string_lossy(), &root.path().to_string_lossy())
+            .unwrap();
+
+        assert_eq!(read.content, "rooted content");
+        assert_eq!(
+            std::path::Path::new(&read.canonical_path),
+            crate::core::pathutil::canonicalize_secure(&path).unwrap()
+        );
+    }
+
+    #[test]
+    fn rooted_read_rejects_outside_source_and_binary_content() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_path = outside.path().join("outside.txt");
+        std::fs::write(&outside_path, "outside").unwrap();
+        assert!(
+            read_file_lossy_rooted(
+                &outside_path.to_string_lossy(),
+                &root.path().to_string_lossy(),
+            )
+            .is_err()
+        );
+
+        let binary = root.path().join("binary.txt");
+        std::fs::write(&binary, b"text\0binary").unwrap();
+        let error =
+            read_file_lossy_rooted(&binary.to_string_lossy(), &root.path().to_string_lossy())
+                .unwrap_err();
+        assert!(error.to_string().contains("Binary file detected"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rooted_read_resolves_safe_alias_and_rejects_escape_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let inside = root.path().join("inside.txt");
+        std::fs::write(&inside, "inside").unwrap();
+        let safe_alias = root.path().join("safe-alias.txt");
+        symlink(&inside, &safe_alias).unwrap();
+        assert_eq!(
+            read_file_lossy_rooted(
+                &safe_alias.to_string_lossy(),
+                &root.path().to_string_lossy(),
+            )
+            .unwrap()
+            .content,
+            "inside"
+        );
+
+        let outside = tempfile::tempdir().unwrap();
+        let outside_path = outside.path().join("outside.txt");
+        std::fs::write(&outside_path, "outside").unwrap();
+        let escape = root.path().join("escape.txt");
+        symlink(outside_path, &escape).unwrap();
+        assert!(
+            read_file_lossy_rooted(&escape.to_string_lossy(), &root.path().to_string_lossy(),)
+                .is_err()
+        );
+    }
 }

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -54,7 +54,8 @@ impl McpTool for CtxReadTool {
                     "limit": { "type": "integer", "description": "Max lines" },
                     "fresh": { "type": "boolean", "description": "Bypass cache" },
                     "aggressiveness": { "type": "number", "description": "0.0–1.0 density (entropy/task)" },
-                    "protect": { "type": "array", "items": { "type": "string" }, "description": "Symbols kept verbatim" }
+                    "protect": { "type": "array", "items": { "type": "string" }, "description": "Symbols kept verbatim" },
+                    "engine_interface": engine::interface_schema()
                 },
                 "required": []
             }),
@@ -66,6 +67,8 @@ impl McpTool for CtxReadTool {
         args: &Map<String, Value>,
         ctx: &ToolContext,
     ) -> Result<ToolOutput, ErrorData> {
+        let engine_interface_v1 = engine::interface_v1_requested(args)?;
+        engine::validate_v1_request_shape(args, engine_interface_v1)?;
         // #509: ctx_read absorbs multi-file batch reads (supersedes ctx_multi_read).
         // A non-empty `paths` array routes to the one shared batch implementation.
         if args
@@ -101,7 +104,7 @@ impl McpTool for CtxReadTool {
         };
 
         let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.handle_inner(args, ctx, &path)
+            self.handle_inner(args, ctx, &path, engine_interface_v1)
         })) {
             Ok(result) => result,
             Err(_) => Err(ErrorData::internal_error(
@@ -149,6 +152,7 @@ impl CtxReadTool {
         args: &Map<String, Value>,
         ctx: &ToolContext,
         path: &str,
+        engine_interface_v1: bool,
     ) -> Result<ToolOutput, ErrorData> {
         let session_lock = ctx
             .session
@@ -226,7 +230,7 @@ impl CtxReadTool {
         let mut fresh = get_bool(args, "fresh").unwrap_or(false);
         // #513: a raw/verbatim request always reads from disk — the whole point
         // is exact current bytes, never a cached stub or delta.
-        if arg_raw {
+        if arg_raw || engine_interface_v1 {
             fresh = true;
         }
         let cache_policy = crate::server::compaction_sync::effective_cache_policy();
@@ -274,12 +278,13 @@ impl CtxReadTool {
             pressure_action,
             resolved_agent_id.as_deref(),
         );
-        if gate_result.budget_blocked {
-            let msg = gate_result
-                .budget_warning
-                .unwrap_or_else(|| "Agent token budget exceeded".to_string());
-            return Err(ErrorData::invalid_params(msg, None));
-        }
+        let engine_policy_admission = engine::admission_or_reject(
+            engine_interface_v1,
+            &gate_result,
+            &mode,
+            &ctx.project_root,
+            path,
+        )?;
         let budget_warning = gate_result.budget_warning.clone();
         // #513: an explicit raw/verbatim request is never silently downgraded by
         // the budget gate — the caller asked for exact bytes.
@@ -308,6 +313,7 @@ impl CtxReadTool {
             } else {
                 auto_degrade_read_mode(&mode)
             };
+        engine::require_aggressive(engine_interface_v1, &mode)?;
 
         // Delta-aware explicit re-reads (opt-in: config `delta_explicit`, env
         // LCTX_DELTA_EXPLICIT). Re-requesting full/lines:N-M content for a file
@@ -380,6 +386,7 @@ impl CtxReadTool {
         // channel overhead for the ~90% of calls that are cache hits.
         let read_timeout = std::time::Duration::from_secs(30);
         let cancelled = Arc::new(AtomicBool::new(false));
+        let engine_snapshot = engine::SourceSnapshot::default();
         // Hash once for cross-agent delivery (avoids re-reading on record).
         let delivery_metadata = crate::core::config::Config::load()
             .ocla
@@ -443,6 +450,7 @@ impl CtxReadTool {
                 let protect_owned = protect.clone();
                 let path_owned = path.to_string();
                 let cancel_flag = cancelled.clone();
+                let snapshot_worker = engine_snapshot.clone();
                 let (tx, rx) = std::sync::mpsc::sync_channel(1);
                 std::thread::spawn(move || {
                     let file_lock = per_file_lock(&path_owned);
@@ -838,6 +846,8 @@ impl CtxReadTool {
                         unreachable!()
                     };
 
+                    snapshot_worker.capture(engine_interface_v1, &resolved_mode, &compute_content);
+
                     if cancel_flag.load(Ordering::Relaxed) {
                         return;
                     }
@@ -1006,6 +1016,8 @@ impl CtxReadTool {
             return Err(ErrorData::invalid_params(output, None));
         }
 
+        let engine_warning =
+            engine_snapshot.record_if_enabled(&ctx.project_root, path, engine_policy_admission);
         let output_tokens = crate::core::tokens::count_tokens(&output);
         let saved = original.saturating_sub(output_tokens);
 
@@ -1278,7 +1290,7 @@ impl CtxReadTool {
                 .unwrap_or_default();
             crate::core::rule_discovery::rules_suffix_for_read(path, &ctx.project_root, &client_id)
         };
-        let mut warnings = Vec::new();
+        let mut warnings: Vec<&str> = engine_warning.as_deref().into_iter().collect();
         if let Some(ref w) = budget_warning {
             warnings.push(w.as_str());
         }
@@ -1352,6 +1364,8 @@ impl CtxReadTool {
     }
 }
 
+#[path = "ctx_read_engine.rs"]
+mod engine;
 #[path = "ctx_read_window.rs"]
 mod window;
 #[allow(unused_imports)]

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rmcp::ErrorData;
-use rmcp::model::{ContentBlock, Tool};
+use rmcp::model::Tool;
 use serde_json::{Map, Value, json};
 
 use crate::core::cache::ReuseOutcome;
@@ -278,7 +278,7 @@ impl CtxReadTool {
             pressure_action,
             resolved_agent_id.as_deref(),
         );
-        let engine_policy_admission = engine::admission_or_reject(
+        let mut engine_policy_admission = engine::admission_or_reject(
             engine_interface_v1,
             &gate_result,
             &mode,
@@ -313,7 +313,13 @@ impl CtxReadTool {
             } else {
                 auto_degrade_read_mode(&mode)
             };
-        engine::require_aggressive(engine_interface_v1, &mode)?;
+        engine::require_aggressive(
+            engine_interface_v1,
+            &mode,
+            &ctx.project_root,
+            path,
+            &mut engine_policy_admission,
+        )?;
 
         // Delta-aware explicit re-reads (opt-in: config `delta_explicit`, env
         // LCTX_DELTA_EXPLICIT). Re-requesting full/lines:N-M content for a file
@@ -348,14 +354,20 @@ impl CtxReadTool {
             fresh = true;
         }
 
+        engine::reject_non_text_extension(
+            engine_interface_v1,
+            &ctx.project_root,
+            path,
+            &mut engine_policy_admission,
+        )?;
         if crate::core::binary_detect::is_llm_viewable_image(path) {
             return read_image_file(path);
         }
-        if crate::core::binary_detect::is_binary_file(path) {
+        if !engine_interface_v1 && crate::core::binary_detect::is_binary_file(path) {
             let msg = crate::core::binary_detect::binary_file_message(path);
             return Err(ErrorData::invalid_params(msg, None));
         }
-        {
+        if !engine_interface_v1 {
             let cap = crate::core::limits::max_read_bytes() as u64;
             if let Ok(meta) = std::fs::metadata(path)
                 && meta.len() > cap
@@ -388,11 +400,10 @@ impl CtxReadTool {
         let cancelled = Arc::new(AtomicBool::new(false));
         let engine_snapshot = engine::SourceSnapshot::default();
         // Hash once for cross-agent delivery (avoids re-reading on record).
-        let delivery_metadata = crate::core::config::Config::load()
-            .ocla
-            .delivery_enabled()
-            .then(|| crate::tools::ctx_read::file_blake3_prefix(path))
-            .flatten();
+        let delivery_metadata = (!engine_interface_v1
+            && crate::core::config::Config::load().ocla.delivery_enabled())
+        .then(|| crate::tools::ctx_read::file_blake3_prefix(path))
+        .flatten();
         let (output, resolved_mode, original, is_cache_hit, file_ref, cache_stats, reuse_outcome) = {
             let crp_mode = ctx.crp_mode;
             let fast_result = 'fast: {
@@ -449,6 +460,7 @@ impl CtxReadTool {
                 let task_owned = current_task.clone();
                 let protect_owned = protect.clone();
                 let path_owned = path.to_string();
+                let project_root_owned = ctx.project_root.clone();
                 let cancel_flag = cancelled.clone();
                 let snapshot_worker = engine_snapshot.clone();
                 let (tx, rx) = std::sync::mpsc::sync_channel(1);
@@ -539,10 +551,27 @@ impl CtxReadTool {
                     }
 
                     // Phase 2a: disk I/O under per-file lock but WITHOUT cache lock.
-                    let preread = match crate::tools::ctx_read::read_file_lossy(&path_owned) {
+                    let preread = match engine::read_source(
+                        engine_interface_v1,
+                        &path_owned,
+                        &project_root_owned,
+                        &snapshot_worker,
+                    ) {
                         Ok(c) => Some(c),
                         Err(e) => {
                             tracing::warn!("ctx_read: cannot read {path_owned}: {e}");
+                            if engine_interface_v1 {
+                                let _ = tx.send((
+                                    "Engine v1 source read failed".to_owned(),
+                                    "error".into(),
+                                    0,
+                                    false,
+                                    None,
+                                    (0, 0),
+                                    ReuseOutcome::Cold,
+                                ));
+                                return;
+                            }
                             None
                         }
                     };
@@ -846,8 +875,6 @@ impl CtxReadTool {
                         unreachable!()
                     };
 
-                    snapshot_worker.capture(engine_interface_v1, &resolved_mode, &compute_content);
-
                     if cancel_flag.load(Ordering::Relaxed) {
                         return;
                     }
@@ -1012,12 +1039,26 @@ impl CtxReadTool {
             } // end else (slow path)
         };
 
+        engine::reject_read_failure_if_enabled(
+            engine_interface_v1,
+            &resolved_mode,
+            &ctx.project_root,
+            path,
+            &mut engine_policy_admission,
+        )?;
+        engine::require_aggressive(
+            engine_interface_v1,
+            &resolved_mode,
+            &ctx.project_root,
+            path,
+            &mut engine_policy_admission,
+        )?;
         if resolved_mode == "error" {
             return Err(ErrorData::invalid_params(output, None));
         }
 
         let engine_warning =
-            engine_snapshot.record_if_enabled(&ctx.project_root, path, engine_policy_admission);
+            engine_snapshot.record_if_enabled(&ctx.project_root, engine_policy_admission);
         let output_tokens = crate::core::tokens::count_tokens(&output);
         let saved = original.saturating_sub(output_tokens);
 
@@ -1366,6 +1407,9 @@ impl CtxReadTool {
 
 #[path = "ctx_read_engine.rs"]
 mod engine;
+#[path = "ctx_read_image.rs"]
+mod image;
+use image::read_image_file;
 #[path = "ctx_read_window.rs"]
 mod window;
 #[allow(unused_imports)]
@@ -1444,53 +1488,12 @@ fn extract_file_summary(output: &str, path: &str) -> String {
 #[path = "ctx_read_inline_tests.rs"]
 mod tests;
 
+#[cfg(test)]
+#[path = "ctx_read_security_tests.rs"]
+mod security_tests;
+
 // #660 LOC gate: repo-param tests split out to keep this file under the line
 // cap — see `ctx_read_repo_param_tests.rs`.
-
-/// Read an image file and return it as MCP ContentBlock::Image for visual LLM processing.
-fn read_image_file(path: &str) -> Result<ToolOutput, ErrorData> {
-    use crate::core::binary_detect::{IMAGE_MAX_BYTES, image_mime_type};
-    use base64::Engine;
-
-    let metadata = std::fs::metadata(path)
-        .map_err(|e| ErrorData::invalid_params(format!("Cannot read image: {e}"), None))?;
-
-    if metadata.len() > IMAGE_MAX_BYTES {
-        return Err(ErrorData::invalid_params(
-            format!(
-                "Image too large ({:.1} MB, limit {:.0} MB). Resize or use a smaller image.",
-                metadata.len() as f64 / 1024.0 / 1024.0,
-                IMAGE_MAX_BYTES as f64 / 1024.0 / 1024.0,
-            ),
-            None,
-        ));
-    }
-
-    let mime_type = image_mime_type(path)
-        .ok_or_else(|| ErrorData::invalid_params("Unsupported image format".to_string(), None))?;
-
-    let bytes = std::fs::read(path)
-        .map_err(|e| ErrorData::invalid_params(format!("Cannot read image: {e}"), None))?;
-
-    let base64_data = base64::prelude::BASE64_STANDARD.encode(&bytes);
-    let short_name = std::path::Path::new(path)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(path);
-
-    let text_block = ContentBlock::text(format!(
-        "[Image: {} ({} KB, {})]",
-        short_name,
-        bytes.len() / 1024,
-        mime_type
-    ));
-    let image_block = ContentBlock::image(base64_data, mime_type);
-
-    Ok(ToolOutput::image(
-        vec![text_block, image_block],
-        path.to_string(),
-    ))
-}
 
 #[cfg(test)]
 #[path = "ctx_read_repo_param_tests.rs"]

--- a/rust/src/tools/registered/ctx_read_engine.rs
+++ b/rust/src/tools/registered/ctx_read_engine.rs
@@ -14,23 +14,28 @@ use crate::core::engine_interface::NativeContextEngine;
 use crate::server::context_gate::PreDispatchResult;
 
 #[derive(Clone, Default)]
-pub(super) struct SourceSnapshot(Arc<Mutex<Option<String>>>);
+pub(super) struct SourceSnapshot(Arc<Mutex<Option<CapturedSource>>>);
+
+struct CapturedSource {
+    input: String,
+    canonical_path: String,
+}
 
 impl SourceSnapshot {
-    pub(super) fn capture(&self, enabled: bool, mode: &str, input: &str) {
-        if enabled && mode == "aggressive" {
-            let mut snapshot = self
-                .0
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            *snapshot = Some(input.to_owned());
-        }
+    fn capture_rooted(&self, source: crate::tools::ctx_read::RootedRead) {
+        let mut snapshot = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *snapshot = Some(CapturedSource {
+            input: source.content,
+            canonical_path: source.canonical_path,
+        });
     }
 
     pub(super) fn record(
         self,
         project_root: &str,
-        path: &str,
         policy_admission: EnginePolicyAdmissionV1,
     ) -> Result<(), String> {
         let snapshot = self
@@ -38,21 +43,35 @@ impl SourceSnapshot {
             .lock()
             .map_err(|_| "Engine source snapshot lock poisoned".to_owned())?
             .take();
-        record_aggressive_snapshot(snapshot, project_root, path, policy_admission)
+        record_aggressive_snapshot(snapshot, project_root, policy_admission)
     }
 
     pub(super) fn record_if_enabled(
         self,
         project_root: &str,
-        path: &str,
         policy_admission: Option<EnginePolicyAdmissionV1>,
     ) -> Option<String> {
         policy_admission.and_then(|admission| {
-            self.record(project_root, path, admission)
+            self.record(project_root, admission)
                 .err()
                 .map(|error| stable_warning(&error))
         })
     }
+}
+
+pub(super) fn read_source(
+    enabled: bool,
+    path: &str,
+    project_root: &str,
+    snapshot: &SourceSnapshot,
+) -> Result<String, std::io::Error> {
+    if !enabled {
+        return crate::tools::ctx_read::read_file_lossy(path);
+    }
+    let source = crate::tools::ctx_read::read_file_lossy_rooted(path, project_root)?;
+    let content = source.content.clone();
+    snapshot.capture_rooted(source);
+    Ok(content)
 }
 
 pub(super) fn interface_schema() -> Value {
@@ -111,11 +130,66 @@ pub(super) fn validate_v1_request_shape(
     Ok(())
 }
 
-pub(super) fn require_aggressive(enabled: bool, mode: &str) -> Result<(), ErrorData> {
+pub(super) fn require_aggressive(
+    enabled: bool,
+    mode: &str,
+    project_root: &str,
+    path: &str,
+    policy_admission: &mut Option<EnginePolicyAdmissionV1>,
+) -> Result<(), ErrorData> {
     if enabled && mode != "aggressive" {
-        return Err(ErrorData::invalid_params(
-            "engine_interface=\"v1\" requires effective mode=\"aggressive\"",
-            None,
+        return Err(reject_after_admission(
+            project_root,
+            path,
+            policy_admission,
+            "effective_mode_not_aggressive",
+            mode,
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn reject_non_text_extension(
+    enabled: bool,
+    project_root: &str,
+    path: &str,
+    policy_admission: &mut Option<EnginePolicyAdmissionV1>,
+) -> Result<(), ErrorData> {
+    if enabled && crate::core::binary_detect::is_llm_viewable_image(path) {
+        return Err(reject_after_admission(
+            project_root,
+            path,
+            policy_admission,
+            "unsupported_input_image",
+            "image",
+        ));
+    }
+    if enabled && crate::core::binary_detect::has_binary_extension(path) {
+        return Err(reject_after_admission(
+            project_root,
+            path,
+            policy_admission,
+            "unsupported_input_binary",
+            "binary_extension",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn reject_read_failure_if_enabled(
+    enabled: bool,
+    resolved_mode: &str,
+    project_root: &str,
+    path: &str,
+    policy_admission: &mut Option<EnginePolicyAdmissionV1>,
+) -> Result<(), ErrorData> {
+    if enabled && resolved_mode == "error" {
+        return Err(reject_after_admission(
+            project_root,
+            path,
+            policy_admission,
+            "source_read_failed",
+            resolved_mode,
         ));
     }
     Ok(())
@@ -130,6 +204,14 @@ struct GateAdmissionIdentityV1<'a> {
     pressure_downgraded: bool,
     budget_blocked: bool,
     triage_filter_level: u8,
+}
+
+#[derive(Serialize)]
+struct PostAdmissionRejectionIdentityV1<'a> {
+    schema_version: u32,
+    admitted_policy_ref: &'a str,
+    reason_code: &'a str,
+    detail: &'a str,
 }
 
 /// Convert the actual pre-dispatch decision into the Engine admission record.
@@ -196,6 +278,48 @@ pub(super) fn admission_or_reject(
     Ok(Some(admission))
 }
 
+fn reject_after_admission(
+    project_root: &str,
+    path: &str,
+    policy_admission: &mut Option<EnginePolicyAdmissionV1>,
+    reason_code: &'static str,
+    detail: &str,
+) -> ErrorData {
+    let Some(admitted) = policy_admission.take() else {
+        return ErrorData::internal_error(
+            "Engine v1 post-admission rejection has no admission identity",
+            None,
+        );
+    };
+    let identity = PostAdmissionRejectionIdentityV1 {
+        schema_version: 1,
+        admitted_policy_ref: admitted.policy_ref.as_str(),
+        reason_code,
+        detail,
+    };
+    let digest = crate::core::agent_identity::hex_encode(&Sha256::digest(
+        crate::core::canonical::canonical_serialize(&identity),
+    ));
+    let rejected = EnginePolicyAdmissionV1 {
+        policy_ref: match ProtocolReference::new(format!(
+            "policy:ctx-read-runtime-rejection-v1:sha256:{digest}"
+        )) {
+            Ok(reference) => reference,
+            Err(error) => return ErrorData::internal_error(error.to_string(), None),
+        },
+        decision: EnginePolicyDecisionV1::Rejected,
+    };
+    match record_policy_rejection(project_root, path, rejected) {
+        Ok(receipt_ref) => ErrorData::invalid_params(
+            format!(
+                "engine_interface=\"v1\" rejected after admission; reason={reason_code}; receipt_ref={receipt_ref}"
+            ),
+            None,
+        ),
+        Err(error) => ErrorData::internal_error(stable_warning(&error), None),
+    }
+}
+
 /// Keep user-visible fallback deterministic and free of OS/path error text.
 pub(super) fn stable_warning(error: &str) -> String {
     let mut warning = "[ENGINE RECEIPT WARNING] code=engine_record_unavailable".to_owned();
@@ -220,14 +344,18 @@ pub(super) fn stable_warning(error: &str) -> String {
 
 /// Record the exact input snapshot captured by the cold read worker.
 /// Omitted Engine calls may hit legacy cache; explicit v1 calls force fresh.
-pub(super) fn record_aggressive_snapshot(
-    snapshot: Option<String>,
+fn record_aggressive_snapshot(
+    snapshot: Option<CapturedSource>,
     project_root: &str,
-    path: &str,
     policy_admission: EnginePolicyAdmissionV1,
 ) -> Result<(), String> {
-    let input = snapshot.ok_or_else(|| "Engine v1 source snapshot unavailable".to_owned())?;
-    record_aggressive_invocation(project_root, path, &input, policy_admission)
+    let source = snapshot.ok_or_else(|| "Engine v1 source snapshot unavailable".to_owned())?;
+    record_aggressive_invocation(
+        project_root,
+        &source.canonical_path,
+        &source.input,
+        policy_admission,
+    )
 }
 
 pub(super) fn record_policy_rejection(
@@ -255,7 +383,8 @@ fn record_aggressive_invocation(
     policy_admission: EnginePolicyAdmissionV1,
 ) -> Result<(), String> {
     let engine = NativeContextEngine::with_root(project_root);
-    let (_, observation) = engine.execute_ctx_read_snapshot(path, input, policy_admission)?;
+    let (_, observation) =
+        engine.execute_ctx_read_rooted_snapshot(path, input, policy_admission)?;
     let receipt_link = observation
         .receipt_link
         .ok_or_else(|| "native Engine terminal observation omitted its receipt link".to_owned())?;
@@ -349,8 +478,7 @@ mod tests {
     #[test]
     fn enabled_recording_never_silently_accepts_a_missing_snapshot() {
         let admission = admission_from_gate(&gate(false, None), "aggressive").unwrap();
-        let error =
-            record_aggressive_snapshot(None, "/tmp", "/tmp/missing", admission).unwrap_err();
+        let error = record_aggressive_snapshot(None, "/tmp", admission).unwrap_err();
         assert_eq!(error, "Engine v1 source snapshot unavailable");
     }
 
@@ -369,13 +497,42 @@ mod tests {
 
     #[test]
     fn engine_v1_rejects_non_aggressive_effective_mode() {
-        require_aggressive(true, "aggressive").unwrap();
-        let error = require_aggressive(true, "full").unwrap_err();
-        assert_eq!(
-            error.message,
-            "engine_interface=\"v1\" requires effective mode=\"aggressive\""
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("mode.rs");
+        std::fs::write(&file, "fn mode_fixture() {}").unwrap();
+        let mut admitted = Some(admission_from_gate(&gate(false, None), "aggressive").unwrap());
+        require_aggressive(
+            true,
+            "aggressive",
+            &dir.path().to_string_lossy(),
+            &file.to_string_lossy(),
+            &mut admitted,
+        )
+        .unwrap();
+        let error = require_aggressive(
+            true,
+            "full",
+            &dir.path().to_string_lossy(),
+            &file.to_string_lossy(),
+            &mut admitted,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .message
+                .contains("reason=effective_mode_not_aggressive")
         );
-        require_aggressive(false, "full").unwrap();
+        assert!(error.message.contains("receipt_ref=receipt:sha256:"));
+        let mut legacy = None;
+        require_aggressive(
+            false,
+            "full",
+            &dir.path().to_string_lossy(),
+            &file.to_string_lossy(),
+            &mut legacy,
+        )
+        .unwrap();
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -383,18 +540,18 @@ mod tests {
         let _data_dir = crate::core::data_dir::isolated_data_dir();
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("snapshot.rs");
-        let cached = "fn cache_snapshot_marker() {}\n".repeat(40);
-        std::fs::write(&file, "fn changed_disk_marker() {}\n").unwrap();
+        let source = "fn cache_snapshot_marker() {}\n".repeat(40);
+        std::fs::write(&file, &source).unwrap();
         let path = file.to_string_lossy().into_owned();
         let admission = admission_from_gate(&gate(false, None), "aggressive").unwrap();
+        let snapshot = SourceSnapshot::default();
 
-        record_aggressive_snapshot(
-            Some(cached),
-            &dir.path().to_string_lossy(),
-            &path,
-            admission,
-        )
-        .unwrap();
+        let captured = read_source(true, &path, &dir.path().to_string_lossy(), &snapshot).unwrap();
+        assert_eq!(captured, source);
+        std::fs::write(&file, "fn changed_disk_marker() {}\n").unwrap();
+        snapshot
+            .record(&dir.path().to_string_lossy(), admission)
+            .unwrap();
 
         let output_dir = crate::core::data_dir::lean_ctx_data_dir()
             .unwrap()

--- a/rust/src/tools/registered/ctx_read_engine.rs
+++ b/rust/src/tools/registered/ctx_read_engine.rs
@@ -1,0 +1,412 @@
+//! Production `ctx_read` bridge for the first receipt-backed Engine operation.
+
+use std::sync::{Arc, Mutex};
+
+use lean_ctx_protocol::{
+    EngineObservationStatusV1, EnginePolicyAdmissionV1, EnginePolicyDecisionV1, ProtocolReference,
+};
+use rmcp::ErrorData;
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::core::engine_interface::NativeContextEngine;
+use crate::server::context_gate::PreDispatchResult;
+
+#[derive(Clone, Default)]
+pub(super) struct SourceSnapshot(Arc<Mutex<Option<String>>>);
+
+impl SourceSnapshot {
+    pub(super) fn capture(&self, enabled: bool, mode: &str, input: &str) {
+        if enabled && mode == "aggressive" {
+            let mut snapshot = self
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *snapshot = Some(input.to_owned());
+        }
+    }
+
+    pub(super) fn record(
+        self,
+        project_root: &str,
+        path: &str,
+        policy_admission: EnginePolicyAdmissionV1,
+    ) -> Result<(), String> {
+        let snapshot = self
+            .0
+            .lock()
+            .map_err(|_| "Engine source snapshot lock poisoned".to_owned())?
+            .take();
+        record_aggressive_snapshot(snapshot, project_root, path, policy_admission)
+    }
+
+    pub(super) fn record_if_enabled(
+        self,
+        project_root: &str,
+        path: &str,
+        policy_admission: Option<EnginePolicyAdmissionV1>,
+    ) -> Option<String> {
+        policy_admission.and_then(|admission| {
+            self.record(project_root, path, admission)
+                .err()
+                .map(|error| stable_warning(&error))
+        })
+    }
+}
+
+pub(super) fn interface_schema() -> Value {
+    json!({
+        "type": "string",
+        "enum": ["v1"],
+        "description": "Opt into one receipt-backed Engine v1 invocation (single-path aggressive reads only)"
+    })
+}
+
+pub(super) fn interface_v1_requested(args: &Map<String, Value>) -> Result<bool, ErrorData> {
+    match args.get("engine_interface") {
+        None => Ok(false),
+        Some(Value::String(version)) if version == "v1" => Ok(true),
+        Some(_) => Err(ErrorData::invalid_params(
+            "engine_interface must be the string \"v1\" when provided",
+            None,
+        )),
+    }
+}
+
+pub(super) fn validate_v1_request_shape(
+    args: &Map<String, Value>,
+    enabled: bool,
+) -> Result<(), ErrorData> {
+    if !enabled {
+        return Ok(());
+    }
+    if args.contains_key("paths") {
+        return Err(ErrorData::invalid_params(
+            "engine_interface=\"v1\" supports only single-path ctx_read",
+            None,
+        ));
+    }
+    if args.get("mode").and_then(Value::as_str) != Some("aggressive") {
+        return Err(ErrorData::invalid_params(
+            "engine_interface=\"v1\" requires mode=\"aggressive\"",
+            None,
+        ));
+    }
+    for unsupported in [
+        "raw",
+        "start_line",
+        "offset",
+        "limit",
+        "aggressiveness",
+        "protect",
+    ] {
+        if args.contains_key(unsupported) {
+            return Err(ErrorData::invalid_params(
+                format!("engine_interface=\"v1\" does not support the {unsupported} parameter"),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn require_aggressive(enabled: bool, mode: &str) -> Result<(), ErrorData> {
+    if enabled && mode != "aggressive" {
+        return Err(ErrorData::invalid_params(
+            "engine_interface=\"v1\" requires effective mode=\"aggressive\"",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct GateAdmissionIdentityV1<'a> {
+    schema_version: u32,
+    requested_mode: &'a str,
+    overridden_mode: Option<&'a str>,
+    reason: Option<&'a str>,
+    pressure_downgraded: bool,
+    budget_blocked: bool,
+    triage_filter_level: u8,
+}
+
+/// Convert the actual pre-dispatch decision into the Engine admission record.
+pub(super) fn admission_from_gate(
+    gate: &PreDispatchResult,
+    requested_mode: &str,
+) -> Result<EnginePolicyAdmissionV1, String> {
+    let identity = GateAdmissionIdentityV1 {
+        schema_version: 1,
+        requested_mode,
+        overridden_mode: gate.overridden_mode.as_deref(),
+        reason: gate.reason,
+        pressure_downgraded: gate.pressure_downgraded,
+        budget_blocked: gate.budget_blocked,
+        triage_filter_level: gate.triage_filter_level,
+    };
+    let bytes = crate::core::canonical::canonical_serialize(&identity);
+    let digest = crate::core::agent_identity::hex_encode(&Sha256::digest(bytes));
+    Ok(EnginePolicyAdmissionV1 {
+        policy_ref: ProtocolReference::new(format!(
+            "policy:ctx-read-context-gate-v1:sha256:{digest}"
+        ))
+        .map_err(|error| error.to_string())?,
+        decision: if gate.budget_blocked
+            || gate.pressure_downgraded
+            || gate.overridden_mode.is_some()
+            || gate.triage_filter_level > 0
+        {
+            EnginePolicyDecisionV1::Rejected
+        } else {
+            EnginePolicyDecisionV1::Admitted
+        },
+    })
+}
+
+pub(super) fn admission_or_reject(
+    enabled: bool,
+    gate: &PreDispatchResult,
+    requested_mode: &str,
+    project_root: &str,
+    path: &str,
+) -> Result<Option<EnginePolicyAdmissionV1>, ErrorData> {
+    if !enabled {
+        if gate.budget_blocked {
+            return Err(ErrorData::invalid_params(
+                gate.budget_warning
+                    .clone()
+                    .unwrap_or_else(|| "Agent token budget exceeded".to_owned()),
+                None,
+            ));
+        }
+        return Ok(None);
+    }
+    let admission = admission_from_gate(gate, requested_mode)
+        .map_err(|error| ErrorData::internal_error(error, None))?;
+    if admission.decision == EnginePolicyDecisionV1::Rejected {
+        let receipt_ref = record_policy_rejection(project_root, path, admission)
+            .map_err(|error| ErrorData::internal_error(stable_warning(&error), None))?;
+        return Err(ErrorData::invalid_params(
+            format!("engine_interface=\"v1\" rejected by context gate; receipt_ref={receipt_ref}"),
+            None,
+        ));
+    }
+    Ok(Some(admission))
+}
+
+/// Keep user-visible fallback deterministic and free of OS/path error text.
+pub(super) fn stable_warning(error: &str) -> String {
+    let mut warning = "[ENGINE RECEIPT WARNING] code=engine_record_unavailable".to_owned();
+    for key in ["receipt_ref", "recovery_ref"] {
+        let marker = format!("{key}=");
+        let Some(value) = error
+            .split_ascii_whitespace()
+            .find_map(|token| token.strip_prefix(&marker))
+            .map(|value| value.trim_end_matches([';', ',']))
+        else {
+            continue;
+        };
+        if ProtocolReference::new(value.to_owned()).is_ok() {
+            warning.push(' ');
+            warning.push_str(key);
+            warning.push('=');
+            warning.push_str(value);
+        }
+    }
+    warning
+}
+
+/// Record the exact input snapshot captured by the cold read worker.
+/// Omitted Engine calls may hit legacy cache; explicit v1 calls force fresh.
+pub(super) fn record_aggressive_snapshot(
+    snapshot: Option<String>,
+    project_root: &str,
+    path: &str,
+    policy_admission: EnginePolicyAdmissionV1,
+) -> Result<(), String> {
+    let input = snapshot.ok_or_else(|| "Engine v1 source snapshot unavailable".to_owned())?;
+    record_aggressive_invocation(project_root, path, &input, policy_admission)
+}
+
+pub(super) fn record_policy_rejection(
+    project_root: &str,
+    path: &str,
+    policy_admission: EnginePolicyAdmissionV1,
+) -> Result<String, String> {
+    let engine = NativeContextEngine::with_root(project_root);
+    let (_, observation) = engine.execute_ctx_read_rejection(path, policy_admission)?;
+    if observation.status != EngineObservationStatusV1::Rejected {
+        return Err("native Engine policy rejection returned a non-rejected status".to_owned());
+    }
+    observation
+        .receipt_link
+        .map(|link| link.receipt_ref.as_str().to_owned())
+        .ok_or_else(|| "native Engine policy rejection omitted its receipt link".to_owned())
+}
+
+/// Record the native aggressive-compression capability against the source
+/// snapshot already acquired by `ctx_read`; Engine applies active redaction.
+fn record_aggressive_invocation(
+    project_root: &str,
+    path: &str,
+    input: &str,
+    policy_admission: EnginePolicyAdmissionV1,
+) -> Result<(), String> {
+    let engine = NativeContextEngine::with_root(project_root);
+    let (_, observation) = engine.execute_ctx_read_snapshot(path, input, policy_admission)?;
+    let receipt_link = observation
+        .receipt_link
+        .ok_or_else(|| "native Engine terminal observation omitted its receipt link".to_owned())?;
+    if observation.status != EngineObservationStatusV1::Succeeded {
+        let recovery_ref = observation
+            .failure
+            .as_ref()
+            .and_then(|failure| failure.recovery_ref.as_ref())
+            .map_or("none", ProtocolReference::as_str);
+        return Err(format!(
+            "Engine status={:?}; receipt_ref={}; recovery_ref={recovery_ref}",
+            observation.status,
+            receipt_link.receipt_ref.as_str()
+        ));
+    }
+    tracing::debug!(
+        status = ?observation.status,
+        receipt_ref = receipt_link.receipt_ref.as_str(),
+        "ctx_read Engine observation recorded"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gate(blocked: bool, overridden_mode: Option<&str>) -> PreDispatchResult {
+        PreDispatchResult {
+            overridden_mode: overridden_mode.map(str::to_owned),
+            reason: overridden_mode.map(|_| "fixture-override"),
+            pressure_downgraded: overridden_mode.is_some(),
+            budget_blocked: blocked,
+            budget_warning: None,
+            triage_filter_level: u8::from(overridden_mode.is_some()),
+        }
+    }
+
+    #[test]
+    fn gate_admission_preserves_decision_and_exact_policy_identity() {
+        let admitted = admission_from_gate(&gate(false, None), "aggressive").unwrap();
+        let rejected = admission_from_gate(&gate(true, None), "aggressive").unwrap();
+        let overridden =
+            admission_from_gate(&gate(false, Some("signatures")), "aggressive").unwrap();
+
+        assert_eq!(admitted.decision, EnginePolicyDecisionV1::Admitted);
+        assert_eq!(rejected.decision, EnginePolicyDecisionV1::Rejected);
+        assert_eq!(overridden.decision, EnginePolicyDecisionV1::Rejected);
+        assert_ne!(admitted.policy_ref, rejected.policy_ref);
+        assert_ne!(admitted.policy_ref, overridden.policy_ref);
+        assert!(
+            admitted
+                .policy_ref
+                .as_str()
+                .starts_with("policy:ctx-read-context-gate-v1:sha256:")
+        );
+    }
+
+    #[test]
+    fn rejected_gate_persists_a_receipt_without_native_output() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("rejected.rs");
+        std::fs::write(&file, "fn must_not_execute() {}").unwrap();
+        let error = admission_or_reject(
+            true,
+            &gate(true, None),
+            "aggressive",
+            &dir.path().to_string_lossy(),
+            &file.to_string_lossy(),
+        )
+        .unwrap_err();
+        assert!(error.message.contains("receipt_ref=receipt:sha256:"));
+        let data_dir = crate::core::data_dir::lean_ctx_data_dir().unwrap();
+        assert!(!data_dir.join("engine-interface/v1/outputs").exists());
+        let receipt = std::fs::read_dir(data_dir.join("engine-interface/v1/receipts"))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let receipt: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(receipt).unwrap()).unwrap();
+        assert_eq!(receipt["observation"]["status"], "rejected");
+        assert_eq!(
+            receipt["invocation"]["policy_admission"]["decision"],
+            "rejected"
+        );
+    }
+
+    #[test]
+    fn enabled_recording_never_silently_accepts_a_missing_snapshot() {
+        let admission = admission_from_gate(&gate(false, None), "aggressive").unwrap();
+        let error =
+            record_aggressive_snapshot(None, "/tmp", "/tmp/missing", admission).unwrap_err();
+        assert_eq!(error, "Engine v1 source snapshot unavailable");
+    }
+
+    #[test]
+    fn warning_redacts_nondeterministic_storage_error_details() {
+        let warning = stable_warning(
+            "persist Engine receipt: /tmp/private: errno 13; recovery_ref=recovery:sha256:abc",
+        );
+        assert_eq!(
+            warning,
+            "[ENGINE RECEIPT WARNING] code=engine_record_unavailable recovery_ref=recovery:sha256:abc"
+        );
+        assert!(!warning.contains("/tmp/private"));
+        assert!(!warning.contains("errno"));
+    }
+
+    #[test]
+    fn engine_v1_rejects_non_aggressive_effective_mode() {
+        require_aggressive(true, "aggressive").unwrap();
+        let error = require_aggressive(true, "full").unwrap_err();
+        assert_eq!(
+            error.message,
+            "engine_interface=\"v1\" requires effective mode=\"aggressive\""
+        );
+        require_aggressive(false, "full").unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn production_bridge_uses_cache_snapshot_without_second_disk_read() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("snapshot.rs");
+        let cached = "fn cache_snapshot_marker() {}\n".repeat(40);
+        std::fs::write(&file, "fn changed_disk_marker() {}\n").unwrap();
+        let path = file.to_string_lossy().into_owned();
+        let admission = admission_from_gate(&gate(false, None), "aggressive").unwrap();
+
+        record_aggressive_snapshot(
+            Some(cached),
+            &dir.path().to_string_lossy(),
+            &path,
+            admission,
+        )
+        .unwrap();
+
+        let output_dir = crate::core::data_dir::lean_ctx_data_dir()
+            .unwrap()
+            .join("engine-interface/v1/outputs");
+        let output_path = std::fs::read_dir(output_dir)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let output = std::fs::read_to_string(output_path).unwrap();
+        assert!(output.contains("cache_snapshot_marker"));
+        assert!(!output.contains("changed_disk_marker"));
+    }
+}

--- a/rust/src/tools/registered/ctx_read_image.rs
+++ b/rust/src/tools/registered/ctx_read_image.rs
@@ -1,0 +1,117 @@
+use std::io::Read;
+
+use base64::Engine;
+use rmcp::ErrorData;
+use rmcp::model::ContentBlock;
+
+use crate::server::tool_trait::ToolOutput;
+
+fn open_image_nofollow(path: &str) -> Result<std::fs::File, ErrorData> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| ErrorData::invalid_params(format!("Cannot read image: {error}"), None))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| ErrorData::invalid_params(format!("Cannot read image: {error}"), None))?;
+    if crate::core::pathutil::is_symlink_or_reparse(&metadata) || !metadata.is_file() {
+        return Err(ErrorData::invalid_params(
+            "Cannot read image: path is not a regular non-symlink file",
+            None,
+        ));
+    }
+    Ok(file)
+}
+
+/// Read one bounded image descriptor into MCP multimodal content blocks.
+pub(super) fn read_image_file(path: &str) -> Result<ToolOutput, ErrorData> {
+    use crate::core::binary_detect::{IMAGE_MAX_BYTES, image_mime_type};
+
+    let mut file = open_image_nofollow(path)?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| ErrorData::invalid_params(format!("Cannot read image: {error}"), None))?;
+    if metadata.len() > IMAGE_MAX_BYTES {
+        return Err(ErrorData::invalid_params(
+            format!(
+                "Image too large ({:.1} MB, limit {:.0} MB). Resize or use a smaller image.",
+                metadata.len() as f64 / 1024.0 / 1024.0,
+                IMAGE_MAX_BYTES as f64 / 1024.0 / 1024.0,
+            ),
+            None,
+        ));
+    }
+    let mime_type = image_mime_type(path)
+        .ok_or_else(|| ErrorData::invalid_params("Unsupported image format".to_string(), None))?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    (&mut file)
+        .take(IMAGE_MAX_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| ErrorData::invalid_params(format!("Cannot read image: {error}"), None))?;
+    if bytes.len() as u64 > IMAGE_MAX_BYTES {
+        return Err(ErrorData::invalid_params(
+            "Image grew beyond the 20 MB limit while being read",
+            None,
+        ));
+    }
+    let base64_data = base64::prelude::BASE64_STANDARD.encode(&bytes);
+    let short_name = std::path::Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path);
+    Ok(ToolOutput::image(
+        vec![
+            ContentBlock::text(format!(
+                "[Image: {} ({} KB, {})]",
+                short_name,
+                bytes.len() / 1024,
+                mime_type
+            )),
+            ContentBlock::image(base64_data, mime_type),
+        ],
+        path.to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_image_file;
+
+    #[test]
+    fn regular_image_is_read_from_one_bounded_descriptor() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = dir.path().join("fixture.png");
+        std::fs::write(&image, b"\x89PNG\r\n\x1a\nfixture").unwrap();
+
+        let output = read_image_file(&image.to_string_lossy()).unwrap();
+
+        assert_eq!(output.content_blocks.as_ref().map(Vec::len), Some(2));
+        assert_eq!(output.path.as_deref(), image.to_str());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn image_reader_refuses_a_symlink_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.png");
+        let link = dir.path().join("link.png");
+        std::fs::write(&target, b"\x89PNG\r\n\x1a\nfixture").unwrap();
+        symlink(target, &link).unwrap();
+
+        assert!(read_image_file(&link.to_string_lossy()).is_err());
+    }
+}

--- a/rust/src/tools/registered/ctx_read_inline_tests.rs
+++ b/rust/src/tools/registered/ctx_read_inline_tests.rs
@@ -164,6 +164,220 @@ async fn mcp_ctx_read_serves_cross_agent_delivery_stub_before_disk_read() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_aggressive_read_records_deterministic_engine_receipt() {
+    use crate::core::cache::SessionCache;
+    use crate::core::session::SessionState;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let _data_dir = crate::core::data_dir::isolated_data_dir();
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("engine-real-path.rs");
+    let source = "fn stable_engine_path() {\n    let context = 42;\n}\n".repeat(40);
+    std::fs::write(&file, &source).unwrap();
+    let path = file.to_string_lossy().to_string();
+    let ctx = ToolContext {
+        project_root: dir.path().to_string_lossy().to_string(),
+        resolved_paths: std::collections::HashMap::from([("path".to_string(), path.clone())]),
+        cache: Some(Arc::new(RwLock::new(SessionCache::new()))),
+        session: Some(Arc::new(RwLock::new(SessionState::new()))),
+        ..ToolContext::default()
+    };
+    let legacy_args = json!({ "path": path, "mode": "aggressive", "fresh": true })
+        .as_object()
+        .unwrap()
+        .clone();
+    let legacy = tokio::task::block_in_place(|| CtxReadTool.handle(&legacy_args, &ctx))
+        .expect("omitted Engine interface preserves legacy aggressive read");
+    let data_dir = crate::core::data_dir::lean_ctx_data_dir().unwrap();
+    assert!(!data_dir.join("engine-interface/v1/receipts").exists());
+
+    let args = json!({
+        "path": path,
+        "mode": "aggressive",
+        "engine_interface": "v1"
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    let output = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx))
+        .expect("real ctx_read aggressive path succeeds");
+    assert_eq!(output.mode.as_deref(), Some("aggressive"));
+    assert!(output.text.contains("stable_engine_path"));
+    assert_eq!(output.text, legacy.text);
+    let repeated = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx))
+        .expect("repeated real ctx_read aggressive path succeeds");
+    assert_eq!(repeated.text, output.text);
+
+    let receipt_dir = data_dir.join("engine-interface/v1/receipts");
+    let receipts: Vec<_> = std::fs::read_dir(receipt_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    assert_eq!(
+        receipts.len(),
+        1,
+        "identical real reads must reuse one deterministic receipt"
+    );
+    let receipt_bytes = std::fs::read(&receipts[0]).unwrap();
+    let receipt: serde_json::Value = serde_json::from_slice(&receipt_bytes).unwrap();
+    assert_eq!(receipt["observation"]["status"], "succeeded");
+    assert!(
+        receipt["invocation"]["policy_admission"]["policy_ref"]
+            .as_str()
+            .unwrap()
+            .starts_with("policy:ctx-read-context-gate-v1:sha256:")
+    );
+    assert_eq!(
+        receipt["invocation"]["policy_admission"]["decision"],
+        "admitted"
+    );
+    assert!(
+        receipt["invocation"]["input_ref"]
+            .as_str()
+            .unwrap()
+            .starts_with("input:ctx-read-snapshot-sha256:")
+    );
+    assert!(
+        receipt["invocation"]["source_refs"][1]
+            .as_str()
+            .unwrap()
+            .starts_with("source:canonical-path-sha256:")
+    );
+    assert!(
+        receipt["observation"]["measurements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|measurement| measurement["name"] != "latency_ms")
+    );
+    assert!(!String::from_utf8_lossy(&receipt_bytes).contains("stable_engine_path"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_aggressive_read_surfaces_engine_receipt_failure_without_hiding_content() {
+    use crate::core::cache::SessionCache;
+    use crate::core::session::SessionState;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let _data_dir = crate::core::data_dir::isolated_data_dir();
+    let data_dir = crate::core::data_dir::lean_ctx_data_dir().unwrap();
+    let engine_dir = data_dir.join("engine-interface/v1");
+    std::fs::create_dir_all(&engine_dir).unwrap();
+    std::fs::write(engine_dir.join("receipts"), "blocks receipt directory").unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("engine-recovery.rs");
+    let source = "fn legacy_content_survives() {}\n".repeat(40);
+    std::fs::write(&file, &source).unwrap();
+    let path = file.to_string_lossy().to_string();
+    let ctx = ToolContext {
+        project_root: dir.path().to_string_lossy().to_string(),
+        resolved_paths: std::collections::HashMap::from([("path".to_string(), path.clone())]),
+        cache: Some(Arc::new(RwLock::new(SessionCache::new()))),
+        session: Some(Arc::new(RwLock::new(SessionState::new()))),
+        ..ToolContext::default()
+    };
+    let args = json!({
+        "path": path,
+        "mode": "aggressive",
+        "fresh": true,
+        "engine_interface": "v1"
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    let output = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx))
+        .expect("legacy ctx_read remains available with an explicit Engine warning");
+
+    assert!(
+        output
+            .text
+            .starts_with("[ENGINE RECEIPT WARNING] code=engine_record_unavailable")
+    );
+    assert!(output.text.contains("recovery_ref=recovery:sha256:"));
+    assert!(output.text.contains("legacy_content_survives"));
+
+    let recovery_dir = engine_dir.join("recovery");
+    let recovery: Vec<_> = std::fs::read_dir(&recovery_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    assert_eq!(recovery.len(), 1);
+    let recovery_bytes = std::fs::read(&recovery[0]).unwrap();
+    assert!(!String::from_utf8_lossy(&recovery_bytes).contains("legacy_content_survives"));
+
+    std::fs::remove_file(engine_dir.join("receipts")).unwrap();
+    std::fs::create_dir(engine_dir.join("receipts")).unwrap();
+    let retried = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx))
+        .expect("ctx_read retries Engine recording after storage recovery");
+    assert!(!retried.text.starts_with("[ENGINE RECEIPT WARNING]"));
+    assert!(retried.text.contains("legacy_content_survives"));
+}
+
+#[test]
+fn engine_interface_boundary_rejects_invalid_versions_and_batch_use() {
+    let ctx = ToolContext::default();
+    for invalid in [
+        Value::Null,
+        Value::Bool(true),
+        Value::String(String::new()),
+        Value::String("v2".to_owned()),
+        json!(1),
+    ] {
+        let args = json!({ "engine_interface": invalid })
+            .as_object()
+            .unwrap()
+            .clone();
+        let Err(error) = CtxReadTool.handle(&args, &ctx) else {
+            panic!("invalid Engine interface version must fail");
+        };
+        assert_eq!(
+            error.message,
+            "engine_interface must be the string \"v1\" when provided"
+        );
+    }
+
+    for paths in [json!([]), json!(["/tmp/one", "/tmp/two"]), json!("bad")] {
+        let args = json!({
+            "paths": paths,
+            "mode": "aggressive",
+            "engine_interface": "v1"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let Err(error) = CtxReadTool.handle(&args, &ctx) else {
+            panic!("Engine v1 paths parameter must fail");
+        };
+        assert_eq!(
+            error.message,
+            "engine_interface=\"v1\" supports only single-path ctx_read"
+        );
+    }
+
+    for args in [
+        json!({ "engine_interface": "v1" }),
+        json!({ "mode": "full", "engine_interface": "v1" }),
+        json!({ "mode": "aggressive", "raw": false, "engine_interface": "v1" }),
+        json!({ "mode": "aggressive", "limit": 10, "engine_interface": "v1" }),
+        json!({
+            "mode": "aggressive",
+            "aggressiveness": 0.7,
+            "engine_interface": "v1"
+        }),
+    ] {
+        let Err(error) = CtxReadTool.handle(args.as_object().unwrap(), &ctx) else {
+            panic!("conflicting Engine v1 request shape must fail");
+        };
+        assert!(error.message.contains("engine_interface=\"v1\""));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcp_ctx_read_records_new_cross_agent_delivery() {
     use crate::core::cache::SessionCache;
     use crate::core::ocla::OclaRegistry;
@@ -523,16 +737,25 @@ fn offset_limit_overrides_explicit_map_to_lines() {
 /// otherwise agents (and the generated docs/manifest) can't discover the
 /// aliases and the divergence that caused this bug returns.
 #[test]
-fn schema_advertises_line_window_aliases() {
+fn schema_advertises_line_window_aliases_and_engine_opt_in() {
     let tool = CtxReadTool.tool_def();
     let props = tool
         .input_schema
         .get("properties")
         .and_then(|p| p.as_object())
         .expect("ctx_read schema has a properties object");
-    for key in ["path", "mode", "start_line", "offset", "limit", "fresh"] {
+    for key in [
+        "path",
+        "mode",
+        "start_line",
+        "offset",
+        "limit",
+        "fresh",
+        "engine_interface",
+    ] {
         assert!(props.contains_key(key), "ctx_read schema missing '{key}'");
     }
+    assert_eq!(props["engine_interface"]["enum"], json!(["v1"]));
 }
 
 // -- Regression: GitHub Issue #262 --

--- a/rust/src/tools/registered/ctx_read_inline_tests.rs
+++ b/rust/src/tools/registered/ctx_read_inline_tests.rs
@@ -2,6 +2,34 @@
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+fn engine_test_context(root: &std::path::Path, path: &std::path::Path) -> ToolContext {
+    ToolContext {
+        project_root: root.to_string_lossy().into_owned(),
+        resolved_paths: std::collections::HashMap::from([(
+            "path".to_owned(),
+            path.to_string_lossy().into_owned(),
+        )]),
+        cache: Some(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::core::cache::SessionCache::new(),
+        ))),
+        session: Some(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::core::session::SessionState::new(),
+        ))),
+        ..ToolContext::default()
+    }
+}
+
+fn engine_receipt_path(data_dir: &std::path::Path, message: &str) -> std::path::PathBuf {
+    let digest = message
+        .split_once("receipt_ref=receipt:sha256:")
+        .map(|(_, digest)| digest.trim_end_matches([';', ',', ' ']))
+        .expect("Engine rejection must expose a receipt SHA-256");
+    assert_eq!(digest.len(), 64);
+    assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    data_dir
+        .join("engine-interface/v1/receipts")
+        .join(format!("{digest}.json"))
+}
 #[test]
 fn raw_alias_forces_raw_mode_over_explicit_mode() {
     // #513: raw=true is the verbatim escape hatch and must win over any
@@ -341,6 +369,18 @@ fn engine_interface_boundary_rejects_invalid_versions_and_batch_use() {
         );
     }
 
+    let invalid_before_batch = json!({
+        "paths": ["/tmp/one"],
+        "engine_interface": "v2"
+    });
+    let Err(error) = CtxReadTool.handle(invalid_before_batch.as_object().unwrap(), &ctx) else {
+        panic!("invalid Engine interface must fail before batch dispatch");
+    };
+    assert_eq!(
+        error.message,
+        "engine_interface must be the string \"v1\" when provided"
+    );
+
     for paths in [json!([]), json!(["/tmp/one", "/tmp/two"]), json!("bad")] {
         let args = json!({
             "paths": paths,
@@ -375,6 +415,186 @@ fn engine_interface_boundary_rejects_invalid_versions_and_batch_use() {
         };
         assert!(error.message.contains("engine_interface=\"v1\""));
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn omitted_engine_interface_preserves_legacy_image_and_binary_paths() {
+    let _data_dir = crate::core::data_dir::isolated_data_dir();
+    let data_dir = crate::core::data_dir::lean_ctx_data_dir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    let image = dir.path().join("legacy-image.png");
+    std::fs::write(&image, b"\x89PNG\r\n\x1a\nlegacy-image-payload").unwrap();
+    let image_ctx = engine_test_context(dir.path(), &image);
+    let image_args = json!({
+        "path": image.to_string_lossy(),
+        "mode": "aggressive",
+        "fresh": true
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let image_output = tokio::task::block_in_place(|| CtxReadTool.handle(&image_args, &image_ctx))
+        .expect("omitted Engine interface must preserve image passthrough");
+    assert_eq!(image_output.content_blocks.as_ref().map(Vec::len), Some(2));
+    let direct_image = read_image_file(&image.to_string_lossy())
+        .expect("legacy image helper must remain authoritative");
+    assert_eq!(image_output.text, direct_image.text);
+    assert_eq!(image_output.path, direct_image.path);
+    assert_eq!(image_output.mode, direct_image.mode);
+    assert_eq!(
+        serde_json::to_value(&image_output.content_blocks).unwrap(),
+        serde_json::to_value(&direct_image.content_blocks).unwrap()
+    );
+
+    let binary = dir.path().join("legacy-binary.bin");
+    std::fs::write(&binary, b"\0legacy-binary-payload").unwrap();
+    let binary_ctx = engine_test_context(dir.path(), &binary);
+    let binary_args = json!({
+        "path": binary.to_string_lossy(),
+        "mode": "aggressive",
+        "fresh": true
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let Err(error) = tokio::task::block_in_place(|| CtxReadTool.handle(&binary_args, &binary_ctx))
+    else {
+        panic!("omitted Engine interface must preserve binary rejection");
+    };
+    assert_eq!(
+        error.message,
+        crate::core::binary_detect::binary_file_message(&binary.to_string_lossy())
+    );
+    assert!(!data_dir.join("engine-interface").exists());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_v1_rejects_image_and_binary_with_payload_free_receipts() {
+    let _data_dir = crate::core::data_dir::isolated_data_dir();
+    let data_dir = crate::core::data_dir::lean_ctx_data_dir().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let fixtures = [
+        (
+            dir.path().join("secret-image.png"),
+            b"\x89PNG\r\n\x1a\nIMAGE_SECRET_PAYLOAD".as_slice(),
+            "unsupported_input_image",
+        ),
+        (
+            dir.path().join("secret-binary.bin"),
+            b"\0BINARY_SECRET_PAYLOAD".as_slice(),
+            "unsupported_input_binary",
+        ),
+        (
+            dir.path().join("secret-nul.txt"),
+            b"\0NUL_SECRET_PAYLOAD".as_slice(),
+            "source_read_failed",
+        ),
+    ];
+
+    for (path, payload, reason) in &fixtures {
+        std::fs::write(path, payload).unwrap();
+        let ctx = engine_test_context(dir.path(), path);
+        let args = json!({
+            "path": path.to_string_lossy(),
+            "mode": "aggressive",
+            "engine_interface": "v1"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let Err(first) = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx)) else {
+            panic!("Engine v1 must reject non-text input");
+        };
+        assert!(first.message.contains(&format!("reason={reason}")));
+        let first_path = engine_receipt_path(&data_dir, &first.message);
+        let first_bytes = std::fs::read(&first_path).unwrap();
+
+        let Err(repeated) = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx)) else {
+            panic!("identical Engine v1 rejection must be deterministic");
+        };
+        assert_eq!(first.message, repeated.message);
+        assert_eq!(
+            first_path,
+            engine_receipt_path(&data_dir, &repeated.message)
+        );
+        assert_eq!(first_bytes, std::fs::read(&first_path).unwrap());
+    }
+
+    let receipt_dir = data_dir.join("engine-interface/v1/receipts");
+    let receipts: Vec<_> = std::fs::read_dir(&receipt_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    assert_eq!(receipts.len(), 3);
+    for receipt_path in receipts {
+        let bytes = std::fs::read(receipt_path).unwrap();
+        let text = String::from_utf8(bytes.clone()).unwrap();
+        assert!(!text.contains("IMAGE_SECRET_PAYLOAD"));
+        assert!(!text.contains("BINARY_SECRET_PAYLOAD"));
+        assert!(!text.contains("NUL_SECRET_PAYLOAD"));
+        assert!(!text.contains(&dir.path().to_string_lossy().to_string()));
+        let receipt: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(receipt["observation"]["status"], "rejected");
+        assert_eq!(
+            receipt["invocation"]["policy_admission"]["decision"],
+            "rejected"
+        );
+        assert!(receipt["observation"]["output_ref"].is_null());
+        assert!(
+            receipt["observation"]["measurements"]
+                .as_array()
+                .is_some_and(Vec::is_empty)
+        );
+    }
+    assert!(!data_dir.join("engine-interface/v1/outputs").exists());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_v1_rejects_worker_late_protected_path_mode_change() {
+    let _data_dir = crate::core::data_dir::isolated_data_dir();
+    let data_dir = crate::core::data_dir::lean_ctx_data_dir().unwrap();
+    std::fs::write(
+        data_dir.join("config.toml"),
+        "[proxy]\ncompress_protect = [\"*.protected\"]\n",
+    )
+    .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("late-mode.protected");
+    std::fs::write(&source, "LATE_MODE_SECRET_PAYLOAD\n".repeat(40)).unwrap();
+    let ctx = engine_test_context(dir.path(), &source);
+    let args = json!({
+        "path": source.to_string_lossy(),
+        "mode": "aggressive",
+        "engine_interface": "v1"
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+
+    let Err(first) = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx)) else {
+        panic!("Engine v1 must reject a worker-late effective mode change");
+    };
+    assert!(
+        first
+            .message
+            .contains("reason=effective_mode_not_aggressive")
+    );
+    let receipt_path = engine_receipt_path(&data_dir, &first.message);
+    let first_bytes = std::fs::read(&receipt_path).unwrap();
+
+    let Err(repeated) = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx)) else {
+        panic!("worker-late effective mode rejection must be deterministic");
+    };
+    assert_eq!(first.message, repeated.message);
+    assert_eq!(first_bytes, std::fs::read(&receipt_path).unwrap());
+    assert!(
+        !String::from_utf8(first_bytes)
+            .unwrap()
+            .contains("LATE_MODE_SECRET_PAYLOAD")
+    );
+    assert!(!data_dir.join("engine-interface/v1/outputs").exists());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/src/tools/registered/ctx_read_inline_tests.rs
+++ b/rust/src/tools/registered/ctx_read_inline_tests.rs
@@ -308,6 +308,21 @@ async fn mcp_aggressive_read_surfaces_engine_receipt_failure_without_hiding_cont
         session: Some(Arc::new(RwLock::new(SessionState::new()))),
         ..ToolContext::default()
     };
+    let legacy_args = json!({
+        "path": path,
+        "mode": "aggressive",
+        "fresh": true
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let legacy = tokio::task::block_in_place(|| CtxReadTool.handle(&legacy_args, &ctx))
+        .expect("omitted Engine interface ignores unavailable receipt storage");
+    assert!(!legacy.text.starts_with("[ENGINE RECEIPT WARNING]"));
+    assert!(legacy.text.contains("legacy_content_survives"));
+    assert!(!engine_dir.join("outputs").exists());
+    assert!(!engine_dir.join("recovery").exists());
+
     let args = json!({
         "path": path,
         "mode": "aggressive",
@@ -328,6 +343,11 @@ async fn mcp_aggressive_read_surfaces_engine_receipt_failure_without_hiding_cont
     );
     assert!(output.text.contains("recovery_ref=recovery:sha256:"));
     assert!(output.text.contains("legacy_content_survives"));
+    let (_, preserved) = output
+        .text
+        .split_once("\n\n")
+        .expect("stable Engine warning must be one paragraph before legacy content");
+    assert_eq!(preserved, legacy.text);
 
     let recovery_dir = engine_dir.join("recovery");
     let recovery: Vec<_> = std::fs::read_dir(&recovery_dir)

--- a/rust/src/tools/registered/ctx_read_security_tests.rs
+++ b/rust/src/tools/registered/ctx_read_security_tests.rs
@@ -1,5 +1,6 @@
 //! Security-boundary tests for the explicit Engine v1 read path.
 
+#[cfg(unix)]
 use super::*;
 
 #[cfg(unix)]

--- a/rust/src/tools/registered/ctx_read_security_tests.rs
+++ b/rust/src/tools/registered/ctx_read_security_tests.rs
@@ -1,0 +1,74 @@
+//! Security-boundary tests for the explicit Engine v1 read path.
+
+use super::*;
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_v1_rooted_read_failure_never_falls_back_to_outside_content() {
+    use std::os::unix::fs::symlink;
+
+    let _data_dir = crate::core::data_dir::isolated_data_dir();
+    let data_dir = crate::core::data_dir::lean_ctx_data_dir().expect("isolated data dir");
+    let root = tempfile::tempdir().expect("Engine root");
+    let outside = tempfile::tempdir().expect("outside directory");
+    let outside_file = outside.path().join("secret.txt");
+    let secret = "OUTSIDE_ENGINE_PAYLOAD_MUST_NOT_ESCAPE";
+    std::fs::write(&outside_file, secret).expect("outside fixture");
+    symlink(outside.path(), root.path().join("linkdir")).expect("outside directory link");
+    let requested = root.path().join("linkdir/secret.txt");
+    let path = requested.to_string_lossy().into_owned();
+    let ctx = ToolContext {
+        project_root: root.path().to_string_lossy().into_owned(),
+        resolved_paths: std::collections::HashMap::from([("path".to_owned(), path.clone())]),
+        cache: Some(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::core::cache::SessionCache::new(),
+        ))),
+        session: Some(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::core::session::SessionState::new(),
+        ))),
+        ..ToolContext::default()
+    };
+    let args = json!({
+        "path": path,
+        "mode": "aggressive",
+        "engine_interface": "v1"
+    })
+    .as_object()
+    .expect("Engine args")
+    .clone();
+
+    let Err(first) = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx)) else {
+        panic!("outside-root Engine v1 source must be rejected");
+    };
+    let Err(repeated) = tokio::task::block_in_place(|| CtxReadTool.handle(&args, &ctx)) else {
+        panic!("identical outside-root Engine v1 source must remain rejected");
+    };
+    assert_eq!(first.message, repeated.message);
+    assert!(first.message.contains("reason=source_read_failed"));
+    assert!(!first.message.contains(secret));
+
+    let digest = first
+        .message
+        .split_once("receipt_ref=receipt:sha256:")
+        .map(|(_, digest)| digest)
+        .expect("rejection receipt digest");
+    assert_eq!(digest.len(), 64);
+    assert!(digest.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    let receipt_path = data_dir
+        .join("engine-interface/v1/receipts")
+        .join(format!("{digest}.json"));
+    let receipt_bytes = std::fs::read(&receipt_path).expect("rejection receipt");
+    assert_eq!(receipt_bytes, std::fs::read(&receipt_path).unwrap());
+    let receipt_text = String::from_utf8(receipt_bytes.clone()).expect("receipt text");
+    assert!(!receipt_text.contains(secret));
+    assert!(!receipt_text.contains(&outside.path().to_string_lossy().to_string()));
+    let receipt: serde_json::Value = serde_json::from_slice(&receipt_bytes).expect("receipt JSON");
+    assert_eq!(receipt["observation"]["status"], "rejected");
+    assert!(receipt["observation"]["output_ref"].is_null());
+    assert!(
+        receipt["invocation"]["source_refs"][1]
+            .as_str()
+            .is_some_and(|reference| reference.starts_with("source:requested-path-sha256:"))
+    );
+    assert!(!data_dir.join("engine-interface/v1/outputs").exists());
+}


### PR DESCRIPTION
## Summary

- add explicit opt-in Engine Interface v1 for single-path `ctx_read` while preserving exact legacy behavior when omitted
- capture source and image inputs through rooted no-follow descriptors and deterministic rejection receipts
- persist content-addressed artifacts with contained, failure-atomic temp writes and atomic no-replace publication
- enforce real host deadlines with no late artifact publication
- document the security boundary and acceptance commands

## Verification

- `cargo test --lib`: 10,319 passed, 0 failed, 22 ignored
- focused artifact security and failure-atomicity tests: 4 passed
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt --check` and `git diff --check`
- Windows GNU cross-check and warnings-denied pre-push Windows lib/tests cross-check
- pre-push CI-parity gate: 7 passed, 1 not-applicable skip
- independent artifact atomicity final review: PASS

## Compatibility and boundary

- Engine Interface behavior is enabled only by `engine_interface="v1"`
- omitted `engine_interface` keeps existing image, binary, batch, and text behavior
- pre-existing symlink/reparse escapes and payload writes outside the resolved data root fail closed
- malicious same-user relocation after artifact-handle validation is explicitly outside the P1 threat boundary
- no Cloud/control-plane implementation, credentials, or private repository material is included