### PR TITLE
refactor(kernel): retire behavioral outcome inference

### DIFF
--- a/rust/src/core/context_kernel/outcome_signal.rs
+++ b/rust/src/core/context_kernel/outcome_signal.rs
@@ -1,225 +1,33 @@
-//! Outcome quality signals inferred from observable LLM behavior.
+//! Frozen compatibility DTOs for the retired behavioral-outcome inference path.
+//!
+//! The Engine does not infer task acceptance from retries, response length, or
+//! delivery success. Explicit host/evaluator observations own outcome semantics.
+//! These serialized labels remain only because ProxyKernelResult exposed them.
+//! Remove them in the next public API major after consumers migrate to explicit
+//! evaluator observations.
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use super::types::ReceiptOutcome;
 
-use super::activation::{connect_feedback, record_real_outcome};
-use super::types::{ContextReceiptV1, ReceiptOutcome};
-
-/// The signal that determined the outcome classification.
+/// Legacy compatibility label; the Engine emits only [Self::Ambiguous].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum OutcomeSignal {
-    /// LLM used the context on first try.
+    /// Legacy label retained for serialized compatibility.
     FirstPass,
-    /// LLM retried after receiving this context (indicates rejection).
+    /// Legacy label retained for serialized compatibility.
     Retry,
-    /// LLM produced zero response tokens (likely ignored the context).
+    /// Legacy label retained for serialized compatibility.
     Ignored,
-    /// Ambiguous — not enough signal to determine.
+    /// No explicit evaluator outcome is available.
     Ambiguous,
 }
 
-/// An outcome inferred from LLM behavior heuristics.
+/// Frozen compatibility representation for an unevaluated proxy outcome.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InferredOutcome {
-    /// Accept/reject classification inferred from the observed behavior.
+    /// Explicit evaluator result, or [ReceiptOutcome::Unknown].
     pub outcome: ReceiptOutcome,
-    /// Confidence in the inferred classification, from zero to one.
+    /// Evaluator confidence; zero when no evaluator result exists.
     pub confidence: f64,
-    /// Behavioral signal used to determine the classification.
+    /// Compatibility signal; [OutcomeSignal::Ambiguous] when unevaluated.
     pub signal: OutcomeSignal,
-}
-
-/// Infers a context outcome from request and response behavior.
-pub fn infer_outcome(
-    request_count: usize,
-    was_retry: bool,
-    response_tokens: usize,
-) -> InferredOutcome {
-    if was_retry && request_count > 1 {
-        InferredOutcome {
-            outcome: ReceiptOutcome::Rejected,
-            confidence: 0.8,
-            signal: OutcomeSignal::Retry,
-        }
-    } else if response_tokens == 0 {
-        InferredOutcome {
-            outcome: ReceiptOutcome::Rejected,
-            confidence: 0.6,
-            signal: OutcomeSignal::Ignored,
-        }
-    } else if request_count == 1 {
-        InferredOutcome {
-            outcome: ReceiptOutcome::Accepted,
-            confidence: 0.9,
-            signal: OutcomeSignal::FirstPass,
-        }
-    } else {
-        InferredOutcome {
-            outcome: ReceiptOutcome::Accepted,
-            confidence: 0.5,
-            signal: OutcomeSignal::Ambiguous,
-        }
-    }
-}
-
-/// Records an inferred outcome and feeds it into provider learning.
-///
-/// Feedback failures are contained so outcome tracking cannot disrupt delivery.
-pub fn record_and_learn(outcome: &InferredOutcome, receipt: &ContextReceiptV1, project_root: &str) {
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let recorded = record_real_outcome(receipt, outcome.outcome == ReceiptOutcome::Accepted);
-        connect_feedback(&recorded, project_root);
-    }));
-}
-
-/// Tracks recent inferred outcomes for aggregate quality monitoring.
-#[derive(Debug, Clone, Default)]
-pub struct OutcomeTracker {
-    outcomes: Vec<(OutcomeSignal, f64)>,
-}
-
-impl OutcomeTracker {
-    /// Appends an inferred outcome with its observation timestamp.
-    pub fn record(&mut self, outcome: &InferredOutcome) {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0.0, |duration| duration.as_secs_f64());
-        self.outcomes.push((outcome.signal, timestamp));
-    }
-
-    /// Returns the fraction of tracked outcomes classified as accepted.
-    pub fn acceptance_rate(&self) -> f64 {
-        if self.outcomes.is_empty() {
-            return 0.0;
-        }
-
-        let accepted = self
-            .outcomes
-            .iter()
-            .filter(|(signal, _)| is_accepted(*signal))
-            .count();
-        accepted as f64 / self.outcomes.len() as f64
-    }
-
-    /// Returns whether a complete recent window has below 50% acceptance.
-    pub fn is_degrading(&self, window: usize) -> bool {
-        if window == 0 || self.outcomes.len() < window {
-            return false;
-        }
-
-        let accepted = self
-            .outcomes
-            .iter()
-            .rev()
-            .take(window)
-            .filter(|(signal, _)| is_accepted(*signal))
-            .count();
-        accepted * 2 < window
-    }
-
-    /// Returns the number of tracked outcomes.
-    pub fn len(&self) -> usize {
-        self.outcomes.len()
-    }
-
-    /// Returns whether the tracker contains no outcomes.
-    pub fn is_empty(&self) -> bool {
-        self.outcomes.is_empty()
-    }
-}
-
-fn is_accepted(signal: OutcomeSignal) -> bool {
-    matches!(signal, OutcomeSignal::FirstPass | OutcomeSignal::Ambiguous)
-}
-
-#[cfg(test)]
-pub mod tests {
-    use std::collections::HashMap;
-
-    use super::{InferredOutcome, OutcomeSignal, OutcomeTracker, infer_outcome, record_and_learn};
-    use crate::core::context_kernel::types::{ContextReceiptV1, ReceiptOutcome};
-
-    fn receipt() -> ContextReceiptV1 {
-        ContextReceiptV1 {
-            receipt_id: "receipt-1".to_owned(),
-            plan_id: "plan-1".to_owned(),
-            task_id: None,
-            delivered_tokens: 10,
-            cache_hits: 0,
-            cache_misses: 0,
-            outcome: ReceiptOutcome::Unknown,
-            quality_signals: Vec::new(),
-            feedback_attribution: HashMap::new(),
-        }
-    }
-
-    fn tracked(outcome: ReceiptOutcome, signal: OutcomeSignal) -> InferredOutcome {
-        InferredOutcome {
-            outcome,
-            confidence: 1.0,
-            signal,
-        }
-    }
-
-    #[test]
-    fn first_pass_accepted() {
-        let inferred = infer_outcome(1, false, 20);
-        assert_eq!(inferred.outcome, ReceiptOutcome::Accepted);
-        assert_eq!(inferred.confidence, 0.9);
-        assert_eq!(inferred.signal, OutcomeSignal::FirstPass);
-    }
-
-    #[test]
-    fn retry_rejected() {
-        let inferred = infer_outcome(2, true, 20);
-        assert_eq!(inferred.outcome, ReceiptOutcome::Rejected);
-        assert_eq!(inferred.confidence, 0.8);
-        assert_eq!(inferred.signal, OutcomeSignal::Retry);
-    }
-
-    #[test]
-    fn zero_tokens_ignored() {
-        let inferred = infer_outcome(1, false, 0);
-        assert_eq!(inferred.outcome, ReceiptOutcome::Rejected);
-        assert_eq!(inferred.confidence, 0.6);
-        assert_eq!(inferred.signal, OutcomeSignal::Ignored);
-    }
-
-    #[test]
-    fn ambiguous_default_accepted() {
-        let inferred = infer_outcome(2, false, 20);
-        assert_eq!(inferred.outcome, ReceiptOutcome::Accepted);
-        assert_eq!(inferred.confidence, 0.5);
-        assert_eq!(inferred.signal, OutcomeSignal::Ambiguous);
-    }
-
-    #[test]
-    fn tracker_acceptance_rate() {
-        let mut tracker = OutcomeTracker::default();
-        for _ in 0..7 {
-            tracker.record(&tracked(ReceiptOutcome::Accepted, OutcomeSignal::FirstPass));
-        }
-        for _ in 0..3 {
-            tracker.record(&tracked(ReceiptOutcome::Rejected, OutcomeSignal::Retry));
-        }
-
-        assert!((tracker.acceptance_rate() - 0.7).abs() < f64::EPSILON);
-        assert_eq!(tracker.len(), 10);
-    }
-
-    #[test]
-    fn tracker_detects_degradation() {
-        let mut tracker = OutcomeTracker::default();
-        for _ in 0..5 {
-            tracker.record(&tracked(ReceiptOutcome::Rejected, OutcomeSignal::Retry));
-        }
-
-        assert!(tracker.is_degrading(5));
-    }
-
-    #[test]
-    fn record_and_learn_no_panic() {
-        let inferred = infer_outcome(2, true, 20);
-        record_and_learn(&inferred, &receipt(), "/path/that/does/not/exist");
-    }
 }

--- a/rust/src/core/context_kernel/quality_e2e.rs
+++ b/rust/src/core/context_kernel/quality_e2e.rs
@@ -4,8 +4,6 @@
 mod tests {
     use super::super::accounting_fix;
     use super::super::hotpath_wiring;
-    use super::super::outcome_signal;
-    use super::super::types::ReceiptOutcome;
 
     fn assert_close(actual: f64, expected: f64) {
         assert!(
@@ -23,23 +21,6 @@ mod tests {
     }
 
     #[test]
-    fn outcome_signal_first_pass() {
-        let inference = outcome_signal::infer_outcome(1, false, 500);
-
-        assert_eq!(inference.outcome, ReceiptOutcome::Accepted);
-        assert_eq!(format!("{:?}", inference.signal), "FirstPass");
-        assert!(inference.confidence >= 0.8);
-    }
-
-    #[test]
-    fn outcome_signal_retry_rejected() {
-        let inference = outcome_signal::infer_outcome(3, true, 200);
-
-        assert_eq!(inference.outcome, ReceiptOutcome::Rejected);
-        assert_eq!(format!("{:?}", inference.signal), "Retry");
-    }
-
-    #[test]
     fn honest_accounting_vs_phantom() {
         let accounting = accounting_fix::compute_honest_accounting(1_000, 300, 100, 50);
 
@@ -47,22 +28,6 @@ mod tests {
         assert_close(accounting.actual_compression_ratio, 0.55);
         assert_close(accounting.reported_compression_ratio, 0.70);
         assert_close(accounting.phantom_savings_pct, 0.15);
-    }
-
-    #[test]
-    fn outcome_tracker_quality_trend() {
-        let mut tracker = outcome_signal::OutcomeTracker::default();
-        for _ in 0..3 {
-            let inf = outcome_signal::infer_outcome(1, false, 100);
-            tracker.record(&inf);
-        }
-        for _ in 0..5 {
-            let inf = outcome_signal::infer_outcome(3, true, 100);
-            tracker.record(&inf);
-        }
-
-        assert_close(tracker.acceptance_rate(), 0.375);
-        assert!(tracker.is_degrading(5));
     }
 
     #[test]

--- a/rust/src/core/execution_ledger/canonical_receipt.rs
+++ b/rust/src/core/execution_ledger/canonical_receipt.rs
@@ -101,6 +101,7 @@ mod tests {
 
     #[test]
     fn durable_receipt_precedes_idempotent_ledger_projection() {
+        let _data_dir = crate::core::data_dir::isolated_data_dir();
         let directory = tempfile::tempdir().unwrap();
         let ledger = ExecutionLedgerStore::new(directory.path().join("ledger.jsonl"));
         let timestamp = UtcTimestamp::new("2026-08-23T12:00:00Z").unwrap();


### PR DESCRIPTION
## Summary
- remove Engine-owned behavioral outcome inference and provider-learning heuristics
- preserve the public OutcomeSignal and InferredOutcome DTOs for compatibility
- emit only factual/unknown unevaluated state; explicit evaluators remain authoritative

## P4 scope
R5-D2 decommission after protocol freeze. Public compatibility DTOs remain; no Cloud/P5 scope.

## Evidence
- independent static review: PASS; no P0-P2 findings
- stable patch ID: 1aa0a9b475e85dc6192844a0bfedba177f243ede
- rebased on R4G merge 73bca34676
- no local cargo loop; GitHub CI is authoritative