### PR TITLE
fix(setup): honor rules_injection=off on Codex paths; point wrap at init for supported agents

### DIFF
--- a/rust/src/cli/wrap_cmd.rs
+++ b/rust/src/cli/wrap_cmd.rs
@@ -86,6 +86,14 @@ impl FromStr for WrapAgent {
             "grok" => Ok(Self::Grok),
             "aider" => Ok(Self::Aider),
             "copilot" | "copilot-cli" => Ok(Self::Copilot),
+            // GH #1520: agents that ARE fully supported via `init`/`setup` but
+            // have no proxy-wrap profile must point users at the working path
+            // instead of a bare "unsupported agent".
+            other if crate::hooks::is_supported_agent(other) => Err(format!(
+                "'{value}' has no proxy wrap profile, but it IS supported — run:\n  \
+                 lean-ctx init --agent {value}\n\
+                 (installs MCP server, hooks and rules for {value})"
+            )),
             _ => Err(format!("unsupported agent '{value}'")),
         }
     }
@@ -697,6 +705,21 @@ mod tests {
         assert_eq!(parsed.agent, WrapAgent::Codex);
         assert_eq!(parsed.port, DEFAULT_PROXY_PORT);
         assert!(!parsed.unwrap);
+    }
+
+    /// GH #1520: a supported-but-not-wrappable agent (opencode et al.) must be
+    /// pointed at `init --agent`, not dismissed as "unsupported agent".
+    #[test]
+    fn supported_non_wrap_agent_points_at_init() {
+        let err = WrapAgent::from_str("opencode").expect_err("opencode has no wrap profile");
+        assert!(
+            err.contains("lean-ctx init --agent opencode"),
+            "error must name the working command: {err}"
+        );
+        assert!(!err.starts_with("unsupported agent"));
+        // Genuinely unknown agents keep the plain error.
+        let unknown = WrapAgent::from_str("nonexistent-agent-xyz").expect_err("unknown agent");
+        assert!(unknown.contains("unsupported agent"));
     }
 
     #[test]

--- a/rust/src/hooks/agents/codex.rs
+++ b/rust/src/hooks/agents/codex.rs
@@ -691,6 +691,11 @@ command = \"lean-ctx\"
 
     #[test]
     fn codex_docs_steer_to_reliable_mcp_path_without_false_hook_claim() {
+        // GH #1526 follow-up: install_codex_instruction_docs branches on
+        // rules_injection now — pin Shared under the env lock so the
+        // off-mode regression test cannot poison this one in parallel.
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
         let tmp = std::env::temp_dir().join("lean-ctx-test-codex-desktop-note");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
@@ -727,6 +732,11 @@ command = \"lean-ctx\"
 
     #[test]
     fn install_codex_docs_preserves_existing_user_instructions() {
+        // GH #1526 follow-up: install_codex_instruction_docs branches on
+        // rules_injection now — pin Shared under the env lock so the
+        // off-mode regression test cannot poison this one in parallel.
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
         let tmp = std::env::temp_dir().join("lean-ctx-test-codex-preserve");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
@@ -761,6 +771,11 @@ command = \"lean-ctx\"
 
     #[test]
     fn install_codex_docs_updates_only_marked_block() {
+        // GH #1526 follow-up: install_codex_instruction_docs branches on
+        // rules_injection now — pin Shared under the env lock so the
+        // off-mode regression test cannot poison this one in parallel.
+        let _lock = crate::core::data_dir::test_env_lock();
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "shared");
         let tmp = std::env::temp_dir().join("lean-ctx-test-codex-marked");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();

--- a/rust/src/hooks/agents/codex.rs
+++ b/rust/src/hooks/agents/codex.rs
@@ -34,6 +34,30 @@ pub fn install_codex_hook() {
 
 fn install_codex_solution_rules(codex_dir: &std::path::Path) -> bool {
     let rules_path = codex_dir.join("instructions.md");
+    // GH #1526: `rules_injection = off` must not write the instructions.md
+    // rules block — and it strips the block a prior install left behind.
+    if crate::core::config::Config::load().rules_injection_effective()
+        == crate::core::config::RulesInjection::Off
+    {
+        if rules_path.exists()
+            && std::fs::read_to_string(&rules_path).is_ok_and(|c| {
+                crate::marked_block::contains_marker_line(
+                    &c,
+                    crate::core::rules_canonical::START_MARK,
+                )
+            })
+        {
+            crate::marked_block::remove_from_file(
+                &rules_path,
+                crate::core::rules_canonical::START_MARK,
+                crate::core::rules_canonical::END_MARK,
+                true,
+                "Codex rules",
+            );
+            return true;
+        }
+        return false;
+    }
     let block = solution_aware_rules_block(crate::rules_inject::canonical_rules_block());
     upsert_solution_rules(&rules_path, &block)
 }
@@ -429,6 +453,71 @@ mod tests {
         upsert_lean_ctx_codex_hook_entries,
     };
     use serde_json::json;
+
+    /// GH #1526: `rules_injection = off` must not write ANY Codex steering
+    /// file (instructions.md rules block, AGENTS.md block, LEAN-CTX.md) — and
+    /// it removes what a prior install left behind.
+    #[test]
+    fn rules_injection_off_writes_no_codex_steering_files() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let tmp = tempfile::tempdir().expect("temp codex dir");
+        let codex_dir = tmp.path();
+
+        // Simulate a prior shared install's artifacts.
+        std::fs::write(
+            codex_dir.join("LEAN-CTX.md"),
+            "old lean-ctx steering content",
+        )
+        .expect("seed LEAN-CTX.md");
+        std::fs::write(
+            codex_dir.join("AGENTS.md"),
+            format!(
+                "# Global Agent Instructions\n\n{}\nlean-ctx block\n{}\n",
+                crate::core::rules_canonical::AGENTS_BLOCK_START,
+                crate::core::rules_canonical::AGENTS_BLOCK_END
+            ),
+        )
+        .expect("seed AGENTS.md");
+        std::fs::write(
+            codex_dir.join("instructions.md"),
+            format!(
+                "{}\nold rules\n{}\n",
+                crate::core::rules_canonical::START_MARK,
+                crate::core::rules_canonical::END_MARK
+            ),
+        )
+        .expect("seed instructions.md");
+
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "off");
+        let docs_changed = crate::hooks::install_codex_instruction_docs(codex_dir);
+        let rules_changed = super::install_codex_solution_rules(codex_dir);
+        crate::test_env::remove_var("LEAN_CTX_RULES_INJECTION");
+
+        assert!(docs_changed, "stale steering artifacts must be removed");
+        assert!(rules_changed, "stale instructions block must be removed");
+        assert!(
+            !codex_dir.join("LEAN-CTX.md").exists(),
+            "off must remove the lean-ctx-owned LEAN-CTX.md"
+        );
+        let agents = std::fs::read_to_string(codex_dir.join("AGENTS.md")).unwrap_or_default();
+        assert!(
+            !agents.contains(crate::core::rules_canonical::AGENTS_BLOCK_START),
+            "off must strip the AGENTS.md lean-ctx block: {agents}"
+        );
+        let instructions =
+            std::fs::read_to_string(codex_dir.join("instructions.md")).unwrap_or_default();
+        assert!(
+            !instructions.contains(crate::core::rules_canonical::START_MARK),
+            "off must strip the instructions.md rules block: {instructions}"
+        );
+
+        // Idempotent: a second run on the cleaned directory writes nothing.
+        crate::test_env::set_var("LEAN_CTX_RULES_INJECTION", "off");
+        let docs_again = crate::hooks::install_codex_instruction_docs(codex_dir);
+        let rules_again = super::install_codex_solution_rules(codex_dir);
+        crate::test_env::remove_var("LEAN_CTX_RULES_INJECTION");
+        assert!(!docs_again && !rules_again, "off must be idempotent");
+    }
 
     /// Minimal env block (data dir only) for the config-rewrite tests that do
     /// not exercise project-root/extra-roots propagation.

--- a/rust/src/hooks/mod.rs
+++ b/rust/src/hooks/mod.rs
@@ -101,6 +101,15 @@ pub const HYBRID_AGENTS: &[&str] = &[
     "verdent",
 ];
 
+/// True when `agent` is integrated via `init --agent` / `setup` (hooks, rules,
+/// MCP registration). GH #1520: used by `wrap`'s error path to point users of
+/// a supported-but-not-proxy-wrappable agent (e.g. opencode) at the working
+/// command instead of a bare "unsupported agent".
+pub fn is_supported_agent(agent: &str) -> bool {
+    let key = agent.to_ascii_lowercase();
+    REPLACE_AGENTS.contains(&key.as_str()) || HYBRID_AGENTS.contains(&key.as_str())
+}
+
 /// Auto-detect the best hook mode for a given agent key.
 ///
 /// Priority: disabled/shadow_mode cap > config override > Replace > Hybrid > Mcp

--- a/rust/src/hooks/support.rs
+++ b/rust/src/hooks/support.rs
@@ -101,9 +101,37 @@ const CODEX_AGENTS_BLOCK_END: &str = crate::core::rules_canonical::AGENTS_BLOCK_
 pub(super) fn install_codex_instruction_docs(codex_dir: &Path) -> bool {
     let agents_path = codex_dir.join("AGENTS.md");
     let lean_ctx_md = codex_dir.join("LEAN-CTX.md");
-    let lean_ctx_content = codex_instruction_doc_content();
 
     let mut changed = false;
+
+    // GH #1526: `rules_injection = off` must not write ANY steering file — the
+    // Codex path previously only special-cased Dedicated, so Off fell through
+    // to the Shared branch and wrote AGENTS.md + LEAN-CTX.md anyway. Off now
+    // removes the lean-ctx-owned artifacts a prior install left behind.
+    if crate::core::config::Config::load().rules_injection_effective()
+        == crate::core::config::RulesInjection::Off
+    {
+        if lean_ctx_md.exists() && std::fs::remove_file(&lean_ctx_md).is_ok() {
+            changed = true;
+        }
+        if agents_path.exists()
+            && std::fs::read_to_string(&agents_path).is_ok_and(|c| {
+                crate::marked_block::contains_marker_line(&c, CODEX_AGENTS_BLOCK_START)
+            })
+        {
+            crate::marked_block::remove_from_file(
+                &agents_path,
+                CODEX_AGENTS_BLOCK_START,
+                CODEX_AGENTS_BLOCK_END,
+                true,
+                "Codex AGENTS.md lean-ctx block",
+            );
+            changed = true;
+        }
+        return changed;
+    }
+
+    let lean_ctx_content = codex_instruction_doc_content();
 
     // LEAN-CTX.md (full rules) is lean-ctx-owned and fully removable — written in
     // both modes, never the user's AGENTS.md.

--- a/rust/src/rules_inject/skills.rs
+++ b/rust/src/rules_inject/skills.rs
@@ -96,6 +96,16 @@ fn is_skill_agent_detected(agent_key: &str, home: &std::path::Path) -> bool {
 
 /// Install SKILL.md for a specific agent. Returns the installed path.
 pub fn install_skill_for_agent(home: &std::path::Path, agent_key: &str) -> Result<PathBuf, String> {
+    // GH #1526: `rules_injection = off` opts out of every lean-ctx-authored
+    // steering file. `install_all_skills` already honors this (GH #361); the
+    // single-agent path used by `init --agent`/`setup` missed the same guard.
+    if crate::core::config::Config::load().rules_injection_effective()
+        == crate::core::config::RulesInjection::Off
+    {
+        return Err(format!(
+            "rules_injection=off — skill install skipped for '{agent_key}'"
+        ));
+    }
     let targets = build_skill_targets(home);
     let target = targets
         .into_iter()


### PR DESCRIPTION
Fixes #1526 and #1520.

**#1526** — `lean-ctx init --agent codex` wrote every steering file (instructions.md rules block, AGENTS.md block, LEAN-CTX.md, SKILL.md) even with `rules_injection=off`: the Codex path only special-cased `Dedicated`, so `Off` fell through to the Shared branch, and the single-agent skill installer missed the guard `install_all_skills` already had (GH #361). `Off` now writes nothing and removes the lean-ctx-owned artifacts a prior install left behind — idempotent, with a regression test covering seed → strip → no-op. Credit to @massimomazzariol for the isolated per-mode reproduction that made the gap obvious.

**#1520** — `lean-ctx wrap opencode` answered "unsupported agent" although opencode is fully supported via `init`/`setup`; it just has no proxy-wrap profile. The wrap error now points supported-but-not-wrappable agents at `lean-ctx init --agent <name>` (new `hooks::is_supported_agent` over the REPLACE/HYBRID lists); genuinely unknown agents keep the plain error.

Targeted tests green; full lib suite green on the branch base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)