### PR TITLE
protocol: reject noncanonical v2 signatures

### DIFF
--- a/docs/contracts/evidence-bundle-v2.schema.json
+++ b/docs/contracts/evidence-bundle-v2.schema.json
@@ -649,7 +649,7 @@
         },
         "signature": {
           "type": "string",
-          "pattern": "^[A-Za-z0-9+/]{86}==$"
+          "pattern": "^[A-Za-z0-9+/]{85}[AQgw]==$"
         }
       }
     }

--- a/rust/tests/evidence_bundle_v2_contract.rs
+++ b/rust/tests/evidence_bundle_v2_contract.rs
@@ -155,6 +155,40 @@ fn v2_schema_is_strict_and_fixtures_are_canonical() {
 }
 
 #[test]
+fn schema_rejects_noncanonical_signature_pad_bits() {
+    let schema_path = root().join("docs/contracts/evidence-bundle-v2.schema.json");
+    let schema = read_json(&schema_path);
+    let validator = jsonschema::validator_for(&schema).expect("v2 schema compiles");
+    let valid = read_json(&fixture("valid.json"));
+    assert_valid(&validator, &valid, "canonical valid fixture");
+
+    let signature = string(&valid, "/signing/signature");
+    assert_eq!(signature.len(), 88);
+    assert!(signature.ends_with("=="));
+    assert!(matches!(
+        signature.as_bytes()[signature.len() - 3],
+        b'A' | b'Q' | b'g' | b'w'
+    ));
+
+    let mut noncanonical = valid.clone();
+    let invalid_signature = format!("{}x==", &signature[..signature.len() - 3]);
+    assert_eq!(invalid_signature.len(), signature.len());
+    assert!(invalid_signature.ends_with("x=="));
+    assert!(
+        invalid_signature
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/' | b'='))
+    );
+    *noncanonical
+        .pointer_mut("/signing/signature")
+        .expect("signature pointer") = Value::String(invalid_signature);
+    assert!(
+        validator.iter_errors(&noncanonical).next().is_some(),
+        "same-length Base64 with non-zero pad bits must fail v2 schema"
+    );
+}
+
+#[test]
 fn valid_fixture_enforces_contract_only_match_and_bound_invariants() {
     let value = read_json(&fixture("valid.json"));
     let control = "/matched_arms/control/identity";


### PR DESCRIPTION
## Summary

- require canonical RFC 4648 pad bits for 64-byte Ed25519 signatures in evidence-bundle v2
- keep the JSON Schema aligned with the strict base64 0.22.1 runtime decoder
- add a same-length, alphabet-valid noncanonical regression case

## Evidence

- focused evidence bundle contract: 3 passed
- cargo test --lib: 10323 passed, 0 failed, 22 ignored
- cargo clippy --all-features -- -D warnings: passed
- cargo fmt --check: passed
- open-core boundary: PASS
- history policy gate: 0 new findings
- independent Luna review: PASS

## Scope

Public protocol validation only. No private implementation, Cloud behavior,
producer logic, verifier path handling, or receipt semantics are added.
