### PR TITLE
fix(doctor): surface output-triage filter state on the board (#1534)

### DIFF
--- a/rust/src/doctor/checks/environment.rs
+++ b/rust/src/doctor/checks/environment.rs
@@ -47,6 +47,35 @@ pub(crate) fn compact_format_passthrough_outcome() -> Outcome {
         ),
     }
 }
+
+/// Surfaces the post-dispatch output-triage filter state (#1534): the 3.9.19
+/// filter dropped MCP tool output while `doctor` reported every check green.
+/// From 3.9.20 the filter is opt-in (`decision_loop.max_filter_level`,
+/// default 0) and this line keeps its state on the board either way.
+pub(crate) fn output_triage_outcome() -> Outcome {
+    output_triage_outcome_for(
+        crate::core::config::Config::load()
+            .decision_loop
+            .max_filter_level,
+    )
+}
+
+pub(super) fn output_triage_outcome_for(max_filter_level: u8) -> Outcome {
+    if max_filter_level == 0 {
+        return Outcome {
+            ok: true,
+            line: format!(
+                "{BOLD}Output triage{RST}  {GREEN}off{RST}  {DIM}(decision_loop.max_filter_level = 0 — tool output is never dropped){RST}"
+            ),
+        };
+    }
+    Outcome {
+        ok: true,
+        line: format!(
+            "{BOLD}Output triage{RST}  {YELLOW}active (max level {max_filter_level}){RST}  {DIM}(lossy; disable: lean-ctx config set decision_loop.max_filter_level 0){RST}"
+        ),
+    }
+}
 pub(crate) fn shell_aliases_outcome() -> Outcome {
     let Some(home) = dirs::home_dir() else {
         return Outcome {

--- a/rust/src/doctor/checks/tests.rs
+++ b/rust/src/doctor/checks/tests.rs
@@ -246,3 +246,33 @@ fn standard_data_pin_is_not_flagged_as_divergent() {
     assert!(!standard_diverges, "standard XDG data pin must not diverge");
     assert!(custom_diverges, "a custom data pin diverges config");
 }
+
+// --- #1534: output-triage visibility ---
+// The 3.9.19 filter dropped tool output while doctor reported all checks
+// green; its state must be on the board in both directions.
+
+#[test]
+fn output_triage_off_names_the_key_and_reads_off() {
+    let out = environment::output_triage_outcome_for(0);
+    assert!(out.ok);
+    assert!(out.line.contains("Output triage"), "{}", out.line);
+    assert!(
+        out.line.contains("decision_loop.max_filter_level"),
+        "{}",
+        out.line
+    );
+    assert!(out.line.contains("off"), "{}", out.line);
+}
+
+#[test]
+fn output_triage_active_states_level_and_disable_command() {
+    let out = environment::output_triage_outcome_for(2);
+    assert!(out.ok, "active filtering is configuration, not a failure");
+    assert!(out.line.contains("active (max level 2)"), "{}", out.line);
+    assert!(
+        out.line
+            .contains("lean-ctx config set decision_loop.max_filter_level 0"),
+        "the line must name the command that turns it off: {}",
+        out.line
+    );
+}

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -425,6 +425,11 @@ fn run_inner(json: bool) -> u32 {
     let skill = skill_files_outcome();
     board.check(&skill);
 
+    // 9b) Output triage (#1534): the 3.9.19 filter ran invisibly while doctor
+    // reported all green — its state stays on the board whether on or off.
+    let output_triage = output_triage_outcome();
+    board.check(&output_triage);
+
     // 10) Port
     let port = port_3333_outcome();
     board.check(&port);


### PR DESCRIPTION
Closes the one remaining gap from #1534: `lean-ctx doctor` reported all checks green while the 3.9.19 triage filter was dropping MCP tool output.

Adds an **Output triage** line to the doctor board:
- green `off` at the default (`decision_loop.max_filter_level = 0` — tool output is never dropped)
- yellow `active (max level N)` naming the exact disable command when filtering is enabled

Pure-function core with tests for both states; the board counts checks dynamically, so no count pins needed.

All other findings in #1534 are already fixed on main (opt-in default, ladder de-inversion #1495, markdown-only lossy filtering #1527, escape-hatch bypass contract, visible elision, dedup invalidation) — see the point-by-point reply on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)