### PR TITLE
refactor(engine): keep delivery evidence factual

### DIFF
--- a/rust/src/core/context_kernel/bridge_e2e.rs
+++ b/rust/src/core/context_kernel/bridge_e2e.rs
@@ -54,13 +54,16 @@ mod tests {
     }
 
     #[test]
-    fn proxy_records_etpao() {
+    fn proxy_records_request_without_inventing_etpao() {
         let _guard = isolated();
         for _ in 0..5 {
             let _ = proxy_bridge::process_proxy_request(&request_for("alice"));
         }
 
-        assert!(proxy_bridge::current_etpao() > 0.0);
+        let summary = proxy_bridge::etpao_summary();
+        assert_eq!(proxy_bridge::current_etpao(), 0.0);
+        assert!(summary.total_tokens > 0);
+        assert_eq!(summary.accepted_outcomes, 0);
     }
 
     #[test]
@@ -114,7 +117,7 @@ mod tests {
     }
 
     #[test]
-    fn end_to_end_identity_to_etpao() {
+    fn end_to_end_identity_to_request_metrics() {
         let _guard = isolated();
         for index in 0..10 {
             let user = format!("user-{}", index % 3);
@@ -124,11 +127,12 @@ mod tests {
         assert!(proxy_bridge::identity_summary().total_users >= 3);
         let summary = proxy_bridge::etpao_summary();
         assert!(summary.total_tokens > 0);
-        assert!(summary.accepted_outcomes > 0);
+        assert_eq!(summary.accepted_outcomes, 0);
+        assert_eq!(summary.etpao, 0.0);
     }
 
     #[test]
-    fn outcome_signal_integrated() {
+    fn unevaluated_outcome_remains_unknown() {
         let _guard = isolated();
         let request = ProxyRequestData {
             is_retry: true,
@@ -140,7 +144,7 @@ mod tests {
 
         assert_eq!(
             result.outcome_signal.outcome,
-            super::super::types::ReceiptOutcome::Rejected
+            super::super::types::ReceiptOutcome::Unknown
         );
     }
 }

--- a/rust/src/core/context_kernel/envelope_e2e.rs
+++ b/rust/src/core/context_kernel/envelope_e2e.rs
@@ -135,7 +135,7 @@ mod tests {
         }
 
         let snapshot = live_dashboard::snapshot();
-        assert!(snapshot.proxy_etpao > 0.0);
+        assert_eq!(snapshot.proxy_etpao, 0.0);
         assert_eq!(snapshot.usage.total_requests, 5);
         assert_eq!(snapshot.chain.total_entries, 5);
     }
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(snapshot.usage.total_tokens, envelope.total_tokens());
         assert_eq!(snapshot.chain.total_entries, 1);
         assert_eq!(snapshot.chain.accepted, 1);
-        assert!(snapshot.proxy_etpao > 0.0);
+        assert_eq!(snapshot.proxy_etpao, 0.0);
     }
 
     #[test]

--- a/rust/src/core/context_kernel/envelope_wiring.rs
+++ b/rust/src/core/context_kernel/envelope_wiring.rs
@@ -1,7 +1,8 @@
 //! Activation wiring for the kernel evidence pipeline.
 
 use super::{
-    accounting_fix, kernel_config, outcome_signal, receipt_chain, token_envelope, usage_normalizer,
+    accounting_fix, kernel_config, receipt_chain, token_envelope, types::ReceiptOutcome,
+    usage_normalizer,
 };
 
 const PROXY_SOURCE: &str = "proxy";
@@ -72,17 +73,11 @@ pub(crate) fn process_mcp_evidence(data: &super::mcp_bridge::McpCallData) {
     let accounting =
         accounting_fix::compute_honest_accounting(data.input_tokens, data.output_tokens, 0, 0);
     if kernel_config::is_feature_enabled("receipt_chain") {
-        let call_number = if data.is_retry {
-            data.call_number.max(2)
-        } else {
-            data.call_number
-        };
-        let outcome = outcome_signal::infer_outcome(call_number, data.is_retry, data.output_tokens);
         receipt_chain::record_chain_entry(
             MCP_SOURCE,
             envelope,
             accounting,
-            outcome.outcome,
+            ReceiptOutcome::Unknown,
             false,
             0,
         );
@@ -127,8 +122,8 @@ mod tests {
     use std::sync::MutexGuard;
 
     use super::{
-        EvidenceSummary, evidence_summary, process_mcp_evidence, process_proxy_evidence,
-        reset_evidence,
+        EvidenceSummary, ReceiptOutcome, evidence_summary, process_mcp_evidence,
+        process_proxy_evidence, reset_evidence,
     };
     use crate::core::context_kernel::kernel_config::{self, KernelFeatures};
     use crate::core::context_kernel::mcp_bridge::McpCallData;
@@ -182,7 +177,9 @@ mod tests {
     fn proxy_evidence_records_chain() {
         let _guard = isolated();
         process_proxy();
-        assert!(receipt_chain::chain_length() > 0);
+        let entries = receipt_chain::chain_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].outcome, ReceiptOutcome::Unknown);
     }
 
     #[test]
@@ -190,6 +187,10 @@ mod tests {
         let _guard = isolated();
         process_mcp_evidence(&mcp_data(1));
         assert_eq!(usage_normalizer::session_usage().total_requests, 1);
+        assert_eq!(
+            receipt_chain::chain_entries()[0].outcome,
+            ReceiptOutcome::Unknown
+        );
     }
 
     #[test]

--- a/rust/src/core/context_kernel/etpao_live.rs
+++ b/rust/src/core/context_kernel/etpao_live.rs
@@ -82,12 +82,16 @@ impl EtpaoLive {
 
     /// Returns aggregate tokens per accepted outcome.
     pub fn current_etpao(&self) -> f64 {
+        let accepted = self.accepted_outcomes();
+        if accepted == 0 {
+            return 0.0;
+        }
         let tokens = self
             .requests
             .iter()
             .map(total_request_tokens)
             .sum::<usize>();
-        tokens as f64 / self.accepted_outcomes().max(1) as f64
+        tokens as f64 / accepted as f64
     }
 
     /// Returns tokens per accepted outcome for a client with recorded requests.
@@ -105,7 +109,11 @@ impl EtpaoLive {
             .iter()
             .filter(|outcome| outcome.client_id == client_id && outcome.accepted)
             .count();
-        Some(tokens as f64 / accepted.max(1) as f64)
+        Some(if accepted == 0 {
+            0.0
+        } else {
+            tokens as f64 / accepted as f64
+        })
     }
 
     /// Returns the fraction of tokens consumed by requests with retries.
@@ -155,6 +163,16 @@ impl EtpaoLive {
         self.requests.len()
     }
 
+    /// Returns factual input and output token totals across recorded requests.
+    pub fn request_token_totals(&self) -> (usize, usize) {
+        self.requests.iter().fold((0, 0), |totals, request| {
+            (
+                totals.0.saturating_add(request.input_tokens),
+                totals.1.saturating_add(request.output_tokens),
+            )
+        })
+    }
+
     /// Returns the number of recorded outcomes.
     pub fn outcome_count(&self) -> usize {
         self.outcomes.len()
@@ -187,7 +205,12 @@ impl EtpaoLive {
                             })
                     })
                     .count();
-                (format!("{class:?}"), tokens as f64 / accepted.max(1) as f64)
+                let etpao = if accepted == 0 {
+                    0.0
+                } else {
+                    tokens as f64 / accepted as f64
+                };
+                (format!("{class:?}"), etpao)
             })
             .collect()
     }
@@ -221,6 +244,9 @@ pub mod tests {
 
     #[test]
     fn empty_etpao_is_zero() { assert_eq!(EtpaoLive::new().current_etpao(), 0.0); }
+
+    #[test]
+    fn request_without_evaluated_outcome_is_zero() { let mut live = EtpaoLive::new(); live.record_request(request("a", 100, CoverageClass::FullInline)); assert_eq!(live.current_etpao(), 0.0); assert_eq!(live.etpao_for_client("a"), Some(0.0)); assert_eq!(live.summary().by_coverage_class.get("FullInline"), Some(&0.0)); }
 
     #[test]
     fn single_request_single_outcome() { let mut live = EtpaoLive::new(); live.record_request(request("a", 1_000, CoverageClass::FullInline)); live.record_outcome(outcome("a", true, true)); assert_eq!(live.current_etpao(), 1_000.0); }

--- a/rust/src/core/context_kernel/identity.rs
+++ b/rust/src/core/context_kernel/identity.rs
@@ -66,14 +66,8 @@ impl IdentityLedger {
         Self::default()
     }
 
-    /// Records token usage, savings, and outcome acceptance for a caller.
-    pub fn record(
-        &mut self,
-        identity: &CallerIdentity,
-        consumed: usize,
-        saved: usize,
-        accepted: bool,
-    ) {
+    /// Records factual token usage and savings for a caller without asserting an outcome.
+    pub fn record_usage(&mut self, identity: &CallerIdentity, consumed: usize, saved: usize) {
         let key = Self::ledger_key(identity);
         let attribution = self
             .entries
@@ -88,8 +82,22 @@ impl IdentityLedger {
         attribution.tokens_consumed = attribution.tokens_consumed.saturating_add(consumed);
         attribution.tokens_saved = attribution.tokens_saved.saturating_add(saved);
         attribution.request_count = attribution.request_count.saturating_add(1);
+    }
+
+    /// Records token usage, savings, and an explicit outcome acceptance for a caller.
+    pub fn record(
+        &mut self,
+        identity: &CallerIdentity,
+        consumed: usize,
+        saved: usize,
+        accepted: bool,
+    ) {
+        self.record_usage(identity, consumed, saved);
         if accepted {
-            attribution.accepted_outcomes = attribution.accepted_outcomes.saturating_add(1);
+            let key = Self::ledger_key(identity);
+            if let Some(attribution) = self.entries.get_mut(&key) {
+                attribution.accepted_outcomes = attribution.accepted_outcomes.saturating_add(1);
+            }
         }
     }
 
@@ -229,6 +237,18 @@ pub mod tests {
         assert_eq!(entry.tokens_saved, 20);
         assert_eq!(entry.request_count, 1);
         assert_eq!(entry.accepted_outcomes, 1);
+    }
+
+    #[test]
+    fn ledger_usage_does_not_invent_an_outcome() {
+        let mut ledger = IdentityLedger::new();
+        ledger.record_usage(&identity("alice", "platform"), 80, 20);
+
+        let entry = ledger
+            .attribution_for("alice")
+            .expect("alice must have attribution");
+        assert_eq!(entry.request_count, 1);
+        assert_eq!(entry.accepted_outcomes, 0);
     }
 
     #[test]

--- a/rust/src/core/context_kernel/live_dashboard.rs
+++ b/rust/src/core/context_kernel/live_dashboard.rs
@@ -228,8 +228,8 @@ pub mod tests {
         });
 
         let value = snapshot();
-        assert!(value.proxy_etpao > 0.0);
-        assert!(value.mcp_etpao > 0.0);
+        assert_eq!(value.proxy_etpao, 0.0);
+        assert_eq!(value.mcp_etpao, 0.0);
         assert!(value.identity.total_tokens > 0);
     }
 }

--- a/rust/src/core/context_kernel/mcp_bridge.rs
+++ b/rust/src/core/context_kernel/mcp_bridge.rs
@@ -5,10 +5,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::client_wiring::OptimizationLevel;
 use super::coverage_class::{self, CoverageClass};
-use super::etpao_live::{EtpaoLive, OutcomeMetrics, RequestMetrics};
+use super::etpao_live::{EtpaoLive, RequestMetrics};
 use super::identity::{CallerIdentity, CallerRole, IdentityLedger};
-use super::outcome_signal::{self, OutcomeSignal};
-use super::types::ReceiptOutcome;
 
 static MCP_ETPAO: OnceLock<Mutex<EtpaoLive>> = OnceLock::new();
 static MCP_IDENTITY: OnceLock<Mutex<IdentityLedger>> = OnceLock::new();
@@ -28,7 +26,7 @@ pub struct McpClientInfo {
     pub tool_count: usize,
 }
 
-/// Data for a single MCP tool call, used to record ETPAO metrics.
+/// Data for a single MCP tool call, used to record factual request metrics.
 #[derive(Debug, Clone, Default)]
 pub struct McpCallData {
     /// Name of the tool called.
@@ -67,7 +65,7 @@ pub struct McpSummary {
     pub total_input_tokens: usize,
     /// Output tokens across all calls.
     pub total_output_tokens: usize,
-    /// Calls inferred to have been accepted.
+    /// Calls with an explicit evaluated acceptance outcome.
     pub accepted_calls: usize,
     /// Effective tokens consumed per accepted outcome.
     pub etpao: f64,
@@ -94,16 +92,8 @@ pub fn process_mcp_context(info: &McpClientInfo) -> McpKernelResult {
     }
 }
 
-/// Records token usage, inferred outcome, and session identity for an MCP call.
+/// Records factual token usage and session identity for an MCP call.
 pub fn record_mcp_call(data: &McpCallData) {
-    let call_number = if data.is_retry {
-        data.call_number.max(2)
-    } else {
-        data.call_number
-    };
-    let inferred = outcome_signal::infer_outcome(call_number, data.is_retry, data.output_tokens);
-    let accepted = inferred.outcome == ReceiptOutcome::Accepted;
-
     lock_etpao().record_request(RequestMetrics {
         input_tokens: data.input_tokens,
         output_tokens: data.output_tokens,
@@ -114,18 +104,11 @@ pub fn record_mcp_call(data: &McpCallData) {
         client_id: MCP_SESSION_ID.to_owned(),
         coverage_class: CoverageClass::ContextControlled,
     });
-    lock_etpao().record_outcome(OutcomeMetrics {
-        accepted,
-        quality_score: inferred.confidence,
-        first_pass: inferred.signal == OutcomeSignal::FirstPass,
-        client_id: MCP_SESSION_ID.to_owned(),
-    });
 
-    lock_identity().record(
+    lock_identity().record_usage(
         &mcp_identity(),
-        data.input_tokens,
-        data.output_tokens,
-        accepted,
+        data.input_tokens.saturating_add(data.output_tokens),
+        0,
     );
 }
 
@@ -169,13 +152,12 @@ pub fn mcp_summary() -> McpSummary {
     let etpao = lock_etpao();
     let etpao_summary = etpao.summary();
     let total_calls = etpao.request_count();
-    drop(etpao);
+    let (total_input_tokens, total_output_tokens) = etpao.request_token_totals();
 
-    let identity_summary = lock_identity().summary();
     McpSummary {
         total_calls,
-        total_input_tokens: identity_summary.total_tokens,
-        total_output_tokens: identity_summary.total_savings,
+        total_input_tokens,
+        total_output_tokens,
         accepted_calls: etpao_summary.accepted_outcomes,
         etpao: etpao_summary.etpao,
         coverage_label: coverage_class::coverage_label(CoverageClass::ContextControlled).to_owned(),
@@ -288,15 +270,19 @@ pub mod tests {
     }
 
     #[test]
-    fn record_call_updates_etpao() {
+    fn record_call_preserves_usage_without_inventing_outcome() {
         let _guard = test_guard();
         reset_mcp_state();
         record_mcp_call(&call(1, false));
-        assert!(mcp_etpao() > 0.0);
+        let summary = mcp_summary();
+        assert_eq!(mcp_etpao(), 0.0);
+        assert_eq!(summary.accepted_calls, 0);
+        assert_eq!(summary.total_input_tokens, 100);
+        assert_eq!(summary.total_output_tokens, 20);
     }
 
     #[test]
-    fn record_retry_is_rejected() {
+    fn record_retry_does_not_invent_rejection_or_acceptance() {
         let _guard = test_guard();
         reset_mcp_state();
         record_mcp_call(&call(2, true));

--- a/rust/src/core/context_kernel/mcp_e2e.rs
+++ b/rust/src/core/context_kernel/mcp_e2e.rs
@@ -63,7 +63,7 @@ mod tests {
             mcp_receipt::record_receipt(receipt("ctx_read"));
         }
 
-        assert!(mcp_bridge::mcp_etpao() > 0.0);
+        assert_eq!(mcp_bridge::mcp_etpao(), 0.0);
         let accounting = mcp_receipt::mcp_accounting();
         assert!(accounting.delivered_tokens > 0);
     }
@@ -145,14 +145,16 @@ mod tests {
     }
 
     #[test]
-    fn etpao_tracks_mcp_calls() {
+    fn request_metrics_track_mcp_calls_without_inventing_etpao() {
         let _guard = isolated_test();
         for index in 0..10 {
             mcp_bridge::record_mcp_call(&call("ctx_read", 50 + index));
         }
 
-        assert!(mcp_bridge::mcp_etpao() > 0.0);
-        assert_eq!(mcp_bridge::mcp_summary().total_calls, 10);
+        let summary = mcp_bridge::mcp_summary();
+        assert_eq!(mcp_bridge::mcp_etpao(), 0.0);
+        assert_eq!(summary.accepted_calls, 0);
+        assert_eq!(summary.total_calls, 10);
     }
 
     #[test]

--- a/rust/src/core/context_kernel/proxy_bridge.rs
+++ b/rust/src/core/context_kernel/proxy_bridge.rs
@@ -5,9 +5,9 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use super::client_wiring::{self, OptimizationLevel};
 use super::context_broker::BrokerBudget;
 use super::coverage_class::{self, CoverageClass};
-use super::etpao_live::{EtpaoLive, EtpaoSummary, OutcomeMetrics, RequestMetrics};
+use super::etpao_live::{EtpaoLive, EtpaoSummary, RequestMetrics};
 use super::identity::{CallerIdentity, IdentityLedger, IdentityLedgerSummary};
-use super::outcome_signal::{self, InferredOutcome, OutcomeSignal};
+use super::outcome_signal::{InferredOutcome, OutcomeSignal};
 use super::types::ReceiptOutcome;
 
 static IDENTITY_LEDGER: OnceLock<Mutex<IdentityLedger>> = OnceLock::new();
@@ -32,7 +32,7 @@ pub struct ProxyRequestData {
     pub provider: Option<String>,
     /// Whether this request retries an earlier attempt.
     pub is_retry: bool,
-    /// Attempt number used to infer the request outcome.
+    /// Attempt number retained for factual retry accounting.
     pub request_count: usize,
 }
 
@@ -51,7 +51,7 @@ pub struct ProxyKernelResult {
     pub optimization_level: OptimizationLevel,
     /// Broker-computed token allocation.
     pub kernel_budget: BrokerBudget,
-    /// Outcome inferred from observable proxy behavior.
+    /// Compatibility outcome; unknown until an explicit evaluator reports one.
     pub outcome_signal: InferredOutcome,
 }
 
@@ -77,15 +77,15 @@ fn lock_etpao_tracker() -> MutexGuard<'static, EtpaoLive> {
     }
 }
 
-/// Resolves kernel context and records identity and ETPAO metrics for one request.
+/// Resolves kernel context and records factual identity and request metrics.
 #[must_use]
 pub fn process_proxy_request(data: &ProxyRequestData) -> ProxyKernelResult {
     let context = client_wiring::build_request_context(&data.headers, true, false, false);
-    let outcome =
-        outcome_signal::infer_outcome(data.request_count, data.is_retry, data.output_tokens);
-    let accepted = outcome.outcome == ReceiptOutcome::Accepted;
-    let client_id = context.profile.client_id.clone();
-
+    let outcome = InferredOutcome {
+        outcome: ReceiptOutcome::Unknown,
+        confidence: 0.0,
+        signal: OutcomeSignal::Ambiguous,
+    };
     {
         let mut tracker = lock_etpao_tracker();
         tracker.record_request(RequestMetrics {
@@ -95,14 +95,8 @@ pub fn process_proxy_request(data: &ProxyRequestData) -> ProxyKernelResult {
             schema_tokens: 0,
             cache_write_tokens: 0,
             retry_count: usize::from(data.is_retry),
-            client_id: client_id.clone(),
+            client_id: context.profile.client_id.clone(),
             coverage_class: context.coverage,
-        });
-        tracker.record_outcome(OutcomeMetrics {
-            accepted,
-            quality_score: outcome.confidence,
-            first_pass: outcome.signal == OutcomeSignal::FirstPass,
-            client_id,
         });
     }
 
@@ -110,7 +104,7 @@ pub fn process_proxy_request(data: &ProxyRequestData) -> ProxyKernelResult {
         .input_tokens
         .saturating_add(data.output_tokens)
         .saturating_add(data.reasoning_tokens);
-    lock_identity_ledger().record(&context.identity, consumed, data.tokens_saved, accepted);
+    lock_identity_ledger().record_usage(&context.identity, consumed, data.tokens_saved);
 
     let coverage = context.coverage;
     let optimization_level = client_wiring::optimization_level(&context);
@@ -204,12 +198,14 @@ pub mod tests {
     }
 
     #[test]
-    fn process_records_etpao() {
+    fn process_records_usage_without_inventing_outcome() {
         let _guard = isolated_test();
         let _ = process_proxy_request(&request());
 
-        assert!(current_etpao() > 0.0);
-        assert_eq!(etpao_summary().accepted_outcomes, 1);
+        let summary = etpao_summary();
+        assert_eq!(current_etpao(), 0.0);
+        assert_eq!(summary.total_tokens, 120);
+        assert_eq!(summary.accepted_outcomes, 0);
     }
 
     #[test]
@@ -224,22 +220,24 @@ pub mod tests {
     }
 
     #[test]
-    fn outcome_first_pass() {
+    fn first_pass_outcome_remains_unknown() {
         let _guard = isolated_test();
         let result = process_proxy_request(&request());
 
-        assert_eq!(result.outcome_signal.outcome, ReceiptOutcome::Accepted);
+        assert_eq!(result.outcome_signal.outcome, ReceiptOutcome::Unknown);
+        assert_eq!(result.outcome_signal.confidence, 0.0);
     }
 
     #[test]
-    fn outcome_retry() {
+    fn retry_outcome_remains_unknown() {
         let _guard = isolated_test();
         let mut data = request();
         data.is_retry = true;
         data.request_count = 2;
 
         let result = process_proxy_request(&data);
-        assert_eq!(result.outcome_signal.outcome, ReceiptOutcome::Rejected);
+        assert_eq!(result.outcome_signal.outcome, ReceiptOutcome::Unknown);
+        assert_eq!(result.outcome_signal.confidence, 0.0);
     }
 
     #[test]

--- a/rust/src/server/context_gate.rs
+++ b/rust/src/server/context_gate.rs
@@ -451,41 +451,12 @@ pub fn post_dispatch_record_with_task(
     let prefetch_hint =
         project_root.and_then(|root| crate::core::fep_prefetch::prefetch_hint(root, path, ledger));
 
-    // Context Kernel: generate receipt for delivered context
-    {
-        if let (Some(task_str), Some(root)) = (task, project_root) {
-            let kernel =
-                crate::core::context_kernel::orchestrator::ContextKernel::for_project(root);
-            let ctx = crate::core::context_kernel::types::RetrievalContext {
-                query: task_str.to_owned(),
-                task: Some(task_str.to_owned()),
-                project_root: root.to_owned(),
-                budget: crate::core::context_field::TokenBudget {
-                    total: original_tokens,
-                    used: 0,
-                },
-                max_candidates: 10,
-            };
-            let plan = kernel.plan(&ctx);
-            let receipt = kernel.record_receipt(&plan, sent_tokens, delivery_receipt_outcome());
-            let logger =
-                crate::core::context_kernel::shadow::ShadowLogger::default_for_project(root);
-            logger.log_receipt(&receipt);
-        }
-    }
-
     PostDispatchResult {
         eviction_hint: None,
         elicitation_hint: elicitation,
         resource_changed,
         prefetch_hint,
     }
-}
-
-fn delivery_receipt_outcome() -> crate::core::context_kernel::types::ReceiptOutcome {
-    // Delivery is an Engine fact. Task-quality acceptance requires a separate,
-    // explicit evaluator/host/customer outcome.
-    crate::core::context_kernel::types::ReceiptOutcome::Unknown
 }
 
 /// #715: a resolvable evict target for hint output — project-root-relative
@@ -679,14 +650,6 @@ fn is_boilerplate_line(line: &str) -> bool {
 mod tests {
     use super::*;
     use crate::core::triage::profile::TaskProfileLocal;
-
-    #[test]
-    fn successful_delivery_does_not_imply_task_acceptance() {
-        assert_eq!(
-            delivery_receipt_outcome(),
-            crate::core::context_kernel::types::ReceiptOutcome::Unknown
-        );
-    }
 
     #[test]
     fn eviction_target_display_emits_resolvable_targets() {

--- a/rust/src/server/post_dispatch.rs
+++ b/rust/src/server/post_dispatch.rs
@@ -144,7 +144,6 @@ impl LeanCtxServer {
         let input_token_count = crate::core::tokens::count_tokens(&input) as u64;
         let output_token_count_u64 = output_token_count as u64;
         let name_owned = name.to_string();
-        let task_id_for_receipt = task_id.clone();
         tokio::task::spawn_blocking(move || {
             let pricing = crate::core::gain::model_pricing::ModelPricing::load();
             // Honors a declared model for MCP-only IDEs (`[cost.models]`/default).
@@ -173,47 +172,6 @@ impl LeanCtxServer {
                 input_token_count as usize,
                 output_token_count_u64 as usize,
                 0, // savings tracked separately per-tool
-            );
-
-            // Context Kernel: record MCP tool call for ETPAO and receipt tracking.
-            crate::core::context_kernel::mcp_bridge::record_mcp_call(
-                &crate::core::context_kernel::mcp_bridge::McpCallData {
-                    tool_name: name_owned.clone(),
-                    input_tokens: input_token_count as usize,
-                    output_tokens: output_token_count_u64 as usize,
-                    is_retry: false,
-                    call_number: 1,
-                },
-            );
-
-            // Emit canonical ContextReceiptV1 on OclaBus.
-            let mut receipt = crate::core::context_kernel::mcp_bridge::generate_mcp_receipt(
-                "mcp-dispatch",
-                &name_owned,
-                input_token_count as usize,
-                output_token_count_u64 as usize,
-                false,
-            );
-            receipt.task_id = task_id_for_receipt;
-            crate::core::context_kernel::bridge::emit_receipt_event(&receipt);
-
-            // Evidence pipeline: MCP data → envelope → normalizer → receipt chain.
-            let mcp_call_data = crate::core::context_kernel::mcp_bridge::McpCallData {
-                tool_name: name_owned.clone(),
-                input_tokens: input_token_count as usize,
-                output_tokens: output_token_count_u64 as usize,
-                is_retry: false,
-                call_number: 1,
-            };
-            crate::core::context_kernel::envelope_wiring::process_mcp_evidence(&mcp_call_data);
-            crate::core::context_kernel::mcp_receipt::record_receipt(
-                crate::core::context_kernel::mcp_receipt::McpReceipt {
-                    tool: name_owned.clone(),
-                    tokens_in: input_token_count as usize,
-                    tokens_out: output_token_count_u64 as usize,
-                    kernel_overhead: 0,
-                    accepted: true,
-                },
             );
 
             // R30: Response evidence — output token tracking.


### PR DESCRIPTION
## Summary
- remove duplicate Product receipt bookkeeping from the Engine delivery path
- keep post-dispatch evidence factual; stop inferring success/failure outcomes
- preserve public/wire/security compatibility and factual counters/token evidence

## P4 scope
R4F factual-boundary cleanup after the Field and Compiler seams. No Cloud/P5 scope.

## Evidence
- independent static review: PASS
- reviewed patch IDs:
  - f03788b2c8bc6a522a3147c1b549677d57c5e034
  - b323e99a41e39a046df55d0ab970a990946389ba
- local cargo loop intentionally skipped; GitHub CI is the authoritative quality gate