### PR TITLE
refactor(engine): isolate explicit field and compiler selection

### DIFF
--- a/rust/src/core/context_compiler.rs
+++ b/rust/src/core/context_compiler.rs
@@ -80,7 +80,7 @@ pub(crate) struct CompileResult {
     pub warnings: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct SelectedItem {
     pub id: String,
     pub path: String,
@@ -90,11 +90,30 @@ pub(crate) struct SelectedItem {
     pub pinned: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct ExcludedItem {
     pub id: String,
     pub path: String,
     pub reason: String,
+}
+
+/// Pure output of explicit candidate selection.
+///
+/// This boundary intentionally excludes clocks, process identity, providers,
+/// persistence, global policy state, and instrumentation. Callers supply all
+/// selection inputs through `candidates` and `budget`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CompileSelection {
+    pub budget_total: usize,
+    pub budget_used: usize,
+    pub items_considered: usize,
+    pub items_selected: usize,
+    pub items_excluded: usize,
+    pub items_pinned: usize,
+    pub selected: Vec<SelectedItem>,
+    pub excluded_reasons: Vec<ExcludedItem>,
+    pub warnings: Vec<String>,
+    redundancy_applied: bool,
 }
 
 /// Compile a minimal context package from candidates under budget constraints.
@@ -111,7 +130,31 @@ pub(crate) fn compile(
         chrono::Utc::now().format("%Y%m%d_%H%M%S"),
         std::process::id() % 1000
     );
+    let selection = select_explicit(candidates, budget);
+    if selection.redundancy_applied {
+        crate::core::introspect::tick("integration_phi");
+    }
 
+    CompileResult {
+        run_id,
+        mode: mode.as_str().to_string(),
+        budget_total: selection.budget_total,
+        budget_used: selection.budget_used,
+        items_considered: selection.items_considered,
+        items_selected: selection.items_selected,
+        items_excluded: selection.items_excluded,
+        items_pinned: selection.items_pinned,
+        selected: selection.selected,
+        excluded_reasons: selection.excluded_reasons,
+        warnings: selection.warnings,
+    }
+}
+
+/// Select a bounded context package from fully explicit inputs.
+pub(crate) fn select_explicit(
+    candidates: &[CompileCandidate],
+    budget: TokenBudget,
+) -> CompileSelection {
     let mut selected: Vec<SelectedItem> = Vec::new();
     let mut excluded: Vec<ExcludedItem> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
@@ -250,10 +293,6 @@ pub(crate) fn compile(
             reason: "budget exhausted".to_string(),
         });
     }
-    if redundancy_applied {
-        crate::core::introspect::tick("integration_phi");
-    }
-
     for c in candidates
         .iter()
         .filter(|c| c.state == ContextState::Excluded)
@@ -333,9 +372,7 @@ pub(crate) fn compile(
         ));
     }
 
-    CompileResult {
-        run_id,
-        mode: mode.as_str().to_string(),
+    CompileSelection {
         budget_total: budget.total,
         budget_used: tokens_used,
         items_considered: candidates.len(),
@@ -345,6 +382,7 @@ pub(crate) fn compile(
         selected,
         excluded_reasons: excluded,
         warnings,
+        redundancy_applied,
     }
 }
 
@@ -610,6 +648,96 @@ mod tests {
         let paths1: Vec<&str> = r1.selected.iter().map(|s| s.path.as_str()).collect();
         let paths2: Vec<&str> = r2.selected.iter().map(|s| s.path.as_str()).collect();
         assert_eq!(paths1, paths2, "selection order must be deterministic");
+    }
+
+    #[test]
+    fn select_explicit_golden_selection() {
+        let candidates = vec![
+            make_candidate("a.rs", 0.7, 400, false),
+            make_candidate("b.rs", 0.6, 300, true),
+            make_candidate("c.rs", 0.8, 500, false),
+        ];
+        let budget = TokenBudget {
+            total: 5000,
+            used: 250,
+        };
+
+        let result = select_explicit(&candidates, budget);
+
+        assert_eq!(
+            result
+                .selected
+                .iter()
+                .map(|item| {
+                    (
+                        item.path.as_str(),
+                        item.view.as_str(),
+                        item.tokens,
+                        item.phi,
+                        item.pinned,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                ("c.rs", "full", 500, 0.8, false),
+                ("b.rs", "full", 300, 0.6, true),
+                ("a.rs", "full", 400, 0.7, false),
+            ]
+        );
+        assert_eq!(result.budget_total, 5000);
+        assert_eq!(result.budget_used, 1200);
+        assert_eq!(result.items_considered, 3);
+        assert_eq!(result.items_selected, 3);
+        assert_eq!(result.items_excluded, 0);
+        assert_eq!(result.items_pinned, 1);
+        assert!(result.excluded_reasons.is_empty());
+        assert!(result.warnings.is_empty());
+        assert!(!result.redundancy_applied);
+    }
+
+    #[test]
+    fn select_explicit_is_pure_and_repeatable() {
+        let candidates = vec![
+            make_candidate("a.rs", 0.7, 400, false),
+            make_candidate("b.rs", 0.6, 300, true),
+            make_candidate("c.rs", 0.8, 500, false),
+        ];
+        let budget = TokenBudget {
+            total: 5000,
+            used: 250,
+        };
+
+        let expected = select_explicit(&candidates, budget);
+        for _mode in [
+            CompileMode::HandleManifest,
+            CompileMode::Compressed,
+            CompileMode::FullPrompt,
+        ] {
+            assert_eq!(select_explicit(&candidates, budget), expected);
+        }
+    }
+
+    #[test]
+    fn compile_preserves_legacy_run_id_shape() {
+        let result = compile(
+            &[make_candidate("a.rs", 0.7, 400, false)],
+            TokenBudget {
+                total: 5000,
+                used: 0,
+            },
+            CompileMode::HandleManifest,
+        );
+        let parts: Vec<&str> = result.run_id.split('_').collect();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0], "run");
+        assert_eq!(parts[1].len(), 8);
+        assert_eq!(parts[2].len(), 6);
+        assert!((1..=3).contains(&parts[3].len()));
+        assert!(
+            parts[1..]
+                .iter()
+                .all(|part| part.bytes().all(|byte| byte.is_ascii_digit()))
+        );
     }
 
     #[test]

--- a/rust/src/core/context_kernel/orchestrator.rs
+++ b/rust/src/core/context_kernel/orchestrator.rs
@@ -22,12 +22,17 @@ pub struct ContextKernel {
 }
 
 impl ContextKernel {
+    /// Create a kernel with an explicit field policy.
+    pub(crate) fn with_field(
+        providers: Vec<Box<dyn CandidateProvider>>,
+        field: ContextField,
+    ) -> Self {
+        Self { providers, field }
+    }
+
     /// Create a new kernel with the given providers.
     pub fn new(providers: Vec<Box<dyn CandidateProvider>>) -> Self {
-        Self {
-            providers,
-            field: ContextField::active(),
-        }
+        Self::with_field(providers, ContextField::active())
     }
 
     /// Create a kernel with default providers for a project.
@@ -348,7 +353,9 @@ pub mod tests {
     use super::super::types::{Freshness, SensitivityLevel, SideEffectPolicy};
     use std::collections::HashMap;
 
-    use crate::core::context_field::{ContextItemId, Provenance, TokenBudget, ViewCosts};
+    use crate::core::context_field::{
+        ContextItemId, FieldWeights, Provenance, TokenBudget, ViewCosts,
+    };
 
     use super::*;
 
@@ -472,6 +479,35 @@ pub mod tests {
                 .iter()
                 .any(|entry| entry.object_id == high.id.to_string())
         );
+    }
+
+    #[test]
+    fn explicit_field_controls_scoring_without_global_strategy() {
+        let providers = || -> Vec<Box<dyn CandidateProvider>> {
+            vec![Box::new(MockProvider {
+                items: vec![object("one", "reference", 0.8)],
+            })]
+        };
+        let weights = |w_relevance| FieldWeights {
+            w_relevance,
+            w_surprise: 0.0,
+            w_graph: 0.0,
+            w_history: 0.0,
+            w_cost: 0.0,
+            w_redundancy: 0.0,
+        };
+
+        let relevance_plan =
+            ContextKernel::with_field(providers(), ContextField::with_weights(weights(1.0)))
+                .plan(&context());
+        let zero_plan =
+            ContextKernel::with_field(providers(), ContextField::with_weights(weights(0.0)))
+                .plan(&context());
+
+        assert_eq!(relevance_plan.selected.len(), 1);
+        assert_eq!(zero_plan.selected.len(), 1);
+        assert_eq!(relevance_plan.selected[0].phi, 1.0);
+        assert_eq!(zero_plan.selected[0].phi, 0.0);
     }
 
     #[test]

--- a/rust/src/tools/ctx_compile.rs
+++ b/rust/src/tools/ctx_compile.rs
@@ -6,7 +6,7 @@
 
 use serde_json::Value;
 
-use crate::core::context_compiler::{CompileMode, compile, format_compile_result};
+use crate::core::context_compiler::{CompileMode, CompileResult, compile, format_compile_result};
 use crate::core::context_field::TokenBudget;
 use crate::core::context_handles::HandleRegistry;
 use crate::core::context_ledger::ContextLedger;
@@ -65,14 +65,18 @@ pub fn handle(
                 );
             }
             let mut out = registry.format_manifest(budget_tokens, result.budget_used);
-            out.push_str(&format!(
-                "\n\nRun ID: {} | Items: {} selected, {} excluded\n",
-                result.run_id, result.items_selected, result.items_excluded
-            ));
+            append_handle_summary(&mut out, &result);
             out
         }
         CompileMode::Compressed | CompileMode::FullPrompt => format_compile_result(&result),
     }
+}
+
+fn append_handle_summary(out: &mut String, result: &CompileResult) {
+    out.push_str(&format!(
+        "\n\nRun ID: {} | Items: {} selected, {} excluded\n",
+        result.run_id, result.items_selected, result.items_excluded
+    ));
 }
 
 fn get_str(args: Option<&serde_json::Map<String, Value>>, key: &str) -> Option<String> {
@@ -80,4 +84,32 @@ fn get_str(args: Option<&serde_json::Map<String, Value>>, key: &str) -> Option<S
         .get(key)?
         .as_str()
         .map(std::string::ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_manifest_preserves_run_id_label_and_counts() {
+        let result = CompileResult {
+            run_id: "run_20260825_120000_7".into(),
+            mode: "handles".into(),
+            budget_total: 100,
+            budget_used: 10,
+            items_considered: 3,
+            items_selected: 2,
+            items_excluded: 1,
+            items_pinned: 0,
+            selected: Vec::new(),
+            excluded_reasons: Vec::new(),
+            warnings: Vec::new(),
+        };
+        let mut output = "manifest".to_string();
+
+        append_handle_summary(&mut output, &result);
+
+        assert!(output.contains("Run ID: run_20260825_120000_7"));
+        assert!(output.contains("Items: 2 selected, 1 excluded"));
+    }
 }


### PR DESCRIPTION
## Scope
- inject explicit context field selection through the Engine orchestrator
- isolate compiler selection without changing legacy defaults
- limit the change to three Engine compiler/orchestrator files

## Evidence
- exact implementation patches independently reviewed with no P0/P1 findings
- focused compatibility tests passed before serialization
- full Linux, Windows, clippy, security, coverage, benchmark, and CodeQL gates delegated to this PR CI

No SDK artifact rebuild and no local broad Cargo rerun.