### PR TITLE
refactor(engine): isolate consumed profile mechanisms

### DIFF
--- a/rust/src/core/auto_mode_resolver.rs
+++ b/rust/src/core/auto_mode_resolver.rs
@@ -122,7 +122,8 @@ pub fn configured_default_mode() -> Option<String> {
         .or_else(|| crate::core::persona::active().read_mode_override())
         .or_else(|| {
             let profile = crate::core::profiles::active_profile();
-            let mode = profile.read.default_mode_effective();
+            let engine = profile.engine_config();
+            let mode = engine.read.default_mode;
             (mode != "auto").then(|| mode.to_string())
         })
 }

--- a/rust/src/core/instruction_compiler.rs
+++ b/rust/src/core/instruction_compiler.rs
@@ -51,10 +51,11 @@ pub(crate) fn compile(
 
     let profile = profiles::load_profile(profile_name)
         .ok_or_else(|| format!("unknown profile '{profile_name}'"))?;
+    let engine = profile.engine_config();
 
     let crp_mode = opts
         .crp_mode_override
-        .or_else(|| CrpMode::parse(profile.compression.crp_mode_effective()))
+        .or_else(|| CrpMode::parse(engine.compression.crp_mode))
         .unwrap_or(CrpMode::Tdd);
 
     let mcp_instructions = crate::instructions::build_instructions_with_client_for_compiler(

--- a/rust/src/core/profiles/engine_config.rs
+++ b/rust/src/core/profiles/engine_config.rs
@@ -1,0 +1,35 @@
+use super::types::Profile;
+
+/// Pure, borrowed view of deterministic Engine mechanism configuration.
+///
+/// The legacy `Profile` remains the loader and compatibility adapter while
+/// Product policy fields stay outside this Engine-facing seam.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EngineConfig<'a> {
+    pub(crate) read: EngineReadConfig<'a>,
+    pub(crate) compression: EngineCompressionConfig<'a>,
+}
+
+/// Read mechanism values only; reuse policy such as `prefer_cache` is excluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EngineReadConfig<'a> {
+    pub(crate) default_mode: &'a str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EngineCompressionConfig<'a> {
+    pub(crate) crp_mode: &'a str,
+}
+
+impl Profile {
+    pub(crate) fn engine_config(&self) -> EngineConfig<'_> {
+        EngineConfig {
+            read: EngineReadConfig {
+                default_mode: self.read.default_mode_effective(),
+            },
+            compression: EngineCompressionConfig {
+                crp_mode: self.compression.crp_mode_effective(),
+            },
+        }
+    }
+}

--- a/rust/src/core/profiles/mod.rs
+++ b/rust/src/core/profiles/mod.rs
@@ -10,6 +10,7 @@
 //! parent fields; unset fields inherit.
 
 mod builtins;
+mod engine_config;
 mod loading;
 pub mod types;
 

--- a/rust/src/core/profiles/tests.rs
+++ b/rust/src/core/profiles/tests.rs
@@ -42,6 +42,32 @@ fn profile_roundtrip_toml() {
 }
 
 #[test]
+fn engine_config_projects_consumed_mechanisms_without_changing_legacy_toml() {
+    let profile = builtin_exploration();
+    let before = format_as_toml(&profile);
+    let engine = profile.engine_config();
+
+    assert_eq!(engine.read.default_mode, "map");
+    assert_eq!(engine.compression.crp_mode, "tdd");
+    assert_eq!(format_as_toml(&profile), before);
+}
+
+#[test]
+fn engine_config_excludes_product_policy() {
+    let mut profile = builtin_exploration();
+    profile.read.prefer_cache = Some(false);
+    profile.routing.max_model_tier = Some("fast".into());
+    profile.budget.max_context_tokens = Some(1);
+    profile.constraints.quality_floor = Some(0.1);
+    profile.autonomy.auto_prefetch = Some(true);
+    profile.degradation.enforce = Some(true);
+
+    let engine = profile.engine_config();
+    assert_eq!(engine.read.default_mode, "map");
+    assert_eq!(engine.compression.crp_mode, "tdd");
+}
+
+#[test]
 fn merge_child_overrides_parent() {
     let parent = builtin_exploration();
     let child = Profile {


### PR DESCRIPTION
P4 R4A one-theme extraction.

- Adds a borrowed EngineConfig mechanism view over existing profile data.
- Migrates only auto-mode and instruction-compiler consumers.
- Preserves TOML shape and excludes Product policy fields.
- No SDK, Cloud, protocol, or lifecycle expansion.

Evidence: rebased patch is byte-equivalent to independently reviewed a4862248f4; focused profile 2/2 and instruction-compiler 3/3 gates previously passed; diff/format review passed. Broad validation is delegated to this PR CI.