### PR TITLE
Land #1495: stop deriving triage level 2 from a rules profile (conflict-resolved)

### DIFF
--- a/rust/src/core/decision_loop.rs
+++ b/rust/src/core/decision_loop.rs
@@ -178,7 +178,10 @@ mod tests {
     fn test_unknown_query() {
         let result = DecisionLoop::default().execute_task("", "session", "agent");
 
-        assert_eq!(result.profile.confidence_milli, 300);
+        assert_eq!(
+            result.profile.confidence_milli,
+            crate::core::triage::confidence::RULES_FALLBACK_MILLI
+        );
         assert!(result.envelope_created);
     }
 

--- a/rust/src/core/decision_loop.rs
+++ b/rust/src/core/decision_loop.rs
@@ -180,7 +180,10 @@ mod tests {
     fn test_unknown_query() {
         let result = DecisionLoop::default().execute_task("", "session", "agent");
 
-        assert_eq!(result.profile.confidence_milli, 300);
+        assert_eq!(
+            result.profile.confidence_milli,
+            crate::core::triage::confidence::RULES_FALLBACK_MILLI
+        );
         assert!(result.envelope_created);
     }
 

--- a/rust/src/core/decision_loop_integration_test.rs
+++ b/rust/src/core/decision_loop_integration_test.rs
@@ -151,6 +151,25 @@ async fn decision_loop_integration_simple_read() {
     .await;
     assert_completed_task(&server, &task_id, "ctx_read").await;
 
+    // #1484: `ctx_read` carries neither `query` nor `task`, so the ingress must
+    // hand the triage no task text at all. Classifying the tool name instead
+    // ("ctx_read: ctx_read") yields a confident SingleFile profile and filter
+    // level 2 — the regression this binds shut.
+    let session_id = server.session.read().await.id.clone();
+    let profile = DecisionLoopRuntime::get_or_init()
+        .profile_for_session(&session_id)
+        .expect("a tool call must record a triage profile for its session");
+    assert_eq!(
+        profile.confidence_milli,
+        crate::core::triage::confidence::RULES_FALLBACK_MILLI,
+        "a call without a task text must reach rules::fallback(), not a classification"
+    );
+    assert_eq!(
+        crate::server::context_gate::triage_filter_level(&profile),
+        0,
+        "a task-text-less profile must pass output through unfiltered"
+    );
+
     // SAFETY: test_env_lock serializes process-wide data directory changes.
     unsafe { std::env::remove_var("LEAN_CTX_DATA_DIR") };
 }

--- a/rust/src/core/decision_loop_runtime.rs
+++ b/rust/src/core/decision_loop_runtime.rs
@@ -62,7 +62,7 @@ impl DecisionLoopRuntime {
     pub fn on_tool_start(
         &self,
         tool_name: &str,
-        query: &str,
+        query: Option<&str>,
         session_id: &str,
         agent_id: &str,
     ) -> TaskContext {
@@ -83,20 +83,21 @@ impl DecisionLoopRuntime {
     fn on_tool_start_inner(
         &self,
         tool_name: &str,
-        query: &str,
+        query: Option<&str>,
         session_id: &str,
         agent_id: &str,
     ) -> TaskContext {
         let profile = self
             .triage
             .analyze(&TaskAnalysisInput {
-                query: format!("{tool_name}: {query}"),
+                query: query.map_or_else(String::new, |text| format!("{tool_name}: {text}")),
                 ..Default::default()
             })
             .map(|hypothesis| hypothesis.profile)
             .unwrap_or_default();
         self.remember_profile(session_id, profile.clone());
-        let mut envelope = TaskSpine::create_envelope(query, session_id, agent_id);
+        let mut envelope =
+            TaskSpine::create_envelope(query.unwrap_or(tool_name), session_id, agent_id);
         TaskSpine::enrich_from_triage(&mut envelope, &protocol_profile(&profile));
         TaskContext {
             task_id: envelope.task_id.as_str().to_owned(),

--- a/rust/src/core/decision_loop_runtime_tests.rs
+++ b/rust/src/core/decision_loop_runtime_tests.rs
@@ -28,7 +28,7 @@ fn test_runtime_init() {
 fn test_on_tool_start() {
     let context = DecisionLoopRuntime::get_or_init().on_tool_start(
         "ctx_read",
-        "read lib.rs",
+        Some("read lib.rs"),
         "runtime-test",
         "agent",
     );
@@ -39,7 +39,7 @@ fn test_on_tool_start() {
 #[test]
 fn test_on_tool_end_success() {
     let runtime = DecisionLoopRuntime::with_triage(TriageEngine::default());
-    let context = runtime.on_tool_start("ctx_read", "read", "runtime-test", "agent");
+    let context = runtime.on_tool_start("ctx_read", Some("read"), "runtime-test", "agent");
     runtime.on_tool_end(&context, 1, 1, "gpt-4o", true);
     assert_eq!(runtime.latest_assessment_accepted(), Some(true));
 }
@@ -47,7 +47,7 @@ fn test_on_tool_end_success() {
 #[test]
 fn test_on_tool_end_failure() {
     let runtime = DecisionLoopRuntime::with_triage(TriageEngine::default());
-    let context = runtime.on_tool_start("ctx_read", "read", "runtime-test", "agent");
+    let context = runtime.on_tool_start("ctx_read", Some("read"), "runtime-test", "agent");
     runtime.on_tool_end(&context, 1, 1, "gpt-4o", false);
     assert_eq!(runtime.latest_assessment_accepted(), Some(false));
 }
@@ -58,8 +58,22 @@ fn test_error_does_not_block() {
         DecisionLoopRuntime::with_triage(TriageEngine::new(vec![Box::new(FailingAnalyzer)]));
     assert!(
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            runtime.on_tool_start("ctx_read", "", "test", "agent")
+            runtime.on_tool_start("ctx_read", None, "test", "agent")
         }))
         .is_ok()
     );
+}
+
+#[test]
+fn missing_task_text_yields_passthrough_profile() {
+    use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+    use crate::server::context_gate::triage_filter_level;
+
+    let runtime = DecisionLoopRuntime::with_triage(TriageEngine::default());
+    let context = runtime.on_tool_start("ctx_read", None, "no-task-text", "agent");
+
+    assert_eq!(context.profile_intent, "explore");
+    let profile = runtime.profile_for_session("no-task-text").unwrap();
+    assert!(profile.confidence_milli < ACTIONABLE_FLOOR_MILLI);
+    assert_eq!(triage_filter_level(&profile), 0);
 }

--- a/rust/src/core/shell_allowlist/function_def_tests.rs
+++ b/rust/src/core/shell_allowlist/function_def_tests.rs
@@ -1,0 +1,72 @@
+//! Shell function definitions and inline-env error text (#1488, #1489).
+//! Split out of `tests.rs` to keep that file under the LOC gate.
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// #1488: shell function definitions must not be blocked by the allowlist.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gh1488_function_definition_not_blocked() {
+    let allowlist: Vec<String> = vec!["echo".into()];
+    let result = check_all_segments("greet() { echo hi; }; greet", &allowlist);
+    assert!(
+        result.is_ok(),
+        "function definition + call should not be blocked: {result:?}"
+    );
+}
+
+#[test]
+fn gh1488_function_with_disallowed_body_is_blocked() {
+    let allowlist: Vec<String> = vec!["echo".into(), "ls".into()];
+    let result = check_all_segments("bad() { evil_command; }; bad", &allowlist);
+    assert!(
+        result.is_err(),
+        "function with disallowed body command must be blocked"
+    );
+}
+
+#[test]
+fn gh1488_detect_function_def_forms() {
+    use super::super::tokenizer::detect_function_def;
+    assert_eq!(
+        detect_function_def("greet() { echo hi; }"),
+        Some("greet".into())
+    );
+    assert_eq!(
+        detect_function_def("function greet { echo hi; }"),
+        Some("greet".into())
+    );
+    assert_eq!(
+        detect_function_def("function greet() { echo hi; }"),
+        Some("greet".into())
+    );
+    assert_eq!(detect_function_def("echo hello"), None);
+    assert_eq!(detect_function_def("ls -la"), None);
+}
+
+#[test]
+fn gh1488_extract_function_body_commands() {
+    use super::super::tokenizer::extract_function_body_commands;
+    let cmds = extract_function_body_commands("greet() { echo hi; echo bye; }");
+    assert_eq!(cmds, vec!["echo hi", "echo bye"]);
+}
+
+// ---------------------------------------------------------------------------
+// #1489: inline env override error must mention the `env` parameter.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gh1489_inline_env_block_message_mentions_env_parameter() {
+    let result = check_all_segments("PATH=/evil/bin echo hi", &["echo".into()]);
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("env parameter"),
+        "error must mention `env` parameter: {err}"
+    );
+    assert!(
+        err.contains("ctx_shell"),
+        "error must mention ctx_shell: {err}"
+    );
+}

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -3,6 +3,8 @@
 
 #[path = "comment_strip_tests.rs"]
 mod comment_strip_tests;
+#[path = "function_def_tests.rs"]
+mod function_def_tests;
 #[path = "substitution_tests.rs"]
 mod substitution_tests;
 #[path = "tests_powershell.rs"]
@@ -1494,72 +1496,4 @@ fn extract_bash_interpreters_from_json() {
     let mut out = Vec::new();
     extract_bash_interpreters(&json, &mut out);
     assert_eq!(out, vec!["python3", "node", "ruby"]);
-}
-
-// ---------------------------------------------------------------------------
-// #1488: shell function definitions must not be blocked by the allowlist.
-// ---------------------------------------------------------------------------
-
-#[test]
-fn gh1488_function_definition_not_blocked() {
-    let allowlist: Vec<String> = vec!["echo".into()];
-    let result = check_all_segments("greet() { echo hi; }; greet", &allowlist);
-    assert!(
-        result.is_ok(),
-        "function definition + call should not be blocked: {result:?}"
-    );
-}
-
-#[test]
-fn gh1488_function_with_disallowed_body_is_blocked() {
-    let allowlist: Vec<String> = vec!["echo".into(), "ls".into()];
-    let result = check_all_segments("bad() { evil_command; }; bad", &allowlist);
-    assert!(
-        result.is_err(),
-        "function with disallowed body command must be blocked"
-    );
-}
-
-#[test]
-fn gh1488_detect_function_def_forms() {
-    use super::tokenizer::detect_function_def;
-    assert_eq!(
-        detect_function_def("greet() { echo hi; }"),
-        Some("greet".into())
-    );
-    assert_eq!(
-        detect_function_def("function greet { echo hi; }"),
-        Some("greet".into())
-    );
-    assert_eq!(
-        detect_function_def("function greet() { echo hi; }"),
-        Some("greet".into())
-    );
-    assert_eq!(detect_function_def("echo hello"), None);
-    assert_eq!(detect_function_def("ls -la"), None);
-}
-
-#[test]
-fn gh1488_extract_function_body_commands() {
-    use super::tokenizer::extract_function_body_commands;
-    let cmds = extract_function_body_commands("greet() { echo hi; echo bye; }");
-    assert_eq!(cmds, vec!["echo hi", "echo bye"]);
-}
-
-// ---------------------------------------------------------------------------
-// #1489: inline env override error must mention the `env` parameter.
-// ---------------------------------------------------------------------------
-
-#[test]
-fn gh1489_inline_env_block_message_mentions_env_parameter() {
-    let result = check_all_segments("PATH=/evil/bin echo hi", &["echo".into()]);
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("env parameter"),
-        "error must mention `env` parameter: {err}"
-    );
-    assert!(
-        err.contains("ctx_shell"),
-        "error must mention ctx_shell: {err}"
-    );
 }

--- a/rust/src/core/stats/io.rs
+++ b/rust/src/core/stats/io.rs
@@ -33,13 +33,19 @@ pub(super) fn load_from_disk() -> StatsStore {
 }
 
 /// One-time sanitation (#1283). Stores written before the extrapolation fix
-/// can carry `reread_tokens_saved` values thousands of times larger than every
-/// input token ever processed (measured: ~119 trillion vs 2.4B input). Those
-/// values are products of turn arithmetic, not measurements, and cannot be
-/// decomposed retroactively — reset with a loud log. Legitimate measured
-/// values sit well under the total input volume and pass through untouched.
+/// can carry `reread_tokens_saved` values orders of magnitude larger than
+/// every input token ever processed (measured: ~119 trillion vs 2.4B input).
+/// Those values are products of turn arithmetic, not measurements, and cannot
+/// be decomposed retroactively — reset with a loud log.
+///
+/// Cap = 1x total input (was 100x): during the mixed-version window a still-
+/// running pre-fix server keeps re-inflating the store between sanitations,
+/// sawtoothing anywhere below the cap — measured live at 59.8B (~24x input),
+/// which rendered as ~$18k "cost saved" on the dashboard. Measured cache-hit
+/// savings sit around 8% of daily input, so 1x is still generous; kept as a
+/// floor of 1M tokens for young stores.
 fn sanitize_extrapolated_rereads(mut store: StatsStore) -> StatsStore {
-    let plausible_cap = store.total_input_tokens.saturating_mul(100).max(1_000_000);
+    let plausible_cap = store.total_input_tokens.max(1_000_000);
     if store.reread_tokens_saved > plausible_cap {
         tracing::warn!(
             "reread_tokens_saved={} exceeds plausibility cap {} (total input {}) — \
@@ -349,5 +355,48 @@ fn merge_cep(merged: &mut CepStats, current: &CepStats, baseline: &CepStats) {
         merged.last_session_compressed = current.last_session_compressed;
         merged.last_session_cache_hits = current.last_session_cache_hits;
         merged.last_session_cache_reads = current.last_session_cache_reads;
+    }
+}
+
+#[cfg(test)]
+mod sanitation_tests {
+    use super::*;
+
+    /// #1283 mixed-version window: a still-running pre-fix server sawtooths
+    /// the persisted value anywhere above real measurements (live: 59.8B at
+    /// 2.5B total input rendered as ~$18k "cost saved"). The cap is 1x total
+    /// input; plausible measured values pass through untouched.
+    #[test]
+    fn sanitation_resets_above_total_input_and_keeps_plausible_values() {
+        let inflated = StatsStore {
+            total_input_tokens: 2_500_000_000,
+            reread_tokens_saved: 59_800_000_000, // 24x input — sawtooth
+            ..Default::default()
+        };
+        assert_eq!(
+            sanitize_extrapolated_rereads(inflated).reread_tokens_saved,
+            0
+        );
+
+        let plausible = StatsStore {
+            total_input_tokens: 2_500_000_000,
+            reread_tokens_saved: 200_000_000, // 8% of input — measured scale
+            ..Default::default()
+        };
+        assert_eq!(
+            sanitize_extrapolated_rereads(plausible).reread_tokens_saved,
+            200_000_000
+        );
+
+        // Young stores keep the 1M floor so tiny installs are never reset.
+        let young = StatsStore {
+            total_input_tokens: 10_000,
+            reread_tokens_saved: 900_000,
+            ..Default::default()
+        };
+        assert_eq!(
+            sanitize_extrapolated_rereads(young).reread_tokens_saved,
+            900_000
+        );
     }
 }

--- a/rust/src/core/triage/confidence.rs
+++ b/rust/src/core/triage/confidence.rs
@@ -8,6 +8,13 @@ pub fn is_low_confidence(milli: u16) -> bool {
     milli < 500
 }
 
+/// Below this a profile is not actionable and output passes through unfiltered.
+pub const ACTIONABLE_FLOOR_MILLI: u16 = 300;
+
+/// Confidence reported by the rules fallback — deliberately below the floor:
+/// a rules-only profile without a task text is a guess, and says so.
+pub const RULES_FALLBACK_MILLI: u16 = 200;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -26,5 +33,11 @@ mod tests {
     #[test]
     fn low_is_exclusive() {
         assert!(!is_low_confidence(500));
+    }
+    #[test]
+    fn rules_fallback_stays_below_the_actionable_floor() {
+        // Compile-time pin (clippy: assertions_on_constants) — the fallback
+        // profile must never clear the passthrough gate.
+        const _: () = assert!(RULES_FALLBACK_MILLI < ACTIONABLE_FLOOR_MILLI);
     }
 }

--- a/rust/src/core/triage/confidence.rs
+++ b/rust/src/core/triage/confidence.rs
@@ -8,6 +8,13 @@ pub fn is_low_confidence(milli: u16) -> bool {
     milli < 500
 }
 
+/// Below this a profile is not actionable and output passes through unfiltered.
+pub const ACTIONABLE_FLOOR_MILLI: u16 = 300;
+
+/// Confidence reported by the rules fallback — deliberately below the floor:
+/// a rules-only profile without a task text is a guess, and says so.
+pub const RULES_FALLBACK_MILLI: u16 = 200;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -26,5 +33,9 @@ mod tests {
     #[test]
     fn low_is_exclusive() {
         assert!(!is_low_confidence(500));
+    }
+    #[test]
+    fn rules_fallback_stays_below_the_actionable_floor() {
+        assert!(RULES_FALLBACK_MILLI < ACTIONABLE_FLOOR_MILLI);
     }
 }

--- a/rust/src/core/triage/rules.rs
+++ b/rust/src/core/triage/rules.rs
@@ -1,6 +1,6 @@
 use super::{
     ProfileHypothesis, TaskAnalysisInput, TaskAnalyzer, TriageBackendLocal,
-    confidence::clamp_milli,
+    confidence::{RULES_FALLBACK_MILLI, clamp_milli},
     profile::{TaskProfileLocal, TaskScopeLocal},
 };
 use crate::core::{
@@ -60,12 +60,12 @@ fn fallback() -> ProfileHypothesis {
     let profile = TaskProfileLocal {
         task_class: "coding".into(),
         intent: "explore".into(),
-        confidence_milli: 300,
+        confidence_milli: RULES_FALLBACK_MILLI,
         ..Default::default()
     };
     ProfileHypothesis {
         profile,
-        confidence_milli: 300,
+        confidence_milli: RULES_FALLBACK_MILLI,
         backend: TriageBackendLocal::Rules,
     }
 }
@@ -134,7 +134,7 @@ mod tests {
                 .analyze(&TaskAnalysisInput::default())
                 .unwrap()
                 .confidence_milli,
-            300
+            RULES_FALLBACK_MILLI
         );
     }
 }

--- a/rust/src/core/triage/rules.rs
+++ b/rust/src/core/triage/rules.rs
@@ -1,6 +1,6 @@
 use super::{
     ProfileHypothesis, TaskAnalysisInput, TaskAnalyzer, TriageBackendLocal,
-    confidence::clamp_milli,
+    confidence::{RULES_FALLBACK_MILLI, clamp_milli},
     profile::{TaskProfileLocal, TaskScopeLocal},
 };
 use crate::core::{
@@ -60,12 +60,12 @@ fn fallback() -> ProfileHypothesis {
     let profile = TaskProfileLocal {
         task_class: "coding".into(),
         intent: "explore".into(),
-        confidence_milli: 300,
+        confidence_milli: RULES_FALLBACK_MILLI,
         ..Default::default()
     };
     ProfileHypothesis {
         profile,
-        confidence_milli: 300,
+        confidence_milli: RULES_FALLBACK_MILLI,
         backend: TriageBackendLocal::Rules,
     }
 }
@@ -73,7 +73,10 @@ fn milli(value: f64) -> u16 {
     if value.is_finite() {
         clamp_milli((value.clamp(0.0, 1.0) * 1000.0).round() as u16)
     } else {
-        300
+        // A non-finite confidence is an absent signal, not a middling one — it
+        // reports the same guess-level confidence as `fallback()` so it stays
+        // below `ACTIONABLE_FLOOR_MILLI` (#1484).
+        RULES_FALLBACK_MILLI
     }
 }
 fn intent_name(t: TaskType) -> &'static str {
@@ -134,7 +137,18 @@ mod tests {
                 .analyze(&TaskAnalysisInput::default())
                 .unwrap()
                 .confidence_milli,
-            300
+            RULES_FALLBACK_MILLI
         );
+    }
+    #[test]
+    fn non_finite_confidence_stays_below_the_actionable_floor() {
+        use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                milli(value) < ACTIONABLE_FLOOR_MILLI,
+                "a non-finite confidence is an absent signal, not an actionable one"
+            );
+        }
     }
 }

--- a/rust/src/core/triage/rules.rs
+++ b/rust/src/core/triage/rules.rs
@@ -73,7 +73,10 @@ fn milli(value: f64) -> u16 {
     if value.is_finite() {
         clamp_milli((value.clamp(0.0, 1.0) * 1000.0).round() as u16)
     } else {
-        300
+        // A non-finite confidence is an absent signal, not a middling one — it
+        // reports the same guess-level confidence as `fallback()` so it stays
+        // below `ACTIONABLE_FLOOR_MILLI` (#1484).
+        RULES_FALLBACK_MILLI
     }
 }
 fn intent_name(t: TaskType) -> &'static str {
@@ -136,5 +139,16 @@ mod tests {
                 .confidence_milli,
             RULES_FALLBACK_MILLI
         );
+    }
+    #[test]
+    fn non_finite_confidence_stays_below_the_actionable_floor() {
+        use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                milli(value) < ACTIONABLE_FLOOR_MILLI,
+                "a non-finite confidence is an absent signal, not an actionable one"
+            );
+        }
     }
 }

--- a/rust/src/server/call_tool/guarded.rs
+++ b/rust/src/server/call_tool/guarded.rs
@@ -127,8 +127,7 @@ impl LeanCtxServer {
             .and_then(|values| values.get("query").and_then(serde_json::Value::as_str))
             .or_else(|| {
                 args.and_then(|values| values.get("task").and_then(serde_json::Value::as_str))
-            })
-            .unwrap_or(name);
+            });
         let session_id = self.session.read().await.id.clone();
         let agent_id = match self.agent_id.read().await.clone() {
             Some(agent_id) => agent_id,

--- a/rust/src/server/call_tool/guarded.rs
+++ b/rust/src/server/call_tool/guarded.rs
@@ -140,8 +140,7 @@ impl LeanCtxServer {
             .and_then(|values| values.get("query").and_then(serde_json::Value::as_str))
             .or_else(|| {
                 args.and_then(|values| values.get("task").and_then(serde_json::Value::as_str))
-            })
-            .unwrap_or(name);
+            });
         let session_id = self.session.read().await.id.clone();
         let agent_id = match self.agent_id.read().await.clone() {
             Some(agent_id) => agent_id,

--- a/rust/src/server/call_tool/tests.rs
+++ b/rust/src/server/call_tool/tests.rs
@@ -828,7 +828,7 @@ mod shell_outcome_tests {
         let context = crate::core::decision_loop_runtime::DecisionLoopRuntime::get_or_init()
             .on_tool_start(
                 "ctx_shell",
-                "fix a coding bug in one file",
+                Some("fix a coding bug in one file"),
                 &session_id,
                 "mes1609-triage-test",
             );

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -1170,7 +1170,7 @@ mod tests {
 
     #[test]
     fn no_model_installed_means_passthrough() {
-        use crate::core::triage::{rules::RuleTriageBackend, TaskAnalysisInput, TaskAnalyzer};
+        use crate::core::triage::{TaskAnalysisInput, TaskAnalyzer, rules::RuleTriageBackend};
 
         let profile = RuleTriageBackend
             .analyze(&TaskAnalysisInput::default())

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -525,27 +525,28 @@ fn try_load_graph(project_root: &str) -> Option<crate::core::graph_provider::Ope
 
 /// Determines the output-filtering aggressiveness from a task profile.
 ///
-/// Fail-safe ladder (community reports on 3.9.19, "triage always level 2"):
-/// the old ladder inverted fail-safety — the empty-query fallback profile
-/// (confidence exactly 300, context_need 0) landed on the MOST aggressive
-/// level, and per-tool-call profiles almost always report context_need < 300
-/// (a single tool call classifies as SingleFile, base 250). Level 2 now
-/// requires real classification confidence (>= 600); uncertainty degrades
-/// toward passthrough, never toward harder filtering.
+/// Fail-safe by construction (community reports on 3.9.19, "triage always
+/// level 2"): the original ladder inverted fail-safety — the empty-query
+/// fallback profile landed on the MOST aggressive level, and per-tool-call
+/// profiles almost always report a low context need (a single tool call
+/// classifies as SingleFile, base 250). A rules-derived profile can now
+/// select at most level 1; uncertainty degrades toward passthrough, never
+/// toward harder filtering.
 pub fn triage_filter_level(profile: &crate::core::triage::profile::TaskProfileLocal) -> u8 {
-    if profile.confidence_milli < 300 {
+    use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+    // An unset context need means "unknown", never "needs no context".
+    if profile.confidence_milli < ACTIONABLE_FLOOR_MILLI || profile.context_need_milli == 0 {
         return 0;
     }
-    // Low-confidence band (incl. the exact-300 fallback profile): at most the
-    // lossless-ish boilerplate strip, never line-level deletion.
-    if profile.confidence_milli < 600 {
-        return u8::from(profile.context_need_milli < 600);
-    }
-    if profile.context_need_milli < 300 {
-        2
-    } else {
-        u8::from(profile.context_need_milli < 600)
-    }
+    // Level 2 removes declarations and leaves output that parses but no longer
+    // means what it says (#1484). Nothing in a rules-derived profile is precise
+    // enough to justify that: `confidence_milli` measures how sure the intent
+    // classification is, not how much information loss the output tolerates.
+    // The level stays reachable through `apply_triage_filter` for callers that
+    // ask for it — where it is additionally markdown-only, so source code and
+    // logs never lose non-comment lines — and should return here again only
+    // once a model backend can supply that prediction.
+    u8::from(profile.context_need_milli < 600)
 }
 
 /// Filters output according to the task profile and selected triage level.
@@ -1174,17 +1175,19 @@ mod tests {
     fn triage_filter_level_selects_expected_level() {
         for (confidence, context_need, expected) in [
             (200, 200, 0),
-            // Fail-safe ladder: the mid-confidence band (300..600) — which
-            // includes the empty-query fallback profile at exactly 300 —
-            // never reaches the lossy level 2.
-            (300, 0, 1),
+            // context_need == 0 means "unknown", never "needs no context" —
+            // the fallback profile must pass through untouched.
+            (300, 0, 0),
+            (500, 0, 0),
             (500, 200, 1),
             (500, 450, 1),
             (500, 700, 0),
-            // Level 2 requires real classification confidence.
-            (700, 200, 2),
+            // A rules-derived profile never selects the lossy level 2, no
+            // matter how confident the intent classification is.
+            (700, 200, 1),
             (700, 450, 1),
             (700, 700, 0),
+            (1000, 100, 1),
         ] {
             assert_eq!(
                 triage_filter_level(&test_profile(confidence, context_need)),
@@ -1192,6 +1195,17 @@ mod tests {
                 "confidence={confidence} context_need={context_need}"
             );
         }
+    }
+
+    #[test]
+    fn no_model_installed_means_passthrough() {
+        use crate::core::triage::{TaskAnalysisInput, TaskAnalyzer, rules::RuleTriageBackend};
+
+        let profile = RuleTriageBackend
+            .analyze(&TaskAnalysisInput::default())
+            .unwrap()
+            .profile;
+        assert_eq!(triage_filter_level(&profile), 0);
     }
 
     #[test]

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -523,13 +523,19 @@ fn try_load_graph(project_root: &str) -> Option<crate::core::graph_provider::Ope
 
 /// Determines the output-filtering aggressiveness from a task profile.
 pub fn triage_filter_level(profile: &crate::core::triage::profile::TaskProfileLocal) -> u8 {
-    if profile.confidence_milli < 300 {
-        0
-    } else if profile.context_need_milli < 300 {
-        2
-    } else {
-        u8::from(profile.context_need_milli < 600)
+    use crate::core::triage::confidence::ACTIONABLE_FLOOR_MILLI;
+    // An unset context need means "unknown", never "needs no context".
+    if profile.confidence_milli < ACTIONABLE_FLOOR_MILLI || profile.context_need_milli == 0 {
+        return 0;
     }
+    // Level 2 removes declarations and leaves output that parses but no longer
+    // means what it says (#1484). Nothing in a rules-derived profile is precise
+    // enough to justify that: `confidence_milli` measures how sure the intent
+    // classification is, not how much information loss the output tolerates.
+    // The level stays reachable through `apply_triage_filter` for callers that
+    // ask for it, and should return here again only once a model backend can
+    // supply the prediction.
+    u8::from(profile.context_need_milli < 600)
 }
 
 /// Filters output according to the task profile and selected triage level.
@@ -1148,14 +1154,29 @@ mod tests {
 
     #[test]
     fn triage_filter_level_selects_expected_level() {
-        for (confidence, context_need, expected) in
-            [(200, 200, 0), (500, 200, 2), (500, 450, 1), (500, 700, 0)]
-        {
+        for (confidence, context_need, expected) in [
+            (200, 200, 0),
+            (500, 200, 1),
+            (500, 450, 1),
+            (500, 700, 0),
+            (500, 0, 0),
+        ] {
             assert_eq!(
                 triage_filter_level(&test_profile(confidence, context_need)),
                 expected
             );
         }
+    }
+
+    #[test]
+    fn no_model_installed_means_passthrough() {
+        use crate::core::triage::{rules::RuleTriageBackend, TaskAnalysisInput, TaskAnalyzer};
+
+        let profile = RuleTriageBackend
+            .analyze(&TaskAnalysisInput::default())
+            .unwrap()
+            .profile;
+        assert_eq!(triage_filter_level(&profile), 0);
     }
 
     #[test]

--- a/scripts/loc-gate.sh
+++ b/scripts/loc-gate.sh
@@ -14,7 +14,6 @@ ALLOWLIST=(
   "rust/src/cli/config_cmd.rs"
   "rust/src/cli/completions/spec.rs"
   "rust/src/core/config/sections.rs"
-  "rust/src/core/shell_allowlist/tests.rs"
 )
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
Lands dasTholo's #1495 onto current main via the protected-branch flow. Merging this marks #1495 as merged (its head is a parent of the merge commit).

The original PR's analysis is the sharpest statement of the 3.9.19 triage root cause: `confidence_milli` measures how sure the intent classification is, **not** how much information loss the output tolerates — so nothing in a rules-derived profile justifies the lossy level 2. It also fixes the ingress side: the tool name is no longer classified as the user's task (`\"ctx_read: ctx_read\"` → mechanical/SingleFile → level 2 on nearly every call, with `rules::fallback()` unreachable), `context_need == 0` now means \"unknown → passthrough\", and the previously free-floating thresholds are bound as named constants (`ACTIONABLE_FLOOR_MILLI`, `RULES_FALLBACK_MILLI`) including the NaN arm.

Merge-resolution notes:
- The confidence-≥600 ladder from #1527 is superseded by this PR's stricter position (rules-derived profiles cap at level 1); the markdown-only lossy-deletion guard and the `rerun with raw=true` footer from #1527 remain in `apply_triage_filter` for explicit level-2 callers.
- The #1510 pipeline test adapts to `on_tool_start(query: Option<&str>)`.
- The constant-relation test pin moves into a `const` block (clippy 1.97 `assertions_on_constants`).

Level matrix on this head: fallback/unknown → 0, any rules profile → at most 1, level 2 only for explicit callers and then markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)