### PR TITLE
refactor(protocol): freeze legacy product routing types

### DIFF
--- a/rust/crates/lean-ctx-protocol/src/control_plane.rs
+++ b/rust/crates/lean-ctx-protocol/src/control_plane.rs
@@ -1,4 +1,7 @@
 //! Model and context-selection control-plane contracts.
+//!
+//! `ContextBundleV1` is retained only for historical wire compatibility. It
+//! does not grant the Engine Product context-selection authority.
 
 use crate::{CapabilityManifestV1, ContextBundleV1, TaskComplexity, TaskEnvelopeV1};
 use serde::{Deserialize, Serialize};
@@ -8,6 +11,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct ControlPlaneRequest {
     pub task_envelope: TaskEnvelopeV1,
+    /// Frozen legacy Product bundle; removal follows the knowledge-routing gate.
     pub context_bundle: ContextBundleV1,
     pub available_capabilities: Vec<CapabilityManifestV1>,
 }

--- a/rust/crates/lean-ctx-protocol/src/knowledge_routing.rs
+++ b/rust/crates/lean-ctx-protocol/src/knowledge_routing.rs
@@ -1,4 +1,12 @@
-//! Knowledge-source discovery and context-routing contracts.
+//! Frozen compatibility contracts for historical knowledge routing.
+//!
+//! These Product-shaped selection types remain wire-compatible for existing
+//! control-plane consumers, but they are not Engine mechanism authority. New
+//! Engine integrations must use factual source/view/search/recovery/capability
+//! contracts instead of extending this module.
+//!
+//! Removal gate: a protocol-major release after `ControlPlaneRequest` no longer
+//! embeds `ContextBundleV1` and one complete compatibility window has elapsed.
 
 use crate::common::{ValidationError, deserialize_milliunit, validate_milliunit};
 use serde::{Deserialize, Serialize};
@@ -125,6 +133,8 @@ impl ContextReceiptV1 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::*;
 
     fn manifest() -> KnowledgeSourceManifestV1 {
@@ -257,5 +267,31 @@ mod tests {
             .validate()
             .expect("default receipt should be valid");
         assert_eq!(CostClass::default(), CostClass::Negligible);
+    }
+
+    #[test]
+    fn frozen_candidate_schema_has_no_product_expansion() {
+        let value = serde_json::to_value(candidate()).expect("candidate should serialize");
+        let keys = value
+            .as_object()
+            .expect("candidate should be an object")
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        let expected = [
+            "candidate_id",
+            "confidence_milli",
+            "content_hash",
+            "estimated_tokens",
+            "freshness_milli",
+            "kind",
+            "relevance_milli",
+            "source_id",
+            "task_id",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+        assert_eq!(keys, expected);
     }
 }

--- a/rust/crates/lean-ctx-protocol/src/lib.rs
+++ b/rust/crates/lean-ctx-protocol/src/lib.rs
@@ -22,6 +22,7 @@ mod identity;
 mod invocation_context_binding;
 mod invocation_evidence;
 pub mod knowledge;
+#[doc(hidden)]
 pub mod knowledge_routing;
 pub mod outcome;
 pub mod outcome_engine;
@@ -59,6 +60,7 @@ pub use invocation_evidence::{
     InvocationSourceRoleV1, MAX_INVOCATION_EVIDENCE_ITEMS,
 };
 pub use knowledge::{ClassificationLevel, KnowledgeObjectV1, ValidityWindow};
+#[doc(hidden)]
 pub use knowledge_routing::{
     ContextBundleV1, ContextCandidateV1, ContextReceiptV1, CostClass, KnowledgeSourceManifestV1,
     SourceCapabilities,

--- a/security/public-protocol-surface-freeze-v1.json
+++ b/security/public-protocol-surface-freeze-v1.json
@@ -67,7 +67,7 @@
       "review_release": "v1",
       "removal_not_before_release": "v2",
       "module_path": "rust/crates/lean-ctx-protocol/src/control_plane.rs",
-      "module_sha256": "bec68f5d55e9a3b07fbbba269ed4b36db0d89f252013b9009d60e73a98119ea3",
+      "module_sha256": "e6f77f2876421aa9264d726186bce70fb622a467b67e014fc1f8c4f4e0431b33",
       "module_roots": [
         {
           "path": "rust/crates/lean-ctx-protocol/src/lib.rs",


### PR DESCRIPTION
## Summary
- freeze the legacy Product-shaped protocol routing types without changing wire fields
- hide legacy routing types from generated public documentation while preserving source compatibility
- add a deterministic schema guard and an explicit protocol-major removal gate

## P4 scope
R4G protocol stop-line after factual delivery cleanup. No Cloud/P5 scope.

## Evidence
- independent static review: PASS; no P0-P2 findings
- stable patch ID: 56700356e90968db145cb45c742db423ed877416
- rebased on R4F merge 5cedbda3f3
- local cargo loop intentionally skipped; GitHub CI is the authoritative quality gate