### PR TITLE
fix: preserve context fidelity and Windows shell behavior

### DIFF
--- a/docs/reference/appendix-paths-and-config.md
+++ b/docs/reference/appendix-paths-and-config.md
@@ -145,7 +145,7 @@ or the single dir for legacy/mixed installs — see §1); per-project override a
 | `[archive]` | Zero-loss tool-output archive: `enabled`, `threshold_chars` (800), `max_age_hours` (48), `max_disk_mb` (500) |
 | `[search]` | BM25/dense/splade weights + candidate counts |
 | `[autonomy]` | Auto preload/dedup/consolidate, cognition loop |
-| `[decision_loop]` | Enable the MCP decision-loop runtime (`enabled = true` by default) |
+| `[decision_loop]` | MCP decision loop plus optional lossy output triage (`enabled = true`, `max_filter_level = 0` by default) |
 | `[shadow]` | Counterfactual baseline comparisons: `enabled`, `report_interval`, `baseline_model` |
 | `[knowledge_routing]` | Add focused cross-source knowledge hints: `enabled`, `max_references` |
 | `[providers]` | GitHub/GitLab/Jira/Postgres + MCP bridges |
@@ -171,6 +171,7 @@ Key defaults worth knowing:
 ```toml
 [decision_loop]
 enabled = true
+max_filter_level = 0
 
 [shadow]
 enabled = false
@@ -183,6 +184,10 @@ max_references = 5
 ```
 
 - `[decision_loop].enabled` enables outcome-aware decision-loop runtime; default `true`.
+- `[decision_loop].max_filter_level` caps lossy output triage: `0` preserves output
+  unchanged (default), `1` removes low-value comments, and `2` permits aggressive
+  task-profile filtering. `ctx_read` always trusts its selected read mode and
+  bypasses this second-stage filter; explicit lossless modes on other tools do too.
 - `[shadow].enabled` records counterfactual comparisons; default `false`.
 - `[shadow].report_interval` creates a report after this many measurements; default `10`.
 - `[shadow].baseline_model` names the model used for baseline cost comparisons; default `"gpt-4o"`.

--- a/packages/pi-lean-ctx/extensions/config.ts
+++ b/packages/pi-lean-ctx/extensions/config.ts
@@ -116,6 +116,40 @@ export function piConfigPath(): string {
   return existsSync(legacy) ? legacy : direct;
 }
 
+function piSettingsPath(): string {
+  return resolve(process.env.PI_CODING_AGENT_DIR ?? resolve(homedir(), ".pi", "agent"), "settings.json");
+}
+
+/**
+ * Resolve the shell used by this extension's private bash tools (#1512).
+ * Pi injects `settings.json.shellPath` only into its native bash tool, so the
+ * extension must forward the same setting explicitly. Invalid paths fail open
+ * to Pi's normal resolver instead of breaking every `ctx_shell` call.
+ */
+export function resolvePiShellPath(): string | undefined {
+  for (const value of [process.env.LEAN_CTX_SHELL, process.env.PI_SHELL_PATH]) {
+    const path = value?.trim();
+    if (path && existsSync(path)) return path;
+  }
+
+  const settingsPath = piSettingsPath();
+  if (!existsSync(settingsPath)) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(settingsPath, "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const value = (parsed as { shellPath?: unknown }).shellPath;
+      if (typeof value === "string") {
+        const path = value.trim();
+        if (path && existsSync(path)) return path;
+      }
+    }
+  } catch {
+    // Pi owns this file. A malformed/unreadable setting must preserve its
+    // built-in shell discovery rather than making the extension unload.
+  }
+  return undefined;
+}
+
 function envFlag(name: string): boolean {
   const raw = process.env[name];
   if (!raw) return false;

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -25,7 +25,7 @@ import { readFile, stat } from "node:fs/promises";
 import { extname, resolve } from "node:path";
 import { homedir, platform } from "node:os";
 import { McpBridge } from "./mcp-bridge.js";
-import { loadPiConfig, resolveSuppressedBuiltins } from "./config.js";
+import { loadPiConfig, resolvePiShellPath, resolveSuppressedBuiltins } from "./config.js";
 import type { CompressionStats } from "./types.js";
 
 const BRIDGE_STARTUP_TIMEOUT_MS = 10_000;
@@ -414,7 +414,9 @@ export default async function (pi: ExtensionAPI) {
     }
   }) as unknown as ExtensionAPI["registerTool"];
 
+  const shellPath = resolvePiShellPath();
   const baseBashTool = createBashToolDefinition(process.cwd(), {
+    shellPath,
     spawnHook: ({ command, cwd, env }) => {
       const bin = resolveBinary();
       return {
@@ -425,7 +427,7 @@ export default async function (pi: ExtensionAPI) {
     },
   });
 
-  const rawBash = createBashToolDefinition(process.cwd());
+  const rawBash = createBashToolDefinition(process.cwd(), { shellPath });
 
   const bashSchemaWithRaw = Type.Object({
     command: Type.String({ description: "Bash command to execute" }),

--- a/packages/pi-lean-ctx/test/config.test.ts
+++ b/packages/pi-lean-ctx/test/config.test.ts
@@ -7,6 +7,7 @@ import {
   loadPiConfig,
   piConfigPath,
   REPLACEABLE_BUILTIN_TOOLS,
+  resolvePiShellPath,
   resolveRouteShell,
   resolveSuppressedBuiltins,
   resolveToolProfile,
@@ -14,11 +15,57 @@ import {
 
 const ENV_KEY = "LEAN_CTX_PI_ROUTE_SHELL";
 const PROFILE_ENV_KEYS = ["LEAN_CTX_PI_TOOL_PROFILE", "LEAN_CTX_TOOL_PROFILE"];
+const SHELL_ENV_KEYS = ["LEAN_CTX_SHELL", "PI_SHELL_PATH"];
 
 afterEach(() => {
   delete process.env[ENV_KEY];
   delete process.env.PI_CODING_AGENT_DIR;
   for (const key of PROFILE_ENV_KEYS) delete process.env[key];
+  for (const key of SHELL_ENV_KEYS) delete process.env[key];
+});
+
+describe("resolvePiShellPath", () => {
+  it("honors Pi's settings.json under PI_CODING_AGENT_DIR", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-lean-ctx-shell-"));
+    const shellPath = join(agentDir, "Git", "bin", "bash.exe");
+    mkdirSync(join(agentDir, "Git", "bin"), { recursive: true });
+    writeFileSync(shellPath, "");
+    writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ shellPath }));
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+
+    try {
+      expect(resolvePiShellPath()).toBe(shellPath);
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers LEAN_CTX_SHELL, then PI_SHELL_PATH, over settings.json", () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-lean-ctx-shell-env-"));
+    const configured = join(root, "configured-bash.exe");
+    const piEnv = join(root, "pi-env-bash.exe");
+    const leanEnv = join(root, "lean-env-bash.exe");
+    for (const path of [configured, piEnv, leanEnv]) writeFileSync(path, "");
+    writeFileSync(join(root, "settings.json"), JSON.stringify({ shellPath: configured }));
+    process.env.PI_CODING_AGENT_DIR = root;
+    process.env.PI_SHELL_PATH = piEnv;
+    expect(resolvePiShellPath()).toBe(piEnv);
+    process.env.LEAN_CTX_SHELL = leanEnv;
+    expect(resolvePiShellPath()).toBe(leanEnv);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("fails open to Pi's normal resolver for missing or malformed paths", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-lean-ctx-shell-missing-"));
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.LEAN_CTX_SHELL = join(agentDir, "missing.exe");
+    writeFileSync(join(agentDir, "settings.json"), "{not-json");
+    try {
+      expect(resolvePiShellPath()).toBeUndefined();
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("piConfigPath", () => {

--- a/rust/src/core/config/sections.rs
+++ b/rust/src/core/config/sections.rs
@@ -871,11 +871,18 @@ pub struct CostConfig {
 #[serde(default)]
 pub struct DecisionLoopConfig {
     pub enabled: bool,
+    /// Maximum lossy post-dispatch triage level (`0` disables output filtering).
+    /// Classification and decision-loop accounting remain active at level 0.
+    #[serde(default)]
+    pub max_filter_level: u8,
 }
 
 impl Default for DecisionLoopConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            max_filter_level: 0,
+        }
     }
 }
 

--- a/rust/src/core/shell_allowlist/compound.rs
+++ b/rust/src/core/shell_allowlist/compound.rs
@@ -2,7 +2,7 @@ use crate::core::error::ShellError;
 
 use super::{
     contains_double_semicolon, extract_all_commands, find_shell_word, quote_aware_token_end,
-    rewrite_case_constructs, shell_tokenize, skip_env_assignments,
+    rewrite_case_constructs, shell_tokenize, skip_env_assignments, skip_powershell_assignment,
 };
 
 /// Shell reserved words whose operator-delimited segment carries no validatable
@@ -78,7 +78,21 @@ fn resolve_segment_leaves(
         }
         break;
     }
+    let assignment_rhs = skip_powershell_assignment(s);
+    if assignment_rhs.len() != s.len() {
+        return resolve_segment_leaves(assignment_rhs, depth + 1, out);
+    }
     if let Some(inner) = balanced_paren_inner(s) {
+        for inner_seg in extract_all_commands(inner) {
+            resolve_segment_leaves(&inner_seg, depth + 1, out)?;
+        }
+        return Ok(());
+    }
+    // #1514: PowerShell commonly wraps a read-only cmdlet before selecting a
+    // property: `(Get-Item 'x').VersionInfo`. Validate the inner command and
+    // accept only a conservative property chain. Method calls, indexers and
+    // operators fall through to deny-by-default as an unrecognized command.
+    if let Some(inner) = powershell_property_expression_inner(s) {
         for inner_seg in extract_all_commands(inner) {
             resolve_segment_leaves(&inner_seg, depth + 1, out)?;
         }
@@ -135,7 +149,7 @@ fn resolve_segment_leaves(
 /// a nested quoted `)` — e.g. inside a jq filter — doesn't end the walk early.
 /// Returns `(inner, end)` with `end` just past the matching `)`; `None` if
 /// unbalanced.
-fn balanced_paren_at(s: &str, open: usize) -> Option<(&str, usize)> {
+pub(super) fn balanced_paren_at(s: &str, open: usize) -> Option<(&str, usize)> {
     let bytes = s.as_bytes();
     let len = bytes.len();
     let mut depth: i32 = 0;
@@ -187,6 +201,29 @@ fn balanced_paren_at(s: &str, open: usize) -> Option<(&str, usize)> {
         }
     }
     None
+}
+
+fn powershell_property_expression_inner(segment: &str) -> Option<&str> {
+    let trimmed = segment.trim();
+    if !trimmed.starts_with('(') {
+        return None;
+    }
+    let (inner, end) = balanced_paren_at(trimmed, 0)?;
+    let mut suffix = trimmed[end..].trim();
+    if suffix.is_empty() {
+        return None;
+    }
+    while let Some(rest) = suffix.strip_prefix('.') {
+        let name_len = rest
+            .bytes()
+            .take_while(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+            .count();
+        if name_len == 0 || !rest.as_bytes()[0].is_ascii_alphabetic() {
+            return None;
+        }
+        suffix = &rest[name_len..];
+    }
+    suffix.is_empty().then_some(inner)
 }
 
 /// #855: the leading run of `VAR=value` assignment tokens in `s` (the same

--- a/rust/src/core/shell_allowlist/substitution.rs
+++ b/rust/src/core/shell_allowlist/substitution.rs
@@ -1,4 +1,7 @@
-use super::{SHELL_BUILTINS, ShellError, effective_allowlist, extract_base_from_segment};
+use super::{
+    SHELL_BUILTINS, ShellError, effective_allowlist, extract_all_commands,
+    extract_base_from_segment,
+};
 
 /// $(), backticks, <() in arguments: warn by default, **block** when
 /// `shell_strict_mode = true` (GH #391 — the strict knob previously only
@@ -96,13 +99,14 @@ fn extract_substitution_commands(command: &str) -> Vec<String> {
                 if ch == b'$'
                     && i + 1 < len
                     && bytes[i + 1] == b'('
-                    && let Some(inner) = extract_paren_content(bytes, i + 1)
+                    && let Some((inner, end)) = super::compound::balanced_paren_at(command, i + 1)
                 {
                     let trimmed = inner.trim();
                     if !trimmed.is_empty() {
-                        results.push(trimmed.to_string());
+                        results.extend(extract_all_commands(trimmed));
+                        results.extend(extract_substitution_commands(trimmed));
                     }
-                    i += 2 + inner.len() + 1;
+                    i = end;
                     continue;
                 }
                 i += 1;
@@ -110,30 +114,6 @@ fn extract_substitution_commands(command: &str) -> Vec<String> {
         }
     }
     results
-}
-
-/// Extracts content between `(` at `start` and matching `)`, handling nesting.
-fn extract_paren_content(bytes: &[u8], start: usize) -> Option<String> {
-    if start >= bytes.len() || bytes[start] != b'(' {
-        return None;
-    }
-    let mut depth: u32 = 1;
-    let mut i = start + 1;
-    while i < bytes.len() && depth > 0 {
-        match bytes[i] {
-            b'(' => depth += 1,
-            b')' => depth -= 1,
-            _ => {}
-        }
-        if depth > 0 {
-            i += 1;
-        }
-    }
-    if depth == 0 {
-        Some(String::from_utf8_lossy(&bytes[start + 1..i]).to_string())
-    } else {
-        None
-    }
 }
 
 /// Check for $(), backticks, <(, >( in arguments wherever the shell would

--- a/rust/src/core/shell_allowlist/substitution_tests.rs
+++ b/rust/src/core/shell_allowlist/substitution_tests.rs
@@ -84,3 +84,21 @@ fn substitution_with_builtin_cmd_passes() {
         "builtin in substitution must pass: {result:?}"
     );
 }
+
+#[test]
+fn substitution_scanner_respects_quoted_parens_and_checks_every_inner_segment() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let result =
+        check_substitution_in_args(r#"git commit -m "$(echo ')'; evil_binary --attack)""#, true);
+    assert!(
+        result.is_err(),
+        "a quoted ')' must not hide a later non-allowlisted inner command"
+    );
+
+    let nested =
+        check_substitution_in_args(r#"git commit -m "$(echo "$(evil_binary --nested)")""#, true);
+    assert!(
+        nested.is_err(),
+        "nested substitutions must be validated recursively"
+    );
+}

--- a/rust/src/core/shell_allowlist/tests_powershell.rs
+++ b/rust/src/core/shell_allowlist/tests_powershell.rs
@@ -210,6 +210,49 @@ fn powershell_pipeline_with_destructive_blocked() {
     assert!(result.is_err());
 }
 
+/// GH #1514: PowerShell assignment and member-expression wrappers are syntax,
+/// not command names. The wrapped cmdlet still owns the security decision.
+#[test]
+fn powershell_assignment_and_member_wrappers_validate_inner_cmdlets() {
+    let list = allow(&["git"]);
+
+    assert!(
+        check_all_segments(
+            "$d = Get-Content 'C:\\Users\\Max\\notes.json' -Raw | ConvertFrom-Json -AsHashtable",
+            &list,
+        )
+        .is_ok()
+    );
+    assert!(check_all_segments("$d['items'] | ConvertTo-Json -Depth 6", &list).is_ok());
+    assert!(check_all_segments("$d = (Get-Item 'C:\\Temp').Name", &list).is_ok());
+    assert!(
+        check_all_segments(
+            "(Get-Item 'C:\\Users\\Max\\.cargo\\bin\\lean-ctx.exe').VersionInfo | Format-List *",
+            &list,
+        )
+        .is_ok()
+    );
+
+    assert!(check_all_segments("$d = Remove-Item file.txt", &list).is_err());
+    assert!(check_all_segments("(Invoke-Expression 'Get-Process').Length", &list).is_err());
+    assert!(
+        check_all_segments("(Get-Item 'C:\\Temp\\victim.txt').Delete()", &list).is_err(),
+        "method calls must not be mistaken for safe property access"
+    );
+    assert!(
+        check_all_segments("$d = (Get-Item 'C:\\Temp\\victim.txt').Delete()", &list).is_err(),
+        "assignment wrappers must not hide method calls"
+    );
+    assert!(
+        check_all_segments("$env:PATH = 'C:\\attacker'", &list).is_err(),
+        "environment mutation must not be normalized into a safe local assignment"
+    );
+    assert!(
+        check_all_segments("$env:PATH='C:\\attacker'", &list).is_err(),
+        "compact scoped assignments must not be consumed as POSIX environment prefixes"
+    );
+}
+
 /// Case insensitivity: PowerShell cmdlets are case-insensitive.
 #[test]
 fn powershell_case_insensitive_enforcement() {

--- a/rust/src/core/shell_allowlist/tokenizer.rs
+++ b/rust/src/core/shell_allowlist/tokenizer.rs
@@ -249,8 +249,11 @@ pub(super) fn extract_base_from_segment(segment: &str) -> String {
         return String::new();
     }
 
-    let cmd_part = skip_env_assignments(trimmed);
+    let cmd_part = skip_powershell_assignment(skip_env_assignments(trimmed));
     if cmd_part.is_empty() {
+        return String::new();
+    }
+    if is_powershell_value_expression(cmd_part) {
         return String::new();
     }
 
@@ -270,6 +273,55 @@ pub(super) fn extract_base_from_segment(segment: &str) -> String {
         .next()
         .unwrap_or(first_token)
         .to_string()
+}
+
+/// Skip a local PowerShell assignment (`$result = Get-Content …`) so the
+/// wrapped cmdlet is validated. Environment/scoped variables contain `:` and
+/// intentionally remain unrecognized, preventing `$env:PATH = …` bypasses.
+pub(super) fn skip_powershell_assignment(segment: &str) -> &str {
+    let trimmed = segment.trim_start();
+    let Some(variable_end) = powershell_local_variable_end(trimmed) else {
+        return trimmed;
+    };
+    let after_variable = trimmed[variable_end..].trim_start();
+    let Some(after_equals) = after_variable.strip_prefix('=') else {
+        return trimmed;
+    };
+    after_equals.trim_start()
+}
+
+fn powershell_local_variable_end(segment: &str) -> Option<usize> {
+    let bytes = segment.as_bytes();
+    if bytes.first() != Some(&b'$') {
+        return None;
+    }
+    let mut end = 1;
+    let first = *bytes.get(end)?;
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return None;
+    }
+    end += 1;
+    while bytes
+        .get(end)
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+    {
+        end += 1;
+    }
+    (bytes.get(end) != Some(&b':')).then_some(end)
+}
+
+/// A bare local variable or simple index lookup is pipeline data, not a command.
+/// Method calls and scoped variables deliberately fall through to deny-by-default.
+fn is_powershell_value_expression(segment: &str) -> bool {
+    let trimmed = segment.trim();
+    let Some(variable_end) = powershell_local_variable_end(trimmed) else {
+        return false;
+    };
+    let suffix = trimmed[variable_end..].trim();
+    suffix.is_empty()
+        || (suffix.starts_with('[')
+            && suffix.ends_with(']')
+            && !suffix.contains(['(', ')', ';', '|', '&', '=']))
 }
 
 /// #1488: detect whether a segment is a shell function definition.
@@ -360,11 +412,14 @@ pub(super) fn skip_env_assignments(segment: &str) -> &str {
             rest = &rest_trimmed[end..];
             continue;
         }
-        if unquoted.contains('=')
-            && !unquoted.starts_with('-')
-            && !unquoted.starts_with('/')
-            && !unquoted.starts_with('.')
-        {
+        let is_posix_assignment = unquoted.split_once('=').is_some_and(|(name, _)| {
+            let mut bytes = name.bytes();
+            bytes
+                .next()
+                .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+                && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        });
+        if is_posix_assignment {
             rest = &rest_trimmed[end..];
         } else {
             return rest_trimmed;

--- a/rust/src/hook_handlers/file_rewrite.rs
+++ b/rust/src/hook_handlers/file_rewrite.rs
@@ -142,13 +142,7 @@ fn is_compound(cmd: &str) -> bool {
 }
 
 pub(super) fn wrap_single_command(cmd: &str, binary: &str) -> String {
-    if cfg!(windows) {
-        let escaped = cmd.replace('"', "\\\"");
-        format!("{binary} -c \"{escaped}\"")
-    } else {
-        let shell_escaped = cmd.replace('\'', "'\\''");
-        format!("{binary} -c '{shell_escaped}'")
-    }
+    crate::shell::join_command(&[binary.to_owned(), "-c".to_owned(), cmd.to_owned()])
 }
 
 /// Quote-aware check for stdout file redirects (`>`, `>>`).

--- a/rust/src/hook_handlers/tests.rs
+++ b/rust/src/hook_handlers/tests.rs
@@ -4,13 +4,7 @@
 use super::*;
 
 fn expect_wrapped(cmd: &str, binary: &str) -> String {
-    if cfg!(windows) {
-        let escaped = cmd.replace('"', "\\\"");
-        format!("{binary} -c \"{escaped}\"")
-    } else {
-        let shell_escaped = cmd.replace('\'', "'\\''");
-        format!("{binary} -c '{shell_escaped}'")
-    }
+    crate::shell::join_command(&[binary.to_owned(), "-c".to_owned(), cmd.to_owned()])
 }
 
 /// Pins a deterministic shell allowlist while `body` runs, so the `passes_enforced`

--- a/rust/src/hook_handlers/vibe.rs
+++ b/rust/src/hook_handlers/vibe.rs
@@ -210,13 +210,12 @@ mod tests {
         .unwrap();
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let ti = &v["hook_specific_output"]["tool_input"];
-        // `wrap_single_command` quotes with `"..."` on Windows (cmd) and
-        // `'...'` on POSIX shells, so the expected wrapping is platform-aware.
-        let expected = if cfg!(windows) {
-            "lean-ctx -c \"git status\""
-        } else {
-            "lean-ctx -c 'git status'"
-        };
+        // Wrapping follows the detected shell, which can be Git Bash on Windows.
+        let expected = crate::shell::join_command(&[
+            "lean-ctx".to_owned(),
+            "-c".to_owned(),
+            "git status".to_owned(),
+        ]);
         assert_eq!(ti["command"], expected);
         assert_eq!(ti["timeout"], 42, "non-command fields must be preserved");
     }

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -68,28 +68,14 @@ pub(in crate::server) async fn dispatch_and_post_process(
     // agent-chosen minimal selection — triage has nothing useful to strip.
     // #1492: mode="full" is documented as "verbatim, edit-ready" — triaging it
     // defeats its contract and causes agents to edit against incomplete content.
-    let triage_bypass = args.is_some_and(|a| {
-        a.get("raw")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false)
-            || a.get("mode").and_then(|v| v.as_str()).is_some_and(|m| {
-                m == "raw"
-                    || m == "full"
-                    || m == "full-compact"
-                    || m.starts_with("lines:")
-                    || m.starts_with("anchored:")
-                    || m == "diff"
-            })
-            || a.get("aggressiveness")
-                .and_then(serde_json::Value::as_f64)
-                .is_some_and(|v| v == 0.0)
-            || a.get("fresh")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false)
-    });
+    let triage_bypass = triage_bypass_requested(name, args);
     if !triage_bypass {
-        result_text =
-            apply_task_triage_filter(result_text, task_profile.as_ref(), &mut decision_context);
+        result_text = apply_task_triage_filter(
+            result_text,
+            task_profile.as_ref(),
+            &mut decision_context,
+            config.decision_loop.max_filter_level.min(2),
+        );
     }
 
     // #1484 (bug 3): if triage filtered lines, invalidate the dedup cache for
@@ -1009,19 +995,57 @@ pub(in crate::server) async fn dispatch_and_post_process(
     Ok(result)
 }
 
+/// `ctx_read` already owns mode selection and edit-safety guarantees. Running a
+/// second lossy pass after it resolved `auto` to `full` would hide content the
+/// caller must see (#1511), so every read result bypasses post-dispatch triage.
+fn triage_bypass_requested(
+    name: &str,
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> bool {
+    name == "ctx_read"
+        || args.is_some_and(|args| {
+            args.get("raw")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+                || args
+                    .get("mode")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|mode| {
+                        mode == "raw"
+                            || mode == "full"
+                            || mode == "full-compact"
+                            || mode.starts_with("lines:")
+                            || mode.starts_with("anchored:")
+                            || mode == "diff"
+                    })
+                || args
+                    .get("aggressiveness")
+                    .and_then(serde_json::Value::as_f64)
+                    .is_some_and(|value| value == 0.0)
+                || args
+                    .get("fresh")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+        })
+}
+
 /// Applies task triage at the native dispatch chokepoint. If no profile is
 /// available or filtering panics, preserve the raw tool response unchanged.
 fn apply_task_triage_filter(
     result_text: String,
     profile: Option<&crate::core::triage::profile::TaskProfileLocal>,
     decision_context: &mut Option<crate::core::decision_loop_runtime::TaskContext>,
+    max_filter_level: u8,
 ) -> String {
+    if max_filter_level == 0 {
+        return result_text;
+    }
     let Some(profile) = profile else {
         return result_text;
     };
 
     let filtered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let level = context_gate::triage_filter_level(profile);
+        let level = context_gate::triage_filter_level(profile).min(max_filter_level);
         (level > 0).then(|| context_gate::apply_triage_filter(&result_text, profile, level))
     }));
     let Ok(Some((filtered_text, filtered_lines))) = filtered else {
@@ -1132,7 +1156,7 @@ fn record_decision_loop(
 
 #[cfg(test)]
 mod savings_tests {
-    use super::{apply_task_triage_filter, compression_tracker_tokens};
+    use super::{apply_task_triage_filter, compression_tracker_tokens, triage_bypass_requested};
 
     #[test]
     fn test_tracker_in_pipeline() {
@@ -1169,7 +1193,7 @@ mod savings_tests {
         });
         let raw = format!("// boilerplate\n{}", "content\n".repeat(100));
 
-        let filtered = apply_task_triage_filter(raw, Some(&profile), &mut context);
+        let filtered = apply_task_triage_filter(raw, Some(&profile), &mut context, 2);
 
         assert!(!filtered.starts_with("// boilerplate"));
         assert_eq!(context.as_ref().unwrap().filtered_lines, 1);
@@ -1181,8 +1205,36 @@ mod savings_tests {
         let mut context = None;
 
         assert_eq!(
-            apply_task_triage_filter(raw.clone(), None, &mut context),
+            apply_task_triage_filter(raw.clone(), None, &mut context, 2),
             raw
         );
+    }
+
+    #[test]
+    fn triage_filter_cap_zero_preserves_output_unchanged() {
+        let profile = crate::core::triage::profile::TaskProfileLocal {
+            confidence_milli: 500,
+            context_need_milli: 200,
+            ..Default::default()
+        };
+        let raw = format!("fn render() {{\n{}\n}}", "    token_value();\n".repeat(40));
+        let mut context = None;
+
+        assert_eq!(
+            apply_task_triage_filter(raw.clone(), Some(&profile), &mut context, 0),
+            raw
+        );
+    }
+
+    #[test]
+    fn ctx_read_always_bypasses_second_lossy_filter() {
+        let auto = serde_json::Map::from_iter([(
+            "mode".to_owned(),
+            serde_json::Value::String("auto".to_owned()),
+        )]);
+        assert!(triage_bypass_requested("ctx_read", Some(&auto)));
+
+        let shell = serde_json::Map::new();
+        assert!(!triage_bypass_requested("ctx_shell", Some(&shell)));
     }
 }


### PR DESCRIPTION
## Summary
- default lossy triage filtering to off while retaining decision-loop accounting
- keep ctx_read output faithful to its selected read mode
- honor Pi settings.json shellPath for both routed and raw bash tools
- validate PowerShell assignments and property wrappers without permitting scoped mutation or method calls
- harden nested substitution parsing and cross-shell rewrite quoting

## Verification
- cargo test --lib: 10,327 passed, 0 failed
- cargo clippy --all-features -- -D warnings
- cargo fmt --check
- Pi: 39 tests passed and typecheck passed
- Windows x86_64-pc-windows-gnu cross-check passed
- open-core boundary and LOC gates passed
- independent Luna security review: PASS

Closes #1511
Closes #1512
Closes #1514