### PR TITLE
fix(config): expose decision-loop controls

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -181,6 +181,13 @@ Custom command aliases (array of {command, alias} entries). Note: field names ar
 - `alias` (string, default `""`) — The alias definition to execute
 - `command` (string, default `""`) — The command pattern to match (e.g. 'deploy')
 
+## `[decision_loop]`
+
+MCP decision-loop runtime settings
+
+- `enabled` (bool, default `true`) — Enable the MCP decision-loop runtime
+- `max_filter_level` (u8, default `0`) — Maximum lossy post-dispatch triage level (0 disables output filtering)
+
 ## `[embedding]`
 
 Semantic-embedding engine settings (model selection for ctx_semantic_search)

--- a/rust/src/core/config/schema/mod.rs
+++ b/rust/src/core/config/schema/mod.rs
@@ -292,6 +292,21 @@ mod tests {
     }
 
     #[test]
+    fn decision_loop_keys_are_cli_settable_with_types_and_defaults() {
+        let schema = ConfigSchema::generate();
+        for (key, ty, default) in [
+            ("decision_loop.enabled", "bool", serde_json::json!(true)),
+            ("decision_loop.max_filter_level", "u8", serde_json::json!(0)),
+        ] {
+            let entry = schema
+                .lookup(key)
+                .unwrap_or_else(|| panic!("config set {key} must be recognized"));
+            assert_eq!(entry.ty, ty, "schema type for {key}");
+            assert_eq!(entry.default, default, "schema default for {key}");
+        }
+    }
+
+    #[test]
     fn permission_inheritance_defaults_to_on() {
         let cfg = super::super::Config::default();
         assert_eq!(

--- a/rust/src/core/config/schema/sections_advanced.rs
+++ b/rust/src/core/config/schema/sections_advanced.rs
@@ -668,4 +668,29 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             description: "Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable.".into(),
             keys: llm_keys,
         });
+
+    let mut decision_loop = BTreeMap::new();
+    decision_loop.insert(
+        "enabled".into(),
+        key(
+            "bool",
+            serde_json::json!(cfg.decision_loop.enabled),
+            "Enable the MCP decision-loop runtime",
+        ),
+    );
+    decision_loop.insert(
+        "max_filter_level".into(),
+        key(
+            "u8",
+            serde_json::json!(cfg.decision_loop.max_filter_level),
+            "Maximum lossy post-dispatch triage level (0 disables output filtering)",
+        ),
+    );
+    sections.insert(
+        "decision_loop".into(),
+        SectionSchema {
+            description: "MCP decision-loop runtime settings".into(),
+            keys: decision_loop,
+        },
+    );
 }

--- a/rust/src/core/config/setter.rs
+++ b/rust/src/core/config/setter.rs
@@ -263,6 +263,23 @@ mod tests {
     }
 
     #[test]
+    fn decision_loop_keys_round_trip_through_cli_setter() {
+        let schema = ConfigSchema::generate();
+        let mut table = toml::Table::new();
+        for (key, value) in [
+            ("decision_loop.enabled", "false"),
+            ("decision_loop.max_filter_level", "0"),
+        ] {
+            let key_schema = schema.lookup(key).expect("decision-loop key in schema");
+            set_nested(&mut table, key, parse_value(value, key_schema).unwrap()).unwrap();
+        }
+
+        let cfg: Config = toml::Value::Table(table).try_into().unwrap();
+        assert!(!cfg.decision_loop.enabled);
+        assert_eq!(cfg.decision_loop.max_filter_level, 0);
+    }
+
+    #[test]
     fn set_nested_flat_key() {
         let mut table = toml::Table::new();
         set_nested(&mut table, "ultra_compact", toml::Value::Boolean(true)).unwrap();


### PR DESCRIPTION
## Summary

- expose `decision_loop.enabled` and `decision_loop.max_filter_level` through `lean-ctx config set`
- verify both dotted keys through schema lookup, typed parsing, nested TOML construction, and `Config` deserialization
- complete the user-facing closure for the triage regressions already fixed on `main`: lossless `ctx_read`, preserved raw ranges, fail-open shell output, and triage disabled by default

## User commands

```bash
lean-ctx config set decision_loop.max_filter_level 0
lean-ctx config set decision_loop.enabled false
```

## Verification

- `cargo test --lib` (10,351 tests)
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt --check`
- focused config schema and setter round-trip tests
- open-core boundary gate
- LOC gate
- independent Luna review: PASS

Closes #1484
Closes #1490
Closes #1492
Closes #1493
