### PR TITLE
feat(health): foreign MCP server audit + cross-layer rules dedup detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to lean-ctx are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added — context-budget transparency (`tools health`)
+
+- **Foreign MCP server audit** — `tools health` now cross-references every
+  non-lean-ctx MCP server the client loads (local config, project `.mcp.json`,
+  and observed connections incl. claude.ai connectors) with recorded
+  `tool_use` calls from local Claude Code transcripts, and flags servers that
+  were never called — their schemas are pure fixed cost lean-ctx cannot
+  compress. Honest by design: usage is measured, schema size is never
+  estimated.
+- **Cross-layer rules dedup detection** — a rules carrier on a dedicated host
+  (claude/codex/codebuddy) holding more than a pointer duplicates the mapping
+  the MCP `instructions` already deliver every session; `tools health` now
+  flags it with the reclaimable size. `.claude/rules/*.md` project files are
+  now included in the fixed-cost scan.
+
 ## [3.9.20] — 2026-08-25
 
 ### Fixed — triage (community incident, 3.9.19)

--- a/rust/src/cli/tools_health_cmd.rs
+++ b/rust/src/cli/tools_health_cmd.rs
@@ -157,16 +157,44 @@ fn print_report(r: &ToolHealthReport, show_all: bool) {
     }
 
     // ── Rules ─────────────────────────────────────────────────────────
-    if !r.duplicate_clients.is_empty() {
+    let cross_layer_rules: Vec<_> = r
+        .rules
+        .iter()
+        .filter(|e| !e.action.is_empty() && !e.action.starts_with("duplicate"))
+        .collect();
+    if !r.duplicate_clients.is_empty() || !cross_layer_rules.is_empty() {
         println!("\n{BOLD}Rules{RST}");
         for (client, n) in &r.duplicate_clients {
             println!(
                 "  {YELLOW}⚠ {client}: {n} files carry full lean-ctx rules — billed {n}× per session{RST}"
             );
         }
+        for e in &cross_layer_rules {
+            println!("  {YELLOW}⚠ {}{RST}\n    {DIM}{}{RST}", e.path, e.action);
+        }
         println!(
             "  {DIM}→ `lean-ctx rules dedup --apply` keeps one canonical source per client.{RST}"
         );
+    }
+
+    // ── Foreign MCP servers ───────────────────────────────────────────
+    if !r.foreign_servers.is_empty() {
+        println!(
+            "\n{BOLD}Foreign MCP servers{RST}  {DIM}(their schemas load every session; size not measurable locally){RST}"
+        );
+        for s in &r.foreign_servers {
+            if s.action.is_empty() {
+                println!(
+                    "  {GREEN}✓{RST} {:<24} {:>5} calls in {} session(s)  {DIM}{}{RST}",
+                    s.name, s.calls, s.sessions_with_use, s.source
+                );
+            } else {
+                println!(
+                    "  {YELLOW}⚠ {:<24}{RST} {}  {DIM}{}{RST}",
+                    s.name, s.action, s.source
+                );
+            }
+        }
     }
 
     // ── Knowledge ─────────────────────────────────────────────────────

--- a/rust/src/core/foreign_mcp.rs
+++ b/rust/src/core/foreign_mcp.rs
@@ -1,0 +1,391 @@
+//! Foreign MCP server audit — non-lean-ctx MCP servers the host client loads
+//! into every session.
+//!
+//! lean-ctx measures its own fixed cost precisely, but every *other* configured
+//! MCP server bills its tool schemas + instructions into the same context
+//! budget — often more than lean-ctx's whole surface — and nothing reports
+//! whether those servers are ever used. This module cross-references:
+//!
+//! * **configured** servers: `~/.claude.json` `mcpServers` (global and
+//!   per-project) and the project `.mcp.json`, and
+//! * **observed** servers: Claude Code per-project MCP log directories, which
+//!   also capture claude.ai account connectors that appear in no local config,
+//!
+//! with **recorded usage**: `mcp__<server>__*` `tool_use` entries in the local
+//! Claude Code transcripts (`~/.claude/projects/*/*.jsonl`).
+//!
+//! Deterministic, local-only, read-only — findings are suggestions the
+//! operator acts on explicitly (mirrors [`crate::core::tool_health`]).
+//!
+//! Honesty note: a foreign server's schema size is not measurable locally
+//! without connecting to it, so the report states *measured usage* only and
+//! never invents a token estimate.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Serialize;
+
+/// Transcripts modified within this many days are scanned for usage.
+const TRANSCRIPT_WINDOW_DAYS: u64 = 45;
+
+/// One foreign (non-lean-ctx) MCP server the client loads.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ForeignServerEntry {
+    pub name: String,
+    /// Where the server was discovered (config scope or observed connection).
+    pub source: String,
+    /// `tool_use` calls recorded in scanned transcripts.
+    pub calls: u64,
+    /// Distinct transcripts containing at least one call.
+    pub sessions_with_use: usize,
+    /// Transcripts scanned for the window.
+    pub transcripts_scanned: usize,
+    /// Non-empty when the server looks like pure cost (never called).
+    pub action: String,
+}
+
+/// Canonical comparison key: the `mcp__<server>__` tool-name form. Claude Code
+/// replaces every non-alphanumeric byte with `_` (e.g. "claude.ai Figma" →
+/// `claude_ai_Figma`), so config names, log-dir names, and tool prefixes all
+/// normalize to the same key.
+#[must_use]
+fn tool_prefix_form(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// Claude Code encodes paths and server names for cache directories by
+/// replacing every non-alphanumeric byte with `-`.
+#[must_use]
+fn dir_form(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// True for lean-ctx itself, under any spelling a client config may use.
+#[must_use]
+fn is_lean_ctx(name: &str) -> bool {
+    tool_prefix_form(name).eq_ignore_ascii_case("lean_ctx")
+}
+
+/// Inserts every server name under `servers` (a `mcpServers` JSON object).
+fn insert_server_names(
+    out: &mut BTreeMap<String, String>,
+    servers: Option<&serde_json::Value>,
+    source: &str,
+) {
+    if let Some(map) = servers.and_then(|s| s.as_object()) {
+        for name in map.keys() {
+            out.entry(name.clone())
+                .or_insert_with(|| source.to_string());
+        }
+    }
+}
+
+/// Servers named in local Claude Code configuration: global + per-project
+/// `mcpServers` in `~/.claude.json`, and the project `.mcp.json`.
+fn configured_servers(home: &Path, project: &Path) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    if let Ok(raw) = std::fs::read_to_string(home.join(".claude.json"))
+        && let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw)
+    {
+        insert_server_names(
+            &mut out,
+            v.get("mcpServers"),
+            "global config (~/.claude.json)",
+        );
+        if let Some(p) = v
+            .get("projects")
+            .and_then(|p| p.as_object())
+            .and_then(|projects| projects.get(project.to_string_lossy().as_ref()))
+        {
+            insert_server_names(
+                &mut out,
+                p.get("mcpServers"),
+                "project config (~/.claude.json)",
+            );
+        }
+    }
+    if let Ok(raw) = std::fs::read_to_string(project.join(".mcp.json"))
+        && let Ok(v) = serde_json::from_str::<serde_json::Value>(&raw)
+    {
+        insert_server_names(&mut out, v.get("mcpServers"), ".mcp.json");
+    }
+    out
+}
+
+/// Servers Claude Code actually connected to for this project, recovered from
+/// its per-project MCP log directories. This is the only local trace of
+/// claude.ai account connectors, which appear in no local config file.
+fn observed_servers(home: &Path, project: &Path) -> BTreeMap<String, String> {
+    let slug = dir_form(&project.to_string_lossy());
+    let mut out = BTreeMap::new();
+    for base in [
+        home.join("Library/Caches/claude-cli-nodejs"),
+        home.join(".cache/claude-cli-nodejs"),
+    ] {
+        let Ok(entries) = std::fs::read_dir(base.join(&slug)) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            let name = e.file_name().to_string_lossy().into_owned();
+            if let Some(server) = name.strip_prefix("mcp-logs-") {
+                out.entry(server.to_string())
+                    .or_insert_with(|| "observed connection (MCP logs)".to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Pure: counts `tool_use` invocations per `mcp__<server>__` prefix across one
+/// transcript's JSONL lines.
+fn count_tool_use_by_server<I, S>(lines: I) -> BTreeMap<String, u64>
+where
+    I: Iterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut out: BTreeMap<String, u64> = BTreeMap::new();
+    for line in lines {
+        let line = line.as_ref();
+        if !line.contains("\"mcp__") {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(content) = v
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        else {
+            continue;
+        };
+        for item in content {
+            if item.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                continue;
+            }
+            let Some(name) = item.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            let Some((server, _tool)) = name
+                .strip_prefix("mcp__")
+                .and_then(|rest| rest.split_once("__"))
+            else {
+                continue;
+            };
+            *out.entry(server.to_string()).or_default() += 1;
+        }
+    }
+    out
+}
+
+/// Scans recent Claude Code transcripts and aggregates per-server usage:
+/// returns (transcripts scanned, server → (calls, transcripts with ≥1 call)).
+fn transcript_usage(home: &Path) -> (usize, BTreeMap<String, (u64, usize)>) {
+    use std::io::BufRead;
+
+    let mut scanned = 0usize;
+    let mut usage: BTreeMap<String, (u64, usize)> = BTreeMap::new();
+    let cutoff = std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(
+        TRANSCRIPT_WINDOW_DAYS * 86_400,
+    ));
+    let Ok(dirs) = std::fs::read_dir(home.join(".claude/projects")) else {
+        return (0, usage);
+    };
+    for d in dirs.flatten() {
+        let Ok(files) = std::fs::read_dir(d.path()) else {
+            continue;
+        };
+        for f in files.flatten() {
+            let path = f.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if let (Some(cutoff), Ok(meta)) = (cutoff, f.metadata())
+                && meta.modified().is_ok_and(|m| m < cutoff)
+            {
+                continue;
+            }
+            let Ok(file) = std::fs::File::open(&path) else {
+                continue;
+            };
+            scanned += 1;
+            let reader = std::io::BufReader::new(file);
+            let counts = count_tool_use_by_server(reader.lines().map_while(Result::ok));
+            for (server, calls) in counts {
+                let e = usage.entry(server).or_default();
+                e.0 += calls;
+                e.1 += 1;
+            }
+        }
+    }
+    (scanned, usage)
+}
+
+/// Pure: joins discovered servers with recorded usage and renders verdicts.
+/// Never-called servers sort first (they are the actionable rot).
+#[must_use]
+fn build_entries(
+    discovered: Vec<(String, String)>,
+    usage: &BTreeMap<String, (u64, usize)>,
+    transcripts_scanned: usize,
+) -> Vec<ForeignServerEntry> {
+    let mut out: Vec<ForeignServerEntry> = discovered
+        .into_iter()
+        .map(|(name, source)| {
+            let key = tool_prefix_form(&name);
+            let (calls, sessions_with_use) = usage
+                .iter()
+                .find(|(s, _)| tool_prefix_form(s) == key)
+                .map_or((0, 0), |(_, &(c, s))| (c, s));
+            let action = if calls == 0 && transcripts_scanned > 0 {
+                format!(
+                    "never called in {transcripts_scanned} transcript(s) over {TRANSCRIPT_WINDOW_DAYS}d — its schemas still load every session; disable via `/mcp` (claude.ai connectors: claude.ai → Settings → Connectors)"
+                )
+            } else {
+                String::new()
+            };
+            ForeignServerEntry {
+                name,
+                source,
+                calls,
+                sessions_with_use,
+                transcripts_scanned,
+                action,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| a.calls.cmp(&b.calls).then_with(|| a.name.cmp(&b.name)));
+    out
+}
+
+/// Gathers on-disk configuration, observed connections, and transcript usage,
+/// and builds the foreign-server audit for `home`/`project`.
+#[must_use]
+pub(crate) fn audit(home: &Path, project: &Path) -> Vec<ForeignServerEntry> {
+    // Merge keyed on the normalized tool-prefix form so "claude.ai Figma"
+    // (config) and "claude-ai-Figma" (log dir) collapse into one entry;
+    // configured names win the display slot.
+    let mut merged: BTreeMap<String, (String, String)> = BTreeMap::new();
+    for (name, source) in configured_servers(home, project) {
+        if is_lean_ctx(&name) {
+            continue;
+        }
+        merged
+            .entry(tool_prefix_form(&name))
+            .or_insert((name, source));
+    }
+    for (name, source) in observed_servers(home, project) {
+        if is_lean_ctx(&name) {
+            continue;
+        }
+        merged
+            .entry(tool_prefix_form(&name))
+            .or_insert((name, source));
+    }
+    let (scanned, usage) = transcript_usage(home);
+    build_entries(merged.into_values().collect(), &usage, scanned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalization_collapses_config_dir_and_tool_prefix_forms() {
+        assert_eq!(tool_prefix_form("claude.ai Figma"), "claude_ai_Figma");
+        assert_eq!(tool_prefix_form("claude-ai-Figma"), "claude_ai_Figma");
+        assert_eq!(dir_form("claude.ai Figma"), "claude-ai-Figma");
+        assert_eq!(dir_form("/a/b"), "-a-b");
+    }
+
+    #[test]
+    fn lean_ctx_is_recognized_under_any_spelling() {
+        assert!(is_lean_ctx("lean-ctx"));
+        assert!(is_lean_ctx("lean_ctx"));
+        assert!(is_lean_ctx("Lean Ctx"));
+        assert!(!is_lean_ctx("claude.ai Figma"));
+    }
+
+    #[test]
+    fn counts_tool_use_per_server_and_ignores_junk() {
+        let lines = [
+            r#"{"message":{"content":[{"type":"tool_use","name":"mcp__claude_ai_Figma__get_screenshot"}]}}"#,
+            r#"{"message":{"content":[{"type":"tool_use","name":"mcp__lean-ctx__ctx_read"},{"type":"text","text":"mcp__decoy__x"}]}}"#,
+            r#"{"message":{"content":[{"type":"tool_use","name":"Bash"}]}}"#,
+            "not json at all",
+            r#"{"message":"no content array with mcp__ mention"}"#,
+        ];
+        let counts = count_tool_use_by_server(lines.iter().copied());
+        assert_eq!(counts.get("claude_ai_Figma"), Some(&1));
+        assert_eq!(counts.get("lean-ctx"), Some(&1));
+        assert_eq!(
+            counts.len(),
+            2,
+            "text blocks and native tools must not count"
+        );
+    }
+
+    #[test]
+    fn build_entries_flags_never_called_and_sorts_them_first() {
+        let mut usage = BTreeMap::new();
+        usage.insert("github".to_string(), (12u64, 3usize));
+        let entries = build_entries(
+            vec![
+                ("github".to_string(), "global config".to_string()),
+                (
+                    "claude.ai Figma".to_string(),
+                    "observed connection".to_string(),
+                ),
+            ],
+            &usage,
+            14,
+        );
+        assert_eq!(entries[0].name, "claude.ai Figma");
+        assert_eq!(entries[0].calls, 0);
+        assert!(
+            entries[0]
+                .action
+                .contains("never called in 14 transcript(s)")
+        );
+        assert_eq!(entries[1].name, "github");
+        assert_eq!(entries[1].calls, 12);
+        assert_eq!(entries[1].sessions_with_use, 3);
+        assert!(
+            entries[1].action.is_empty(),
+            "used servers carry no verdict"
+        );
+    }
+
+    #[test]
+    fn build_entries_matches_usage_across_name_forms() {
+        let mut usage = BTreeMap::new();
+        usage.insert("claude_ai_Figma".to_string(), (5u64, 2usize));
+        let entries = build_entries(
+            vec![("claude.ai Figma".to_string(), "config".to_string())],
+            &usage,
+            10,
+        );
+        assert_eq!(
+            entries[0].calls, 5,
+            "config name must match tool-prefix usage key"
+        );
+    }
+
+    #[test]
+    fn build_entries_without_telemetry_stays_neutral() {
+        let entries = build_entries(
+            vec![("figma".to_string(), "config".to_string())],
+            &BTreeMap::new(),
+            0,
+        );
+        assert!(
+            entries[0].action.is_empty(),
+            "no transcripts scanned → cannot judge, no verdict"
+        );
+    }
+}

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -30,6 +30,7 @@ pub mod eval_harness;
 pub(crate) mod extractive;
 pub mod finops_export;
 pub mod fleet_analytics;
+pub(crate) mod foreign_mcp;
 pub mod html_crush;
 #[allow(unused_imports)]
 pub mod ib;

--- a/rust/src/core/rules_overhead.rs
+++ b/rust/src/core/rules_overhead.rs
@@ -91,6 +91,20 @@ fn scan_mdc_dir(out: &mut Vec<RulesFileCost>, dir: &Path, clients: &[&'static st
     }
 }
 
+/// Claude Code auto-loads every `.md` under a project's `.claude/rules/`
+/// directory — same fixed-cost semantics as `.cursor/rules/*.mdc` (#684).
+fn scan_claude_rules_dir(out: &mut Vec<RulesFileCost>, dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            push_rules_file(out, &path, vec!["claude"]);
+        }
+    }
+}
+
 /// Collects every rules file that an agent auto-loads for work in `project`:
 /// global per-client files, the project root, and the parent chain up to
 /// `home` (Cursor merges parent `.cursor/rules/` and AGENTS.md in monorepos).
@@ -121,6 +135,7 @@ pub(crate) fn collect_rules_files(home: &Path, project: &Path) -> Vec<RulesFileC
     while let Some(d) = dir {
         push_rules_file(out.as_mut(), &d.join(".cursorrules"), vec!["cursor"]);
         scan_mdc_dir(out.as_mut(), &d.join(".cursor/rules"), &["cursor"]);
+        scan_claude_rules_dir(out.as_mut(), &d.join(".claude/rules"));
         // AGENTS.md is the shared instruction file: Cursor, Codex and several
         // other agents auto-load it.
         push_rules_file(out.as_mut(), &d.join("AGENTS.md"), vec!["cursor", "codex"]);
@@ -335,6 +350,28 @@ more user stuff that is not ours
             dups.iter().any(|(c, n)| c == "cursor" && *n == 2),
             "cursor loads 2 full lean-ctx sources (pointer AGENTS.md excluded): {dups:?}"
         );
+    }
+
+    /// Claude Code auto-loads `.claude/rules/*.md` — the scan must attribute
+    /// those files to the claude client (fixed cost billed every session).
+    #[test]
+    fn collect_includes_project_claude_rules_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let project = home.join("projects/app");
+        std::fs::create_dir_all(project.join(".claude/rules")).unwrap();
+        std::fs::write(
+            project.join(".claude/rules/lean-ctx.md"),
+            format!("{START_MARK}\n<!-- version: 1 -->\n\nbody\n"),
+        )
+        .unwrap();
+        std::fs::write(project.join(".claude/rules/notes.txt"), "not a rules file").unwrap();
+
+        let files = collect_rules_files(home, &project);
+        assert_eq!(files.len(), 1, "only the .md rules file counts: {files:?}");
+        assert!(files[0].path.ends_with("lean-ctx.md"));
+        assert_eq!(files[0].clients, vec!["claude"]);
+        assert!(files[0].lean_ctx_tokens > 0);
     }
 
     #[test]

--- a/rust/src/core/tool_health.rs
+++ b/rust/src/core/tool_health.rs
@@ -30,6 +30,16 @@ const LOW_USE_TOKEN_FLOOR: usize = 150;
 const LOW_USE_CALL_SHARE: f64 = 0.01;
 /// A fact older than this (days) that was never retrieved is a prune candidate.
 const STALE_FACT_DAYS: i64 = 30;
+/// A rules carrier larger than this is more than a pointer (#684). On hosts
+/// whose MCP instructions already deliver the full mapping, anything beyond a
+/// pointer duplicates guidance that is billed once per session anyway.
+const CROSS_LAYER_POINTER_MAX: usize = 120;
+/// Approximate size of a pointer-only lean-ctx block.
+const POINTER_TOKENS: usize = 40;
+/// Clients that receive the full lean-ctx mapping via MCP `instructions` +
+/// SessionStart context (dedicated hosts) — their static rules files only
+/// need a pointer.
+const DEDICATED_INSTRUCTION_CLIENTS: &[&str] = &["claude", "codex", "codebuddy"];
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -114,6 +124,9 @@ pub(crate) struct ToolHealthReport {
     pub rules: Vec<RuleEntry>,
     pub duplicate_clients: Vec<(String, usize)>,
     pub knowledge: KnowledgeHealth,
+    /// Non-lean-ctx MCP servers the client loads every session, with measured
+    /// transcript usage — unused ones are pure fixed cost lean-ctx cannot see.
+    pub foreign_servers: Vec<crate::core::foreign_mcp::ForeignServerEntry>,
 }
 
 fn classify(has_usage: bool, calls: u64, schema_tokens: usize, total_calls: u64) -> ToolStatus {
@@ -243,8 +256,19 @@ pub(crate) fn build_report(
         .iter()
         .map(|r| {
             let is_dup = r.carries_full && r.clients.iter().any(|c| dup_clients.contains(c));
+            let cross_layer = !is_dup
+                && r.lean_ctx_tokens > CROSS_LAYER_POINTER_MAX
+                && r.clients
+                    .iter()
+                    .any(|c| DEDICATED_INSTRUCTION_CLIENTS.contains(c));
             let action = if is_dup {
                 "duplicate full lean-ctx source — run `lean-ctx rules dedup --apply`".to_string()
+            } else if cross_layer {
+                format!(
+                    "carries {} lean-ctx tokens although MCP instructions already deliver the full mapping on dedicated hosts — thin to a pointer to reclaim ~{} tok/session",
+                    r.lean_ctx_tokens,
+                    r.lean_ctx_tokens.saturating_sub(POINTER_TOKENS)
+                )
             } else {
                 String::new()
             };
@@ -281,6 +305,7 @@ pub(crate) fn build_report(
         rules: rules_out,
         duplicate_clients: duplicates,
         knowledge,
+        foreign_servers: Vec::new(),
     }
 }
 
@@ -389,6 +414,7 @@ pub(crate) fn compute(home: &Path, project: &Path) -> ToolHealthReport {
         knowledge,
     );
     report.footprint_note = latest_footprint_note();
+    report.foreign_servers = crate::core::foreign_mcp::audit(home, project);
     report
 }
 
@@ -573,6 +599,89 @@ mod tests {
             "both cursor full sources flagged as duplicates"
         );
         assert_eq!(report.rules_tokens, 350);
+    }
+
+    /// Cross-layer dedup: a dedicated-host carrier (claude) holding more than a
+    /// pointer duplicates what MCP instructions already deliver — flagged with
+    /// the reclaimable size. Non-dedicated clients (gemini) are left alone.
+    #[test]
+    fn build_report_flags_dedicated_carrier_exceeding_pointer() {
+        let rules = vec![
+            RulesFileCost {
+                path: "/home/u/.claude/CLAUDE.md".into(),
+                file_tokens: 700,
+                lean_ctx_tokens: 384,
+                carries_full: false,
+                clients: vec!["claude"],
+            },
+            RulesFileCost {
+                path: "/home/u/.gemini/GEMINI.md".into(),
+                file_tokens: 800,
+                lean_ctx_tokens: 800,
+                carries_full: true,
+                clients: vec!["gemini"],
+            },
+        ];
+        let report = build_report(
+            &[tool("ctx_read")],
+            &usage_with(&[("ctx_read", 5)]),
+            &rules,
+            Vec::new(),
+            0,
+            "lean (default)".to_string(),
+            KnowledgeHealth::default(),
+        );
+        let claude = report
+            .rules
+            .iter()
+            .find(|r| r.path.contains("CLAUDE"))
+            .unwrap();
+        assert!(
+            claude.action.contains("thin to a pointer"),
+            "dedicated carrier above pointer size must be flagged: {}",
+            claude.action
+        );
+        assert!(
+            claude.action.contains("~344 tok"),
+            "reclaimable size = lean tokens minus pointer: {}",
+            claude.action
+        );
+        let gemini = report
+            .rules
+            .iter()
+            .find(|r| r.path.contains("GEMINI"))
+            .unwrap();
+        assert!(
+            gemini.action.is_empty(),
+            "non-dedicated client without duplication stays unflagged"
+        );
+    }
+
+    /// A pointer-only carrier on a dedicated host is exactly the desired end
+    /// state — it must never be flagged.
+    #[test]
+    fn build_report_leaves_pointer_only_dedicated_carrier_alone() {
+        let rules = vec![RulesFileCost {
+            path: "/home/u/.claude/CLAUDE.md".into(),
+            file_tokens: 100,
+            lean_ctx_tokens: 40,
+            carries_full: false,
+            clients: vec!["claude"],
+        }];
+        let report = build_report(
+            &[tool("ctx_read")],
+            &usage_with(&[("ctx_read", 5)]),
+            &rules,
+            Vec::new(),
+            0,
+            "lean (default)".to_string(),
+            KnowledgeHealth::default(),
+        );
+        assert!(report.rules[0].action.is_empty());
+        assert!(
+            report.foreign_servers.is_empty(),
+            "pure builder adds no foreign servers"
+        );
     }
 
     #[test]

--- a/rust/src/dashboard/static/components/cockpit-health.js
+++ b/rust/src/dashboard/static/components/cockpit-health.js
@@ -525,6 +525,55 @@ class CockpitHealth extends HTMLElement {
         '<tbody>' + dupRows + '</tbody></table></div></div>';
     }
 
+    var rules = Array.isArray(d.rules) ? d.rules : [];
+    var crossRules = rules.filter(function (e) {
+      return e.action && e.action.indexOf('duplicate') !== 0;
+    });
+    var crossCard = '';
+    if (crossRules.length > 0) {
+      var crossRows = '';
+      for (var c = 0; c < crossRules.length; c++) {
+        crossRows +=
+          '<tr><td>' + esc(crossRules[c].path || '—') + '</td>' +
+          '<td class="r">' + esc(ff(crossRules[c].lean_ctx_tokens || 0)) + '</td>' +
+          '<td>' + esc(crossRules[c].action || '—') + '</td></tr>';
+      }
+      crossCard =
+        '<div class="card" style="margin-top:14px">' +
+        '<div class="card-header"><h3>Cross-layer rules overlap</h3></div>' +
+        '<p class="hs" style="padding:0 4px 8px">Carriers on dedicated hosts duplicating what ' +
+        'MCP instructions already deliver — thin them to a pointer.</p>' +
+        '<div class="table-scroll"><table>' +
+        '<thead><tr><th>File</th><th class="r">lean-ctx tok</th><th>Suggested action</th></tr></thead>' +
+        '<tbody>' + crossRows + '</tbody></table></div></div>';
+    }
+
+    var foreign = Array.isArray(d.foreign_servers) ? d.foreign_servers : [];
+    var foreignCard = '';
+    if (foreign.length > 0) {
+      var fRows = '';
+      for (var f = 0; f < foreign.length; f++) {
+        var s = foreign[f];
+        var unusedSrv = !s.calls;
+        fRows +=
+          '<tr><td>' + esc(s.name || '—') + '</td>' +
+          '<td><span class="tag ' + (unusedSrv ? 'td' : 'tg') + '">' +
+          (unusedSrv ? 'never called' : 'active') + '</span></td>' +
+          '<td class="r">' + esc(ff(s.calls || 0)) + '</td>' +
+          '<td class="r">' + esc(ff(s.sessions_with_use || 0)) + '/' + esc(ff(s.transcripts_scanned || 0)) + '</td>' +
+          '<td>' + esc(s.source || '—') + '</td></tr>';
+      }
+      foreignCard =
+        '<div class="card" style="margin-top:14px">' +
+        '<div class="card-header"><h3>Foreign MCP servers</h3></div>' +
+        '<p class="hs" style="padding:0 4px 8px">Non-lean-ctx servers load their schemas into every ' +
+        'session; usage below is measured from local transcripts — disable unused servers via <code>/mcp</code>.</p>' +
+        '<div class="table-scroll"><table>' +
+        '<thead><tr><th>Server</th><th>Status</th><th class="r">Calls</th>' +
+        '<th class="r">Sessions</th><th>Source</th></tr></thead>' +
+        '<tbody>' + fRows + '</tbody></table></div></div>';
+    }
+
     var k = d.knowledge || {};
     var knowCard = '';
     if ((k.total_facts || 0) > 0) {
@@ -540,7 +589,7 @@ class CockpitHealth extends HTMLElement {
         '</div>';
     }
 
-    return summary + rotCard + rulesCard + knowCard;
+    return summary + rotCard + rulesCard + crossCard + foreignCard + knowCard;
   }
 
   _renderKernel(esc) {


### PR DESCRIPTION
## Summary

Two context-budget transparency features for `tools health` (#848 follow-up), born from a real finding: a claude.ai Figma connector with ~35 tool schemas loaded into every session of this repo — **0 calls in 14 transcripts over 45 days** — invisible to every existing lean-ctx report.

### Foreign MCP server audit
- Discovers non-lean-ctx MCP servers from local config (`~/.claude.json` global + per-project, project `.mcp.json`) **and** observed connections (per-project MCP log dirs — the only local trace of claude.ai account connectors).
- Cross-references with measured `mcp__<server>__*` `tool_use` calls from local Claude Code transcripts (45d window).
- Flags never-called servers as pure fixed cost. Honest by design: usage is measured, foreign schema size is never estimated (not measurable locally).

### Cross-layer rules dedup detection
- A rules carrier on a dedicated host (claude/codex/codebuddy) holding more than a pointer duplicates the mapping the MCP `instructions` already deliver every session → flagged with reclaimable size.
- Closes a fixed-cost measurement gap: `.claude/rules/*.md` project files are now part of the rules scan.

Both render in the CLI report and the dashboard tool-budget panel. Deterministic, local-only, read-only — findings stay suggestions.

## Test plan
- [x] 7 new unit tests — 28/28 relevant lib tests green
- [x] `scripts/preflight.sh fast` PASSED (fmt, clippy --all-features -D warnings, rustdoc, gen_docs/gen_registry drift, win cross-check)
- [x] End-to-end on real machine state: flags Figma connector (0 calls/14 transcripts) + 3 cross-layer carriers (~344/~310/~334 tok/session reclaimable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)