### PR TITLE
refactor(policy): separate safety from attach compatibility

### DIFF
--- a/rust/src/core/context_policies.rs
+++ b/rust/src/core/context_policies.rs
@@ -63,6 +63,13 @@ impl PolicySet {
 
     /// Built-in default policies that align with existing LeanCTX behavior.
     pub fn defaults() -> Self {
+        let mut policies = Self::security_defaults().policies;
+        policies.extend(Self::attach_compat_defaults().policies);
+        Self { policies }
+    }
+
+    /// Open Engine safety defaults. These remain mechanism-level security policy.
+    pub fn security_defaults() -> Self {
         Self {
             policies: vec![
                 ContextPolicy {
@@ -86,6 +93,17 @@ impl PolicySet {
                     condition: None,
                     reason: Some("credentials".to_string()),
                 },
+            ],
+        }
+    }
+
+    /// Frozen OSS Attach compatibility heuristics.
+    ///
+    /// These preserve the supported Coding-Agent experience but are not the
+    /// canonical Product policy surface and must not gain new lifecycle rules.
+    pub fn attach_compat_defaults() -> Self {
+        Self {
+            policies: vec![
                 ContextPolicy {
                     name: "delta_after_first_read".to_string(),
                     match_pattern: "src/**".to_string(),
@@ -306,6 +324,61 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r.action, PolicyAction::Exclude)),
             "should exclude .env files"
+        );
+    }
+
+    #[test]
+    fn default_policy_partitions_preserve_order_and_ownership() {
+        let security = PolicySet::security_defaults();
+        let attach = PolicySet::attach_compat_defaults();
+        let defaults = PolicySet::defaults();
+
+        let security_names: Vec<_> = security
+            .policies
+            .iter()
+            .map(|policy| policy.name.as_str())
+            .collect();
+        let attach_names: Vec<_> = attach
+            .policies
+            .iter()
+            .map(|policy| policy.name.as_str())
+            .collect();
+        let default_names: Vec<_> = defaults
+            .policies
+            .iter()
+            .map(|policy| policy.name.as_str())
+            .collect();
+
+        assert_eq!(
+            security_names,
+            [
+                "never_include_secrets",
+                "exclude_private_keys",
+                "exclude_credentials",
+            ]
+        );
+        assert_eq!(
+            attach_names,
+            ["delta_after_first_read", "compress_large_files"]
+        );
+        assert_eq!(
+            default_names,
+            security_names
+                .into_iter()
+                .chain(attach_names)
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            security
+                .policies
+                .iter()
+                .all(|policy| matches!(policy.action, PolicyAction::Exclude))
+        );
+        assert!(
+            attach
+                .policies
+                .iter()
+                .all(|policy| matches!(policy.action, PolicyAction::SetView { .. }))
         );
     }
 


### PR DESCRIPTION
## Scope

- separate safety-policy decisions from Attach compatibility
- preserve current Engine behavior while clarifying the ownership boundary
- keep Product policy orchestration outside the Apache Engine

## Evidence

- rebased onto accepted main 77aff10c3f
- stable patch ID unchanged: 302875d580
- focused Policy gate and independent review: PASS
- independent integrated Layer 3: 10,473/10,473 library tests, all-features clippy with warnings denied, fmt: PASS
- current slice cargo fmt and git diff check: PASS

No full local rebuild was repeated; this PRs authoritative CI supplies Layer 4.