### PR TITLE
fix(triage): fail-safe level ladder, markdown-only lossy deletion, escape-hatch footer

### DIFF
--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -998,7 +998,7 @@ pub(in crate::server) async fn dispatch_and_post_process(
 /// `ctx_read` already owns mode selection and edit-safety guarantees. Running a
 /// second lossy pass after it resolved `auto` to `full` would hide content the
 /// caller must see (#1511), so every read result bypasses post-dispatch triage.
-fn triage_bypass_requested(
+pub(super) fn triage_bypass_requested(
     name: &str,
     args: Option<&serde_json::Map<String, serde_json::Value>>,
 ) -> bool {

--- a/rust/src/server/call_tool/tests.rs
+++ b/rust/src/server/call_tool/tests.rs
@@ -2,6 +2,60 @@
 use super::super::*;
 use super::{finalize_call_result, roots_list_failure_is_permanent};
 
+/// Community regression (3.9.19): every documented lossless escape hatch was
+/// ignored — triage ran after the compression pipeline, so per-call
+/// parameters never reached it. These pins guarantee the bypass contract
+/// stays wired at the dispatch chokepoint.
+mod triage_bypass_tests {
+    use super::super::pipeline::triage_bypass_requested;
+
+    fn args(json: &serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        json.as_object().expect("test args are an object").clone()
+    }
+
+    #[test]
+    fn ctx_read_is_always_exempt() {
+        // ctx_read delivers file content agents edit against — and its cache
+        // marks content as fully delivered BEFORE the pipeline runs, so any
+        // post-hoc filtering silently corrupts the dedup contract ("full
+        // content already in this conversation" after a stripped delivery).
+        assert!(triage_bypass_requested("ctx_read", None));
+        assert!(triage_bypass_requested(
+            "ctx_read",
+            Some(&args(&serde_json::json!({"path": "src/identity.rs"})))
+        ));
+    }
+
+    #[test]
+    fn documented_lossless_escape_hatches_bypass_triage() {
+        for a in [
+            serde_json::json!({"raw": true}),
+            serde_json::json!({"mode": "raw"}),
+            serde_json::json!({"mode": "full"}),
+            serde_json::json!({"mode": "full-compact"}),
+            serde_json::json!({"mode": "lines:32-33"}),
+            serde_json::json!({"mode": "anchored:1-10"}),
+            serde_json::json!({"mode": "diff"}),
+            serde_json::json!({"aggressiveness": 0.0}),
+            serde_json::json!({"fresh": true}),
+        ] {
+            assert!(
+                triage_bypass_requested("ctx_shell", Some(&args(&a))),
+                "escape hatch must bypass triage: {a}"
+            );
+        }
+    }
+
+    #[test]
+    fn plain_calls_remain_subject_to_the_level_gate() {
+        assert!(!triage_bypass_requested(
+            "ctx_shell",
+            Some(&args(&serde_json::json!({"command": "git status"})))
+        ));
+        assert!(!triage_bypass_requested("ctx_search", None));
+    }
+}
+
 mod shell_outcome_tests {
     use super::*;
     use crate::server::tool_trait::ShellOutcome;

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -524,10 +524,24 @@ fn try_load_graph(project_root: &str) -> Option<crate::core::graph_provider::Ope
 }
 
 /// Determines the output-filtering aggressiveness from a task profile.
+///
+/// Fail-safe ladder (community reports on 3.9.19, "triage always level 2"):
+/// the old ladder inverted fail-safety — the empty-query fallback profile
+/// (confidence exactly 300, context_need 0) landed on the MOST aggressive
+/// level, and per-tool-call profiles almost always report context_need < 300
+/// (a single tool call classifies as SingleFile, base 250). Level 2 now
+/// requires real classification confidence (>= 600); uncertainty degrades
+/// toward passthrough, never toward harder filtering.
 pub fn triage_filter_level(profile: &crate::core::triage::profile::TaskProfileLocal) -> u8 {
     if profile.confidence_milli < 300 {
-        0
-    } else if profile.context_need_milli < 300 {
+        return 0;
+    }
+    // Low-confidence band (incl. the exact-300 fallback profile): at most the
+    // lossless-ish boilerplate strip, never line-level deletion.
+    if profile.confidence_milli < 600 {
+        return u8::from(profile.context_need_milli < 600);
+    }
+    if profile.context_need_milli < 300 {
         2
     } else {
         u8::from(profile.context_need_milli < 600)
@@ -578,16 +592,18 @@ pub fn apply_triage_filter(
             if crate::core::triage::markdown::looks_like_markdown(&lines) {
                 crate::core::triage::markdown::keep_indices(&lines, &keywords)
             } else {
+                // Community report (3.9.19, "abridged into something that
+                // still looks right"): the structural+keyword keep-set is
+                // provably unsafe for source code — plain `let` bindings
+                // vanished from a Rust fn while the survivors still parsed
+                // (21 of 36 lines dropped, output looked complete, bindings
+                // became undeclared). Line-level lossy triage is therefore
+                // markdown-only; every other content shape gets at most the
+                // level-1 boilerplate strip.
                 lines
                     .iter()
                     .enumerate()
-                    .filter(|(_, line)| {
-                        let trimmed = line.trim();
-                        is_structural_line(trimmed) || {
-                            let lowercase = trimmed.to_lowercase();
-                            keywords.iter().any(|keyword| lowercase.contains(keyword))
-                        }
-                    })
+                    .filter(|(_, line)| !is_boilerplate_line(line.trim_start()))
                     .map(|(i, _)| i)
                     .collect()
             }
@@ -606,9 +622,9 @@ pub fn apply_triage_filter(
     if keep.is_empty() {
         return (output.to_string(), 0);
     }
-    // Heading-only markdown is the same failure mode: ATX titles match
-    // is_structural_line (`#…`) so keep is non-empty, but every body
-    // paragraph is gone. Pass through instead of returning a TOC.
+    // Heading-only markdown is the same failure mode: ATX titles survive the
+    // markdown keep-set so `keep` is non-empty, but every body paragraph is
+    // gone. Pass through instead of returning a TOC.
     if crate::core::triage::markdown::is_heading_only_collapse(&lines, &keep) {
         return (output.to_string(), 0);
     }
@@ -634,7 +650,7 @@ pub fn apply_triage_filter(
         ));
     }
     result.push_str(&format!(
-        "[lean-ctx: {removed} lines filtered by triage (level {level})]"
+        "[lean-ctx: {removed} lines filtered by triage (level {level}) — rerun with raw=true for the unfiltered output]"
     ));
     (result, removed)
 }
@@ -656,18 +672,6 @@ fn is_boilerplate_line(line: &str) -> bool {
         && !line.contains("TODO")
         && !line.contains("FIXME")
         && !line.contains("SAFETY")
-}
-
-fn is_structural_line(line: &str) -> bool {
-    line.contains('{')
-        || line.contains('}')
-        || line.starts_with("pub")
-        || line.starts_with("fn")
-        || line.starts_with("struct")
-        || line.starts_with("impl")
-        || line.starts_with("use")
-        || line.starts_with("mod")
-        || line.starts_with('#')
 }
 
 #[cfg(test)]
@@ -1168,12 +1172,24 @@ mod tests {
 
     #[test]
     fn triage_filter_level_selects_expected_level() {
-        for (confidence, context_need, expected) in
-            [(200, 200, 0), (500, 200, 2), (500, 450, 1), (500, 700, 0)]
-        {
+        for (confidence, context_need, expected) in [
+            (200, 200, 0),
+            // Fail-safe ladder: the mid-confidence band (300..600) — which
+            // includes the empty-query fallback profile at exactly 300 —
+            // never reaches the lossy level 2.
+            (300, 0, 1),
+            (500, 200, 1),
+            (500, 450, 1),
+            (500, 700, 0),
+            // Level 2 requires real classification confidence.
+            (700, 200, 2),
+            (700, 450, 1),
+            (700, 700, 0),
+        ] {
             assert_eq!(
                 triage_filter_level(&test_profile(confidence, context_need)),
-                expected
+                expected,
+                "confidence={confidence} context_need={context_need}"
             );
         }
     }
@@ -1202,8 +1218,36 @@ mod tests {
         assert!(filtered.contains("// TODO: keep this"));
         assert!(filtered.contains("// FIXME: keep this"));
         assert!(filtered.contains("// SAFETY: keep this"));
-        assert!(filtered.contains("[lean-ctx: 30 lines filtered by triage (level 1)]"));
+        assert!(
+            filtered
+                .contains("[lean-ctx: 30 lines filtered by triage (level 1) — rerun with raw=true")
+        );
         assert_eq!(removed, 30);
+    }
+
+    /// Community regression (3.9.19 "abridged into something that still looks
+    /// right"): level 2 on NON-markdown content must never delete a
+    /// non-comment line — plain `let` bindings used to vanish from source
+    /// files while the survivors still parsed.
+    #[test]
+    fn apply_triage_filter_level_two_never_drops_code_lines() {
+        let profile = test_profile(700, 200);
+        let output = "// boilerplate noise\n".repeat(20)
+            + "pub fn read_identity() -> Identity {\n"
+            + "    let serial = read_serial();\n"
+            + "    let model = read_model();\n"
+            + "    Identity { serial, model }\n"
+            + "}\n";
+        let (filtered, removed) = apply_triage_filter(&output, &profile, 2);
+        // Every code line survives — especially the plain `let` bindings that
+        // carry neither braces, keywords, nor task keywords.
+        assert!(filtered.contains("let serial = read_serial();"));
+        assert!(filtered.contains("let model = read_model();"));
+        assert!(filtered.contains("Identity { serial, model }"));
+        // Only the boilerplate comments were stripped, and the footer names
+        // the escape hatch.
+        assert_eq!(removed, 20);
+        assert!(filtered.contains("rerun with raw=true"));
     }
 
     #[test]


### PR DESCRIPTION
Completes the triage hardening for 3.9.20, addressing the community forensics report (Discord 2026-08-24/25; tracked as GL #1290): on 3.9.19 agents received source files silently abridged into code that still parsed, every documented lossless escape hatch was ignored, and the read-dedup cache counted filtered deliveries as full.

On top of what is already on main (max_filter_level default 0, bypass list, inline elision markers, dedup invalidation):

- **Fail-safe level ladder**: level 2 requires classification confidence ≥ 600; the 300–599 band — which includes the empty-query fallback profile at exactly 300 — caps at level 1 (boilerplate-comment strip). The old ladder inverted fail-safety: knowing nothing selected the most aggressive filtering, and per-tool-call profiles (SingleFile base 250 < 300) made level 2 the effective constant.
- **Line-level lossy deletion is markdown-only**: source code and logs get at most the level-1 comment strip. Regression test reproduces the reported case (plain `let` bindings must survive).
- **Footer names the escape hatch** ("rerun with raw=true for the unfiltered output") — one-step recovery instead of agent workaround loops.
- **Bypass contract pinned by tests**: ctx_read exemption + all documented lossless hatches.

10,418/10,418 lib tests green; clippy clean with the pre-commit gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)