### PR TITLE
fix(engine): make artifact writes descriptor-relative

### DIFF
--- a/docs/contracts/native-engine-context-proof-v1.md
+++ b/docs/contracts/native-engine-context-proof-v1.md
@@ -40,20 +40,42 @@ engine-interface/v1/receipts/<sha256>.json
 engine-interface/v1/recovery/<sha256>.json
 ```
 
-- Directories are private on Unix. Every relative directory component is
-  rejected when it is a symlink/reparse point or resolves outside the canonical
-  data root. New content-addressed artifacts are written to an exclusive,
-  no-follow temporary leaf in the validated final directory. Only a fully
-  written, permission-hardened and synchronized temporary artifact may be
-  published under its digest by an atomic no-replace operation; an existing
-  digest path is never overwritten. Any failure before publication leaves the
-  final digest path absent and retryable. Unix artifacts use mode `0600`.
+- Directories are private on Unix. The deepest existing data-root ancestor is
+  acquired directly by a no-follow final-component `open`; there is no separate
+  metadata probe or canonicalize/reopen window. Missing root components and
+  every later `engine-interface/v1/<class>` component are opened or created
+  with `openat`/`mkdirat` relative to the held parent descriptor and no-follow
+  protection. New
+  content-addressed artifacts are written to an exclusive,
+  no-follow temporary leaf through the held final-directory descriptor. Only a
+  fully written, permission-hardened and synchronized temporary artifact may be
+  published under its digest by descriptor-relative atomic no-replace
+  publication (`renameat2` or contained `linkat`); an existing digest path is
+  never overwritten. The named temporary entry's device/inode identity is
+  checked against the held file before and after publication; a swapped entry
+  is removed and rejected. Any failure before publication leaves the final
+  digest path absent and retryable. Unix artifacts use mode `0600`.
+- Windows opens only the drive/UNC anchor by absolute name, validates that
+  handle's final DOS path, then walks every data-root and artifact component by
+  held handles with native relative create/open operations and reparse
+  protection; it has no probe/canonicalize/reopen window. Relative rename and
+  disposition complete publication. If a required native
+  primitive or runtime filesystem behavior is unsupported, the writer returns
+  the stable `engine_artifact_boundary_unsupported` category and never falls
+  back to pathname mutation. Any provisional directory remains confined beneath
+  the held root; temporary leaves are delete-on-close and cleaned by handle.
+  Artifact files are flushed before publication. Directory-handle flush is
+  applied where the filesystem supports it; documented unsupported directory
+  flush results neither weaken containment nor invalidate an already verified
+  content-addressed artifact.
 - Existing artifact paths must be regular, non-symlink files whose contents
   match their address.
 - P1 rejects pre-existing symlink/reparse escape and never writes payload bytes
-  outside the resolved data root. Malicious same-user relocation after artifact
-  handle validation is outside this boundary; that excluded race can leave an
-  empty external leaf, but cannot produce an external payload write.
+  outside the resolved data-root object. That object, not a later pathname
+  lookup, is the boundary after binding. Deterministic root- and parent-swap
+  sentinels relocate the held tree or output directory and replace the old
+  pathname; publication remains inside the held object or fails closed, and the
+  replacement/outside directory remains byte-for-byte unchanged.
 - Receipt JSON is canonical and contains references, digests, status and
   measurements only. It intentionally excludes raw source and output bytes.
 - The production source reference binds the canonical resolved path by SHA-256;
@@ -82,10 +104,14 @@ remain untouched when Engine v1 is omitted. Explicit Engine v1 forces a fresh
 bounded worker snapshot; identical calls reuse the same content-addressed
 output and receipt identities rather than silently accepting a legacy cache hit.
 
-The production worker opens the source through the Engine root one component at
-a time without following links. The Engine receives that descriptor-backed raw
-snapshot and canonical identity; it does not resolve or read the caller path a
-second time. Materialized compression runs in a dedicated worker behind a real
+On Unix, the production worker opens the source through the Engine root one
+component at a time without following links. On Windows, it validates the
+opened regular-file handle's normalized final path against the canonical root
+before reading. The Engine receives that handle-backed raw snapshot and
+canonical identity; it does not resolve or read the caller path a second time.
+Engine construction fails closed when its root cannot be securely canonicalized;
+it never substitutes the unresolved caller path. Materialized compression runs
+in a dedicated worker behind a real
 30-second host deadline. A timed-out worker cannot persist an artifact and late
 completion cannot publish output. The receiving Engine records the terminal
 `failed` / `resource_limit` observation and receipt itself.

--- a/docs/contracts/native-engine-context-proof-v1.md
+++ b/docs/contracts/native-engine-context-proof-v1.md
@@ -58,16 +58,19 @@ engine-interface/v1/recovery/<sha256>.json
 - Windows opens only the drive/UNC anchor by absolute name, validates that
   handle's final DOS path, then walks every data-root and artifact component by
   held handles with native relative create/open operations and reparse
-  protection; it has no probe/canonicalize/reopen window. Relative rename and
-  disposition complete publication. If a required native
+  protection; root binding has no probe/canonicalize/reopen window. Relative
+  rename completes publication; handle-relative disposition removes failed
+  temporary or final objects. The published name is intentionally reopened
+  through the held directory handle and its digest is verified before the
+  original temporary handle is released. If a required native
   primitive or runtime filesystem behavior is unsupported, the writer returns
   the stable `engine_artifact_boundary_unsupported` category and never falls
   back to pathname mutation. Any provisional directory remains confined beneath
-  the held root; temporary leaves are delete-on-close and cleaned by handle.
-  Artifact files are flushed before publication. Directory-handle flush is
-  applied where the filesystem supports it; documented unsupported directory
-  flush results neither weaken containment nor invalidate an already verified
-  content-addressed artifact.
+  the held root; handled failures delete temporary leaves through their held
+  handles. Artifact files are flushed before publication. Directory-handle
+  flush is applied where the filesystem supports it; documented unsupported
+  directory flush results neither weaken containment nor invalidate an already
+  verified content-addressed artifact.
 - Existing artifact paths must be regular, non-symlink files whose contents
   match their address.
 - P1 rejects pre-existing symlink/reparse escape and never writes payload bytes

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -430,6 +430,9 @@ windows-sys = { version = "0.61", features = [
   "Win32_Security",
   "Win32_System_Pipes",
   "Win32_Storage_FileSystem",
+  "Wdk_Foundation",
+  "Wdk_Storage_FileSystem",
+  "Win32_System_IO",
 ] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/rust/src/core/engine_artifact.rs
+++ b/rust/src/core/engine_artifact.rs
@@ -1,7 +1,7 @@
 //! Contained, immutable storage for local Engine Interface artifacts.
 
 use std::io::{Read, Seek, Write};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 #[cfg(test)]
 use std::cell::Cell;
@@ -9,6 +9,20 @@ use std::cell::Cell;
 use sha2::{Digest, Sha256};
 
 use crate::core::data_dir;
+
+const ARTIFACT_BOUNDARY_REJECTED: &str = "engine_artifact_boundary_rejected";
+const ARTIFACT_BOUNDARY_UNSUPPORTED: &str = "engine_artifact_boundary_unsupported";
+const ARTIFACT_DIRECTORY_OPEN_FAILED: &str = "engine_artifact_directory_open_failed";
+const ARTIFACT_DIRECTORY_CREATE_FAILED: &str = "engine_artifact_directory_create_failed";
+const ARTIFACT_TEMP_CREATE_FAILED: &str = "engine_artifact_temp_create_failed";
+const ARTIFACT_WRITE_FAILED: &str = "engine_artifact_write_failed";
+const ARTIFACT_PERMISSIONS_FAILED: &str = "engine_artifact_permissions_failed";
+const ARTIFACT_SYNC_FAILED: &str = "engine_artifact_sync_failed";
+const ARTIFACT_PUBLISH_FAILED: &str = "engine_artifact_publish_failed";
+const ARTIFACT_PUBLISH_UNSUPPORTED: &str = "engine_artifact_publish_unsupported";
+const ARTIFACT_LEAF_UNTRUSTED: &str = "engine_artifact_leaf_untrusted";
+const ARTIFACT_DIGEST_MISMATCH: &str = "engine_artifact_digest_mismatch";
+const ARTIFACT_CLEANUP_FAILED: &str = "engine_artifact_cleanup_failed";
 
 #[cfg(test)]
 thread_local! {
@@ -31,407 +45,100 @@ fn test_pre_publish_failure() -> bool {
     }
 }
 
-struct TempArtifact {
-    file: Option<std::fs::File>,
-    path: PathBuf,
-    published: bool,
-}
-
-impl Drop for TempArtifact {
-    fn drop(&mut self) {
-        // Closing before unlinking is required on Windows. A failed operation
-        // may leave only this private, same-directory temporary leaf behind.
-        self.file.take();
-        if !self.published {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
-}
-
 pub(super) fn persist_content(
     directory: &str,
     digest: &str,
     extension: &str,
     bytes: &[u8],
 ) -> Result<std::fs::File, String> {
+    persist_content_checked(directory, digest, extension, bytes, None, None)
+}
+
+#[cfg(any(unix, windows))]
+pub(super) fn persist_content_with_test_barrier(
+    directory: &str,
+    digest: &str,
+    extension: &str,
+    bytes: &[u8],
+    barrier: Box<dyn FnOnce()>,
+) -> Result<std::fs::File, String> {
+    persist_content_checked(directory, digest, extension, bytes, Some(barrier), None)
+}
+
+#[cfg(all(test, unix))]
+pub(super) fn persist_content_with_test_publish_barrier(
+    directory: &str,
+    digest: &str,
+    extension: &str,
+    bytes: &[u8],
+    barrier: Box<dyn FnOnce()>,
+) -> Result<std::fs::File, String> {
+    persist_content_checked(directory, digest, extension, bytes, None, Some(barrier))
+}
+
+fn persist_content_checked(
+    directory: &str,
+    digest: &str,
+    extension: &str,
+    bytes: &[u8],
+    bind_barrier: Option<Box<dyn FnOnce()>>,
+    publish_barrier: Option<Box<dyn FnOnce()>>,
+) -> Result<std::fs::File, String> {
     validate_artifact_name(digest, extension)?;
     if hex_sha256(bytes) != digest {
-        return Err(
-            "engine_artifact_digest_mismatch: supplied bytes do not match digest".to_owned(),
+        return Err(ARTIFACT_DIGEST_MISMATCH.to_owned());
+    }
+
+    let configured_root =
+        data_dir::lean_ctx_data_dir().map_err(|_| ARTIFACT_BOUNDARY_REJECTED.to_owned())?;
+
+    #[cfg(unix)]
+    {
+        unix::persist_content(
+            &configured_root,
+            directory,
+            digest,
+            extension,
+            bytes,
+            bind_barrier,
+            publish_barrier,
+        )
+    }
+
+    #[cfg(windows)]
+    {
+        windows::persist_content(
+            &configured_root,
+            directory,
+            digest,
+            extension,
+            bytes,
+            bind_barrier,
+            publish_barrier,
+        )
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (
+            configured_root,
+            directory,
+            digest,
+            extension,
+            bytes,
+            bind_barrier,
+            publish_barrier,
         );
-    }
-
-    let configured_root = data_dir::lean_ctx_data_dir()?;
-    std::fs::create_dir_all(&configured_root)
-        .map_err(|error| format!("create Engine data directory: {error}"))?;
-    let root = crate::core::pathutil::canonicalize_secure(&configured_root)
-        .map_err(|error| format!("resolve Engine data directory: {error}"))?;
-    let directory = prepare_directory(&root, directory)?;
-    let path = directory.join(format!("{digest}.{extension}"));
-    let mut temp = create_temp_artifact(&path, &root)
-        .map_err(|_| "engine_artifact_temp_create_failed".to_owned())?;
-    write_temp_artifact(&mut temp, bytes)?;
-
-    if test_pre_publish_failure() {
-        return Err("engine_artifact_test_pre_publish_failure".to_owned());
-    }
-
-    match publish_temp_artifact(&mut temp, &path) {
-        Ok(()) => open_published_artifact(&path, &root, digest),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            verify_existing_artifact(&path, &root, digest)
-        }
-        Err(_) => Err("engine_artifact_publish_failed".to_owned()),
+        Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())
     }
 }
 
 fn validate_artifact_name(digest: &str, extension: &str) -> Result<(), String> {
     if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return Err("Engine artifact digest must be 64 hexadecimal characters".to_owned());
+        return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
     }
     if !matches!(extension, "json" | "txt") {
-        return Err("Engine artifact extension is not allowed".to_owned());
-    }
-    Ok(())
-}
-
-fn prepare_directory(root: &Path, relative: &str) -> Result<PathBuf, String> {
-    let mut current = root.to_path_buf();
-    for component in Path::new(relative).components() {
-        let Component::Normal(component) = component else {
-            return Err("Engine artifact directory must be a relative normal path".to_owned());
-        };
-        let next = current.join(component);
-        match std::fs::symlink_metadata(&next) {
-            Ok(metadata) => validate_directory_metadata(&metadata)?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                match std::fs::create_dir(&next) {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
-                    Err(error) => {
-                        return Err(format!("create Engine artifact directory: {error}"));
-                    }
-                }
-                let metadata = std::fs::symlink_metadata(&next)
-                    .map_err(|error| format!("inspect Engine artifact directory: {error}"))?;
-                validate_directory_metadata(&metadata)?;
-            }
-            Err(error) => {
-                return Err(format!("inspect Engine artifact directory: {error}"));
-            }
-        }
-        let resolved = crate::core::pathutil::canonicalize_secure(&next)
-            .map_err(|error| format!("resolve Engine artifact directory: {error}"))?;
-        if !resolved.starts_with(root) {
-            return Err(
-                "engine_artifact_boundary_rejected: directory escaped data root".to_owned(),
-            );
-        }
-        data_dir::ensure_dir_permissions(&resolved);
-        current = resolved;
-    }
-    Ok(current)
-}
-
-fn validate_directory_metadata(metadata: &std::fs::Metadata) -> Result<(), String> {
-    if crate::core::pathutil::is_symlink_or_reparse(metadata) || !metadata.is_dir() {
-        return Err(
-            "engine_artifact_boundary_rejected: directory must be real and non-symlink".to_owned(),
-        );
-    }
-    Ok(())
-}
-
-fn create_temp_artifact(path: &Path, root: &Path) -> Result<TempArtifact, std::io::Error> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| std::io::Error::other("Engine artifact path has no parent"))?;
-    let filename = path
-        .file_name()
-        .ok_or_else(|| std::io::Error::other("Engine artifact path has no filename"))?
-        .to_string_lossy();
-
-    // The bounded suffix loop handles concurrent writers and a temp left by a
-    // process crash without putting a random name into any persisted record.
-    for suffix in 0..128u16 {
-        let temp_name = if suffix == 0 {
-            format!(".{filename}.tmp")
-        } else {
-            format!(".{filename}.tmp.{suffix}")
-        };
-        let temp_path = parent.join(temp_name);
-        let mut options = std::fs::OpenOptions::new();
-        options.read(true).write(true).create_new(true);
-        apply_nofollow_flags(&mut options);
-        let file = match options.open(&temp_path) {
-            Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
-        };
-        if let Err(error) = verify_open_artifact(&file, &temp_path, root) {
-            drop(file);
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(error);
-        }
-        return Ok(TempArtifact {
-            file: Some(file),
-            path: temp_path,
-            published: false,
-        });
-    }
-
-    Err(std::io::Error::new(
-        std::io::ErrorKind::AlreadyExists,
-        "Engine artifact temporary namespace is occupied",
-    ))
-}
-
-fn write_temp_artifact(temp: &mut TempArtifact, bytes: &[u8]) -> Result<(), String> {
-    let artifact = temp
-        .file
-        .as_mut()
-        .ok_or_else(|| "engine_artifact_temp_closed".to_owned())?;
-    if let Some(permissions) = artifact_permissions() {
-        artifact
-            .set_permissions(permissions)
-            .map_err(|_| "engine_artifact_temp_permissions_failed".to_owned())?;
-    }
-    artifact
-        .write_all(bytes)
-        .map_err(|_| "engine_artifact_temp_write_failed".to_owned())?;
-    artifact
-        .sync_all()
-        .map_err(|_| "engine_artifact_temp_sync_failed".to_owned())?;
-    Ok(())
-}
-
-fn publish_temp_artifact(temp: &mut TempArtifact, path: &Path) -> Result<(), std::io::Error> {
-    // The file is fully written and synchronized before it becomes visible at
-    // its content address. Closing also makes the publication portable.
-    temp.file.take();
-
-    #[cfg(windows)]
-    windows_publish_no_replace(&temp.path, path)?;
-
-    #[cfg(not(windows))]
-    {
-        // hard_link is an atomic create-without-replacement primitive: unlike
-        // rename, it cannot replace an existing addressed artifact.
-        std::fs::hard_link(&temp.path, path)?;
-        #[cfg(unix)]
-        sync_directory(path.parent());
-        std::fs::remove_file(&temp.path)?;
-    }
-
-    temp.published = true;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn windows_publish_no_replace(temp: &Path, path: &Path) -> Result<(), std::io::Error> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_WRITE_THROUGH, MoveFileExW};
-
-    fn wide(path: &Path) -> Vec<u16> {
-        path.as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect()
-    }
-
-    let temp = wide(temp);
-    let path = wide(path);
-    // Omitting MOVEFILE_REPLACE_EXISTING makes an existing final path a
-    // deterministic AlreadyExists failure; the move stays same-volume because
-    // the temp was created in the final directory.
-    let ok = unsafe { MoveFileExW(temp.as_ptr(), path.as_ptr(), MOVEFILE_WRITE_THROUGH) };
-    if ok == 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn sync_directory(parent: Option<&Path>) {
-    if let Some(parent) = parent
-        && let Ok(directory) = std::fs::File::open(parent)
-    {
-        let _ = directory.sync_all();
-    }
-}
-
-fn open_published_artifact(
-    path: &Path,
-    root: &Path,
-    digest: &str,
-) -> Result<std::fs::File, String> {
-    let mut options = std::fs::OpenOptions::new();
-    options.read(true);
-    apply_nofollow_flags(&mut options);
-    let mut artifact = options
-        .open(path)
-        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
-    verify_open_artifact(&artifact, path, root)
-        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
-    let mut bytes = Vec::new();
-    artifact
-        .read_to_end(&mut bytes)
-        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
-    if hex_sha256(&bytes) != digest {
-        return Err("engine_artifact_publish_verification_failed".to_owned());
-    }
-    artifact
-        .rewind()
-        .map_err(|_| "engine_artifact_publish_verification_failed".to_owned())?;
-    Ok(artifact)
-}
-
-fn verify_existing_artifact(
-    path: &Path,
-    root: &Path,
-    digest: &str,
-) -> Result<std::fs::File, String> {
-    if std::fs::symlink_metadata(path)
-        .is_ok_and(|metadata| crate::core::pathutil::is_symlink_or_reparse(&metadata))
-    {
-        return Err(
-            "engine_artifact_leaf_untrusted: artifact must be regular and non-symlink".to_owned(),
-        );
-    }
-    let mut options = std::fs::OpenOptions::new();
-    options.read(true);
-    apply_nofollow_flags(&mut options);
-    let mut artifact = options
-        .open(path)
-        .map_err(|error| format!("open Engine artifact without following links: {error}"))?;
-    verify_open_artifact(&artifact, path, root).map_err(|_| {
-        "engine_artifact_boundary_rejected: opened file escaped data root".to_owned()
-    })?;
-    let mut bytes = Vec::new();
-    artifact
-        .read_to_end(&mut bytes)
-        .map_err(|error| format!("read Engine artifact: {error}"))?;
-    if hex_sha256(&bytes) != digest {
-        return Err(
-            "engine_artifact_digest_mismatch: content differs from addressed digest".to_owned(),
-        );
-    }
-    if let Some(permissions) = artifact_permissions() {
-        artifact
-            .set_permissions(permissions)
-            .map_err(|error| format!("harden Engine artifact permissions: {error}"))?;
-    }
-    artifact
-        .rewind()
-        .map_err(|error| format!("rewind Engine artifact: {error}"))?;
-    Ok(artifact)
-}
-
-fn apply_nofollow_flags(options: &mut std::fs::OpenOptions) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::OpenOptionsExt;
-        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-    }
-}
-
-fn verify_open_artifact(
-    artifact: &std::fs::File,
-    path: &Path,
-    root: &Path,
-) -> Result<(), std::io::Error> {
-    let metadata = artifact.metadata()?;
-    if crate::core::pathutil::is_symlink_or_reparse(&metadata) || !metadata.is_file() {
-        return Err(std::io::Error::other(
-            "Engine artifact must be a regular non-symlink file",
-        ));
-    }
-    verify_handle_path(artifact, path, root, &metadata)
-}
-
-#[cfg(unix)]
-fn verify_handle_path(
-    _artifact: &std::fs::File,
-    path: &Path,
-    root: &Path,
-    metadata: &std::fs::Metadata,
-) -> Result<(), std::io::Error> {
-    use std::os::unix::fs::MetadataExt;
-
-    let resolved = crate::core::pathutil::canonicalize_secure(path)?;
-    let resolved_metadata = std::fs::metadata(&resolved)?;
-    if !resolved.starts_with(root)
-        || metadata.dev() != resolved_metadata.dev()
-        || metadata.ino() != resolved_metadata.ino()
-    {
-        return Err(std::io::Error::other(
-            "opened Engine artifact escaped the data root",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(windows)]
-fn verify_handle_path(
-    artifact: &std::fs::File,
-    _path: &Path,
-    root: &Path,
-    _metadata: &std::fs::Metadata,
-) -> Result<(), std::io::Error> {
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_NAME_NORMALIZED, GetFinalPathNameByHandleW, VOLUME_NAME_DOS,
-    };
-
-    let mut buffer = vec![0u16; 32_768];
-    // SAFETY: the handle is live and buffer is writable for its full length.
-    let length = unsafe {
-        GetFinalPathNameByHandleW(
-            artifact.as_raw_handle() as _,
-            buffer.as_mut_ptr(),
-            buffer.len() as u32,
-            FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
-        )
-    };
-    if length == 0 || length as usize >= buffer.len() {
-        return Err(std::io::Error::last_os_error());
-    }
-    buffer.truncate(length as usize);
-    let opened = crate::core::pathutil::strip_verbatim(PathBuf::from(OsString::from_wide(&buffer)));
-    let opened = opened.to_string_lossy().to_ascii_lowercase();
-    let root = root.to_string_lossy().to_ascii_lowercase();
-    if opened != root
-        && !opened
-            .strip_prefix(&root)
-            .is_some_and(|suffix| suffix.starts_with('\\') || suffix.starts_with('/'))
-    {
-        return Err(std::io::Error::other(
-            "opened Engine artifact escaped the data root",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(not(any(unix, windows)))]
-fn verify_handle_path(
-    _artifact: &std::fs::File,
-    path: &Path,
-    root: &Path,
-    _metadata: &std::fs::Metadata,
-) -> Result<(), std::io::Error> {
-    let resolved = crate::core::pathutil::canonicalize_secure(path)?;
-    if !resolved.starts_with(root) {
-        return Err(std::io::Error::other(
-            "opened Engine artifact escaped the data root",
-        ));
+        return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
     }
     Ok(())
 }
@@ -440,14 +147,1182 @@ fn hex_sha256(bytes: &[u8]) -> String {
     crate::core::agent_identity::hex_encode(&Sha256::digest(bytes))
 }
 
-fn artifact_permissions() -> Option<std::fs::Permissions> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        Some(std::fs::Permissions::from_mode(0o600))
+#[cfg(unix)]
+#[allow(clippy::wildcard_imports)]
+mod unix {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    const ROOT_FLAGS: libc::c_int =
+        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    const DIRECTORY_FLAGS: libc::c_int =
+        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    const LEAF_READ_FLAGS: libc::c_int = libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+    const TEMP_FLAGS: libc::c_int =
+        libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW;
+
+    struct ArtifactDirectory {
+        _root: std::fs::File,
+        final_dir: std::fs::File,
     }
-    #[cfg(not(unix))]
-    {
-        None
+
+    struct TempArtifact {
+        file: Option<std::fs::File>,
+        directory_fd: RawFd,
+        name: CString,
+        disarmed: bool,
+    }
+
+    impl TempArtifact {
+        fn cleanup(&mut self) -> Result<(), String> {
+            if self.disarmed {
+                return Ok(());
+            }
+            self.file.take();
+            // SAFETY: directory_fd remains held; name is NUL-terminated.
+            let result = unsafe { libc::unlinkat(self.directory_fd, self.name.as_ptr(), 0) };
+            if result == 0 || errno() == libc::ENOENT {
+                self.disarmed = true;
+                Ok(())
+            } else {
+                Err(ARTIFACT_CLEANUP_FAILED.to_owned())
+            }
+        }
+    }
+
+    impl Drop for TempArtifact {
+        fn drop(&mut self) {
+            if !self.disarmed {
+                self.file.take();
+                // SAFETY: directory_fd remains held; name is NUL-terminated.
+                unsafe {
+                    let _ = libc::unlinkat(self.directory_fd, self.name.as_ptr(), 0);
+                }
+            }
+        }
+    }
+
+    pub(super) fn persist_content(
+        configured_root: &Path,
+        relative: &str,
+        digest: &str,
+        extension: &str,
+        bytes: &[u8],
+        bind_barrier: Option<Box<dyn FnOnce()>>,
+        publish_barrier: Option<Box<dyn FnOnce()>>,
+    ) -> Result<std::fs::File, String> {
+        let root = bind_root(configured_root)?;
+        let directories = prepare_directory(&root, relative)?;
+
+        if let Some(barrier) = bind_barrier {
+            barrier();
+        }
+
+        let final_name = cstring(format!("{digest}.{extension}"))?;
+        let mut temp = create_temp_artifact(&directories.final_dir, &final_name)?;
+        if let Err(error) = write_temp_artifact(&mut temp, bytes) {
+            return Err(temp.cleanup().err().unwrap_or(error));
+        }
+        if let Some(barrier) = publish_barrier {
+            barrier();
+        }
+
+        if super::test_pre_publish_failure() {
+            temp.cleanup()?;
+            return Err("engine_artifact_test_pre_publish_failure".to_owned());
+        }
+
+        publish_temp_artifact(
+            &mut temp,
+            directories.final_dir.as_raw_fd(),
+            &final_name,
+            digest,
+        )
+    }
+
+    fn bind_root(configured_root: &Path) -> Result<std::fs::File, String> {
+        if !configured_root.is_absolute() {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        let (mut root, missing) = open_existing_ancestor(configured_root)?;
+        for name in missing.iter().rev() {
+            let child_fd = open_directory_at(root.as_raw_fd(), name)?;
+            // SAFETY: child_fd is a successful descriptor owned immediately.
+            root = unsafe { std::fs::File::from_raw_fd(child_fd) };
+        }
+        chmod_directory(root.as_raw_fd())?;
+        Ok(root)
+    }
+
+    fn open_existing_ancestor(path: &Path) -> Result<(std::fs::File, Vec<CString>), String> {
+        let mut cursor = path.to_path_buf();
+        let mut missing = Vec::new();
+        loop {
+            let path = CString::new(cursor.as_os_str().as_bytes())
+                .map_err(|_| ARTIFACT_BOUNDARY_REJECTED.to_owned())?;
+            // SAFETY: path is NUL-terminated; File owns a successful descriptor.
+            let fd = unsafe { libc::open(path.as_ptr(), ROOT_FLAGS) };
+            if fd >= 0 {
+                // SAFETY: fd is a successful descriptor owned immediately by File.
+                return Ok((unsafe { std::fs::File::from_raw_fd(fd) }, missing));
+            }
+            match errno() {
+                libc::ENOENT => {
+                    let name = cursor
+                        .file_name()
+                        .ok_or_else(|| ARTIFACT_BOUNDARY_REJECTED.to_owned())?;
+                    missing.push(
+                        CString::new(name.as_bytes())
+                            .map_err(|_| ARTIFACT_BOUNDARY_REJECTED.to_owned())?,
+                    );
+                    cursor = cursor
+                        .parent()
+                        .ok_or_else(|| ARTIFACT_BOUNDARY_REJECTED.to_owned())?
+                        .to_path_buf();
+                }
+                libc::ELOOP | libc::ENOTDIR => {
+                    return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+                }
+                _ => return Err(ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned()),
+            }
+        }
+    }
+
+    fn prepare_directory(
+        root: &std::fs::File,
+        relative: &str,
+    ) -> Result<ArtifactDirectory, String> {
+        let mut parent = root
+            .try_clone()
+            .map_err(|_| ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned())?;
+        let mut saw_component = false;
+
+        for component in Path::new(relative).components() {
+            let Component::Normal(component) = component else {
+                return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+            };
+            saw_component = true;
+            let name = CString::new(component.as_bytes())
+                .map_err(|_| ARTIFACT_BOUNDARY_REJECTED.to_owned())?;
+            let child_fd = open_directory_at(parent.as_raw_fd(), &name)?;
+            // SAFETY: child_fd is a successful descriptor owned immediately.
+            let child = unsafe { std::fs::File::from_raw_fd(child_fd) };
+            if !child
+                .metadata()
+                .map_err(|_| ARTIFACT_DIRECTORY_OPEN_FAILED)?
+                .is_dir()
+            {
+                return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+            }
+            chmod_directory(child.as_raw_fd())?;
+            parent = child;
+        }
+
+        if !saw_component {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        Ok(ArtifactDirectory {
+            _root: root
+                .try_clone()
+                .map_err(|_| ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned())?,
+            final_dir: parent,
+        })
+    }
+
+    fn open_directory_at(parent_fd: RawFd, name: &CString) -> Result<RawFd, String> {
+        // SAFETY: parent_fd is held and name is NUL-terminated.
+        let mut child_fd = unsafe { libc::openat(parent_fd, name.as_ptr(), DIRECTORY_FLAGS) };
+        if child_fd < 0 && errno() == libc::ENOENT {
+            // SAFETY: parent_fd is held and name is NUL-terminated.
+            let created = unsafe { libc::mkdirat(parent_fd, name.as_ptr(), 0o700) };
+            if created != 0 && errno() != libc::EEXIST {
+                return Err(ARTIFACT_DIRECTORY_CREATE_FAILED.to_owned());
+            }
+            // SAFETY: parent_fd is held and name is NUL-terminated.
+            child_fd = unsafe { libc::openat(parent_fd, name.as_ptr(), DIRECTORY_FLAGS) };
+        }
+        if child_fd < 0 {
+            return Err(if matches!(errno(), libc::ELOOP | libc::ENOTDIR) {
+                ARTIFACT_BOUNDARY_REJECTED.to_owned()
+            } else {
+                ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned()
+            });
+        }
+        Ok(child_fd)
+    }
+
+    fn create_temp_artifact(
+        directory: &std::fs::File,
+        final_name: &CString,
+    ) -> Result<TempArtifact, String> {
+        for suffix in 0..128u16 {
+            let name = if suffix == 0 {
+                cstring(format!(".{}.tmp", final_name.to_string_lossy()))?
+            } else {
+                cstring(format!(".{}.tmp.{suffix}", final_name.to_string_lossy()))?
+            };
+            // SAFETY: directory fd is held; name is NUL-terminated.
+            let fd =
+                unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), TEMP_FLAGS, 0o600) };
+            if fd < 0 {
+                if errno() == libc::EEXIST {
+                    continue;
+                }
+                return Err(ARTIFACT_TEMP_CREATE_FAILED.to_owned());
+            }
+            // SAFETY: fd is a successful descriptor owned immediately.
+            let file = unsafe { std::fs::File::from_raw_fd(fd) };
+            return Ok(TempArtifact {
+                file: Some(file),
+                directory_fd: directory.as_raw_fd(),
+                name,
+                disarmed: false,
+            });
+        }
+        Err(ARTIFACT_TEMP_CREATE_FAILED.to_owned())
+    }
+
+    fn write_temp_artifact(temp: &mut TempArtifact, bytes: &[u8]) -> Result<(), String> {
+        let file = temp
+            .file
+            .as_mut()
+            .ok_or_else(|| ARTIFACT_WRITE_FAILED.to_owned())?;
+        chmod_file(file.as_raw_fd())?;
+        file.write_all(bytes)
+            .map_err(|_| ARTIFACT_WRITE_FAILED.to_owned())?;
+        file.sync_all()
+            .map_err(|_| ARTIFACT_SYNC_FAILED.to_owned())?;
+        Ok(())
+    }
+
+    fn publish_temp_artifact(
+        temp: &mut TempArtifact,
+        directory_fd: RawFd,
+        final_name: &CString,
+        digest: &str,
+    ) -> Result<std::fs::File, String> {
+        let temp_file = temp
+            .file
+            .as_ref()
+            .ok_or_else(|| ARTIFACT_PUBLISH_FAILED.to_owned())?;
+        if !named_entry_matches_file(temp_file, directory_fd, &temp.name) {
+            temp.cleanup()?;
+            return Err(ARTIFACT_LEAF_UNTRUSTED.to_owned());
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let result = unsafe {
+                libc::renameat2(
+                    directory_fd,
+                    temp.name.as_ptr(),
+                    directory_fd,
+                    final_name.as_ptr(),
+                    libc::RENAME_NOREPLACE,
+                )
+            };
+            if result == 0 {
+                if !named_entry_matches_file(temp_file, directory_fd, final_name) {
+                    let cleanup = unlink_name(directory_fd, final_name);
+                    temp.disarmed = true;
+                    return Err(cleanup
+                        .err()
+                        .unwrap_or_else(|| ARTIFACT_LEAF_UNTRUSTED.to_owned()));
+                }
+                temp.disarmed = true;
+                return finish_published(temp, directory_fd);
+            }
+            if errno() == libc::EEXIST {
+                return verify_collision(temp, directory_fd, final_name, digest);
+            }
+            if !matches!(errno(), libc::ENOSYS | libc::EINVAL | libc::EOPNOTSUPP) {
+                temp.cleanup()?;
+                return Err(ARTIFACT_PUBLISH_FAILED.to_owned());
+            }
+        }
+
+        // SAFETY: both directory_fd references are held; names are NUL-terminated.
+        let linked = unsafe {
+            libc::linkat(
+                directory_fd,
+                temp.name.as_ptr(),
+                directory_fd,
+                final_name.as_ptr(),
+                0,
+            )
+        };
+        if linked == 0 {
+            if !named_entry_matches_file(temp_file, directory_fd, final_name) {
+                let final_cleanup = unlink_name(directory_fd, final_name);
+                let temp_cleanup = temp.cleanup();
+                return Err(final_cleanup
+                    .err()
+                    .or_else(|| temp_cleanup.err())
+                    .unwrap_or_else(|| ARTIFACT_LEAF_UNTRUSTED.to_owned()));
+            }
+            // SAFETY: directory_fd is held and temp name is NUL-terminated.
+            if unsafe { libc::unlinkat(directory_fd, temp.name.as_ptr(), 0) } != 0 {
+                return Err(ARTIFACT_CLEANUP_FAILED.to_owned());
+            }
+            temp.disarmed = true;
+            return finish_published(temp, directory_fd);
+        }
+        if errno() == libc::EEXIST {
+            return verify_collision(temp, directory_fd, final_name, digest);
+        }
+        let publish_errno = errno();
+        temp.cleanup()?;
+        if matches!(
+            publish_errno,
+            libc::EPERM | libc::ENOTSUP | libc::EOPNOTSUPP | libc::EXDEV
+        ) {
+            Err(ARTIFACT_PUBLISH_UNSUPPORTED.to_owned())
+        } else {
+            Err(ARTIFACT_PUBLISH_FAILED.to_owned())
+        }
+    }
+
+    fn named_entry_matches_file(file: &std::fs::File, directory_fd: RawFd, name: &CString) -> bool {
+        // SAFETY: zeroed is a valid initial state for libc::stat output buffers.
+        let mut held: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: file descriptor is live and held points to writable storage.
+        if unsafe { libc::fstat(file.as_raw_fd(), &raw mut held) } != 0 {
+            return false;
+        }
+        // SAFETY: zeroed is a valid initial state for libc::stat output buffers.
+        let mut named: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: directory is held, name is NUL-terminated, and named is writable.
+        if unsafe {
+            libc::fstatat(
+                directory_fd,
+                name.as_ptr(),
+                &raw mut named,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } != 0
+        {
+            return false;
+        }
+        held.st_dev == named.st_dev
+            && held.st_ino == named.st_ino
+            && (named.st_mode & libc::S_IFMT) == libc::S_IFREG
+    }
+
+    fn unlink_name(directory_fd: RawFd, name: &CString) -> Result<(), String> {
+        // SAFETY: directory is held and name is NUL-terminated.
+        let result = unsafe { libc::unlinkat(directory_fd, name.as_ptr(), 0) };
+        if result == 0 || errno() == libc::ENOENT {
+            Ok(())
+        } else {
+            Err(ARTIFACT_CLEANUP_FAILED.to_owned())
+        }
+    }
+
+    fn verify_collision(
+        temp: &mut TempArtifact,
+        directory_fd: RawFd,
+        final_name: &CString,
+        digest: &str,
+    ) -> Result<std::fs::File, String> {
+        temp.cleanup()?;
+        sync_directory(directory_fd)?;
+        verify_existing_artifact(directory_fd, final_name, digest)
+    }
+
+    fn finish_published(
+        temp: &mut TempArtifact,
+        directory_fd: RawFd,
+    ) -> Result<std::fs::File, String> {
+        sync_directory(directory_fd)?;
+        let mut file = temp
+            .file
+            .take()
+            .ok_or_else(|| ARTIFACT_PUBLISH_FAILED.to_owned())?;
+        file.rewind().map_err(|_| ARTIFACT_SYNC_FAILED.to_owned())?;
+        Ok(file)
+    }
+
+    fn verify_existing_artifact(
+        directory_fd: RawFd,
+        final_name: &CString,
+        digest: &str,
+    ) -> Result<std::fs::File, String> {
+        // SAFETY: directory_fd is held and final_name is NUL-terminated.
+        let fd = unsafe { libc::openat(directory_fd, final_name.as_ptr(), LEAF_READ_FLAGS) };
+        if fd < 0 {
+            return Err(ARTIFACT_LEAF_UNTRUSTED.to_owned());
+        }
+        // SAFETY: fd is a successful descriptor owned immediately.
+        let mut artifact = unsafe { std::fs::File::from_raw_fd(fd) };
+        if !artifact
+            .metadata()
+            .map_err(|_| ARTIFACT_LEAF_UNTRUSTED.to_owned())?
+            .is_file()
+        {
+            return Err(ARTIFACT_LEAF_UNTRUSTED.to_owned());
+        }
+        let mut bytes = Vec::new();
+        artifact
+            .read_to_end(&mut bytes)
+            .map_err(|_| ARTIFACT_LEAF_UNTRUSTED.to_owned())?;
+        if hex_sha256(&bytes) != digest {
+            return Err(ARTIFACT_DIGEST_MISMATCH.to_owned());
+        }
+        chmod_file(artifact.as_raw_fd())?;
+        artifact
+            .rewind()
+            .map_err(|_| ARTIFACT_LEAF_UNTRUSTED.to_owned())?;
+        Ok(artifact)
+    }
+
+    fn chmod_directory(fd: RawFd) -> Result<(), String> {
+        // SAFETY: fd is a live directory descriptor owned by this function.
+        if unsafe { libc::fchmod(fd, 0o700) } != 0 {
+            Err(ARTIFACT_PERMISSIONS_FAILED.to_owned())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn chmod_file(fd: RawFd) -> Result<(), String> {
+        // SAFETY: fd is a live regular-file descriptor owned by this function.
+        if unsafe { libc::fchmod(fd, 0o600) } != 0 {
+            Err(ARTIFACT_PERMISSIONS_FAILED.to_owned())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn sync_directory(fd: RawFd) -> Result<(), String> {
+        // SAFETY: fd is a live descriptor held for the directory lifetime.
+        if unsafe { libc::fsync(fd) } != 0 {
+            Err(ARTIFACT_SYNC_FAILED.to_owned())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn cstring(value: String) -> Result<CString, String> {
+        CString::new(value).map_err(|_| ARTIFACT_BOUNDARY_REJECTED.to_owned())
+    }
+
+    fn errno() -> i32 {
+        std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use super::*;
+    use std::ffi::c_void;
+    use std::mem::size_of;
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use std::path::PathBuf;
+    use std::ptr::{null, null_mut};
+    use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
+    use windows_sys::Wdk::Storage::FileSystem::{
+        FILE_CREATE, FILE_DELETE_ON_CLOSE, FILE_DIRECTORY_FILE, FILE_DISPOSITION_DELETE,
+        FILE_DISPOSITION_DO_NOT_DELETE, FILE_DISPOSITION_INFORMATION_EX, FILE_NON_DIRECTORY_FILE,
+        FILE_OPEN, FILE_OPEN_IF, FILE_OPEN_REPARSE_POINT, FILE_RENAME_INFORMATION,
+        FILE_SYNCHRONOUS_IO_NONALERT, FileDispositionInformationEx, FileRenameInformationEx,
+        NtCreateFile, NtSetInformationFile,
+    };
+    use windows_sys::Win32::Foundation::{
+        ERROR_INVALID_FUNCTION, ERROR_NOT_SUPPORTED, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+        OBJ_CASE_INSENSITIVE, OBJ_DONT_REPARSE, STATUS_INVALID_PARAMETER, STATUS_NOT_SUPPORTED,
+        STATUS_OBJECT_NAME_COLLISION, STATUS_OBJECT_NAME_EXISTS, STATUS_OBJECT_NAME_NOT_FOUND,
+        STATUS_OBJECT_PATH_NOT_FOUND, STATUS_REPARSE_POINT_ENCOUNTERED, STATUS_SUCCESS,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, DELETE, FILE_ADD_FILE, FILE_ADD_SUBDIRECTORY, FILE_ATTRIBUTE_DIRECTORY,
+        FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
+        FILE_DELETE_CHILD, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_LIST_DIRECTORY, FILE_NAME_NORMALIZED, FILE_READ_ATTRIBUTES, FILE_READ_DATA,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_STANDARD_INFO,
+        FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA, FileAttributeTagInfo, FileStandardInfo,
+        FlushFileBuffers, GetFileInformationByHandleEx, GetFinalPathNameByHandleW, OPEN_EXISTING,
+        SYNCHRONIZE, VOLUME_NAME_DOS,
+    };
+    use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
+
+    const TRAVERSE_DIRECTORY_ACCESS: u32 = FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE;
+    const DIRECTORY_ACCESS: u32 = TRAVERSE_DIRECTORY_ACCESS
+        | FILE_ADD_FILE
+        | FILE_ADD_SUBDIRECTORY
+        | FILE_DELETE_CHILD
+        | GENERIC_WRITE;
+    const TEMP_ACCESS: u32 = FILE_READ_DATA
+        | FILE_WRITE_DATA
+        | FILE_READ_ATTRIBUTES
+        | FILE_WRITE_ATTRIBUTES
+        | DELETE
+        | SYNCHRONIZE;
+    const LEAF_ACCESS: u32 =
+        FILE_READ_DATA | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES | SYNCHRONIZE;
+
+    struct ArtifactDirectory {
+        _root: std::fs::File,
+        final_dir: std::fs::File,
+    }
+
+    struct TempArtifact {
+        file: Option<std::fs::File>,
+        disarmed: bool,
+    }
+
+    impl TempArtifact {
+        fn cleanup(&mut self) -> Result<(), String> {
+            if self.disarmed {
+                return Ok(());
+            }
+            if let Some(file) = self.file.as_ref() {
+                mark_delete(file)?;
+            }
+            self.file.take();
+            self.disarmed = true;
+            Ok(())
+        }
+    }
+
+    impl Drop for TempArtifact {
+        fn drop(&mut self) {
+            if !self.disarmed {
+                if let Some(file) = self.file.as_ref() {
+                    let _ = mark_delete(file);
+                }
+                self.file.take();
+            }
+        }
+    }
+
+    pub(super) fn persist_content(
+        configured_root: &Path,
+        relative: &str,
+        digest: &str,
+        extension: &str,
+        bytes: &[u8],
+        bind_barrier: Option<Box<dyn FnOnce()>>,
+        publish_barrier: Option<Box<dyn FnOnce()>>,
+    ) -> Result<std::fs::File, String> {
+        let root = bind_root(configured_root)?;
+        let directories = prepare_directory(&root, relative)?;
+        if let Some(barrier) = bind_barrier {
+            barrier();
+        }
+        let final_name = wide_component(&format!("{digest}.{extension}"))?;
+        let mut temp = create_temp_artifact(&directories.final_dir, &final_name)?;
+        if let Err(error) = write_temp_artifact(&mut temp, bytes) {
+            return Err(temp.cleanup().err().unwrap_or(error));
+        }
+        if let Some(barrier) = publish_barrier {
+            barrier();
+        }
+        if super::test_pre_publish_failure() {
+            temp.cleanup()?;
+            return Err("engine_artifact_test_pre_publish_failure".to_owned());
+        }
+        publish_temp_artifact(&mut temp, &directories.final_dir, &final_name, digest)
+    }
+
+    fn bind_root(configured_root: &Path) -> Result<std::fs::File, String> {
+        let (anchor, components) = split_windows_root(configured_root)?;
+        let name = wide_path(&anchor);
+        let handle = unsafe {
+            CreateFileW(
+                name.as_ptr(),
+                TRAVERSE_DIRECTORY_ACCESS,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE || handle.is_null() {
+            return Err(ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned());
+        }
+        // SAFETY: handle is successful and transferred immediately to File.
+        let mut root = unsafe { std::fs::File::from_raw_handle(handle) };
+        ensure_directory(&root)?;
+        ensure_opened_path(&root, &anchor)?;
+        for (index, name) in components.iter().enumerate() {
+            root = open_root_component(&root, name, index + 1 == components.len())?;
+        }
+        Ok(root)
+    }
+
+    fn split_windows_root(path: &Path) -> Result<(PathBuf, Vec<Vec<u16>>), String> {
+        if !path.is_absolute() {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        let anchor = path
+            .ancestors()
+            .last()
+            .filter(|candidate| candidate.has_root())
+            .ok_or_else(|| ARTIFACT_BOUNDARY_REJECTED.to_owned())?
+            .to_path_buf();
+        let relative = path
+            .strip_prefix(&anchor)
+            .map_err(|_| ARTIFACT_BOUNDARY_REJECTED.to_owned())?;
+        let mut components = Vec::new();
+        for component in relative.components() {
+            let Component::Normal(component) = component else {
+                return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+            };
+            components.push(wide_os_component(component)?);
+        }
+        if components.is_empty() {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        Ok((anchor, components))
+    }
+
+    fn open_root_component(
+        parent: &std::fs::File,
+        name: &[u16],
+        is_final: bool,
+    ) -> Result<std::fs::File, String> {
+        let options = FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT;
+        let access = if is_final {
+            DIRECTORY_ACCESS
+        } else {
+            TRAVERSE_DIRECTORY_ACCESS
+        };
+        let child = match open_relative(parent, name, access, FILE_OPEN, options) {
+            Ok(child) => child,
+            Err(ArtifactStatus::Missing) => {
+                open_relative(parent, name, DIRECTORY_ACCESS, FILE_OPEN_IF, options)
+                    .map_err(map_directory_status)?
+            }
+            Err(status) => return Err(map_directory_status(status)),
+        };
+        ensure_directory(&child)?;
+        Ok(child)
+    }
+
+    fn ensure_opened_path(file: &std::fs::File, expected: &Path) -> Result<(), String> {
+        let actual = final_path_by_handle(file)?;
+        let expected = normalize_dos_path(expected.as_os_str().encode_wide().collect());
+        if wide_path_eq(&actual, &expected) {
+            Ok(())
+        } else {
+            Err(ARTIFACT_BOUNDARY_REJECTED.to_owned())
+        }
+    }
+
+    fn final_path_by_handle(file: &std::fs::File) -> Result<Vec<u16>, String> {
+        let mut buffer = vec![0u16; 512];
+        loop {
+            let capacity = u32::try_from(buffer.len())
+                .map_err(|_| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?;
+            let length = unsafe {
+                GetFinalPathNameByHandleW(
+                    file.as_raw_handle(),
+                    buffer.as_mut_ptr(),
+                    capacity,
+                    FILE_NAME_NORMALIZED | VOLUME_NAME_DOS,
+                )
+            };
+            if length == 0 {
+                return Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned());
+            }
+            let length =
+                usize::try_from(length).map_err(|_| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?;
+            if length < buffer.len() {
+                buffer.truncate(length);
+                return Ok(normalize_dos_path(buffer));
+            }
+            buffer.resize(
+                length
+                    .checked_add(1)
+                    .ok_or_else(|| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?,
+                0,
+            );
+        }
+    }
+
+    fn normalize_dos_path(mut path: Vec<u16>) -> Vec<u16> {
+        const VERBATIM: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
+        const VERBATIM_UNC: &[u16] = &[
+            b'\\' as u16,
+            b'\\' as u16,
+            b'?' as u16,
+            b'\\' as u16,
+            b'U' as u16,
+            b'N' as u16,
+            b'C' as u16,
+            b'\\' as u16,
+        ];
+        if path.starts_with(VERBATIM_UNC) {
+            path.splice(..VERBATIM_UNC.len(), [b'\\' as u16, b'\\' as u16]);
+        } else if path.starts_with(VERBATIM) {
+            path.drain(..VERBATIM.len());
+        }
+        for unit in &mut path {
+            if *unit == b'/' as u16 {
+                *unit = b'\\' as u16;
+            }
+        }
+        path
+    }
+
+    fn wide_path_eq(left: &[u16], right: &[u16]) -> bool {
+        left.len() == right.len()
+            && left.iter().zip(right).all(|(left, right)| {
+                if *left <= u8::MAX as u16 && *right <= u8::MAX as u16 {
+                    (*left as u8).eq_ignore_ascii_case(&(*right as u8))
+                } else {
+                    left == right
+                }
+            })
+    }
+
+    fn prepare_directory(
+        root: &std::fs::File,
+        relative: &str,
+    ) -> Result<ArtifactDirectory, String> {
+        let mut parent = root
+            .try_clone()
+            .map_err(|_| ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned())?;
+        let mut saw_component = false;
+        for component in Path::new(relative).components() {
+            let Component::Normal(component) = component else {
+                return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+            };
+            saw_component = true;
+            let name = wide_os_component(component)?;
+            let child = open_relative(
+                &parent,
+                &name,
+                DIRECTORY_ACCESS,
+                FILE_OPEN_IF,
+                FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
+            )
+            .map_err(map_directory_status)?;
+            ensure_directory(&child)?;
+            parent = child;
+        }
+        if !saw_component {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        Ok(ArtifactDirectory {
+            _root: root
+                .try_clone()
+                .map_err(|_| ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned())?,
+            final_dir: parent,
+        })
+    }
+
+    fn create_temp_artifact(
+        directory: &std::fs::File,
+        final_name: &[u16],
+    ) -> Result<TempArtifact, String> {
+        for suffix in 0..128u16 {
+            let name = if suffix == 0 {
+                wide_component(&format!(".{}.tmp", display_wide(final_name)))?
+            } else {
+                wide_component(&format!(".{}.tmp.{suffix}", display_wide(final_name)))?
+            };
+            match open_relative(
+                directory,
+                &name,
+                TEMP_ACCESS,
+                FILE_CREATE,
+                FILE_NON_DIRECTORY_FILE
+                    | FILE_OPEN_REPARSE_POINT
+                    | FILE_SYNCHRONOUS_IO_NONALERT
+                    | FILE_DELETE_ON_CLOSE,
+            ) {
+                Ok(file) => {
+                    ensure_regular(&file)?;
+                    return Ok(TempArtifact {
+                        file: Some(file),
+                        disarmed: false,
+                    });
+                }
+                Err(ArtifactStatus::Collision) => continue,
+                Err(ArtifactStatus::Unsupported) => {
+                    return Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned());
+                }
+                Err(ArtifactStatus::Reparse) => {
+                    return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+                }
+                Err(ArtifactStatus::Missing | ArtifactStatus::Failure) => {
+                    return Err(ARTIFACT_TEMP_CREATE_FAILED.to_owned());
+                }
+            }
+        }
+        Err(ARTIFACT_TEMP_CREATE_FAILED.to_owned())
+    }
+
+    fn write_temp_artifact(temp: &mut TempArtifact, bytes: &[u8]) -> Result<(), String> {
+        let file = temp
+            .file
+            .as_mut()
+            .ok_or_else(|| ARTIFACT_WRITE_FAILED.to_owned())?;
+        file.write_all(bytes)
+            .map_err(|_| ARTIFACT_WRITE_FAILED.to_owned())?;
+        file.sync_all()
+            .map_err(|_| ARTIFACT_SYNC_FAILED.to_owned())?;
+        Ok(())
+    }
+
+    fn publish_temp_artifact(
+        temp: &mut TempArtifact,
+        directory: &std::fs::File,
+        final_name: &[u16],
+        digest: &str,
+    ) -> Result<std::fs::File, String> {
+        let file = temp
+            .file
+            .as_ref()
+            .ok_or_else(|| ARTIFACT_PUBLISH_FAILED.to_owned())?;
+        clear_delete_on_close(file)?;
+        let publish = match rename_relative(file, directory.as_raw_handle(), final_name) {
+            Ok(result) => result,
+            Err(error) => return Err(temp.cleanup().err().unwrap_or(error)),
+        };
+        match publish {
+            PublishResult::Published => {
+                temp.disarmed = true;
+                finish_published(temp, directory.as_raw_handle())
+            }
+            PublishResult::Collision => {
+                temp.cleanup()?;
+                verify_existing_artifact(directory, final_name, digest)
+            }
+        }
+    }
+
+    fn finish_published(
+        temp: &mut TempArtifact,
+        directory_handle: HANDLE,
+    ) -> Result<std::fs::File, String> {
+        sync_directory(directory_handle)?;
+        let mut file = temp
+            .file
+            .take()
+            .ok_or_else(|| ARTIFACT_PUBLISH_FAILED.to_owned())?;
+        file.rewind().map_err(|_| ARTIFACT_SYNC_FAILED.to_owned())?;
+        Ok(file)
+    }
+
+    fn sync_directory(directory_handle: HANDLE) -> Result<(), String> {
+        if unsafe { FlushFileBuffers(directory_handle) } != 0 {
+            return Ok(());
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(code) if matches!(code as u32, ERROR_INVALID_FUNCTION | ERROR_NOT_SUPPORTED) => {
+                Ok(())
+            }
+            _ => Err(ARTIFACT_SYNC_FAILED.to_owned()),
+        }
+    }
+
+    fn verify_existing_artifact(
+        directory: &std::fs::File,
+        final_name: &[u16],
+        digest: &str,
+    ) -> Result<std::fs::File, String> {
+        let mut artifact = open_relative(
+            directory,
+            final_name,
+            LEAF_ACCESS,
+            FILE_OPEN,
+            FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
+        )
+        .map_err(|status| match status {
+            ArtifactStatus::Unsupported => ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned(),
+            _ => ARTIFACT_LEAF_UNTRUSTED.to_owned(),
+        })?;
+        ensure_regular(&artifact).map_err(|_| ARTIFACT_LEAF_UNTRUSTED.to_owned())?;
+        let mut bytes = Vec::new();
+        artifact
+            .read_to_end(&mut bytes)
+            .map_err(|_| ARTIFACT_LEAF_UNTRUSTED.to_owned())?;
+        if hex_sha256(&bytes) != digest {
+            return Err(ARTIFACT_DIGEST_MISMATCH.to_owned());
+        }
+        artifact
+            .rewind()
+            .map_err(|_| ARTIFACT_LEAF_UNTRUSTED.to_owned())?;
+        Ok(artifact)
+    }
+
+    #[derive(Clone, Copy)]
+    enum ArtifactStatus {
+        Failure,
+        Collision,
+        Missing,
+        Reparse,
+        Unsupported,
+    }
+
+    enum PublishResult {
+        Published,
+        Collision,
+    }
+
+    fn open_relative(
+        parent: &std::fs::File,
+        name: &[u16],
+        desired_access: u32,
+        disposition: u32,
+        options: u32,
+    ) -> Result<std::fs::File, ArtifactStatus> {
+        let mut unicode = unicode_string(name)?;
+        let mut attributes = OBJECT_ATTRIBUTES {
+            Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+            RootDirectory: parent.as_raw_handle(),
+            ObjectName: &mut unicode,
+            Attributes: OBJ_CASE_INSENSITIVE | OBJ_DONT_REPARSE,
+            SecurityDescriptor: null(),
+            SecurityQualityOfService: null(),
+        };
+        let mut handle: HANDLE = null_mut();
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let status = unsafe {
+            NtCreateFile(
+                &mut handle,
+                desired_access,
+                &mut attributes,
+                &mut io_status,
+                null(),
+                FILE_ATTRIBUTE_NORMAL,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                disposition,
+                options,
+                null(),
+                0,
+            )
+        };
+        let opened_existing = disposition == FILE_OPEN_IF && status == STATUS_OBJECT_NAME_EXISTS;
+        if (status == STATUS_SUCCESS || opened_existing)
+            && !handle.is_null()
+            && handle != INVALID_HANDLE_VALUE
+        {
+            // SAFETY: NtCreateFile returned a successful handle owned immediately.
+            return Ok(unsafe { std::fs::File::from_raw_handle(handle) });
+        }
+        if !handle.is_null() && handle != INVALID_HANDLE_VALUE {
+            // SAFETY: an unexpected returned handle is still owned by this call.
+            drop(unsafe { std::fs::File::from_raw_handle(handle) });
+        }
+        Err(
+            if status == STATUS_OBJECT_NAME_COLLISION || status == STATUS_OBJECT_NAME_EXISTS {
+                ArtifactStatus::Collision
+            } else if status == STATUS_REPARSE_POINT_ENCOUNTERED {
+                ArtifactStatus::Reparse
+            } else if status == STATUS_OBJECT_NAME_NOT_FOUND
+                || status == STATUS_OBJECT_PATH_NOT_FOUND
+            {
+                ArtifactStatus::Missing
+            } else if status == STATUS_INVALID_PARAMETER || status == STATUS_NOT_SUPPORTED {
+                ArtifactStatus::Unsupported
+            } else {
+                ArtifactStatus::Failure
+            },
+        )
+    }
+
+    fn rename_relative(
+        file: &std::fs::File,
+        directory_handle: HANDLE,
+        name: &[u16],
+    ) -> Result<PublishResult, String> {
+        let header_size = size_of::<FILE_RENAME_INFORMATION>() - size_of::<u16>();
+        let bytes = header_size
+            .checked_add(
+                name.len()
+                    .checked_mul(size_of::<u16>())
+                    .ok_or_else(|| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?,
+            )
+            .ok_or_else(|| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?;
+        let name_bytes = u32::try_from(
+            name.len()
+                .checked_mul(size_of::<u16>())
+                .ok_or_else(|| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?,
+        )
+        .map_err(|_| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?;
+        let buffer_bytes =
+            u32::try_from(bytes).map_err(|_| ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())?;
+        let words = bytes.div_ceil(size_of::<u64>());
+        let mut storage = vec![0u64; words];
+        let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFORMATION>();
+        unsafe {
+            (*info).Anonymous.Flags = 0;
+            (*info).RootDirectory = directory_handle;
+            (*info).FileNameLength = name_bytes;
+            std::ptr::copy_nonoverlapping(name.as_ptr(), (*info).FileName.as_mut_ptr(), name.len());
+        }
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let status = unsafe {
+            NtSetInformationFile(
+                file.as_raw_handle(),
+                &mut io_status,
+                info.cast::<c_void>(),
+                buffer_bytes,
+                FileRenameInformationEx,
+            )
+        };
+        if status == STATUS_SUCCESS {
+            Ok(PublishResult::Published)
+        } else if status == STATUS_OBJECT_NAME_COLLISION || status == STATUS_OBJECT_NAME_EXISTS {
+            Ok(PublishResult::Collision)
+        } else if status == STATUS_REPARSE_POINT_ENCOUNTERED {
+            Err(ARTIFACT_BOUNDARY_REJECTED.to_owned())
+        } else if status == STATUS_INVALID_PARAMETER || status == STATUS_NOT_SUPPORTED {
+            Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())
+        } else {
+            Err(ARTIFACT_PUBLISH_FAILED.to_owned())
+        }
+    }
+
+    fn mark_delete(file: &std::fs::File) -> Result<(), String> {
+        let mut info = FILE_DISPOSITION_INFORMATION_EX {
+            Flags: FILE_DISPOSITION_DELETE,
+        };
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let status = unsafe {
+            NtSetInformationFile(
+                file.as_raw_handle(),
+                &mut io_status,
+                (&mut info as *mut FILE_DISPOSITION_INFORMATION_EX).cast::<c_void>(),
+                size_of::<FILE_DISPOSITION_INFORMATION_EX>() as u32,
+                FileDispositionInformationEx,
+            )
+        };
+        if status == STATUS_SUCCESS {
+            Ok(())
+        } else {
+            Err(ARTIFACT_CLEANUP_FAILED.to_owned())
+        }
+    }
+
+    fn clear_delete_on_close(file: &std::fs::File) -> Result<(), String> {
+        let mut info = FILE_DISPOSITION_INFORMATION_EX {
+            Flags: FILE_DISPOSITION_DO_NOT_DELETE,
+        };
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let status = unsafe {
+            NtSetInformationFile(
+                file.as_raw_handle(),
+                &mut io_status,
+                (&mut info as *mut FILE_DISPOSITION_INFORMATION_EX).cast::<c_void>(),
+                size_of::<FILE_DISPOSITION_INFORMATION_EX>() as u32,
+                FileDispositionInformationEx,
+            )
+        };
+        if status == STATUS_SUCCESS {
+            Ok(())
+        } else {
+            Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())
+        }
+    }
+
+    fn ensure_directory(file: &std::fs::File) -> Result<(), String> {
+        let info = query_tag(file)?;
+        if info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+            || info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == 0
+        {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        Ok(())
+    }
+
+    fn ensure_regular(file: &std::fs::File) -> Result<(), String> {
+        let tag = query_tag(file)?;
+        if tag.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+            || tag.FileAttributes & FILE_ATTRIBUTE_DIRECTORY != 0
+        {
+            return Err(ARTIFACT_LEAF_UNTRUSTED.to_owned());
+        }
+        let mut standard = FILE_STANDARD_INFO::default();
+        let ok = unsafe {
+            GetFileInformationByHandleEx(
+                file.as_raw_handle(),
+                FileStandardInfo,
+                (&mut standard as *mut FILE_STANDARD_INFO).cast::<c_void>(),
+                size_of::<FILE_STANDARD_INFO>() as u32,
+            )
+        };
+        if ok == 0 || standard.Directory {
+            return Err(ARTIFACT_LEAF_UNTRUSTED.to_owned());
+        }
+        Ok(())
+    }
+
+    fn query_tag(file: &std::fs::File) -> Result<FILE_ATTRIBUTE_TAG_INFO, String> {
+        let mut info = FILE_ATTRIBUTE_TAG_INFO::default();
+        let ok = unsafe {
+            GetFileInformationByHandleEx(
+                file.as_raw_handle(),
+                FileAttributeTagInfo,
+                (&mut info as *mut FILE_ATTRIBUTE_TAG_INFO).cast::<c_void>(),
+                size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+            )
+        };
+        if ok == 0 {
+            Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())
+        } else {
+            Ok(info)
+        }
+    }
+
+    fn map_directory_status(status: ArtifactStatus) -> String {
+        match status {
+            ArtifactStatus::Unsupported => ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned(),
+            ArtifactStatus::Reparse => ARTIFACT_BOUNDARY_REJECTED.to_owned(),
+            ArtifactStatus::Collision | ArtifactStatus::Missing | ArtifactStatus::Failure => {
+                ARTIFACT_DIRECTORY_OPEN_FAILED.to_owned()
+            }
+        }
+    }
+
+    fn unicode_string(
+        name: &[u16],
+    ) -> Result<windows_sys::Win32::Foundation::UNICODE_STRING, ArtifactStatus> {
+        let byte_length = name
+            .len()
+            .checked_mul(size_of::<u16>())
+            .and_then(|length| u16::try_from(length).ok())
+            .ok_or(ArtifactStatus::Unsupported)?;
+        Ok(windows_sys::Win32::Foundation::UNICODE_STRING {
+            Length: byte_length,
+            MaximumLength: byte_length,
+            Buffer: name.as_ptr() as *mut u16,
+        })
+    }
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    fn wide_component(value: &str) -> Result<Vec<u16>, String> {
+        wide_os_component(std::ffi::OsStr::new(value))
+    }
+
+    fn wide_os_component(value: &std::ffi::OsStr) -> Result<Vec<u16>, String> {
+        let value: Vec<u16> = value.encode_wide().collect();
+        let byte_length = value.len().checked_mul(size_of::<u16>());
+        if value.is_empty()
+            || value.iter().any(|unit| matches!(*unit, 0 | 47 | 92))
+            || byte_length
+                .and_then(|length| u16::try_from(length).ok())
+                .is_none()
+        {
+            return Err(ARTIFACT_BOUNDARY_REJECTED.to_owned());
+        }
+        Ok(value)
+    }
+
+    fn display_wide(name: &[u16]) -> String {
+        String::from_utf16_lossy(name)
     }
 }

--- a/rust/src/core/engine_artifact.rs
+++ b/rust/src/core/engine_artifact.rs
@@ -27,6 +27,8 @@ const ARTIFACT_CLEANUP_FAILED: &str = "engine_artifact_cleanup_failed";
 #[cfg(test)]
 thread_local! {
     static TEST_FAIL_BEFORE_PUBLISH: Cell<bool> = const { Cell::new(false) };
+    #[cfg(windows)]
+    static TEST_FAIL_TEMP_VALIDATION: Cell<bool> = const { Cell::new(false) };
 }
 
 #[cfg(test)]
@@ -34,10 +36,27 @@ pub(super) fn inject_test_pre_publish_failure() {
     TEST_FAIL_BEFORE_PUBLISH.with(|failpoint| failpoint.set(true));
 }
 
+#[cfg(all(test, windows))]
+pub(super) fn inject_test_temp_validation_failure() {
+    TEST_FAIL_TEMP_VALIDATION.with(|failpoint| failpoint.set(true));
+}
+
 fn test_pre_publish_failure() -> bool {
     #[cfg(test)]
     {
         TEST_FAIL_BEFORE_PUBLISH.with(|failpoint| failpoint.replace(false))
+    }
+    #[cfg(not(test))]
+    {
+        false
+    }
+}
+
+#[cfg(windows)]
+fn test_temp_validation_failure() -> bool {
+    #[cfg(test)]
+    {
+        TEST_FAIL_TEMP_VALIDATION.with(|failpoint| failpoint.replace(false))
     }
     #[cfg(not(test))]
     {
@@ -622,11 +641,10 @@ mod windows {
     use std::ptr::{null, null_mut};
     use windows_sys::Wdk::Foundation::OBJECT_ATTRIBUTES;
     use windows_sys::Wdk::Storage::FileSystem::{
-        FILE_CREATE, FILE_DELETE_ON_CLOSE, FILE_DIRECTORY_FILE, FILE_DISPOSITION_DELETE,
-        FILE_DISPOSITION_DO_NOT_DELETE, FILE_DISPOSITION_INFORMATION_EX, FILE_NON_DIRECTORY_FILE,
-        FILE_OPEN, FILE_OPEN_IF, FILE_OPEN_REPARSE_POINT, FILE_RENAME_INFORMATION,
-        FILE_SYNCHRONOUS_IO_NONALERT, FileDispositionInformationEx, FileRenameInformationEx,
-        NtCreateFile, NtSetInformationFile,
+        FILE_CREATE, FILE_DIRECTORY_FILE, FILE_DISPOSITION_DELETE, FILE_DISPOSITION_INFORMATION_EX,
+        FILE_NON_DIRECTORY_FILE, FILE_OPEN, FILE_OPEN_IF, FILE_OPEN_REPARSE_POINT,
+        FILE_RENAME_INFORMATION, FILE_SYNCHRONOUS_IO_NONALERT, FileDispositionInformationEx,
+        FileRenameInformationEx, NtCreateFile, NtSetInformationFile,
     };
     use windows_sys::Win32::Foundation::{
         ERROR_INVALID_FUNCTION, ERROR_NOT_SUPPORTED, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
@@ -929,17 +947,26 @@ mod windows {
                 &name,
                 TEMP_ACCESS,
                 FILE_CREATE,
-                FILE_NON_DIRECTORY_FILE
-                    | FILE_OPEN_REPARSE_POINT
-                    | FILE_SYNCHRONOUS_IO_NONALERT
-                    | FILE_DELETE_ON_CLOSE,
+                FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT,
             ) {
                 Ok(file) => {
-                    ensure_regular(&file)?;
-                    return Ok(TempArtifact {
+                    let mut temp = TempArtifact {
                         file: Some(file),
                         disarmed: false,
-                    });
+                    };
+                    let validation = if super::test_temp_validation_failure() {
+                        Err(ARTIFACT_LEAF_UNTRUSTED.to_owned())
+                    } else {
+                        ensure_regular(
+                            temp.file
+                                .as_ref()
+                                .ok_or_else(|| ARTIFACT_TEMP_CREATE_FAILED.to_owned())?,
+                        )
+                    };
+                    if let Err(error) = validation {
+                        return Err(temp.cleanup().err().unwrap_or(error));
+                    }
+                    return Ok(temp);
                 }
                 Err(ArtifactStatus::Collision) => continue,
                 Err(ArtifactStatus::Unsupported) => {
@@ -978,34 +1005,28 @@ mod windows {
             .file
             .as_ref()
             .ok_or_else(|| ARTIFACT_PUBLISH_FAILED.to_owned())?;
-        clear_delete_on_close(file)?;
         let publish = match rename_relative(file, directory.as_raw_handle(), final_name) {
             Ok(result) => result,
             Err(error) => return Err(temp.cleanup().err().unwrap_or(error)),
         };
         match publish {
             PublishResult::Published => {
+                let published = match verify_existing_artifact(directory, final_name, digest) {
+                    Ok(published) => published,
+                    Err(error) => return Err(temp.cleanup().err().unwrap_or(error)),
+                };
+                if let Err(error) = sync_directory(directory.as_raw_handle()) {
+                    return Err(temp.cleanup().err().unwrap_or(error));
+                }
                 temp.disarmed = true;
-                finish_published(temp, directory.as_raw_handle())
+                temp.file.take();
+                Ok(published)
             }
             PublishResult::Collision => {
                 temp.cleanup()?;
                 verify_existing_artifact(directory, final_name, digest)
             }
         }
-    }
-
-    fn finish_published(
-        temp: &mut TempArtifact,
-        directory_handle: HANDLE,
-    ) -> Result<std::fs::File, String> {
-        sync_directory(directory_handle)?;
-        let mut file = temp
-            .file
-            .take()
-            .ok_or_else(|| ARTIFACT_PUBLISH_FAILED.to_owned())?;
-        file.rewind().map_err(|_| ARTIFACT_SYNC_FAILED.to_owned())?;
-        Ok(file)
     }
 
     fn sync_directory(directory_handle: HANDLE) -> Result<(), String> {
@@ -1197,27 +1218,6 @@ mod windows {
             Ok(())
         } else {
             Err(ARTIFACT_CLEANUP_FAILED.to_owned())
-        }
-    }
-
-    fn clear_delete_on_close(file: &std::fs::File) -> Result<(), String> {
-        let mut info = FILE_DISPOSITION_INFORMATION_EX {
-            Flags: FILE_DISPOSITION_DO_NOT_DELETE,
-        };
-        let mut io_status = IO_STATUS_BLOCK::default();
-        let status = unsafe {
-            NtSetInformationFile(
-                file.as_raw_handle(),
-                &mut io_status,
-                (&mut info as *mut FILE_DISPOSITION_INFORMATION_EX).cast::<c_void>(),
-                size_of::<FILE_DISPOSITION_INFORMATION_EX>() as u32,
-                FileDispositionInformationEx,
-            )
-        };
-        if status == STATUS_SUCCESS {
-            Ok(())
-        } else {
-            Err(ARTIFACT_BOUNDARY_UNSUPPORTED.to_owned())
         }
     }
 

--- a/rust/src/core/engine_artifact.rs
+++ b/rust/src/core/engine_artifact.rs
@@ -414,6 +414,7 @@ mod unix {
 
         #[cfg(target_os = "linux")]
         {
+            // SAFETY: both directory descriptors are held; names are NUL-terminated.
             let result = unsafe {
                 libc::renameat2(
                     directory_fd,
@@ -474,10 +475,7 @@ mod unix {
         }
         let publish_errno = errno();
         temp.cleanup()?;
-        if matches!(
-            publish_errno,
-            libc::EPERM | libc::ENOTSUP | libc::EOPNOTSUPP | libc::EXDEV
-        ) {
+        if [libc::EPERM, libc::ENOTSUP, libc::EOPNOTSUPP, libc::EXDEV].contains(&publish_errno) {
             Err(ARTIFACT_PUBLISH_UNSUPPORTED.to_owned())
         } else {
             Err(ARTIFACT_PUBLISH_FAILED.to_owned())

--- a/rust/src/core/engine_interface.rs
+++ b/rust/src/core/engine_interface.rs
@@ -1037,13 +1037,29 @@ mod tests {
         let digest = digest(bytes);
         let final_name = format!("{}.txt", digest.hex());
 
+        let relocated = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let barrier_data_root = data_root.clone();
         let barrier_opened_root = opened_root.clone();
-        let barrier = Box::new(move || {
-            std::fs::rename(&barrier_data_root, &barrier_opened_root)
-                .expect("relocate bound data root");
-            std::fs::create_dir(&barrier_data_root).expect("replacement data root");
-        });
+        let barrier_relocated = std::sync::Arc::clone(&relocated);
+        let barrier =
+            Box::new(
+                move || match std::fs::rename(&barrier_data_root, &barrier_opened_root) {
+                    Ok(()) => {
+                        std::fs::create_dir(&barrier_data_root).expect("replacement data root");
+                        barrier_relocated.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    Err(error) => {
+                        #[cfg(windows)]
+                        assert_eq!(
+                            error.kind(),
+                            std::io::ErrorKind::PermissionDenied,
+                            "Windows may only reject relocation while held handles are open"
+                        );
+                        #[cfg(unix)]
+                        panic!("relocate bound data root: {error}");
+                    }
+                },
+            );
         let result = artifact_store::persist_content_with_test_barrier(
             OUTPUT_DIRECTORY,
             digest.hex(),
@@ -1052,23 +1068,40 @@ mod tests {
             barrier,
         );
 
-        assert_eq!(
-            std::fs::read_dir(&data_root)
-                .expect("replacement data root")
-                .count(),
-            0,
-            "replacement root received no artifact or temporary leaf"
-        );
+        let did_relocate = relocated.load(std::sync::atomic::Ordering::SeqCst);
+        let bound_root = if did_relocate {
+            assert_eq!(
+                std::fs::read_dir(&data_root)
+                    .expect("replacement data root")
+                    .count(),
+                0,
+                "replacement root received no artifact or temporary leaf"
+            );
+            &opened_root
+        } else {
+            #[cfg(unix)]
+            {
+                panic!("Unix relocation must succeed");
+            }
+            #[cfg(windows)]
+            {
+                assert!(
+                    !opened_root.exists(),
+                    "denied relocation must not create a partial target"
+                );
+                &data_root
+            }
+        };
         match result {
             Ok(_) => assert_eq!(
-                std::fs::read(opened_root.join(OUTPUT_DIRECTORY).join(final_name))
+                std::fs::read(bound_root.join(OUTPUT_DIRECTORY).join(final_name))
                     .expect("artifact remains under bound root object"),
                 bytes
             ),
             Err(error) => {
                 assert!(error.starts_with("engine_artifact_"));
                 assert!(
-                    std::fs::read_dir(opened_root.join(OUTPUT_DIRECTORY))
+                    std::fs::read_dir(bound_root.join(OUTPUT_DIRECTORY))
                         .expect("bound output directory")
                         .flatten()
                         .all(|entry| !entry.file_name().to_string_lossy().contains(".tmp")),
@@ -1076,7 +1109,9 @@ mod tests {
                 );
             }
         }
-        std::fs::remove_dir_all(&opened_root).expect("remove relocated test root");
+        if did_relocate {
+            std::fs::remove_dir_all(&opened_root).expect("remove relocated test root");
+        }
     }
 
     #[cfg(unix)]
@@ -1173,6 +1208,37 @@ mod tests {
                 .count(),
             1,
             "successful retry leaves only the addressed artifact"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn failed_windows_temp_validation_cleans_provisional_leaf_and_is_retryable() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let bytes = b"Windows temp validation fixture";
+        let digest = digest(bytes);
+        let output_dir = data_dir::lean_ctx_data_dir()
+            .expect("isolated data dir")
+            .join(OUTPUT_DIRECTORY);
+        let final_path = output_dir.join(format!("{}.txt", digest.hex()));
+
+        artifact_store::inject_test_temp_validation_failure();
+        assert_eq!(
+            persist_output(digest.hex(), bytes).expect_err("injected validation failure"),
+            "engine_artifact_leaf_untrusted"
+        );
+        assert_eq!(
+            std::fs::read_dir(&output_dir)
+                .expect("output directory")
+                .count(),
+            0,
+            "failed validation must delete its provisional leaf"
+        );
+
+        persist_output(digest.hex(), bytes).expect("retry publishes complete artifact");
+        assert_eq!(
+            std::fs::read(&final_path).expect("published artifact after retry"),
+            bytes
         );
     }
 

--- a/rust/src/core/engine_interface.rs
+++ b/rust/src/core/engine_interface.rs
@@ -189,13 +189,12 @@ struct EngineRecoveryArtifactV1 {
 }
 
 impl NativeContextEngine {
-    #[must_use]
-    pub(crate) fn with_root(root: impl AsRef<Path>) -> Self {
+    pub(crate) fn with_root(root: impl AsRef<Path>) -> Result<Self, String> {
         let root = crate::core::pathutil::canonicalize_secure(root.as_ref())
-            .unwrap_or_else(|_| root.as_ref().to_path_buf());
-        Self {
+            .map_err(|_| "ctx_read Engine root cannot be bound securely".to_owned())?;
+        Ok(Self {
             adapter: NativeContextAdapter::with_root(root),
-        }
+        })
     }
 
     fn interface(&self) -> Result<EngineInterfaceV1, String> {
@@ -675,7 +674,7 @@ mod tests {
         let root = tempfile::tempdir().expect("native adapter root");
         let input = b"stable native context";
         std::fs::write(root.path().join("fixture.md"), input).expect("fixture write");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
 
         let (invocation, observation) = engine
             .execute(request(
@@ -713,7 +712,7 @@ mod tests {
         let root = tempfile::tempdir().expect("native adapter root");
         let input = b"stable native context";
         std::fs::write(root.path().join("fixture.md"), input).expect("fixture write");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
         let request = request("fixture.md", input, EnginePolicyDecisionV1::Admitted);
 
         let (first_invocation, first) = engine.execute(request.clone()).expect("first invocation");
@@ -738,7 +737,7 @@ mod tests {
             .expect("fixture write");
         std::fs::create_dir(root.path().join("alias-parent")).expect("alias directory");
         let input = "caller snapshot\nwith stable context";
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
         let policy_ref = "policy:ctx-read-context-gate-v1:fixture";
         let policy_admission = EnginePolicyAdmissionV1 {
             policy_ref: ProtocolReference::new(policy_ref).expect("policy ref"),
@@ -795,7 +794,7 @@ mod tests {
         let outside = tempfile::tempdir().expect("outside root");
         let source = outside.path().join("escape.md");
         std::fs::write(&source, "outside").expect("outside fixture");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
         let admission = EnginePolicyAdmissionV1 {
             policy_ref: ProtocolReference::new("policy:ctx-read-context-gate-v1:fixture")
                 .expect("policy ref"),
@@ -939,6 +938,203 @@ mod tests {
         );
     }
 
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn descriptor_relative_parent_swap_never_writes_replacement_or_outside() {
+        #[cfg(unix)]
+        use std::os::unix::fs::symlink;
+
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_root = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let output_dir = data_root.join(OUTPUT_DIRECTORY);
+        let opened_dir = data_root.join("engine-interface/v1/outputs.opened");
+        let outside = tempfile::tempdir().expect("outside directory");
+        let outside_path = outside.path().to_path_buf();
+        let sentinel = outside_path.join("sentinel.txt");
+        std::fs::write(&sentinel, b"OUTSIDE_SENTINEL_V1").expect("outside sentinel");
+        let bytes = b"descriptor-relative artifact";
+        let digest = digest(bytes);
+        let final_name = format!("{}.txt", digest.hex());
+
+        let barrier_output_dir = output_dir.clone();
+        let barrier_opened_dir = opened_dir.clone();
+        let barrier_outside_path = outside_path.clone();
+        let barrier = Box::new(move || {
+            std::fs::rename(&barrier_output_dir, &barrier_opened_dir)
+                .expect("rename opened directory");
+            #[cfg(unix)]
+            symlink(&barrier_outside_path, &barrier_output_dir).expect("replacement symlink");
+            #[cfg(windows)]
+            {
+                let _ = barrier_outside_path;
+                std::fs::create_dir(&barrier_output_dir).expect("replacement directory");
+            }
+        });
+        let result = artifact_store::persist_content_with_test_barrier(
+            OUTPUT_DIRECTORY,
+            digest.hex(),
+            "txt",
+            bytes,
+            barrier,
+        );
+
+        assert_eq!(
+            std::fs::read(&sentinel)
+                .expect("outside sentinel remains")
+                .as_slice(),
+            b"OUTSIDE_SENTINEL_V1"
+        );
+        assert_eq!(
+            std::fs::read_dir(&outside_path)
+                .expect("outside directory")
+                .count(),
+            1,
+            "replacement/outside received no artifact or temporary leaf"
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            std::fs::read_dir(&output_dir)
+                .expect("replacement directory")
+                .count(),
+            0,
+            "replacement directory received no artifact or temporary leaf"
+        );
+        match result {
+            Ok(_) => {
+                assert_eq!(
+                    std::fs::read(opened_dir.join(final_name)).expect("held directory artifact"),
+                    bytes
+                );
+                assert_eq!(
+                    std::fs::read_dir(opened_dir)
+                        .expect("held directory")
+                        .count(),
+                    1,
+                    "held directory contains only the published artifact"
+                );
+            }
+            Err(error) => {
+                assert!(error.starts_with("engine_artifact_"));
+                assert!(!error.contains("errno"));
+                assert!(
+                    std::fs::read_dir(opened_dir)
+                        .expect("held directory")
+                        .flatten()
+                        .all(|entry| !entry.file_name().to_string_lossy().contains(".tmp")),
+                    "failed publication leaves no temporary leaf"
+                );
+            }
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn descriptor_bound_root_relocation_never_retargets_a_replacement_root() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_root = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let opened_root = data_root.with_extension("opened");
+        let bytes = b"descriptor-bound root artifact";
+        let digest = digest(bytes);
+        let final_name = format!("{}.txt", digest.hex());
+
+        let barrier_data_root = data_root.clone();
+        let barrier_opened_root = opened_root.clone();
+        let barrier = Box::new(move || {
+            std::fs::rename(&barrier_data_root, &barrier_opened_root)
+                .expect("relocate bound data root");
+            std::fs::create_dir(&barrier_data_root).expect("replacement data root");
+        });
+        let result = artifact_store::persist_content_with_test_barrier(
+            OUTPUT_DIRECTORY,
+            digest.hex(),
+            "txt",
+            bytes,
+            barrier,
+        );
+
+        assert_eq!(
+            std::fs::read_dir(&data_root)
+                .expect("replacement data root")
+                .count(),
+            0,
+            "replacement root received no artifact or temporary leaf"
+        );
+        match result {
+            Ok(_) => assert_eq!(
+                std::fs::read(opened_root.join(OUTPUT_DIRECTORY).join(final_name))
+                    .expect("artifact remains under bound root object"),
+                bytes
+            ),
+            Err(error) => {
+                assert!(error.starts_with("engine_artifact_"));
+                assert!(
+                    std::fs::read_dir(opened_root.join(OUTPUT_DIRECTORY))
+                        .expect("bound output directory")
+                        .flatten()
+                        .all(|entry| !entry.file_name().to_string_lossy().contains(".tmp")),
+                    "failed publication leaves no known temporary leaf"
+                );
+            }
+        }
+        std::fs::remove_dir_all(&opened_root).expect("remove relocated test root");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn swapped_unix_temp_leaf_is_rejected_and_never_published() {
+        use std::os::unix::fs::symlink;
+
+        let _data_dir = data_dir::isolated_data_dir();
+        let data_root = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        let output_dir = data_root.join(OUTPUT_DIRECTORY);
+        let outside = tempfile::tempdir().expect("outside directory");
+        let sentinel = outside.path().join("sentinel.txt");
+        std::fs::write(&sentinel, b"OUTSIDE_SENTINEL_V1").expect("outside sentinel");
+        let bytes = b"held temporary artifact";
+        let digest = digest(bytes);
+        let temp_path = output_dir.join(format!(".{}.txt.tmp", digest.hex()));
+        let final_path = output_dir.join(format!("{}.txt", digest.hex()));
+
+        let barrier_temp_path = temp_path.clone();
+        let barrier_sentinel = sentinel.clone();
+        let barrier = Box::new(move || {
+            std::fs::remove_file(&barrier_temp_path).expect("unlink held temporary name");
+            symlink(&barrier_sentinel, &barrier_temp_path).expect("swap temporary name");
+        });
+        let error = artifact_store::persist_content_with_test_publish_barrier(
+            OUTPUT_DIRECTORY,
+            digest.hex(),
+            "txt",
+            bytes,
+            barrier,
+        )
+        .expect_err("swapped temporary leaf rejected");
+
+        assert_eq!(error, "engine_artifact_leaf_untrusted");
+        assert!(!final_path.exists());
+        assert!(!temp_path.exists());
+        assert_eq!(
+            std::fs::read(&sentinel).expect("outside sentinel remains"),
+            b"OUTSIDE_SENTINEL_V1"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn oversized_windows_artifact_component_is_rejected_before_child_mutation() {
+        let _data_dir = data_dir::isolated_data_dir();
+        let bytes = b"bounded Windows component";
+        let digest = digest(bytes);
+        let oversized = "x".repeat((u16::MAX as usize / 2) + 1);
+
+        let error = artifact_store::persist_content(&oversized, digest.hex(), "txt", bytes)
+            .expect_err("oversized component rejected");
+
+        assert_eq!(error, "engine_artifact_boundary_rejected");
+        let data_root = data_dir::lean_ctx_data_dir().expect("isolated data dir");
+        assert_eq!(std::fs::read_dir(data_root).expect("data root").count(), 0);
+    }
+
     #[test]
     fn failed_engine_artifact_publish_leaves_final_absent_and_retryable() {
         let _data_dir = data_dir::isolated_data_dir();
@@ -1031,6 +1227,7 @@ mod tests {
         };
 
         let error = NativeContextEngine::with_root(root.path())
+            .expect("secure Engine root")
             .execute_ctx_read_snapshot(&path.to_string_lossy(), &secret, admission)
             .expect_err("blocked receipt must return a durable recovery error");
         assert!(!error.contains(&secret));
@@ -1048,7 +1245,7 @@ mod tests {
     fn rejected_policy_never_attempts_the_missing_source() {
         let _data_dir = data_dir::isolated_data_dir();
         let root = tempfile::tempdir().expect("native adapter root");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
 
         let (_, observation) = engine
             .execute(request(
@@ -1069,7 +1266,7 @@ mod tests {
     fn missing_source_has_structured_recovery_route() {
         let _data_dir = data_dir::isolated_data_dir();
         let root = tempfile::tempdir().expect("native adapter root");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
 
         let (_, observation) = engine
             .execute(request(
@@ -1089,7 +1286,7 @@ mod tests {
         let _data_dir = data_dir::isolated_data_dir();
         let root = tempfile::tempdir().expect("native adapter root");
         std::fs::write(root.path().join("fixture.md"), b"actual source").expect("fixture write");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
 
         let (_, observation) = engine
             .execute(request(
@@ -1115,7 +1312,7 @@ mod tests {
         let root = tempfile::tempdir().expect("native adapter root");
         let input = b"retryable native context";
         std::fs::write(root.path().join("fixture.md"), input).expect("fixture write");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
         let request = request("fixture.md", input, EnginePolicyDecisionV1::Admitted);
 
         let (_, failed) = engine.execute(request.clone()).expect("failed receipt");
@@ -1133,9 +1330,22 @@ mod tests {
     }
 
     #[test]
+    fn engine_root_binding_never_falls_back_to_an_unresolved_path() {
+        let parent = tempfile::tempdir().expect("root parent");
+        let missing = parent.path().join("missing-root");
+
+        let error = NativeContextEngine::with_root(&missing)
+            .err()
+            .expect("missing Engine root rejected");
+
+        assert_eq!(error, "ctx_read Engine root cannot be bound securely");
+        assert!(!missing.exists());
+    }
+
+    #[test]
     fn interface_matches_the_native_capability_contract() {
         let root = tempfile::tempdir().expect("native adapter root");
-        let engine = NativeContextEngine::with_root(root.path());
+        let engine = NativeContextEngine::with_root(root.path()).expect("secure Engine root");
         let interface = engine.interface().expect("Engine interface");
         assert_eq!(interface.engine.engine_id, ENGINE_ID);
         assert_eq!(interface.supported_operations.len(), 1);

--- a/rust/src/tools/registered/ctx_read_engine.rs
+++ b/rust/src/tools/registered/ctx_read_engine.rs
@@ -363,7 +363,7 @@ pub(super) fn record_policy_rejection(
     path: &str,
     policy_admission: EnginePolicyAdmissionV1,
 ) -> Result<String, String> {
-    let engine = NativeContextEngine::with_root(project_root);
+    let engine = NativeContextEngine::with_root(project_root)?;
     let (_, observation) = engine.execute_ctx_read_rejection(path, policy_admission)?;
     if observation.status != EngineObservationStatusV1::Rejected {
         return Err("native Engine policy rejection returned a non-rejected status".to_owned());
@@ -382,7 +382,7 @@ fn record_aggressive_invocation(
     input: &str,
     policy_admission: EnginePolicyAdmissionV1,
 ) -> Result<(), String> {
-    let engine = NativeContextEngine::with_root(project_root);
+    let engine = NativeContextEngine::with_root(project_root)?;
     let (_, observation) =
         engine.execute_ctx_read_rooted_snapshot(path, input, policy_admission)?;
     let receipt_link = observation


### PR DESCRIPTION
## Outcome

Closes the remaining P1 descriptor-containment gap after #1515.

- binds Unix artifact traversal and publication to held directory descriptors
- binds Windows traversal and publication to held directory handles
- rejects reparse/symlink and root-replacement attacks fail-closed
- makes publication no-replace and verifies the published inode/object
- tightens Windows directory flush and cleanup semantics
- updates the native Engine context-proof contract and adversarial tests

## Verification

- `cargo test --lib`: 10,323 passed, 0 failed, 22 ignored
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt --all --check`
- Windows GNU all-features cross-compile
- independent Luna adjudication: PASS, no blockers
- pre-push fast CI-parity gate: 7/7 passed

No Cloud/private implementation, credentials, website code, or private repository material is included.