### PR TITLE
feat(compiler): add opt-in deterministic run IDs

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -101,8 +101,9 @@ Parameters: `command`, `content`, `ext`, `output`, `path`
 Build minimal context package within token budget. Modes: handles (references), compressed (content), full (all cached).
 WORKFLOW: after ctx_read/ctx_compose, package focused context for handoff/subagent.
 ANTIPATTERN: not for exploration — use ctx_compose/ctx_read first.
+run_id_version=1 preserves legacy timestamp/PID IDs; run_id_version=2 opts into deterministic IDs.
 
-Parameters: `budget`, `mode`
+Parameters: `budget`, `mode`, `run_id_version`
 
 ## `ctx_compose`
 

--- a/rust/src/cli/context_cmd.rs
+++ b/rust/src/cli/context_cmd.rs
@@ -101,13 +101,13 @@ pub(crate) fn cmd_plan(args: &[String]) {
 }
 
 pub(crate) fn cmd_compile(args: &[String]) {
-    let (json, args_map) = build_compile_request(args);
+    let (_json, args_map) = build_compile_request(args);
 
     #[cfg(unix)]
     {
         if let Some(out) = crate::daemon_client::try_daemon_tool_call_blocking_text(
             "ctx_compile",
-            Some(json.clone()),
+            Some(_json.clone()),
         ) {
             println!("{out}");
             return;

--- a/rust/src/cli/context_cmd.rs
+++ b/rust/src/cli/context_cmd.rs
@@ -101,15 +101,7 @@ pub(crate) fn cmd_plan(args: &[String]) {
 }
 
 pub(crate) fn cmd_compile(args: &[String]) {
-    let mode = flag_value(args, "--mode").unwrap_or_else(|| "handles".to_string());
-    let budget = flag_value(args, "--budget");
-
-    let mut json = serde_json::json!({ "mode": mode });
-    if let Some(b) = &budget
-        && let Ok(n) = b.parse::<u64>()
-    {
-        json["budget"] = serde_json::Value::Number(n.into());
-    }
+    let (json, args_map) = build_compile_request(args);
 
     #[cfg(unix)]
     {
@@ -126,10 +118,42 @@ pub(crate) fn cmd_compile(args: &[String]) {
     let ledger = ContextLedger::load();
     let policies = PolicySet::defaults();
 
-    let args_map = build_map(&[("mode", Some(mode)), ("budget", budget)]);
     let result = crate::tools::ctx_compile::handle(Some(&args_map), &ledger, &policies);
 
     println!("{result}");
+}
+
+fn build_compile_request(
+    args: &[String],
+) -> (
+    serde_json::Value,
+    serde_json::Map<String, serde_json::Value>,
+) {
+    let mode = flag_value(args, "--mode").unwrap_or_else(|| "handles".to_string());
+    let budget = flag_value(args, "--budget");
+    let run_id_version = flag_value(args, "--run-id-version");
+
+    let mut json = serde_json::json!({ "mode": mode });
+    if let Some(b) = &budget
+        && let Ok(n) = b.parse::<u64>()
+    {
+        json["budget"] = serde_json::Value::Number(n.into());
+    }
+    if let Some(version) = &run_id_version {
+        json["run_id_version"] = version.parse::<u64>().map_or_else(
+            |_| serde_json::Value::String(version.clone()),
+            |n| serde_json::Value::Number(n.into()),
+        );
+    }
+
+    let mut args_map = build_map(&[("mode", Some(mode)), ("budget", budget)]);
+    if let Some(version) = run_id_version {
+        args_map.insert(
+            "run_id_version".to_string(),
+            serde_json::Value::String(version),
+        );
+    }
+    (json, args_map)
 }
 
 fn flag_value(args: &[String], flag: &str) -> Option<String> {
@@ -147,4 +171,18 @@ fn build_map(pairs: &[(&str, Option<String>)]) -> serde_json::Map<String, serde_
         }
     }
     map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_compile_request_forwards_deterministic_run_id_version() {
+        let args = vec!["--run-id-version".to_string(), "2".to_string()];
+        let (wire, local) = build_compile_request(&args);
+
+        assert_eq!(wire["run_id_version"], 2);
+        assert_eq!(local["run_id_version"], "2");
+    }
 }

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -243,7 +243,8 @@ COMMANDS:
                                    Code smell detection (Property Graph, 8 rules)
     control <action> [--target=<t>] Context field manipulation (exclude/pin/priority)
     plan <task> [--budget=N]       Context planning (optimal Phi-scored context plan)
-    compile [--mode=<m>] [--budget=N] Context compilation (knapsack + Boltzmann)
+    compile [--mode=<m>] [--budget=N] [--run-id-version=2]
+                                   Context compilation (knapsack + Boltzmann)
     visualize [--output F] [--open] Generate interactive HTML report (D3.js graph)
     plugin list|enable|disable|info|init|hooks
                                    Manage lean-ctx plugins

--- a/rust/src/core/context_compiler.rs
+++ b/rust/src/core/context_compiler.rs
@@ -45,6 +45,30 @@ impl CompileMode {
     }
 }
 
+/// Version of the compilation run identifier emitted in a result.
+///
+/// Legacy V1 remains the default so existing callers retain the timestamp/PID
+/// identifier. Deterministic V2 is opt-in and derives its identifier only from
+/// the selected result and output mode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum RunIdVersion {
+    #[default]
+    LegacyV1,
+    DeterministicV2,
+}
+
+impl RunIdVersion {
+    pub(crate) fn from_u64(value: u64) -> Result<Self, String> {
+        match value {
+            1 => Ok(Self::LegacyV1),
+            2 => Ok(Self::DeterministicV2),
+            other => Err(format!(
+                "invalid run_id_version {other}; expected 1 (legacy) or 2 (deterministic)"
+            )),
+        }
+    }
+}
+
 /// A candidate item ready for selection.
 #[derive(Debug, Clone)]
 pub struct CompileCandidate {
@@ -102,7 +126,7 @@ pub(crate) struct ExcludedItem {
 /// This boundary intentionally excludes clocks, process identity, providers,
 /// persistence, global policy state, and instrumentation. Callers supply all
 /// selection inputs through `candidates` and `budget`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct CompileSelection {
     pub budget_total: usize,
     pub budget_used: usize,
@@ -125,15 +149,34 @@ pub(crate) fn compile(
     budget: TokenBudget,
     mode: CompileMode,
 ) -> CompileResult {
-    let run_id = format!(
-        "run_{}_{}",
-        chrono::Utc::now().format("%Y%m%d_%H%M%S"),
-        std::process::id() % 1000
-    );
+    compile_with_run_id_version(candidates, budget, mode, RunIdVersion::LegacyV1)
+}
+
+/// Compile a context package with an explicit run identifier version.
+pub(crate) fn compile_with_run_id_version(
+    candidates: &[CompileCandidate],
+    budget: TokenBudget,
+    mode: CompileMode,
+    run_id_version: RunIdVersion,
+) -> CompileResult {
+    // Keep the legacy clock/process evaluation before selection, matching the
+    // historical compile path exactly. V2 deliberately does not read either.
+    let legacy_run_id = (run_id_version == RunIdVersion::LegacyV1).then(|| {
+        format!(
+            "run_{}_{}",
+            chrono::Utc::now().format("%Y%m%d_%H%M%S"),
+            std::process::id() % 1000
+        )
+    });
     let selection = select_explicit(candidates, budget);
     if selection.redundancy_applied {
         crate::core::introspect::tick("integration_phi");
     }
+
+    let run_id = match run_id_version {
+        RunIdVersion::LegacyV1 => legacy_run_id.expect("legacy run ID initialized above"),
+        RunIdVersion::DeterministicV2 => deterministic_run_id(mode, &selection),
+    };
 
     CompileResult {
         run_id,
@@ -148,6 +191,25 @@ pub(crate) fn compile(
         excluded_reasons: selection.excluded_reasons,
         warnings: selection.warnings,
     }
+}
+
+/// Derive a stable V2 run identifier from canonical mode and selection data.
+fn deterministic_run_id(mode: CompileMode, selection: &CompileSelection) -> String {
+    // Struct serialization fixes field order; selection itself is ordered by the
+    // pure selector, so identical inputs produce identical bytes across runs.
+    #[derive(Serialize)]
+    struct CanonicalRunInputs<'a> {
+        mode: &'static str,
+        selection: &'a CompileSelection,
+    }
+
+    let canonical = CanonicalRunInputs {
+        mode: mode.as_str(),
+        selection,
+    };
+    let bytes = serde_json::to_vec(&canonical).expect("compile selection must be JSON-safe");
+    let digest = blake3::hash(&bytes).to_hex().to_string();
+    format!("run_v2_{}", &digest[..16])
 }
 
 /// Select a bounded context package from fully explicit inputs.
@@ -737,6 +799,90 @@ mod tests {
             parts[1..]
                 .iter()
                 .all(|part| part.bytes().all(|byte| byte.is_ascii_digit()))
+        );
+    }
+
+    #[test]
+    fn deterministic_v2_run_id_is_repeatable_and_versioned() {
+        let candidates = vec![
+            make_candidate("a.rs", 0.7, 400, false),
+            make_candidate("b.rs", 0.6, 300, true),
+        ];
+        let budget = TokenBudget {
+            total: 5000,
+            used: 0,
+        };
+
+        let first = compile_with_run_id_version(
+            &candidates,
+            budget,
+            CompileMode::Compressed,
+            RunIdVersion::DeterministicV2,
+        );
+        let second = compile_with_run_id_version(
+            &candidates,
+            budget,
+            CompileMode::Compressed,
+            RunIdVersion::DeterministicV2,
+        );
+
+        assert_eq!(first.run_id, second.run_id);
+        assert!(first.run_id.starts_with("run_v2_"));
+        assert_eq!(first.run_id.len(), "run_v2_".len() + 16);
+    }
+
+    #[test]
+    fn deterministic_v2_run_id_changes_with_mode_or_selection() {
+        let candidates = vec![make_candidate("a.rs", 0.7, 400, false)];
+        let budget = TokenBudget {
+            total: 5000,
+            used: 0,
+        };
+
+        let compressed = compile_with_run_id_version(
+            &candidates,
+            budget,
+            CompileMode::Compressed,
+            RunIdVersion::DeterministicV2,
+        );
+        let full = compile_with_run_id_version(
+            &candidates,
+            budget,
+            CompileMode::FullPrompt,
+            RunIdVersion::DeterministicV2,
+        );
+        let changed_selection = compile_with_run_id_version(
+            &[make_candidate("different.rs", 0.7, 400, false)],
+            budget,
+            CompileMode::Compressed,
+            RunIdVersion::DeterministicV2,
+        );
+
+        assert_ne!(compressed.run_id, full.run_id);
+        assert_ne!(compressed.run_id, changed_selection.run_id);
+    }
+
+    #[test]
+    fn explicit_legacy_v1_preserves_timestamp_pid_run_id_shape() {
+        let result = compile_with_run_id_version(
+            &[make_candidate("a.rs", 0.7, 400, false)],
+            TokenBudget {
+                total: 5000,
+                used: 0,
+            },
+            CompileMode::HandleManifest,
+            RunIdVersion::LegacyV1,
+        );
+        let parts: Vec<&str> = result.run_id.split('_').collect();
+
+        assert_eq!(parts[0], "run");
+        assert_eq!(parts[1].len(), 8);
+        assert_eq!(parts[2].len(), 6);
+        assert!((1..=3).contains(&parts[3].len()));
+        assert!(
+            parts[1..]
+                .iter()
+                .all(|part| { part.bytes().all(|byte| byte.is_ascii_digit()) })
         );
     }
 

--- a/rust/src/core/context_compiler.rs
+++ b/rust/src/core/context_compiler.rs
@@ -175,7 +175,7 @@ pub(crate) fn compile_with_run_id_version(
 
     let run_id = match run_id_version {
         RunIdVersion::LegacyV1 => legacy_run_id.expect("legacy run ID initialized above"),
-        RunIdVersion::DeterministicV2 => deterministic_run_id(mode, &selection),
+        RunIdVersion::DeterministicV2 => deterministic_run_id(mode, budget, &selection),
     };
 
     CompileResult {
@@ -194,22 +194,33 @@ pub(crate) fn compile_with_run_id_version(
 }
 
 /// Derive a stable V2 run identifier from canonical mode and selection data.
-fn deterministic_run_id(mode: CompileMode, selection: &CompileSelection) -> String {
+fn deterministic_run_id(
+    mode: CompileMode,
+    budget: TokenBudget,
+    selection: &CompileSelection,
+) -> String {
     // Struct serialization fixes field order; selection itself is ordered by the
     // pure selector, so identical inputs produce identical bytes across runs.
     #[derive(Serialize)]
     struct CanonicalRunInputs<'a> {
         mode: &'static str,
+        budget_total: usize,
+        budget_used: usize,
         selection: &'a CompileSelection,
     }
 
     let canonical = CanonicalRunInputs {
         mode: mode.as_str(),
+        budget_total: budget.total,
+        budget_used: budget.used,
         selection,
     };
-    let bytes = serde_json::to_vec(&canonical).expect("compile selection must be JSON-safe");
-    let digest = blake3::hash(&bytes).to_hex().to_string();
-    format!("run_v2_{}", &digest[..16])
+    let payload = serde_json::to_vec(&canonical).expect("compile selection must be JSON-safe");
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"lean-ctx:context-compile:run-id:v2\0");
+    hasher.update(&payload);
+    let digest = hasher.finalize().to_hex().to_string();
+    format!("run_v2_{}", &digest[..32])
 }
 
 /// Select a bounded context package from fully explicit inputs.
@@ -828,7 +839,12 @@ mod tests {
 
         assert_eq!(first.run_id, second.run_id);
         assert!(first.run_id.starts_with("run_v2_"));
-        assert_eq!(first.run_id.len(), "run_v2_".len() + 16);
+        assert_eq!(first.run_id.len(), "run_v2_".len() + 32);
+        assert!(
+            first.run_id[7..]
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        );
     }
 
     #[test]
@@ -857,9 +873,19 @@ mod tests {
             CompileMode::Compressed,
             RunIdVersion::DeterministicV2,
         );
+        let changed_used_budget = compile_with_run_id_version(
+            &candidates,
+            TokenBudget {
+                total: 5000,
+                used: 1,
+            },
+            CompileMode::Compressed,
+            RunIdVersion::DeterministicV2,
+        );
 
         assert_ne!(compressed.run_id, full.run_id);
         assert_ne!(compressed.run_id, changed_selection.run_id);
+        assert_ne!(compressed.run_id, changed_used_budget.run_id);
     }
 
     #[test]

--- a/rust/src/tools/ctx_compile.rs
+++ b/rust/src/tools/ctx_compile.rs
@@ -6,7 +6,9 @@
 
 use serde_json::Value;
 
-use crate::core::context_compiler::{CompileMode, CompileResult, compile, format_compile_result};
+use crate::core::context_compiler::{
+    CompileMode, CompileResult, RunIdVersion, compile_with_run_id_version, format_compile_result,
+};
 use crate::core::context_field::TokenBudget;
 use crate::core::context_handles::HandleRegistry;
 use crate::core::context_ledger::ContextLedger;
@@ -21,6 +23,10 @@ pub fn handle(
 ) -> String {
     let mode_str = get_str(args, "mode").unwrap_or_else(|| "handles".to_string());
     let mode = CompileMode::parse(&mode_str);
+    let run_id_version = match parse_run_id_version(args) {
+        Ok(version) => version,
+        Err(message) => return format!("[ctx_compile] {message}"),
+    };
     let budget_tokens: usize = args
         .and_then(|a| a.get("budget"))
         .and_then(serde_json::Value::as_u64)
@@ -36,7 +42,7 @@ pub fn handle(
         return "[ctx_compile] no context items in ledger — nothing to compile".to_string();
     }
 
-    let result = compile(&candidates, budget, mode);
+    let result = compile_with_run_id_version(&candidates, budget, mode, run_id_version);
 
     match mode {
         CompileMode::HandleManifest => {
@@ -86,6 +92,22 @@ fn get_str(args: Option<&serde_json::Map<String, Value>>, key: &str) -> Option<S
         .map(std::string::ToString::to_string)
 }
 
+fn parse_run_id_version(
+    args: Option<&serde_json::Map<String, Value>>,
+) -> Result<RunIdVersion, String> {
+    let Some(value) = args.and_then(|a| a.get("run_id_version")) else {
+        return Ok(RunIdVersion::default());
+    };
+
+    let parsed = value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|s| s.trim().parse::<u64>().ok()));
+    parsed.map_or_else(
+        || Err("invalid run_id_version; expected integer 1 (legacy) or 2 (deterministic)".into()),
+        RunIdVersion::from_u64,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,5 +133,15 @@ mod tests {
 
         assert!(output.contains("Run ID: run_20260825_120000_7"));
         assert!(output.contains("Items: 2 selected, 1 excluded"));
+    }
+
+    #[test]
+    fn invalid_run_id_version_is_rejected_before_compilation() {
+        let args = serde_json::json!({"run_id_version": 7});
+        let result = parse_run_id_version(args.as_object());
+        assert_eq!(
+            result.unwrap_err(),
+            "invalid run_id_version 7; expected 1 (legacy) or 2 (deterministic)"
+        );
     }
 }

--- a/rust/src/tools/registered/ctx_compile.rs
+++ b/rust/src/tools/registered/ctx_compile.rs
@@ -15,12 +15,18 @@ impl McpTool for CtxCompileTool {
     fn tool_def(&self) -> Tool {
         tool_def(
             "ctx_compile",
-            "Build minimal context package within token budget. Modes: handles (references), compressed (content), full (all cached).\nWORKFLOW: after ctx_read/ctx_compose, package focused context for handoff/subagent.\nANTIPATTERN: not for exploration — use ctx_compose/ctx_read first.",
+            "Build minimal context package within token budget. Modes: handles (references), compressed (content), full (all cached).\nWORKFLOW: after ctx_read/ctx_compose, package focused context for handoff/subagent.\nANTIPATTERN: not for exploration — use ctx_compose/ctx_read first.\nrun_id_version=1 preserves legacy timestamp/PID IDs; run_id_version=2 opts into deterministic IDs.",
             json!({
                 "type": "object",
                 "properties": {
                     "mode": { "type": "string", "description": "handles|compressed|full" },
-                    "budget": { "type": "integer", "description": "Token budget (default: session budget or 12000)" }
+                    "budget": { "type": "integer", "description": "Token budget (default: session budget or 12000)" },
+                    "run_id_version": {
+                        "type": "integer",
+                        "enum": [1, 2],
+                        "default": 1,
+                        "description": "Run ID format: 1=legacy timestamp/PID (default), 2=deterministic"
+                    }
                 }
             }),
         )
@@ -48,5 +54,21 @@ impl McpTool for CtxCompileTool {
         let result = crate::tools::ctx_compile::handle(Some(args), &ledger, &policies);
 
         Ok(ToolOutput::simple(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::tool_trait::McpTool;
+
+    #[test]
+    fn schema_advertises_opt_in_run_id_version() {
+        let schema = serde_json::Value::Object((*CtxCompileTool.tool_def().input_schema).clone());
+        let version = &schema["properties"]["run_id_version"];
+
+        assert_eq!(version["type"], "integer");
+        assert_eq!(version["default"], 1);
+        assert_eq!(version["enum"], serde_json::json!([1, 2]));
     }
 }


### PR DESCRIPTION
## Scope
- add explicit run_id_version=2 for deterministic compile identifiers
- preserve LegacyV1 as the exact default
- bind V2 IDs to canonical mode, selection, and budget inputs under a versioned BLAKE3 domain
- expose CLI and MCP schema validation for the opt-in version

## Evidence
- focused legacy/default, deterministic, schema, help, and invalid-version tests passed before serialization
- independent review PASS with no P0/P1 findings
- full platform, security, coverage, benchmark, clippy, and CodeQL validation delegated to PR CI

No SDK rebuild and no broad local Cargo rerun.