### PR TITLE
fix: shell coverage gaps, zsh pattern-classification bug, honest metrics, stable dashboard auth

### DIFF
--- a/LEAN-CTX.md
+++ b/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 8 -->
+<!-- version: 9 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ install: ## Build release + install to ~/.local/bin
 dev: ## Quick debug build + copy to ~/.local/bin
 	cd rust && cargo build
 	@mkdir -p "$$HOME/.local/bin"
+	@# rm before cp: overwriting an existing Mach-O in place invalidates the
+	@# ad-hoc code signature on Apple Silicon — the copied binary dies with
+	@# SIGKILL (exit 137) on every exec. Removing first gives the new file a
+	@# fresh identity; re-sign ad hoc for good measure where codesign exists.
+	rm -f "$$HOME/.local/bin/lean-ctx"
 	cp rust/target/debug/lean-ctx "$$HOME/.local/bin/lean-ctx"
+	@command -v codesign >/dev/null 2>&1 && codesign -f -s - "$$HOME/.local/bin/lean-ctx" 2>/dev/null || true
 	@echo "Dev installed: $$(lean-ctx --version)"
 
 test: ## Run all Rust tests + clippy

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -82,6 +82,7 @@ Top-level configuration keys
 - `shell_allowlist_extra` (array, default `[]`) — Commands merged on top of shell_allowlist without replacing the defaults. Managed via `lean-ctx allow <cmd>`
 - `shell_heavy_timeout_secs` (u64?, default `null` — env `LEAN_CTX_SHELL_HEAVY_TIMEOUT_SECS`) — Shell command timeout (seconds) for heavy commands (cargo build/test, make, docker build, git commit/push). null = built-in 10-minute ceiling
 - `shell_hook_disabled` (bool, default `false` — env `LEAN_CTX_NO_HOOK`) — Disable shell hook injection
+- `shell_hook_mode` (enum: auto | rewrite | deny, default `auto` — env `LEAN_CTX_SHELL_HOOK_MODE`) — How the PreToolUse shell hook treats native Bash/Shell calls (#1278). rewrite: rewrite known read/search/list commands, unknown commands pass through raw. deny: block native shell outright so every command goes through ctx_shell (fail-opens: lean-ctx disabled, MCP daemon dead, explicit shadow-only surface). auto (default): currently rewrite
 - `shell_security` (string, default `enforce` — env `LEAN_CTX_SHELL_SECURITY`) — Shell command gating: enforce (default, secure), warn (log only, never block) or off (skip allowlist + hard blocks; compression stays active)
 - `shell_strict_mode` (bool, default `false`) — Block $(), backticks, <() in shell arguments. Default false = warn only.
 - `shell_timeout_secs` (u64?, default `null` — env `LEAN_CTX_SHELL_TIMEOUT_SECS`) — Shell command timeout (seconds) for normal commands. null = built-in 2-minute default. LEAN_CTX_SHELL_TIMEOUT_MS overrides both tiers (in ms)

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -59,6 +59,7 @@ Top-level configuration keys
 - `profile` (string, default `""`) — Persistent profile name. Checked after LEAN_CTX_PROFILE env var. Set via: lean-ctx config set profile passthrough
 - `profiles` (table, default `{}`) — Named partial configuration overlays; nested tables merge recursively over base settings
 - `project_root` (string?, default `null` — env `LEAN_CTX_PROJECT_ROOT`) — Explicit project root directory. Prevents accidental home-directory scans
+- `prompt_reinject` (enum: auto | on | off, default `auto` — env `LEAN_CTX_PROMPT_REINJECT`) — Per-turn tool-precedence reinjection (#1288): the UserPromptSubmit hook emits a one-line additionalContext reminder that ctx_* tools are the mandated path, so it always post-dates session-level harness instructions preferring native Bash. auto (default): active only while shadow_mode is on. Costs ~45 tokens per turn when active
 - `proxy_enabled` (bool?, default `null`) — Enable/disable the proxy layer. null = auto-detect, true = force on, false = force off
 - `proxy_loopback_open` (bool, default `false`) — Skip ALL proxy authentication on loopback binds. MCP/HTTP clients work without tokens. Ignored on non-loopback (gateway mode)
 - `proxy_port` (u16?, default `null`) — Custom proxy port (default: 4444). Useful for multi-user systems. Env: LEAN_CTX_PROXY_PORT

--- a/rust/LEAN-CTX.md
+++ b/rust/LEAN-CTX.md
@@ -1,6 +1,6 @@
 <!-- lean-ctx-owned: PROJECT-LEAN-CTX.md v1 -->
 <!-- lean-ctx-rules -->
-<!-- version: 8 -->
+<!-- version: 9 -->
 
 CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. This is NOT optional.
 

--- a/rust/src/cli/config_cmd.rs
+++ b/rust/src/cli/config_cmd.rs
@@ -886,7 +886,11 @@ pub fn cmd_stats(args: &[String]) {
             println!("Commands:    {}", store.total_commands);
             println!("Input:       {} tokens", store.total_input_tokens);
             println!("Output:      {} tokens", store.total_output_tokens);
-            println!("Saved:       {input_saved} tokens ({pct:.1}%)");
+            // #1284: scope the headline honestly — this ratio covers volume
+            // that flowed THROUGH lean-ctx. Native tool calls that bypassed
+            // lean-ctx are not in the denominator (they are counted separately
+            // as native_shell_passthrough in metering).
+            println!("Saved:       {input_saved} tokens ({pct:.1}% of metered lean-ctx volume)");
             println!();
             println!("CEP sessions:  {}", store.cep.sessions);
             println!(

--- a/rust/src/cli/rules_dedup.rs
+++ b/rust/src/cli/rules_dedup.rs
@@ -50,7 +50,41 @@ fn is_owned_rules_file(content: &str) -> bool {
         // CursorMdc has YAML frontmatter before the header.
         || (content.trim_start().starts_with("---")
             && content.contains(crate::core::rules_canonical::START_MARK));
-    starts_with_header && content.contains("<!-- version:")
+    if starts_with_header && content.contains("<!-- version:") {
+        return true;
+    }
+    is_owned_legacy_rules_file(content)
+}
+
+/// #1289: older installs wrote dedicated rule files with versioned markers
+/// (`<!-- lean-ctx-rules-v9 -->`) and no `<!-- version: N -->` line. Those
+/// files never matched the canonical ownership test above, so stale guidance
+/// (e.g. "Write, Delete, Glob → use normally" contradicting the shadow-mode
+/// Glob deny) survived every update and dedup run. A legacy file counts as
+/// owned when lean-ctx plausibly wrote all of it: a legacy rules marker sits
+/// in the first few lines and nothing but whitespace follows the last closing
+/// lean-ctx marker — user-extended files keep getting the Report instead.
+fn is_owned_legacy_rules_file(content: &str) -> bool {
+    let mut lines = content.trim_start().lines();
+    // Legacy files start with a `# lean-ctx …` heading (marker on the next
+    // line) or with the marker itself — a marker merely mentioned mid-text
+    // does not make a file lean-ctx-owned.
+    let first = lines.next().unwrap_or_default().trim();
+    let marker_line = if first.starts_with("# lean-ctx") {
+        lines.next().unwrap_or_default().trim()
+    } else {
+        first
+    };
+    if !marker_line.starts_with(crate::core::rules_canonical::RULES_MARKER_PREFIX) {
+        return false;
+    }
+    let Some(idx) = content.rfind("<!-- /lean-ctx") else {
+        return false;
+    };
+    let Some(end) = content[idx..].find("-->") else {
+        return false;
+    };
+    content[idx + end + 3..].trim().is_empty()
 }
 
 /// Line-based marker pair detection (GL #1158): prose mentions of a marker
@@ -385,6 +419,26 @@ mod tests {
     fn strip_of_pure_block_file_yields_empty() {
         let content = format!("{BLOCK_START}\nonly ours\n{BLOCK_END}\n");
         assert_eq!(strip_lean_ctx_blocks(&content), "");
+    }
+
+    /// #1289: legacy versioned-marker files (rules-v9 era, no `<!-- version:`)
+    /// are owned when wholly lean-ctx-written; user-extended copies are not.
+    #[test]
+    fn legacy_marker_files_owned_only_when_wholly_lean_ctx() {
+        let pristine = "# lean-ctx — Context Engineering Layer\n\
+             <!-- lean-ctx-rules-v9 -->\n\n\
+             PREFER lean-ctx MCP tools.\n\
+             Write, Delete, Glob → use normally.\n\
+             <!-- /lean-ctx -->\n";
+        assert!(is_owned_rules_file(pristine));
+
+        let user_extended = format!("{pristine}\n## My own precedence rules\nkeep me\n");
+        assert!(!is_owned_rules_file(&user_extended));
+
+        // A user file that merely mentions the marker mid-text is not owned.
+        assert!(!is_owned_rules_file(
+            "my notes\nabout <!-- lean-ctx-rules-v9 --> markers\n<!-- /lean-ctx -->\n"
+        ));
     }
 
     #[test]

--- a/rust/src/core/cache/entry.rs
+++ b/rust/src/core/cache/entry.rs
@@ -75,13 +75,23 @@ fn next_compressed_output_access() -> u64 {
 struct CompressedOutputVariant {
     output: String,
     last_access: AtomicU64,
+    /// #1287: the conversation that first received this variant. A later
+    /// re-read from the SAME conversation of the unchanged file can collapse
+    /// to the ~15-token variant stub; other conversations keep receiving the
+    /// full payload (stub semantics must never leak across chats, #1042).
+    /// Set at store time — storing a variant IS delivering it. A payload hit
+    /// from a different conversation does not retarget this field (interior
+    /// mutability would be needed); that conversation simply keeps payload
+    /// delivery, which is correct, just not optimal.
+    delivered_conversation: Option<String>,
 }
 
 impl CompressedOutputVariant {
-    fn new(output: String) -> Self {
+    fn new(output: String, delivered_conversation: Option<String>) -> Self {
         Self {
             output,
             last_access: AtomicU64::new(next_compressed_output_access()),
+            delivered_conversation,
         }
     }
 
@@ -108,10 +118,29 @@ impl CompressedOutputLru {
         Some(&variant.output)
     }
 
+    /// #1287: which conversation first received this variant. Outer `None`
+    /// means the variant does not exist; inner `None` means it was stored
+    /// without a resolvable conversation id (stub must not be served).
+    /// The nested Option is deliberate for this private, allocation-free
+    /// helper — the public API (`SessionCache::compressed_delivered_conversation`)
+    /// exposes it as the explicit `VariantDelivery` enum.
+    #[allow(clippy::option_option)]
+    fn delivered_conversation(&self, mode_key: &str) -> Option<Option<&str>> {
+        self.entries
+            .get(mode_key)
+            .map(|variant| variant.delivered_conversation.as_deref())
+    }
+
     /// Stores a variant and returns the deterministic LRU victim, if any.
-    fn set(&mut self, mode_key: &str, output: String) -> Option<String> {
+    fn set(
+        &mut self,
+        mode_key: &str,
+        output: String,
+        delivered_conversation: Option<String>,
+    ) -> Option<String> {
         if let Some(variant) = self.entries.get_mut(mode_key) {
             variant.output = output;
+            variant.delivered_conversation = delivered_conversation;
             variant.touch();
             return None;
         }
@@ -131,8 +160,10 @@ impl CompressedOutputLru {
             None
         };
 
-        self.entries
-            .insert(mode_key.to_string(), CompressedOutputVariant::new(output));
+        self.entries.insert(
+            mode_key.to_string(),
+            CompressedOutputVariant::new(output, delivered_conversation),
+        );
         evicted
     }
 
@@ -322,8 +353,22 @@ impl CacheEntry {
         self.compressed_outputs.get(mode_key)
     }
 
+    /// #1287: which conversation first received this compressed variant.
+    /// Outer `None` = variant absent; inner `None` = stored without a
+    /// resolvable conversation (variant stub must not be served). Nested
+    /// Option kept allocation-free here; `SessionCache` exposes the explicit
+    /// `VariantDelivery` enum publicly.
+    #[allow(clippy::option_option)]
+    pub fn compressed_delivered_conversation(&self, mode_key: &str) -> Option<Option<&str>> {
+        self.compressed_outputs.delivered_conversation(mode_key)
+    }
+
     pub fn set_compressed(&mut self, mode_key: &str, output: String) {
-        if let Some(evicted_key) = self.compressed_outputs.set(mode_key, output) {
+        // #1287: storing a variant IS delivering it — stamp the conversation
+        // so a same-conversation re-read of the unchanged file can collapse
+        // to the variant stub.
+        let conversation = crate::core::conversation::current_conversation_id();
+        if let Some(evicted_key) = self.compressed_outputs.set(mode_key, output, conversation) {
             self.evicted_compressed_variants.insert(evicted_key);
         }
         self.evicted_compressed_variants.remove(mode_key);

--- a/rust/src/core/cache/session.rs
+++ b/rust/src/core/cache/session.rs
@@ -9,6 +9,18 @@ use super::entry::{
 use super::validation::{compute_md5, is_cache_entry_stale_verified};
 use crate::core::tokens::count_tokens;
 
+/// #1287: delivery state of one compressed render variant. `Absent` = no such
+/// variant cached; `UnknownConversation` = stored without a resolvable
+/// conversation id (the variant stub must not be served — unknown delivery is
+/// never treated as "stub allowed"); `Conversation` = provably delivered to
+/// that conversation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VariantDelivery {
+    Absent,
+    UnknownConversation,
+    Conversation(String),
+}
+
 pub(crate) const DEFAULT_FULL_DEGRADATION_THRESHOLD: u32 = 2;
 
 pub(crate) fn full_degradation_threshold() -> u32 {
@@ -396,6 +408,21 @@ impl SessionCache {
     /// Removes a file from the cache, forcing a fresh read on next access.
     pub fn invalidate(&mut self, path: &str) -> bool {
         self.entries.remove(&normalize_key(path)).is_some()
+    }
+
+    /// #1287: which conversation first received the given compressed variant,
+    /// WITHOUT recording hit statistics — the caller decides between stub and
+    /// payload delivery and records accordingly.
+    pub fn compressed_delivered_conversation(&self, path: &str, mode_key: &str) -> VariantDelivery {
+        match self
+            .entries
+            .get(&normalize_key(path))
+            .and_then(|entry| entry.compressed_delivered_conversation(mode_key))
+        {
+            None => VariantDelivery::Absent,
+            Some(None) => VariantDelivery::UnknownConversation,
+            Some(Some(conversation)) => VariantDelivery::Conversation(conversation.to_string()),
+        }
     }
 
     /// Returns a cached compressed output for a given file and mode key.

--- a/rust/src/core/cache/tests.rs
+++ b/rust/src/core/cache/tests.rs
@@ -454,6 +454,31 @@ fn compressed_outputs_cached_and_retrieved() {
     assert_eq!(cache.get_compressed("/test.rs", "signatures"), None);
 }
 
+/// #1287: storing a variant stamps the delivering conversation; re-storing
+/// restamps it; a missing variant reports `Absent`.
+#[test]
+fn compressed_variant_tracks_delivered_conversation() {
+    let mut cache = SessionCache::new();
+    cache.store("/test.rs", "fn main() {}");
+    assert_eq!(
+        cache.compressed_delivered_conversation("/test.rs", "signatures"),
+        VariantDelivery::Absent
+    );
+    cache.set_compressed("/test.rs", "signatures", "sig view".to_string());
+    // Present variant: either a concrete conversation (agent environments) or
+    // UnknownConversation (no resolvable id — stub must not be served, never
+    // "stub allowed"). Absent would mean the store was lost.
+    assert_ne!(
+        cache.compressed_delivered_conversation("/test.rs", "signatures"),
+        VariantDelivery::Absent,
+        "stored variant must report delivery state"
+    );
+    assert_eq!(
+        cache.compressed_delivered_conversation("/other.rs", "signatures"),
+        VariantDelivery::Absent
+    );
+}
+
 #[test]
 fn compressed_outputs_evict_least_recently_used_variant() {
     let mut cache = SessionCache::new();

--- a/rust/src/core/config/defaults.rs
+++ b/rust/src/core/config/defaults.rs
@@ -142,6 +142,7 @@ impl Default for Config {
             shell_hook_disabled: false,
             shadow_mode: true,
             shell_hook_mode: None,
+            prompt_reinject: None,
             hook_mode: None,
             tool_surface: None,
             debug_log: false,

--- a/rust/src/core/config/defaults.rs
+++ b/rust/src/core/config/defaults.rs
@@ -141,6 +141,7 @@ impl Default for Config {
             embedding: EmbeddingConfig::default(),
             shell_hook_disabled: false,
             shadow_mode: true,
+            shell_hook_mode: None,
             hook_mode: None,
             tool_surface: None,
             debug_log: false,

--- a/rust/src/core/config/model.rs
+++ b/rust/src/core/config/model.rs
@@ -437,6 +437,14 @@ pub struct Config {
     /// choice survives reinstalls and updates.
     #[serde(default)]
     pub shell_hook_mode: Option<String>,
+    /// Per-turn tool-precedence reinjection (#1288): the UserPromptSubmit hook
+    /// emits a one-line `additionalContext` reminder that ctx_* tools are the
+    /// mandated path, so it always post-dates any session-level harness
+    /// instruction preferring native Bash. `on` | `off` | `auto` (default:
+    /// auto = active only while `shadow_mode` is on). Env override:
+    /// `LEAN_CTX_PROMPT_REINJECT`. Costs ~45 tokens per turn when active.
+    #[serde(default)]
+    pub prompt_reinject: Option<String>,
     /// Global hook mode override. When set, overrides the per-agent auto-detection.
     /// - `replace`: Native Read/Grep/Glob/Shell denied, lean-ctx MCP is the only path
     /// - `hybrid`: MCP + shell hooks for compression (legacy)

--- a/rust/src/core/config/model.rs
+++ b/rust/src/core/config/model.rs
@@ -417,12 +417,26 @@ pub struct Config {
     /// Override via LEAN_CTX_NO_HOOK env var.
     #[serde(default)]
     pub shell_hook_disabled: bool,
-    /// Shadow mode (default: true): denies native tools (Read/Grep/Shell) at
-    /// the permission level, forcing agents to use ctx_* MCP tools for maximum
+    /// Shadow mode (default: true): denies native Read/Grep/Glob at the
+    /// permission level, forcing agents to use ctx_* MCP tools for maximum
     /// compression. Without this, many harnesses silently prefer native tools,
     /// negating lean-ctx's token savings. Disable with `shadow_mode = false`.
+    /// Native Shell/Bash coverage is governed separately by `shell_hook_mode`.
     #[serde(default = "serde_defaults::default_true")]
     pub shadow_mode: bool,
+    /// Shell hook mode (#1278): how the PreToolUse shell hook treats native
+    /// Bash/Shell calls.
+    /// - `rewrite` (default): rewrite known read/search/list commands to
+    ///   lean-ctx equivalents; anything unrecognized passes through raw.
+    /// - `deny`: block native shell calls outright so every command goes
+    ///   through `ctx_shell` (same fail-opens as the deny hook: lean-ctx
+    ///   disabled, MCP daemon dead, explicit shadow-only tool surface).
+    /// - `auto`: currently equals `rewrite`; reserved for a future default flip.
+    ///
+    /// Env override: `LEAN_CTX_SHELL_HOOK_MODE`. Lives in config.toml, so the
+    /// choice survives reinstalls and updates.
+    #[serde(default)]
+    pub shell_hook_mode: Option<String>,
     /// Global hook mode override. When set, overrides the per-agent auto-detection.
     /// - `replace`: Native Read/Grep/Glob/Shell denied, lean-ctx MCP is the only path
     /// - `hybrid`: MCP + shell hooks for compression (legacy)

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -444,6 +444,19 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             ),
         );
     root.insert(
+        "shell_hook_mode".into(),
+        key_enum_with_env(
+            &["auto", "rewrite", "deny"],
+            "auto",
+            "How the PreToolUse shell hook treats native Bash/Shell calls (#1278). \
+             rewrite: rewrite known read/search/list commands, unknown commands pass \
+             through raw. deny: block native shell outright so every command goes \
+             through ctx_shell (fail-opens: lean-ctx disabled, MCP daemon dead, \
+             explicit shadow-only surface). auto (default): currently rewrite",
+            "LEAN_CTX_SHELL_HOOK_MODE",
+        ),
+    );
+    root.insert(
         "read_redirect".into(),
         key_enum_with_env(
             &["auto", "on", "off"],

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -457,6 +457,19 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         ),
     );
     root.insert(
+        "prompt_reinject".into(),
+        key_enum_with_env(
+            &["auto", "on", "off"],
+            "auto",
+            "Per-turn tool-precedence reinjection (#1288): the UserPromptSubmit hook \
+             emits a one-line additionalContext reminder that ctx_* tools are the \
+             mandated path, so it always post-dates session-level harness \
+             instructions preferring native Bash. auto (default): active only while \
+             shadow_mode is on. Costs ~45 tokens per turn when active",
+            "LEAN_CTX_PROMPT_REINJECT",
+        ),
+    );
+    root.insert(
         "read_redirect".into(),
         key_enum_with_env(
             &["auto", "on", "off"],

--- a/rust/src/core/events.rs
+++ b/rust/src/core/events.rs
@@ -479,6 +479,14 @@ pub fn emit_agent_action(agent_id: &str, action: &str, tool: Option<&str>) {
 }
 
 pub fn emit_budget_warning(role: &str, dimension: &str, used: &str, limit: &str, percent: u8) {
+    // #1282: the post-dispatch budget guard calls this on EVERY tool call once
+    // a dimension is in Warning — measured 103 of 200 ring-buffer slots in
+    // 5 minutes, drowning the ToolCall events the Live view exists to show.
+    // Rate-limit per (role, dimension): emit only when the 10%-bucket moves
+    // or the last emission is older than 5 minutes.
+    if !budget_warning_due(role, dimension, percent) {
+        return;
+    }
     emit(EventKind::BudgetWarning {
         role: role.to_string(),
         dimension: dimension.to_string(),
@@ -486,6 +494,34 @@ pub fn emit_budget_warning(role: &str, dimension: &str, used: &str, limit: &str,
         limit: limit.to_string(),
         percent,
     });
+}
+
+/// Per-(role, dimension) rate limiter for budget warnings (#1282). In-process
+/// state is sufficient: the emitter lives in the long-running server, and a
+/// short-lived CLI process at worst emits one warning per dimension.
+fn budget_warning_due(role: &str, dimension: &str, percent: u8) -> bool {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    const REPEAT_AFTER: Duration = Duration::from_mins(5);
+
+    type WarnState = HashMap<(String, String), (u8, Instant)>;
+    static LAST: Mutex<Option<WarnState>> = Mutex::new(None);
+
+    let mut guard = LAST
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let map = guard.get_or_insert_with(HashMap::new);
+    let key = (role.to_string(), dimension.to_string());
+    let bucket = percent / 10;
+    match map.get(&key) {
+        Some((last_bucket, at)) if *last_bucket == bucket && at.elapsed() < REPEAT_AFTER => false,
+        _ => {
+            map.insert(key, (bucket, Instant::now()));
+            true
+        }
+    }
 }
 
 pub fn emit_budget_exhausted(role: &str, dimension: &str, used: &str, limit: &str) {
@@ -572,6 +608,20 @@ mod tests {
         assert!(id > 0);
         let events = latest_events(100);
         assert!(events.iter().any(|e| e.id == id));
+    }
+
+    /// #1282: repeated warnings for an unchanged (role, dimension, bucket) are
+    /// suppressed; a bucket move re-arms immediately. Uses a unique role so
+    /// parallel tests never share limiter state.
+    #[test]
+    fn budget_warning_rate_limit_suppresses_repeats() {
+        let role = format!("test-role-{}", std::process::id());
+        assert!(budget_warning_due(&role, "tokens", 85));
+        assert!(!budget_warning_due(&role, "tokens", 85));
+        assert!(!budget_warning_due(&role, "tokens", 87)); // same 10%-bucket
+        assert!(budget_warning_due(&role, "tokens", 95)); // bucket moved
+        assert!(!budget_warning_due(&role, "tokens", 95));
+        assert!(budget_warning_due(&role, "cost", 85)); // other dimension independent
     }
 
     #[test]

--- a/rust/src/core/rules_canonical.rs
+++ b/rust/src/core/rules_canonical.rs
@@ -105,7 +105,10 @@ Never skip: validation, security, error handling.\n\
 /// exploration on hook-covered hosts (Cursor).
 /// Bumping it forces every committed `LEAN-CTX.md` artifact to be regenerated
 /// (see `tests/rules_drift.rs`) and every injected user file to resync.
-pub const RULES_VERSION: usize = 8;
+/// v9 (#1287): the "re-reads ~13 tokens" claim is scoped to unchanged
+/// full/auto re-reads — signatures/map re-reads currently return the full
+/// (cached) payload.
+pub const RULES_VERSION: usize = 9;
 
 /// Banner placed at the top of dedicated rule files (non-shadow only).
 pub const CRITICAL: &str = "CRITICAL: ALWAYS use lean-ctx ctx_* tools instead of native equivalents. \
@@ -249,7 +252,7 @@ provide superior caching, compression, and session memory. Hooks compress native
 Shell/Read/Grep as fallback, but direct ctx_* calls are the primary path.\n\
 ACTUALLY EMIT the ctx_* tool call (ctx_compose first) — describing a tool is not calling it.\n\
 WHY ctx_read > native Read: ctx_read picks the optimal mode (map/signatures/terse) \
-per file, caches for instant re-reads (~13 tokens), and compresses 26-92%. Native \
+per file, caches unchanged full/auto re-reads (~13 tokens), and compresses 26-92%. Native \
 Read through hook redirect is limited to verbatim pass-through (~5% savings).";
 
 /// The tools worth an explicit MCP call on a hook-covered host: capabilities
@@ -257,7 +260,7 @@ Read through hook redirect is limited to verbatim pass-through (~5% savings).";
 /// [`SHADOW_MINIMAL`]'s exclusive-tools line (same rationale, different cause).
 pub const HOOK_COVERED_TOOLS: &str = "\
 MANDATORY MAPPING (always use ctx_* instead of native):\n\
-• Read/cat -> ctx_read(path, mode) — cached, 10 modes, re-reads ~13 tokens\n\
+• Read/cat -> ctx_read(path, mode) — cached, 10 modes, unchanged full/auto re-reads ~13 tokens\n\
 • Grep/search -> ctx_search(pattern, path) — also action=symbol|semantic for definitions/meaning\n\
 • Shell/bash -> ctx_shell(command) — 95+ compression patterns\n\
 • ctx_compose — orient in code FIRST (bundles search + read + symbols) — call before editing/debugging\n\

--- a/rust/src/core/rules_sections.rs
+++ b/rust/src/core/rules_sections.rs
@@ -60,7 +60,7 @@ pub(crate) fn intent_section(p: &ToolProfile) -> String {
 pub(crate) fn hook_covered_tools_section(p: &ToolProfile) -> String {
     let mut lines = vec!["MANDATORY MAPPING (always use ctx_* instead of native):".to_string()];
 
-    lines.push("• Read/cat -> ctx_read(path, mode) — cached, 10 modes, re-reads ~13 tokens".into());
+    lines.push("• Read/cat -> ctx_read(path, mode) — cached, 10 modes, unchanged full/auto re-reads ~13 tokens".into());
     lines.push(
         "• Grep/search -> ctx_search(pattern, path) — also action=symbol|semantic \
          for definitions/meaning"

--- a/rust/src/core/stats/io.rs
+++ b/rust/src/core/stats/io.rs
@@ -18,7 +18,7 @@ pub(super) fn load_from_disk() -> StatsStore {
 
     match std::fs::read_to_string(&path) {
         Ok(content) => match serde_json::from_str(&content) {
-            Ok(store) => store,
+            Ok(store) => sanitize_extrapolated_rereads(store),
             // Corrupt display cache (#706): NEVER silently reset — the next
             // flush would overwrite the good file with an empty store and the
             // whole history would be gone. Quarantine the corrupt bytes so
@@ -30,6 +30,28 @@ pub(super) fn load_from_disk() -> StatsStore {
         },
         Err(_) => StatsStore::default(),
     }
+}
+
+/// One-time sanitation (#1283). Stores written before the extrapolation fix
+/// can carry `reread_tokens_saved` values thousands of times larger than every
+/// input token ever processed (measured: ~119 trillion vs 2.4B input). Those
+/// values are products of turn arithmetic, not measurements, and cannot be
+/// decomposed retroactively — reset with a loud log. Legitimate measured
+/// values sit well under the total input volume and pass through untouched.
+fn sanitize_extrapolated_rereads(mut store: StatsStore) -> StatsStore {
+    let plausible_cap = store.total_input_tokens.saturating_mul(100).max(1_000_000);
+    if store.reread_tokens_saved > plausible_cap {
+        tracing::warn!(
+            "reread_tokens_saved={} exceeds plausibility cap {} (total input {}) — \
+             value stems from the pre-#1283 turn extrapolation and is reset; \
+             future re-read savings are measured from real cache hits",
+            store.reread_tokens_saved,
+            plausible_cap,
+            store.total_input_tokens
+        );
+        store.reread_tokens_saved = 0;
+    }
+    store
 }
 
 /// Moves an unparseable `stats.json` aside to `stats.json.corrupt` (#706)

--- a/rust/src/core/stats/model.rs
+++ b/rust/src/core/stats/model.rs
@@ -67,16 +67,19 @@ impl CompressionTotals {
 }
 
 impl StatsStore {
-    /// Records one tool result at the provider turn that caused it. Advancing
-    /// turns prices every already-resident result as a cache re-read; results
-    /// emitted in the same turn are not spuriously re-billed against each other.
+    /// Records one tool result at the provider turn that caused it.
+    ///
+    /// #1283: this used to price every already-resident result as a re-read on
+    /// each turn advance (`reread += active * elapsed_turns`). Per session that
+    /// model is defensible — a compressed result resident in context saves its
+    /// delta on every later turn — but this store is *global and persistent*:
+    /// `active_tool_result_tokens_saved` accumulated across months and all
+    /// concurrent sessions (measured: 932M), and `last_tool_result_turn` mixed
+    /// unrelated per-session counters (measured: 36k). The product exploded
+    /// `reread_tokens_saved` to ~119 trillion — 50,000x every input token ever
+    /// processed. Persistent counters now hold measured savings only; re-read
+    /// savings come exclusively from the real cache-hit path (`record_reread`).
     pub(crate) fn record_tool_result_savings(&mut self, saved: u64, turn: u64) {
-        if turn > 0 && self.last_tool_result_turn > 0 && turn > self.last_tool_result_turn {
-            let elapsed = turn - self.last_tool_result_turn;
-            self.reread_tokens_saved = self
-                .reread_tokens_saved
-                .saturating_add(self.active_tool_result_tokens_saved.saturating_mul(elapsed));
-        }
         if turn > 0 {
             self.last_tool_result_turn = self.last_tool_result_turn.max(turn);
             self.active_tool_result_tokens_saved =
@@ -86,20 +89,15 @@ impl StatsStore {
         self.stream_tracked_results = self.stream_tracked_results.saturating_add(1);
     }
 
-    /// Stream totals through `observed_turn`, including re-reads since the last
-    /// tool result. Legacy stores fall back to measured compressible savings.
-    pub(crate) fn stream_savings(&self, observed_turn: u64) -> (u64, u64) {
+    /// Stream totals: measured first-inject savings and measured re-read
+    /// savings. Legacy stores fall back to measured compressible savings.
+    /// No turn-based extrapolation (#1283) — the parameter remains for call
+    /// sites that report the observation turn.
+    pub(crate) fn stream_savings(&self, _observed_turn: u64) -> (u64, u64) {
         if self.stream_tracked_results == 0 {
             return (self.compression_totals().saved_tokens(), 0);
         }
-        let pending_turns = observed_turn.saturating_sub(self.last_tool_result_turn);
-        let pending = self
-            .active_tool_result_tokens_saved
-            .saturating_mul(pending_turns);
-        (
-            self.first_inject_tokens_saved,
-            self.reread_tokens_saved.saturating_add(pending),
-        )
+        (self.first_inject_tokens_saved, self.reread_tokens_saved)
     }
 
     /// Computes effective compression from tagged command rows.
@@ -441,27 +439,31 @@ mod tests {
     }
 
     #[test]
-    fn next_turn_rereads_all_prior_results() {
+    fn turn_advance_never_extrapolates_rereads() {
+        // #1283: re-read savings are measured (record_reread), never derived
+        // from turn arithmetic on the lifetime-cumulative active set.
         let mut store = StatsStore::default();
         store.record_tool_result_savings(1_000, 7);
         store.record_tool_result_savings(500, 8);
-        assert_eq!(store.stream_savings(8), (1_500, 1_000));
+        assert_eq!(store.stream_savings(8), (1_500, 0));
+        assert_eq!(store.reread_tokens_saved, 0);
     }
 
     #[test]
-    fn parallel_results_on_same_turn_do_not_reread_each_other() {
+    fn measured_rereads_pass_through_unscaled() {
         let mut store = StatsStore::default();
         store.record_tool_result_savings(1_000, 7);
-        store.record_tool_result_savings(500, 7);
-        assert_eq!(store.stream_savings(7), (1_500, 0));
-        assert_eq!(store.stream_savings(8), (1_500, 1_500));
+        store.reread_tokens_saved = 300; // as recorded by the cache-hit path
+        assert_eq!(store.stream_savings(7), (1_000, 300));
+        // A later observation turn must not inflate the measured value.
+        assert_eq!(store.stream_savings(5_000), (1_000, 300));
     }
 
     #[test]
-    fn skipped_turns_multiply_resident_savings() {
+    fn skipped_turns_do_not_multiply_resident_savings() {
         let mut store = StatsStore::default();
         store.record_tool_result_savings(2_000, 3);
-        assert_eq!(store.stream_savings(6), (2_000, 6_000));
+        assert_eq!(store.stream_savings(6), (2_000, 0));
     }
 
     #[test]
@@ -492,6 +494,8 @@ mod tests {
         store.record_tool_result_savings(u64::MAX, 1);
         store.record_tool_result_savings(u64::MAX, u64::MAX);
         assert_eq!(store.first_inject_tokens_saved, u64::MAX);
-        assert_eq!(store.reread_tokens_saved, u64::MAX);
+        assert_eq!(store.active_tool_result_tokens_saved, u64::MAX);
+        // #1283: no extrapolation — reread stays at its measured value.
+        assert_eq!(store.reread_tokens_saved, 0);
     }
 }

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -162,7 +162,13 @@ pub async fn start(
     // services). When explicitly disabled, run token-less: cross-origin/CSRF and
     // DNS-rebinding attacks are blocked by `no_auth_request_ok` instead.
     let token = if auth_required {
-        let t = requested_token.unwrap_or_else(generate_token);
+        // #1281: reuse the persisted token across restarts. Rotating on every
+        // start silently 401'd any open dashboard tab — the Live view polls
+        // /api/* and just stayed empty. Precedence: --auth-token > env >
+        // saved dashboard.token (0600) > freshly generated.
+        let t = requested_token
+            .or_else(|| load_saved_token().filter(|s| !s.is_empty()))
+            .unwrap_or_else(generate_token);
         Some(Arc::new(t))
     } else {
         if requested_token.is_some() {

--- a/rust/src/dashboard/routes/memory.rs
+++ b/rust/src/dashboard/routes/memory.rs
@@ -18,6 +18,62 @@ pub(super) fn handle(
     }
 }
 
+/// #1284: today's (UTC) totals from metering.jsonl — input tokens, saved
+/// tokens, and native_shell_passthrough call count. Unlike the savings ledger,
+/// metering records EVERY ctx_* call including zero-saving ones, so this is
+/// the honest denominator. Cached on file length: the Live view polls every
+/// few seconds and the file is append-only.
+fn today_metering_summary() -> (u64, u64, u64) {
+    use std::sync::Mutex;
+    static CACHE: Mutex<Option<(u64, (u64, u64, u64))>> = Mutex::new(None);
+
+    let Ok(store) = crate::core::metering::MeterStore::from_data_dir() else {
+        return (0, 0, 0);
+    };
+    let len = std::fs::metadata(store.path())
+        .map(|m| m.len())
+        .unwrap_or(0);
+    if let Ok(guard) = CACHE.lock()
+        && let Some((cached_len, result)) = *guard
+        && cached_len == len
+    {
+        return result;
+    }
+
+    let today = Utc::now().format("%Y-%m-%d").to_string();
+    let mut input = 0u64;
+    let mut saved = 0u64;
+    let mut passthrough = 0u64;
+    if let Ok(content) = std::fs::read_to_string(store.path()) {
+        // Append-only and chronological: walk from the end, stop at yesterday.
+        for line in content.lines().rev() {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).unwrap_or("");
+            if !ts.starts_with(&today) {
+                break;
+            }
+            input += v
+                .get("input_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            saved += v
+                .get("savings_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            if v.get("tool_name").and_then(|t| t.as_str()) == Some("native_shell_passthrough") {
+                passthrough += 1;
+            }
+        }
+    }
+    let result = (input, saved, passthrough);
+    if let Ok(mut guard) = CACHE.lock() {
+        *guard = Some((len, result));
+    }
+    result
+}
+
 fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str, String)> {
     match path {
         "/api/episodes" => {
@@ -121,6 +177,12 @@ fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str
                 .find(|(d, ..)| d == &today)
                 .map(|(_, s, u, b)| (*s, *u, *b))
                 .unwrap_or((0, 0.0, 0));
+            // #1284: the ledger only records calls that saved something, so its
+            // percentage is "of compression events", not "of everything the
+            // agent did". Ship the metering view (ALL metered ctx_* calls,
+            // zero-saving ones included) and the native-passthrough count next
+            // to it so the panel can label the denominator honestly.
+            let (metered_input, metered_saved, native_passthrough) = today_metering_summary();
             let compression_session = serde_json::json!({
                 "savings_tokens": today_saved,
                 "total_raw": today_baseline,
@@ -129,6 +191,14 @@ fn get_routes(path: &str, query_str: &str) -> Option<(&'static str, &'static str
                     today_saved as f64 * 100.0 / today_baseline as f64
                 } else { 0.0 },
                 "savings_usd": today_usd,
+                // #1284 honesty fields (today, UTC):
+                "scope": "savings ledger — compression events only; metered_* covers every metered ctx_* call incl. zero-saving ones",
+                "metered_input_tokens": metered_input,
+                "metered_saved_tokens": metered_saved,
+                "savings_percent_of_metered": if metered_input > 0 {
+                    metered_saved as f64 * 100.0 / metered_input as f64
+                } else { 0.0 },
+                "native_passthrough_calls": native_passthrough,
             });
 
             let global = crate::core::stats::load_for_display();

--- a/rust/src/dashboard/static/components/cockpit-live.js
+++ b/rust/src/dashboard/static/components/cockpit-live.js
@@ -699,6 +699,12 @@ class CockpitLive extends HTMLElement {
       sessionSaved = windowStats.saved;
       sessionOrig = windowStats.original;
     }
+    // #1284 honesty fields: metered_* covers EVERY metered ctx_* call today
+    // (zero-saving ones included); native passthroughs bypassed lean-ctx
+    // entirely and are counted, not tokenized.
+    var meteredInput = comp ? Number(comp.metered_input_tokens || 0) : 0;
+    var meteredPct = comp ? Math.round(Number(comp.savings_percent_of_metered || 0)) : 0;
+    var nativePassthrough = comp ? Number(comp.native_passthrough_calls || 0) : 0;
 
     var allTimeSaved = 0;
     if (stats) {
@@ -735,7 +741,15 @@ class CockpitLive extends HTMLElement {
       esc(ff(sessionSaved)) +
       '</div>' +
       (sessionOrig > 0
-        ? '<p class="hs">of ' + esc(ff(sessionOrig)) + ' original tokens</p>'
+        ? '<p class="hs">of ' + esc(ff(sessionOrig)) + ' tokens in compression events' +
+          (meteredInput > 0
+            ? ' · ' + esc(String(meteredPct)) + '% of all ' + esc(ff(meteredInput)) + ' metered tokens'
+            : '') +
+          (nativePassthrough > 0
+            ? ' · <span title="native shell calls that bypassed lean-ctx — token volume unmetered">' +
+              esc(ff(nativePassthrough)) + ' native passthrough</span>'
+            : '') +
+          '</p>'
         : '<p class="hs">verified savings today</p>') +
       '</div>' +
       '<div class="hc">' +

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -674,15 +674,31 @@ fn run_inner(json: bool) -> u32 {
         board.info(lsp_check);
     }
 
-    // Shadow mode status
+    // Shadow mode status. #1280: the old single line claimed "native tools
+    // denied" wholesale, but that guarantee only covers Read/Grep/Glob — shell
+    // coverage depends on shell_hook_mode (rewrite hooks pass unknown commands
+    // through raw). Report the two surfaces separately so users audit against
+    // reality.
     let cfg = crate::core::config::Config::load();
+    let shell_mode = std::env::var("LEAN_CTX_SHELL_HOOK_MODE")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| cfg.shell_hook_mode.clone())
+        .unwrap_or_default();
+    let shell_desc = if shell_mode.trim().eq_ignore_ascii_case("deny") {
+        format!("{GREEN}deny{RST} {DIM}(all shell via ctx_shell){RST}")
+    } else {
+        format!(
+            "{YELLOW}rewrite{RST} {DIM}(unknown commands pass through raw — shell_hook_mode=deny closes this){RST}"
+        )
+    };
     let shadow_line = if cfg.shadow_mode {
         format!(
-            "{BOLD}Shadow mode{RST}  {GREEN}active{RST}  {DIM}(native tools denied → ctx_* mandatory){RST}"
+            "{BOLD}Shadow mode{RST}  {GREEN}active{RST}  {DIM}(Read/Grep/Glob denied → ctx_* mandatory){RST}  shell: {shell_desc}"
         )
     } else {
         format!(
-            "{BOLD}Shadow mode{RST}  {DIM}disabled{RST}  {DIM}(default: on — explicitly disabled via config){RST}"
+            "{BOLD}Shadow mode{RST}  {DIM}disabled{RST}  {DIM}(default: on — explicitly disabled via config){RST}  shell: {shell_desc}"
         )
     };
     if !json {

--- a/rust/src/hook_handlers/deny.rs
+++ b/rust/src/hook_handlers/deny.rs
@@ -327,14 +327,54 @@ fn print_deny_compression_markers(tool_name: &str, payload: &str) {
              Set LEAN_CTX_ALLOW_COMPRESSED_WRITE=1 to override."
         ),
     };
+    emit_deny(&msg, payload);
+}
+
+/// Emit a deny verdict in every hook dialect at once, then exit.
+///
+/// #1277: the legacy output (`{"decision":"deny",...}` + exit 2) left Claude
+/// Code blind — it expects `hookSpecificOutput.permissionDecision` on exit 0,
+/// or a stderr message on exit 2, and rendered the old shape as
+/// "PreToolUse hook error: No stderr output". The call still blocked, but the
+/// model got no guidance to switch to ctx_*.
+///
+/// Strategy:
+/// - stdout: one JSON object carrying the Cursor legacy keys, the Copilot
+///   top-level `permissionDecision`, and the Claude Code `hookSpecificOutput`.
+/// - stderr: the plain reason (Claude Code surfaces stderr on exit 2).
+/// - exit code: 0 for Claude-Code-shaped payloads (`transcript_path` marker)
+///   so the JSON verdict renders as a clean permission denial; 2 for every
+///   other host, matching their historical exit-code contract.
+fn emit_deny(msg: &str, payload: &str) -> ! {
     let output = serde_json::json!({
+        // Cursor legacy dialect.
         "decision": "deny",
         "reason": msg,
         "permission": "deny",
-        "user_message": msg
+        "user_message": msg,
+        // GitHub Copilot CLI dialect (top-level permissionDecision).
+        "permissionDecision": "deny",
+        // Claude Code / CodeBuddy dialect.
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": msg
+        }
     });
     println!("{output}");
+    eprintln!("{msg}");
+    if payload_is_claude_code(payload) {
+        std::process::exit(0);
+    }
     std::process::exit(2);
+}
+
+/// Claude Code hook payloads carry `transcript_path` (and `hook_event_name`);
+/// no other supported host sends a transcript path. Used only to pick the exit
+/// code Claude Code renders best — the JSON body is host-complete either way.
+fn payload_is_claude_code(payload: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(payload)
+        .is_ok_and(|v| v.get("transcript_path").is_some())
 }
 
 #[derive(Debug)]
@@ -377,14 +417,7 @@ fn detect_marker_source(payload: &str) -> MarkerSource {
 }
 fn print_smart_deny(tool_name: &str, payload: &str) {
     let msg = smart_deny_message(tool_name, payload);
-    let output = serde_json::json!({
-        "decision": "deny",
-        "reason": msg,
-        "permission": "deny",
-        "user_message": msg
-    });
-    println!("{output}");
-    std::process::exit(2);
+    emit_deny(&msg, payload);
 }
 
 /// Build a smart deny message that includes the exact ctx_* call with mapped arguments.

--- a/rust/src/hook_handlers/file_rewrite.rs
+++ b/rust/src/hook_handlers/file_rewrite.rs
@@ -86,6 +86,22 @@ pub(super) fn compute_rewrite() -> String {
                 &cmd,
                 rewrite_skip_reason(&cmd),
             );
+            // #1285: native passthrough was structurally invisible — only
+            // ctx_* calls reach metering.jsonl, so a session leaking reads
+            // through raw Bash showed a clean savings rate. Count every
+            // passthrough (token volumes are unknown pre-exec, so zeros) so
+            // the dashboard's per-tool table shows the leak as a call count.
+            // Synchronous append: hooks are plain CLI processes without a
+            // Tokio reactor, so `append_best_effort` (spawn_blocking) is
+            // unavailable here.
+            if let Ok(store) = crate::core::metering::MeterStore::from_data_dir() {
+                let _ = store.append(&crate::core::metering::MeterEntry::new(
+                    "native_shell_passthrough",
+                    0,
+                    0,
+                    0,
+                ));
+            }
             build_dual_allow_output()
         }
     })

--- a/rust/src/hook_handlers/file_rewrite.rs
+++ b/rust/src/hook_handlers/file_rewrite.rs
@@ -284,7 +284,10 @@ pub(super) fn rewrite_file_read_command(cmd: &str, binary: &str) -> Option<Strin
     // Unix file-read commands come from the central registry; PowerShell-native
     // cmdlets (Get-Content/gc) are detected here so they are not added to the POSIX
     // shell-alias/registry surface (#561).
-    if !rewrite_registry::is_file_read_command(cmd) && !is_powershell_file_read(cmd) {
+    if !rewrite_registry::is_file_read_command(cmd)
+        && !is_powershell_file_read(cmd)
+        && !is_sed_or_awk_line_read(cmd)
+    {
         return None;
     }
 
@@ -305,12 +308,22 @@ pub(super) fn rewrite_file_read_command(cmd: &str, binary: &str) -> Option<Strin
 
     match parts[0].as_str() {
         "cat" => {
-            let path = parts[1..].join(" ");
-            if is_outside_project_path(&path) {
+            // #1279: only a single flag-free path maps faithfully onto `read`.
+            // `cat a.md b.md` used to collapse into `read "a.md b.md"` (one
+            // bogus path) and `cat -n f` into `read "-n f"`. Decline those —
+            // the wrap/passthrough paths own them. A quoted path containing
+            // spaces is one token after shell_tokenize, so it still matches.
+            if parts.len() != 2 || parts[1].starts_with('-') {
                 return None;
             }
-            Some(format!("{binary} read {}", shell_quote(&path)))
+            let path = parts[1].as_str();
+            if is_outside_project_path(path) {
+                return None;
+            }
+            Some(format!("{binary} read {}", shell_quote(path)))
         }
+        "sed" => rewrite_sed_range_print(&parts, binary),
+        "awk" => rewrite_awk_line_range(&parts, binary),
         "head" => {
             let refs: Vec<&str> = parts[1..].iter().map(String::as_str).collect();
             let (n, path) = parse_head_tail_args(&refs);
@@ -343,6 +356,81 @@ pub(super) fn rewrite_file_read_command(cmd: &str, binary: &str) -> Option<Strin
 /// True if the command is a PowerShell-native file-read cmdlet (`Get-Content`/`gc`).
 fn is_powershell_file_read(cmd: &str) -> bool {
     matches!(cmd.split_whitespace().next(), Some("Get-Content" | "gc"))
+}
+
+/// True if the command starts with sed/awk — candidates for the line-range
+/// read rewrites (#1279). Detected here rather than in the registry so plain
+/// sed/awk stay off the generic rewrite surface.
+fn is_sed_or_awk_line_read(cmd: &str) -> bool {
+    matches!(cmd.split_whitespace().next(), Some("sed" | "awk"))
+}
+
+/// #1279: `sed -n 'N,Mp' file` / `sed -n 'Np' file` are line-range reads —
+/// the exact form agent auto-modes recommend for reading files, and until now
+/// a silent passthrough that bypassed lean-ctx entirely. Map them to
+/// `read -m lines:N-M`; every other sed invocation passes through untouched.
+fn rewrite_sed_range_print(parts: &[String], binary: &str) -> Option<String> {
+    if parts.len() != 4 || parts[1] != "-n" {
+        return None;
+    }
+    let (start, end) = parse_line_print_expr(&parts[2])?;
+    let path = parts[3].as_str();
+    if path.starts_with('-') || is_outside_project_path(path) {
+        return None;
+    }
+    Some(format!(
+        "{binary} read {} -m lines:{start}-{end}",
+        shell_quote(path)
+    ))
+}
+
+/// Parses a sed print expression `N,Mp` or `Np` (quotes already stripped by
+/// shell_tokenize). Returns the inclusive 1-based line range.
+fn parse_line_print_expr(expr: &str) -> Option<(u64, u64)> {
+    let body = expr.strip_suffix('p')?;
+    let (a, b) = match body.split_once(',') {
+        Some((a, b)) => (a, b),
+        None => (body, body),
+    };
+    let start: u64 = a.parse().ok()?;
+    let end: u64 = b.parse().ok()?;
+    (start >= 1 && end >= start).then_some((start, end))
+}
+
+/// #1279: `awk 'NR<=N' file` (plus `NR<N`, `NR==N`) are line-limited reads.
+/// Anything beyond a bare NR comparison (actions, field refs, `&&`) declines.
+fn rewrite_awk_line_range(parts: &[String], binary: &str) -> Option<String> {
+    if parts.len() != 3 {
+        return None;
+    }
+    let (start, end) = parse_awk_nr_expr(&parts[1])?;
+    let path = parts[2].as_str();
+    if path.starts_with('-') || is_outside_project_path(path) {
+        return None;
+    }
+    Some(format!(
+        "{binary} read {} -m lines:{start}-{end}",
+        shell_quote(path)
+    ))
+}
+
+/// Parses a bare awk NR comparison (`NR<=N` / `NR<N` / `NR==N`) into an
+/// inclusive line range.
+fn parse_awk_nr_expr(expr: &str) -> Option<(u64, u64)> {
+    let rest = expr.strip_prefix("NR")?;
+    if let Some(n) = rest.strip_prefix("<=") {
+        let n: u64 = n.parse().ok()?;
+        return (n >= 1).then_some((1, n));
+    }
+    if let Some(n) = rest.strip_prefix("==") {
+        let n: u64 = n.parse().ok()?;
+        return (n >= 1).then_some((n, n));
+    }
+    if let Some(n) = rest.strip_prefix('<') {
+        let n: u64 = n.parse().ok()?;
+        return (n >= 2).then_some((1, n - 1));
+    }
+    None
 }
 
 /// Maps `Get-Content`/`gc` to `lean-ctx read`, honoring `-Path`/`-LiteralPath`, the
@@ -499,20 +587,60 @@ pub(super) fn build_rewrite_compound(cmd: &str, binary: &str) -> Option<String> 
         return None;
     }
 
-    // Nothing lean-ctx could compress/redirect → leave it to the native shell.
-    if !commands.iter().any(|c| is_rewritable(c)) {
-        return None;
+    // Wrap-whole when a registry-rewritable segment exists AND the compound
+    // passes the allowlist gate (compression), OR when security is active and
+    // the compound violates the allowlist (#1408: enforcement). The #589 "no
+    // new block" concern only applies when the user has shell_security = off —
+    // in that case lean-ctx -c won't enforce anyway.
+    if commands.iter().any(|c| is_rewritable(c))
+        && (crate::core::shell_allowlist::passes_enforced(cmd) || needs_enforcement_wrap(cmd))
+    {
+        return Some(wrap_single_command(cmd, binary));
     }
 
-    // Wrap-whole when the compound passes the allowlist gate (compression), OR
-    // when security is active and the compound violates the allowlist (#1408:
-    // enforcement). The #589 "no new block" concern only applies when the user
-    // has shell_security = off — in that case lean-ctx -c won't enforce anyway.
-    if crate::core::shell_allowlist::passes_enforced(cmd) || needs_enforcement_wrap(cmd) {
-        Some(wrap_single_command(cmd, binary))
-    } else {
-        None
+    // #1279: segment-wise fallback. `echo hi && cat f` used to escape whole —
+    // wrap-whole declined (lead segment not allowlist-relevant) and the
+    // rewritable tail stayed native. For `&&`/`||`/`;` chains without pipes,
+    // rewrite each directly-mappable file-read segment in place and keep the
+    // rest native.
+    rewrite_segments_in_place(&segments, binary)
+}
+
+/// Rewrites file-read segments of a `&&`/`||`/`;` chain in place (#1279).
+/// Declines whole when the chain contains a pipe: a rewritten left side would
+/// feed different bytes into the consumer on the right.
+pub(super) fn rewrite_segments_in_place(
+    segments: &[compound_lexer::Segment],
+    binary: &str,
+) -> Option<String> {
+    use compound_lexer::Segment;
+    if segments
+        .iter()
+        .any(|s| matches!(s, Segment::Operator(op) if op == "|"))
+    {
+        return None;
     }
+    let mut out = String::new();
+    let mut rewrote = false;
+    for seg in segments {
+        match seg {
+            Segment::Operator(op) => {
+                out.push(' ');
+                out.push_str(op);
+                out.push(' ');
+            }
+            Segment::Command(c) => {
+                let c = c.trim();
+                if let Some(r) = rewrite_file_read_command(c, binary) {
+                    out.push_str(&r);
+                    rewrote = true;
+                } else {
+                    out.push_str(c);
+                }
+            }
+        }
+    }
+    rewrote.then_some(out)
 }
 
 /// Package-manager install/add/remove commands produce interactive progress

--- a/rust/src/hook_handlers/mod.rs
+++ b/rust/src/hook_handlers/mod.rs
@@ -272,7 +272,29 @@ fn is_shell_tool(tool_name: &str) -> bool {
 }
 
 pub fn handle_rewrite() {
+    // #1278: `shell_hook_mode = "deny"` upgrades the shell hook from rewrite
+    // (best-effort, unknown commands pass through raw) to a hard deny with the
+    // deny hook's fail-opens. Routed here so existing installs — whose settings
+    // wire `hook rewrite` for Bash — pick the mode up from config alone,
+    // without rewriting user settings files.
+    if shell_deny_mode_active() {
+        deny::handle_deny();
+        return;
+    }
     emit_gating_decision(HOOK_GATING_TIMEOUT, file_rewrite::compute_rewrite);
+}
+
+/// Effective shell-hook mode is `deny` (#1278). Env wins over config so a
+/// single session can be forced either way without touching config.toml.
+fn shell_deny_mode_active() -> bool {
+    let mode = match std::env::var("LEAN_CTX_SHELL_HOOK_MODE") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => crate::core::config::Config::load()
+            .shell_hook_mode
+            .clone()
+            .unwrap_or_default(),
+    };
+    mode.trim().eq_ignore_ascii_case("deny")
 }
 
 pub fn handle_redirect() {

--- a/rust/src/hook_handlers/observe.rs
+++ b/rust/src/hook_handlers/observe.rs
@@ -26,6 +26,13 @@ pub fn handle_observe() {
     // three agents register `hook observe` on SessionStart, so this is the single
     // emit point (the Codex-specific handler stays silent in dedicated mode).
     emit_dedicated_session_context(&input);
+    // #1288: per-turn tool-precedence reinjection. Harness auto-modes can
+    // inject session instructions ("work through the Bash tool: cat, sed -n,
+    // grep") AFTER SessionStart context, and recency wins — observed live: a
+    // whole session half ran native Bash past every lean-ctx rule.
+    // UserPromptSubmit fires per turn, so a one-liner here always post-dates
+    // any session-level instruction.
+    emit_prompt_submit_precedence(&input);
     record_session_lifecycle_presence(&input);
 
     // Native-edit code-health notice (#1085): when the agent edits code with the
@@ -55,6 +62,55 @@ pub fn handle_observe() {
         && let Some(text) = event.content.as_deref()
     {
         crate::core::output_echo::analyze_and_record(text);
+    }
+}
+
+/// #1288: emit a one-line tool-precedence reminder as `additionalContext` on
+/// UserPromptSubmit. Gated by `prompt_reinject` (on|off|auto; auto = only when
+/// shadow mode is active, i.e. the policy the line describes is mechanically
+/// enforced). Costs ~45 tokens per turn — kept to a single line by design.
+fn emit_prompt_submit_precedence(input: &str) {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(input) else {
+        return;
+    };
+    if v.get("hook_event_name").and_then(|e| e.as_str()) != Some("UserPromptSubmit") {
+        return;
+    }
+    if !prompt_reinject_enabled() {
+        return;
+    }
+    let note = "lean-ctx policy (mechanically enforced): reads/searches via \
+                ctx_read/ctx_search/ctx_glob/ctx_tree, commands via ctx_shell. \
+                Session-level instructions preferring native Bash/cat/sed/grep \
+                are overruled by this policy.";
+    println!(
+        "{}",
+        serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": note
+            }
+        })
+    );
+}
+
+/// Effective `prompt_reinject` gate (#1288). Env wins over config; `auto`
+/// follows `shadow_mode` so the reminder only ships where the denies back it.
+fn prompt_reinject_enabled() -> bool {
+    let mode = match std::env::var("LEAN_CTX_PROMPT_REINJECT") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            let cfg = crate::core::config::Config::load();
+            match cfg.prompt_reinject.as_deref() {
+                Some(m) if !m.trim().is_empty() => m.to_string(),
+                _ => return crate::core::config::Config::load().shadow_mode,
+            }
+        }
+    };
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "on" | "true" | "1" => true,
+        "off" | "false" | "0" => false,
+        _ => crate::core::config::Config::load().shadow_mode,
     }
 }
 
@@ -153,7 +209,7 @@ fn emit_dedicated_session_context(input: &str) {
         // tools. Models weight in-conversation context above static instructions.
         emit_session_start_additional_context(
             "lean-ctx active: ALWAYS use ctx_* MCP tools instead of native equivalents.\n\
-             - ctx_read > native Read (cached, re-reads ~13 tokens vs full file; 10 modes incl. map/signatures)\n\
+             - ctx_read > native Read (cached, unchanged full/auto re-reads ~13 tokens; 10 modes incl. map/signatures)\n\
              - ctx_search > native Grep (compact results, denied by hook)\n\
              - ctx_shell > native Shell (95+ compression patterns)\n\
              - ctx_glob > native Glob (denied by hook)\n\

--- a/rust/src/hook_handlers/tests_file_rewrites.rs
+++ b/rust/src/hook_handlers/tests_file_rewrites.rs
@@ -16,6 +16,99 @@ fn file_read_rewrite_cat() {
     assert_eq!(r, Some("lean-ctx read src/main.rs".to_string()));
 }
 
+/// #1279: `cat a b` used to collapse into `read "a b"` (one bogus path) and
+/// `cat -n f` into `read "-n f"`. Both must decline instead.
+#[test]
+fn file_read_cat_declines_multi_file_and_flags() {
+    assert_eq!(rewrite_file_read_command("cat a.md b.md", "lean-ctx"), None);
+    assert_eq!(
+        rewrite_file_read_command("cat -n src/main.rs", "lean-ctx"),
+        None
+    );
+    // A quoted path with spaces is one token — still rewritten.
+    assert_eq!(
+        rewrite_file_read_command("cat 'my file.md'", "lean-ctx"),
+        Some("lean-ctx read \"my file.md\"".to_string())
+    );
+}
+
+/// #1279: sed -n range prints are line-range reads — the exact form agent
+/// auto-modes recommend, previously a silent passthrough.
+#[test]
+fn file_read_rewrite_sed_range_print() {
+    assert_eq!(
+        rewrite_file_read_command("sed -n '1,90p' src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:1-90".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("sed -n '42p' src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:42-42".to_string())
+    );
+    // Write-mode, open-ended, and regex sed forms must never be touched.
+    assert_eq!(
+        rewrite_file_read_command("sed -i 's/a/b/' f.rs", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_file_read_command("sed -n '5,$p' f.rs", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_file_read_command("sed -n '/foo/p' f.rs", "lean-ctx"),
+        None
+    );
+}
+
+/// #1279: bare awk NR comparisons are line-limited reads.
+#[test]
+fn file_read_rewrite_awk_nr() {
+    assert_eq!(
+        rewrite_file_read_command("awk 'NR<=20' src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:1-20".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("awk 'NR<20' src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:1-19".to_string())
+    );
+    assert_eq!(
+        rewrite_file_read_command("awk 'NR==7' src/main.rs", "lean-ctx"),
+        Some("lean-ctx read src/main.rs -m lines:7-7".to_string())
+    );
+    // Anything beyond a bare NR comparison declines.
+    assert_eq!(
+        rewrite_file_read_command("awk '{print $1}' f.rs", "lean-ctx"),
+        None
+    );
+    assert_eq!(
+        rewrite_file_read_command("awk 'NR>5 && NR<10 {print}' f.rs", "lean-ctx"),
+        None
+    );
+}
+
+/// #1279: chains whose lead segment is not rewritable used to escape whole.
+/// Now the rewritable file-read segments are rewritten in place.
+#[test]
+fn compound_segments_rewritten_in_place() {
+    assert_eq!(
+        build_rewrite_compound("echo hi && cat src/main.rs", "lean-ctx"),
+        Some("echo hi && lean-ctx read src/main.rs".to_string())
+    );
+    assert_eq!(
+        build_rewrite_compound("echo hi && sed -n '1,30p' src/main.rs", "lean-ctx"),
+        Some("echo hi && lean-ctx read src/main.rs -m lines:1-30".to_string())
+    );
+    // Pipes change consumer semantics — segment-wise rewriting must decline.
+    assert_eq!(
+        super::file_rewrite::rewrite_segments_in_place(
+            &crate::compound_lexer::split_compound("cat f.rs | grep foo"),
+            "lean-ctx"
+        ),
+        None
+    );
+    // A chain with nothing rewritable stays untouched.
+    assert_eq!(build_rewrite_compound("echo a && echo b", "lean-ctx"), None);
+}
+
 #[test]
 fn rewrite_skip_reason_tracks_candidate_none_branches() {
     // Every command that `rewrite_candidate` declines must get a stable,

--- a/rust/src/hooks/agents/claude.rs
+++ b/rust/src/hooks/agents/claude.rs
@@ -306,7 +306,7 @@ const CLAUDE_MD_BLOCK_CONTENT_MCP: &str = "\
 ## lean-ctx — Context Runtime
 
 When the `ctx_*` MCP tools are listed in this session, prefer them over native equivalents:
-- `ctx_read` instead of `Read` / `cat` for exploration (cached, 10 modes, re-reads ~13 tokens)
+- `ctx_read` instead of `Read` / `cat` for exploration (cached, 10 modes, unchanged full/auto re-reads ~13 tokens)
 - `ctx_shell` instead of `bash` / `Shell` (95+ compression patterns)
 - `ctx_search` instead of `Grep` / `rg` (compact results)
 - `ctx_tree` instead of `ls` / `find` (compact directory maps)
@@ -328,7 +328,7 @@ const CLAUDE_MD_BLOCK_CONTENT_REPLACE: &str = "\
 ## lean-ctx — Replace Mode (native Grep/Glob denied by policy)
 
 Native Grep/Glob are denied by policy. Prefer `ctx_*` MCP tools for project work:
-- `ctx_read` for exploration reads (cached, 10 modes, re-reads ~13 tokens)
+- `ctx_read` for exploration reads (cached, 10 modes, unchanged full/auto re-reads ~13 tokens)
 - `ctx_shell` for shell commands (95+ compression patterns)
 - `ctx_search` instead of Grep/rg (compact results)
 - `ctx_tree` instead of ls/find (compact directory maps)

--- a/rust/src/hooks/agents/codebuddy.rs
+++ b/rust/src/hooks/agents/codebuddy.rs
@@ -172,7 +172,7 @@ const CODEBUDDY_MD_BLOCK_CONTENT_REPLACE: &str = "\
 ## lean-ctx — Replace Mode (native Grep/Glob/Bash denied by policy)
 
 Native Grep/Glob/Bash are denied by policy. Prefer `ctx_*` MCP tools for project work:
-- `ctx_read` for exploration reads (cached, 10 modes, re-reads ~13 tokens)
+- `ctx_read` for exploration reads (cached, 10 modes, unchanged full/auto re-reads ~13 tokens)
 - `ctx_shell` for shell commands (95+ compression patterns)
 - `ctx_search` instead of Grep/rg (compact results)
 - `ctx_tree` instead of ls/find (compact directory maps)
@@ -193,7 +193,7 @@ const CODEBUDDY_MD_BLOCK_CONTENT_MCP: &str = "\
 ## lean-ctx — Context Runtime
 
 When the `ctx_*` MCP tools are listed in this session, prefer them over native equivalents:
-- `ctx_read` instead of `Read` / `cat` for exploration (cached, 10 modes, re-reads ~13 tokens)
+- `ctx_read` instead of `Read` / `cat` for exploration (cached, 10 modes, unchanged full/auto re-reads ~13 tokens)
 - `ctx_shell` instead of `bash` / `Shell` (95+ compression patterns)
 - `ctx_search` instead of `Grep` / `rg` (compact results)
 - `ctx_tree` instead of `ls` / `find` (compact directory maps)

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -581,7 +581,7 @@ pub fn replace_rules_content() -> String {
         "{start}\n<!-- version: {version} -->\n\n\
 # lean-ctx \u{2014} Replace Mode (native tools denied)\n\n\
 Native Read/Grep/Glob/Bash are denied by policy. Use ONLY ctx_* MCP tools:\n\
-- ctx_read for ALL file reads (cached, 10 modes, re-reads ~13 tokens)\n\
+- ctx_read for ALL file reads (cached, 10 modes, unchanged full/auto re-reads ~13 tokens)\n\
 - ctx_shell for ALL shell commands (95+ compression patterns)\n\
 - ctx_search instead of Grep/rg (compact results)\n\
 - ctx_tree instead of ls/find (compact directory maps)\n\

--- a/rust/src/http_server/mod.rs
+++ b/rust/src/http_server/mod.rs
@@ -660,7 +660,7 @@ async fn mcp_server_card() -> impl IntoResponse {
         ],
         "features": {
             "compression": "deterministic AST-based, 40-70% token reduction",
-            "caching": "session-scoped with zstd, re-reads ~13 tokens",
+            "caching": "session-scoped with zstd, unchanged full/auto re-reads ~13 tokens",
             "audit_trail": "SHA-256 chained JSONL",
             "rbac": "5 built-in roles with capability-based access",
             "sandboxing": "Level 0 (subprocess) + Level 1 (OS-level)",

--- a/rust/src/shell/compress/engine.rs
+++ b/rust/src/shell/compress/engine.rs
@@ -584,7 +584,14 @@ fn compress_if_beneficial_with_exit(
         if level.is_active() {
             let terse_result =
                 crate::core::terse::pipeline::compress(output, &level, Some(&compressed));
-            if terse_result.quality_passed {
+            // #1286: the terse result may only REPLACE the pattern compressor's
+            // output when it is actually smaller. It used to win on
+            // quality_passed alone — measured: `ls -la` had its ~80%-saving
+            // structural compression displaced by a ~6% terse dictionary pass.
+            if terse_result.quality_passed
+                && count_tokens_for(&terse_result.output, family)
+                    < count_tokens_for(&compressed, family)
+            {
                 compressed = terse_result.output;
             }
         }

--- a/rust/src/shell/compress/tests_engine.rs
+++ b/rust/src/shell/compress/tests_engine.rs
@@ -1,5 +1,47 @@
 #[allow(unused_imports)]
 use super::*;
+
+/// #1286: `ls -la` long-format output must reach the structural ls compressor
+/// (name + size per entry) instead of degrading to the generic terse fallback.
+/// Regression guard for two independent breakages: the zsh spawn preamble
+/// leaking into the classified command, and the terse stage displacing a
+/// smaller pattern result.
+#[cfg(test)]
+mod ls_structural_compression {
+    #[test]
+    fn ls_long_listing_compresses_structurally() {
+        let mut output = String::from("total 11168\n");
+        for i in 0..400 {
+            output.push_str(&format!(
+                "-rw-r--r--@   1 yvesgugger  staff  {} Aug  9 21:51 file_{i}.rs\n",
+                1000 + i
+            ));
+        }
+        for i in 0..60 {
+            output.push_str(&format!(
+                "drwxr-xr-x@   5 yvesgugger  staff  160 Aug  9 21:51 dir_{i}\n"
+            ));
+        }
+        let compressed =
+            super::super::engine::compress_if_beneficial("ls -la rust/src/core", &output);
+        assert!(
+            compressed.len() < output.len() / 2,
+            "structural ls compression must at least halve the payload \
+             ({} -> {} bytes)",
+            output.len(),
+            compressed.len()
+        );
+        assert!(
+            compressed.contains("400 files, 60 dirs"),
+            "summary line from the ls compressor must be present"
+        );
+        assert!(
+            compressed.contains("file_0.rs"),
+            "every entry name must survive"
+        );
+    }
+}
+
 /// #342: already-compact TOON output must be preserved verbatim (not recompressed)
 /// regardless of the command, because re-compressing it destroys the exact
 /// line/field shape agents use to validate CLI output contracts.

--- a/rust/src/shell/exec/execution.rs
+++ b/rust/src/shell/exec/execution.rs
@@ -250,7 +250,12 @@ pub fn exec(command: &str) -> i32 {
 
     let (shell, shell_flag) = super::super::platform::shell_and_flag();
     let command = crate::tools::ctx_shell::normalize_command_for_shell(command);
-    let command = super::super::platform::zsh_safe_command(&command, &shell);
+    // #1286: keep the zsh preamble (`setopt nonomatch noequals; `) OUT of the
+    // command string used for classification and compression — every
+    // `starts_with("ls ")`/`git`-style pattern matcher silently stopped
+    // matching under zsh (the default macOS shell), degrading pattern
+    // compression to the generic terse fallback. The preamble is applied to
+    // the SPAWNED command only, inside the exec helpers.
     let command = command.as_str();
 
     if super::super::reentry::is_disabled() {
@@ -422,9 +427,12 @@ fn split_simple_shell_words(command: &str) -> Option<Vec<SimpleShellWord>> {
 }
 
 fn exec_inherit(command: &str, shell: &str, shell_flag: &str) -> i32 {
+    // #1286: the zsh preamble is applied at spawn time only, so `command`
+    // stays clean for classification/compression upstream.
+    let spawn_command = super::super::platform::zsh_safe_command(command, shell);
     let mut cmd = Command::new(shell);
     cmd.arg(shell_flag)
-        .arg(command)
+        .arg(&spawn_command)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
@@ -443,9 +451,10 @@ fn exec_inherit(command: &str, shell: &str, shell_flag: &str) -> i32 {
 }
 
 fn exec_shell_default(command: &str, shell: &str, shell_flag: &str) -> i32 {
+    let spawn_command = super::super::platform::zsh_safe_command(command, shell);
     let mut cmd = Command::new(shell);
     cmd.arg(shell_flag)
-        .arg(command)
+        .arg(&spawn_command)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());

--- a/rust/src/shell/pipeline.rs
+++ b/rust/src/shell/pipeline.rs
@@ -18,6 +18,12 @@ pub(super) fn exec_buffered(
 
     let start = std::time::Instant::now();
 
+    // #1286: `command` is the clean user command (classification, compression,
+    // logging); the zsh preamble is added only to the string handed to the
+    // child shell.
+    let spawn_command = super::platform::zsh_safe_command(command, shell);
+    let spawn_command = spawn_command.as_str();
+
     let mut cmd = Command::new(shell);
 
     #[cfg(windows)]
@@ -51,20 +57,20 @@ pub(super) fn exec_buffered(
                         "lean-ctx: temp script unavailable ({e}); running PowerShell inline"
                     );
                     cmd.arg(shell_flag);
-                    cmd.arg(command);
+                    cmd.arg(spawn_command);
                     ps_tmp_path = None;
                 }
             }
         } else {
             cmd.arg(shell_flag);
-            cmd.arg(command);
+            cmd.arg(spawn_command);
             ps_tmp_path = None;
         }
     }
     #[cfg(not(windows))]
     {
         cmd.arg(shell_flag);
-        cmd.arg(command);
+        cmd.arg(spawn_command);
     }
 
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());

--- a/rust/src/tools/ctx_read/core_logic.rs
+++ b/rust/src/tools/ctx_read/core_logic.rs
@@ -158,6 +158,30 @@ pub(super) fn handle_with_options_inner(
                 tuning.aggressiveness,
                 tuning.protect,
             );
+            // #1287: a same-conversation re-read of the SAME variant of an
+            // unchanged file collapses to the ~15-token variant stub instead
+            // of re-emitting the identical payload. Staleness was verified
+            // above (a stale entry is invalidated before this point), and the
+            // conversation gate mirrors the full-content stub — stubs must
+            // never leak across chats (#1042). Fresh reads bypass the cache
+            // entirely, so `fresh=true` remains the escape hatch.
+            if super::dispatch::stub_policy_allows()
+                && let crate::core::cache::VariantDelivery::Conversation(delivered) =
+                    cache.compressed_delivered_conversation(path, &cache_key)
+                && crate::core::conversation::conversation_allows_stub(
+                    crate::core::conversation::current_conversation_id_fresh().as_deref(),
+                    Some(&delivered),
+                )
+            {
+                crate::core::telemetry::global_metrics().record_cache(true);
+                crate::core::auto_mode_resolver::count_source("compressed_cache_stub");
+                let stub =
+                    super::dispatch::render_unchanged_variant_stub(&file_ref, path, &resolved_mode);
+                crate::core::stats::record_reread(
+                    original_tokens.saturating_sub(stub.output_tokens),
+                );
+                return stub;
+            }
             let hit = cache.get_compressed(path, &cache_key).cloned();
             if let Some(cached_output) = &hit {
                 // get_compressed() already recorded the cache hit (stats + event)
@@ -669,15 +693,28 @@ mod tests {
             None,
         );
         assert!(r2.is_cache_hit, "second map read must hit compressed cache");
-        assert_eq!(
-            r2.content, r1.content,
-            "cached output must be byte-identical"
-        );
+        // #1287: with a resolvable conversation scope the hit collapses to the
+        // tiny variant stub; without one it re-serves the byte-identical
+        // payload. Both are cache hits — assert the matching invariant.
+        if r2.content.contains("unchanged map view") {
+            assert!(r2.content.contains("fresh=true"), "stub carries the escape");
+            assert!(
+                r2.output_tokens < r1.output_tokens,
+                "stub must be smaller than the payload"
+            );
+        } else {
+            assert_eq!(
+                r2.content, r1.content,
+                "cached output must be byte-identical"
+            );
+        }
 
         let counts = crate::core::auto_mode_resolver::source_counts();
         assert!(
-            counts.iter().any(|(k, _)| *k == "compressed_cache_hit"),
-            "compressed_cache_hit counter must fire; got: {counts:?}"
+            counts
+                .iter()
+                .any(|(k, _)| *k == "compressed_cache_hit" || *k == "compressed_cache_stub"),
+            "compressed cache counter must fire; got: {counts:?}"
         );
     }
 }

--- a/rust/src/tools/ctx_read/dispatch.rs
+++ b/rust/src/tools/ctx_read/dispatch.rs
@@ -538,14 +538,7 @@ pub(crate) fn try_stub_hit_readonly_scoped(
     path: &str,
     current_conversation: Option<&str>,
 ) -> Option<ReadOutput> {
-    let no_deg = crate::core::config::Config::load().no_degrade_effective();
-    let prof = crate::core::profiles::active_profile();
-    let force_full = no_deg
-        || (prof.read.default_mode_effective() == "full"
-            && prof.compression.crp_mode_effective() == "off");
-    let policy_allows_stub =
-        crate::server::compaction_sync::effective_cache_policy() != "safe" && !force_full;
-    if !policy_allows_stub {
+    if !stub_policy_allows() {
         return None;
     }
 
@@ -607,6 +600,18 @@ pub(crate) fn try_stub_hit_readonly_scoped(
     Some(render_unchanged_stub(&rec.file_ref, path, rec.line_count))
 }
 
+/// Whether the cache policy and active profile allow serving `[unchanged …]`
+/// stubs at all. Shared by the full-content stub path and the #1287 variant
+/// stub path so the two can never diverge.
+pub(crate) fn stub_policy_allows() -> bool {
+    let no_deg = crate::core::config::Config::load().no_degrade_effective();
+    let prof = crate::core::profiles::active_profile();
+    let force_full = no_deg
+        || (prof.read.default_mode_effective() == "full"
+            && prof.compression.crp_mode_effective() == "off");
+    crate::server::compaction_sync::effective_cache_policy() != "safe" && !force_full
+}
+
 /// Renders the `[unchanged …]` stub body shared by the warm and cold stub paths.
 ///
 /// #498 determinism: the stub is a pure function of (file_ref, path, line_count),
@@ -628,6 +633,30 @@ fn render_unchanged_stub(file_ref: &str, path: &str, line_count: usize) -> ReadO
     ReadOutput {
         content: out,
         resolved_mode: "full".into(),
+        output_tokens: sent,
+        is_cache_hit: true,
+    }
+}
+
+/// #1287: renders the `[unchanged <mode> view]` stub for a compressed-variant
+/// re-read — same conversation, unchanged file, same mode key. Mirrors
+/// [`render_unchanged_stub`]'s #498 determinism contract: a pure function of
+/// (file_ref, path, mode), so identical re-reads stay byte-stable and the
+/// static `fresh=true` escape survives non-meta mode.
+pub(crate) fn render_unchanged_variant_stub(file_ref: &str, path: &str, mode: &str) -> ReadOutput {
+    let short = protocol::shorten_path(path);
+    let out = if crate::core::protocol::meta_visible() {
+        format!(
+            "{file_ref}={short} [unchanged {mode} view]\nSame {mode} output you already received. Use fresh=true to re-emit.",
+        )
+    } else {
+        format!("{file_ref}={short} [unchanged {mode} view · fresh=true to re-emit]")
+    };
+    let out = crate::core::redaction::redact_text_if_enabled(&out);
+    let sent = count_tokens(&out);
+    ReadOutput {
+        content: out,
+        resolved_mode: mode.to_string(),
         output_tokens: sent,
         is_cache_hit: true,
     }

--- a/rust/src/tools/ctx_read/tests_modes.rs
+++ b/rust/src/tools/ctx_read/tests_modes.rs
@@ -1,6 +1,79 @@
 use super::*;
 use std::time::Duration;
 
+/// #1287: the variant stub is a pure function of (file_ref, path, mode) —
+/// byte-stable across identical re-reads (#498, provider prompt caching), tiny,
+/// and always carries the static `fresh=true` escape.
+#[test]
+fn variant_stub_is_byte_stable_and_tiny() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_META", "1");
+    let a = super::dispatch::render_unchanged_variant_stub("F3", "/src/router.js", "signatures");
+    let b = super::dispatch::render_unchanged_variant_stub("F3", "/src/router.js", "signatures");
+    assert_eq!(a.content, b.content, "identical inputs must be byte-stable");
+    assert!(a.content.contains("unchanged signatures view"));
+    assert!(a.content.contains("fresh=true"));
+    assert!(a.is_cache_hit);
+    assert_eq!(a.resolved_mode, "signatures");
+    assert!(
+        a.output_tokens < 40,
+        "stub must stay tiny, got {} tokens",
+        a.output_tokens
+    );
+    crate::test_env::remove_var("LEAN_CTX_META");
+}
+
+/// #1287 gate invariants, valid in every environment: when a conversation
+/// scope is resolvable (e.g. CLAUDECODE per-process scope), the same-scope
+/// variant re-read collapses to the tiny stub with the `fresh=true` escape;
+/// without a provably delivered conversation the full payload is re-served
+/// byte-identically — the stub must never appear on unknown delivery.
+#[test]
+fn variant_reread_stub_or_payload_invariants() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    let dir = std::env::temp_dir().join(format!("lean_ctx_vstub_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let p = dir.join("sample.rs");
+    let mut body = String::new();
+    for i in 0..80 {
+        use std::fmt::Write as _;
+        let _ = writeln!(
+            body,
+            "pub fn generated_function_{i}(value: usize) -> usize {{ value + {i} }}"
+        );
+    }
+    std::fs::write(&p, &body).expect("write sample file");
+    let path = p.to_str().expect("temp path is valid UTF-8");
+
+    let mut cache = SessionCache::new();
+    let first = super::dispatch::handle(&mut cache, path, "signatures", CrpMode::Off);
+    let second = super::dispatch::handle(&mut cache, path, "signatures", CrpMode::Off);
+    let _ = std::fs::remove_file(&p);
+
+    assert!(
+        !first.contains("unchanged signatures view"),
+        "first delivery must always be the real payload"
+    );
+    if second.contains("unchanged signatures view") {
+        // Positive path: a conversation scope was resolvable here.
+        assert!(second.contains("fresh=true"), "stub must carry the escape");
+        assert!(
+            second.len() < first.len() / 3,
+            "stub must be a fraction of the payload ({} vs {})",
+            second.len(),
+            first.len()
+        );
+    } else if second.contains("already in context") {
+        // Pre-existing legacy short-circuit (conversation scoping explicitly
+        // disabled: one daemon == one conversation by contract) — its own
+        // stub, not ours; small by construction.
+        assert!(second.len() < first.len() / 3);
+    } else {
+        // Conservative path: unknown delivery -> byte-identical payload.
+        assert_eq!(first, second, "variant cache hit must be byte-stable");
+    }
+}
+
 #[test]
 fn test_header_toon_format_no_brackets() {
     let _lock = crate::core::data_dir::test_env_lock();


### PR DESCRIPTION
Fixes thirteen issues tracked on the internal GitLab (GL #1277–#1289); full measurements and verification logs live in those issues and MR !132 there.

## Highlights
- **zsh pattern-classification bug**: the exec path prefixed every command with the zsh preamble (`setopt nonomatch noequals; `) *before* classification, so no `starts_with`-based pattern matcher ever fired on macOS/zsh — pattern compression silently degraded to the generic terse fallback. Preamble now applies at spawn time only. Measured: `ls -la` 6% → **71%** saved. Second bug: the terse stage displaced smaller pattern results on `quality_passed` alone.
- **variant re-read stubs**: map/signatures re-reads of unchanged files collapse to a ~15-token `[unchanged <mode> view]` stub, conversation-gated stricter than the full-content stub (unknown delivery never serves a stub).
- **honest metrics**: turn-multiplied `reread_tokens_saved` extrapolation removed (a lifetime-cumulative active set × cross-session turn counters had inflated it to ~119 trillion; sanitized on load). Session panel now shows ledger-% next to metered-% (live: 80.2% vs 47.7%) plus a native-passthrough counter.
- **hook layer**: `hook deny` speaks all three host dialects (was invisible to Claude Code as "hook error: No stderr output"); new `shell_hook_mode = auto|rewrite|deny` config; `sed -n`/`awk NR`/multi-file-`cat`/chain rewrite gaps closed; doctor line no longer overclaims.
- **dashboard**: bearer token persisted across restarts (open tabs no longer silently 401), BudgetWarning events rate-limited (103 of 200 ring slots in 5 min before).
- **per-turn precedence reinjection** (UserPromptSubmit `additionalContext`, `prompt_reinject` config) so session-level harness instructions can't override the ctx_* mandate.
- `make dev`: rm+cp+codesign — overwriting the installed Mach-O in place invalidated the ad-hoc signature on Apple Silicon (SIGKILL/exit 137).

## Verification
- 10,414/10,414 lib tests green on this exact head (rebased onto main), clippy clean, pre-commit gates (fmt, gen_docs, gen_rules, clippy -D warnings) passed on every commit.
- Every fix verified end-to-end against the dev-installed binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)