### PR TITLE
feat(behavior): turn-economy telemetry, in-band nudges, measured output shaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   the MCP `instructions` already deliver every session; `tools health` now
   flags it with the reclaimable size. `.claude/rules/*.md` project files are
   now included in the fixed-cost scan.
+- **Behavior telemetry + in-band nudges** — a new `tools health` Behavior
+  section reports the explicit full/raw read share (from recorded CEP modes)
+  and search→read→search chains vs `ctx_compose` adoption; the server appends
+  at most one ~30-token hint per pattern per session at the moment of waste
+  (new `behavior_nudges` config key, `auto`/`off`; detections are counted
+  either way).
+- **Measured output shaping in `gain`** — surfaces the #895 holdout A/B
+  (`proxy.output_holdout`): measured output-token reduction with 95% CI when
+  enough paired turns exist, honest "measuring"/"not measured" status
+  otherwise.
 
 ## [3.9.20] — 2026-08-25
 

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -17,6 +17,7 @@ Top-level configuration keys
 - `allow_symlink_roots` (string[], default `[]` — env `LEAN_CTX_ALLOW_SYMLINK_ROOTS`) — Trusted roots OUTSIDE $HOME lean-ctx may follow when an agent config is symlinked there (#596). Empty = strict $HOME-only
 - `auto_capture` (bool, default `true`) — Automatic knowledge capture from tool findings
 - `auto_mode_learning` (bool, default `false` — env `LEAN_CTX_AUTO_MODE_LEARNING`) — Opt-in: let adaptive learning signals (predictor, bandit, heatmap, adaptive policy, bounce/path memory) influence `auto` mode. Off by default for a deterministic, I/O-light cascade (capability guards + size/task heuristic only) that keeps output byte-stable for prompt caching. Override via LEAN_CTX_AUTO_MODE_LEARNING
+- `behavior_nudges` (String, default `auto`) — In-band behavior hints (heavy full/raw reads, search→read→search chains): auto (default, one hint per pattern per session) or off. Detections are always counted for `tools health`.
 - `bm25_max_cache_mb` (u64, default `128` — env `LEAN_CTX_BM25_MAX_CACHE_MB`) — Maximum BM25 cache file size in MB
 - `buddy_enabled` (bool, default `true`) — Enable the experimental local buddy helper. It does not enable a public multi-agent product or MCP surface.
 - `bypass_hints` (enum: on | off | aggressive, default `on` — env `LEAN_CTX_BYPASS_HINTS`) — Bypass-hint mode: when agents use native Read/Grep instead of lean-ctx tools, a hint is appended to the next tool response. on (default), off, aggressive (hint on every call, no cooldown). Override via LEAN_CTX_BYPASS_HINTS

--- a/rust/src/cli/dispatch/analytics/gain.rs
+++ b/rust/src/cli/dispatch/analytics/gain.rs
@@ -280,6 +280,7 @@ pub(in crate::cli::dispatch) fn cmd_gain(rest: &[String]) {
     } else {
         println!("{}", core::stats::format_gain_hero());
         print_solution_intelligence();
+        print_output_shaping();
         // Surface available updates where users actually look (#563) — the
         // banner functions existed but had no caller, so terminals never
         // showed update hints at all.
@@ -353,6 +354,35 @@ fn print_solution_intelligence() {
         "Combined: {} total tokens saved ({combined_reduction:.1}% total reduction)",
         format_thousands(combined_saved),
     );
+}
+
+/// Measured output-shaping savings from the proxy holdout (#895 Track B):
+/// a real A/B number when enough paired turns exist, honest status otherwise
+/// — never an invented estimate presented as measurement.
+fn print_output_shaping() {
+    use crate::proxy::output_savings::{self, Savings};
+    match output_savings::current() {
+        Savings::Measured(m) => {
+            println!(
+                "\nOutput shaping (measured, holdout A/B): {:.1}% fewer output tokens/turn (95% CI {:.1}–{:.1}%, control n={}, treatment n={})",
+                m.reduction_pct, m.ci95_low_pct, m.ci95_high_pct, m.control_n, m.treatment_n
+            );
+        }
+        Savings::Pending {
+            control_n,
+            treatment_n,
+            needed,
+        } => {
+            println!(
+                "\nOutput shaping: measuring — holdout active, {control_n}/{needed} control and {treatment_n}/{needed} treatment turns collected"
+            );
+        }
+        Savings::Estimated { .. } => {
+            println!(
+                "\nOutput shaping: not measured — set `proxy.output_holdout` (e.g. 0.1) to A/B-measure output-token reduction"
+            );
+        }
+    }
 }
 
 fn format_thousands(value: u64) -> String {

--- a/rust/src/cli/tools_health_cmd.rs
+++ b/rust/src/cli/tools_health_cmd.rs
@@ -197,6 +197,26 @@ fn print_report(r: &ToolHealthReport, show_all: bool) {
         }
     }
 
+    // ── Behavior (turn economy) ───────────────────────────────────────
+    let b = &r.behavior;
+    if b.total_mode_reads > 0 || b.chains_detected > 0 {
+        println!("\n{BOLD}Behavior{RST}");
+        if let Some(pct) = b.heavy_read_share_pct {
+            let color = if pct >= 40 { YELLOW } else { GREEN };
+            println!(
+                "  explicit full/raw reads  {color}{pct}%{RST} of {} recorded read modes",
+                b.total_mode_reads
+            );
+        }
+        println!(
+            "  chains vs compose        {} search→read→search chain(s) · {} ctx_compose call(s) · {} hint(s) shown",
+            b.chains_detected, b.compose_calls, b.hints_shown
+        );
+        if !b.action.is_empty() {
+            println!("  {YELLOW}→ {}{RST}", b.action);
+        }
+    }
+
     // ── Knowledge ─────────────────────────────────────────────────────
     if r.knowledge.total_facts > 0 {
         println!(

--- a/rust/src/core/behavior_nudge.rs
+++ b/rust/src/core/behavior_nudge.rs
@@ -1,0 +1,317 @@
+//! In-band behavior nudges + turn-economy telemetry.
+//!
+//! `tools health` measured two waste patterns this module targets (#848
+//! follow-up):
+//!
+//! 1. **Heavy reads** — explicit `mode=full`/`raw` dominated recorded
+//!    `ctx_read` modes (62% at introduction time) while the structural modes
+//!    (`signatures`/`map`) cover orientation at a fraction of the tokens.
+//! 2. **Tool-call chains** — `ctx_search` → `ctx_read` → `ctx_search`/
+//!    `ctx_callgraph` sequences that a single `ctx_compose` call bundles;
+//!    every extra turn re-reads the whole conversation server-side.
+//!
+//! The mechanism is one trailing hint line appended to a tool result at the
+//! moment of waste — in-conversation context outweighs static rules. Hints
+//! are budgeted hard: at most one hint per pattern per server process
+//! (~30 tokens each), gated by the `behavior_nudges` config key
+//! (`"auto"` default | `"off"`). Every detection is also counted in a small
+//! local store so `tools health` reports the pattern honestly even with
+//! hints off. Deterministic thresholds, local-only state, no network.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// An explicit full/raw read below this many output tokens is cheap enough to
+/// ignore — nudging small reads would be noise.
+const HEAVY_READ_TOKEN_FLOOR: usize = 1500;
+/// Chain steps further apart than this are unrelated work, not a chain.
+const CHAIN_WINDOW: Duration = Duration::from_mins(2);
+
+/// Cumulative detection counters, persisted across sessions for
+/// `tools health` (mirrors the adaptive-mode policy store pattern).
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub(crate) struct BehaviorStore {
+    /// Explicit full/raw reads at or above [`HEAVY_READ_TOKEN_FLOOR`].
+    pub heavy_reads_detected: u64,
+    /// search→read→search/callgraph sequences inside [`CHAIN_WINDOW`] steps.
+    pub chains_detected: u64,
+    /// Hints actually appended to a tool result.
+    pub hints_shown: u64,
+    pub updated_at: Option<String>,
+}
+
+impl BehaviorStore {
+    pub(crate) fn load() -> Self {
+        let Some(path) = store_path() else {
+            return Self::default();
+        };
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default()
+    }
+
+    fn save(&self) {
+        let Some(path) = store_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent()
+            && std::fs::create_dir_all(parent).is_err()
+        {
+            return;
+        }
+        if let Ok(json) = serde_json::to_string(self) {
+            let tmp = path.with_extension("tmp");
+            if std::fs::write(&tmp, json).is_ok() {
+                let _ = std::fs::rename(&tmp, &path);
+            }
+        }
+    }
+}
+
+fn store_path() -> Option<std::path::PathBuf> {
+    crate::core::paths::state_dir()
+        .ok()
+        .map(|d| d.join("behavior_nudge.json"))
+}
+
+/// Per-process (session) state: the short recent-call window for chain
+/// detection plus the once-per-session hint gates.
+#[derive(Debug, Default)]
+struct SessionState {
+    recent: Vec<(&'static str, Instant)>,
+    heavy_hint_shown: bool,
+    chain_hint_shown: bool,
+}
+
+static SESSION: Mutex<Option<SessionState>> = Mutex::new(None);
+
+/// Which detection (if any) a call triggered.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Detection {
+    HeavyRead,
+    Chain,
+}
+
+/// Classifies a tool call for the chain window. Only orientation tools
+/// participate; a `ctx_compose` call is the desired end state and resets the
+/// window instead of extending it.
+fn chain_step(name: &str) -> Option<&'static str> {
+    match name {
+        "ctx_search" => Some("search"),
+        "ctx_read" => Some("read"),
+        "ctx_callgraph" => Some("graph"),
+        _ => None,
+    }
+}
+
+/// Pure detection core, separated from global state and the clock for tests.
+fn detect(
+    state: &mut SessionState,
+    name: &str,
+    explicit_mode: Option<&str>,
+    output_tokens: usize,
+    now: Instant,
+) -> Option<Detection> {
+    // Heavy read: explicit full/raw at meaningful size.
+    if name == "ctx_read"
+        && matches!(explicit_mode, Some("full" | "raw"))
+        && output_tokens >= HEAVY_READ_TOKEN_FLOOR
+    {
+        return Some(Detection::HeavyRead);
+    }
+
+    if name == "ctx_compose" {
+        state.recent.clear();
+        return None;
+    }
+    let step = chain_step(name)?;
+    state
+        .recent
+        .retain(|(_, at)| now.saturating_duration_since(*at) <= CHAIN_WINDOW);
+    state.recent.push((step, now));
+    if state.recent.len() > 3 {
+        let excess = state.recent.len() - 3;
+        state.recent.drain(0..excess);
+    }
+    let steps: Vec<&str> = state.recent.iter().map(|(s, _)| *s).collect();
+    if steps == ["search", "read", "search"] || steps == ["search", "read", "graph"] {
+        state.recent.clear();
+        return Some(Detection::Chain);
+    }
+    None
+}
+
+/// The one-line hints. Kept short on purpose — a nudge that costs hundreds of
+/// tokens would defeat itself.
+fn hint_for(detection: Detection) -> &'static str {
+    match detection {
+        Detection::HeavyRead => {
+            "[lean-ctx nudge] large explicit full/raw read — mode=signatures/map covers orientation at a fraction of the tokens; reserve full/raw for edit prep. (once per session; behavior_nudges=off to silence)"
+        }
+        Detection::Chain => {
+            "[lean-ctx nudge] search→read→search chain — one ctx_compose call bundles search+read+symbols and saves the extra turns. (once per session; behavior_nudges=off to silence)"
+        }
+    }
+}
+
+/// Observes one dispatched tool call. Counts detections in the persistent
+/// store and returns a hint line to append at most once per pattern per
+/// session — `None` when there is nothing to say. `can_show` suppresses the
+/// hint (machine-readable or firewalled results) without burning the
+/// once-per-session budget; detections are counted either way. Called
+/// post-dispatch, so it must stay cheap: no I/O unless a (rare) detection
+/// fired.
+pub(crate) fn observe(
+    name: &str,
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+    output_tokens: usize,
+    can_show: bool,
+) -> Option<String> {
+    let nudges_on = can_show && crate::core::config::Config::load().behavior_nudges != "off";
+    let explicit_mode = args
+        .and_then(|a| a.get("mode"))
+        .and_then(|m| m.as_str())
+        .map(str::to_string);
+    let mut guard = SESSION
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let state = guard.get_or_insert_with(SessionState::default);
+    let detection = detect(
+        state,
+        name,
+        explicit_mode.as_deref(),
+        output_tokens,
+        Instant::now(),
+    )?;
+
+    let mut store = BehaviorStore::load();
+    match detection {
+        Detection::HeavyRead => store.heavy_reads_detected += 1,
+        Detection::Chain => store.chains_detected += 1,
+    }
+    let show = nudges_on
+        && match detection {
+            Detection::HeavyRead => !std::mem::replace(&mut state.heavy_hint_shown, true),
+            Detection::Chain => !std::mem::replace(&mut state.chain_hint_shown, true),
+        };
+    if show {
+        store.hints_shown += 1;
+    }
+    store.updated_at = Some(chrono::Utc::now().to_rfc3339());
+    store.save();
+    show.then(|| hint_for(detection).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state() -> SessionState {
+        SessionState::default()
+    }
+
+    #[test]
+    fn heavy_read_needs_explicit_heavy_mode_and_size() {
+        let now = Instant::now();
+        let mut s = state();
+        assert_eq!(
+            detect(&mut s, "ctx_read", Some("full"), 2000, now),
+            Some(Detection::HeavyRead)
+        );
+        assert_eq!(detect(&mut s, "ctx_read", Some("full"), 200, now), None);
+        assert_eq!(
+            detect(&mut s, "ctx_read", Some("signatures"), 5000, now),
+            None
+        );
+        assert_eq!(
+            detect(&mut s, "ctx_read", None, 5000, now),
+            None,
+            "auto-resolved reads are the resolver's business, not the agent's"
+        );
+        assert_eq!(
+            detect(&mut s, "ctx_read", Some("raw"), 1500, now),
+            Some(Detection::HeavyRead)
+        );
+    }
+
+    #[test]
+    fn chain_detected_for_search_read_search_within_window() {
+        let now = Instant::now();
+        let mut s = state();
+        assert_eq!(detect(&mut s, "ctx_search", None, 10, now), None);
+        assert_eq!(detect(&mut s, "ctx_read", Some("map"), 10, now), None);
+        assert_eq!(
+            detect(&mut s, "ctx_search", None, 10, now),
+            Some(Detection::Chain)
+        );
+        // Window cleared after a detection — no immediate re-fire.
+        assert_eq!(detect(&mut s, "ctx_search", None, 10, now), None);
+    }
+
+    #[test]
+    fn chain_accepts_callgraph_as_final_step() {
+        let now = Instant::now();
+        let mut s = state();
+        detect(&mut s, "ctx_search", None, 10, now);
+        detect(&mut s, "ctx_read", Some("map"), 10, now);
+        assert_eq!(
+            detect(&mut s, "ctx_callgraph", None, 10, now),
+            Some(Detection::Chain)
+        );
+    }
+
+    #[test]
+    fn compose_resets_the_chain_window() {
+        let now = Instant::now();
+        let mut s = state();
+        detect(&mut s, "ctx_search", None, 10, now);
+        detect(&mut s, "ctx_read", Some("map"), 10, now);
+        detect(&mut s, "ctx_compose", None, 10, now);
+        assert_eq!(
+            detect(&mut s, "ctx_search", None, 10, now),
+            None,
+            "compose is the desired end state — it must not complete a chain"
+        );
+    }
+
+    #[test]
+    fn stale_steps_age_out_of_the_window() {
+        let start = Instant::now();
+        let later = start + CHAIN_WINDOW + Duration::from_secs(1);
+        let mut s = state();
+        detect(&mut s, "ctx_search", None, 10, start);
+        detect(&mut s, "ctx_read", Some("map"), 10, start);
+        assert_eq!(
+            detect(&mut s, "ctx_search", None, 10, later),
+            None,
+            "steps older than the window are unrelated work"
+        );
+    }
+
+    #[test]
+    fn unrelated_tools_do_not_extend_chains() {
+        let now = Instant::now();
+        let mut s = state();
+        detect(&mut s, "ctx_search", None, 10, now);
+        detect(&mut s, "ctx_read", Some("map"), 10, now);
+        assert_eq!(detect(&mut s, "ctx_shell", None, 10, now), None);
+        // ctx_shell is invisible to the window; the chain can still complete.
+        assert_eq!(
+            detect(&mut s, "ctx_search", None, 10, now),
+            Some(Detection::Chain)
+        );
+    }
+
+    #[test]
+    fn hints_stay_short() {
+        for d in [Detection::HeavyRead, Detection::Chain] {
+            assert!(
+                hint_for(d).len() < 220,
+                "a nudge must cost far less than what it saves"
+            );
+        }
+    }
+}

--- a/rust/src/core/config/defaults.rs
+++ b/rust/src/core/config/defaults.rs
@@ -164,6 +164,7 @@ impl Default for Config {
             savings_footer: SavingsFooter::default(),
             compression_annotation: CompressionAnnotation::default(),
             annotation_threshold_pct: serde_defaults::default_annotation_threshold_pct(),
+            behavior_nudges: serde_defaults::default_behavior_nudges(),
             turn_fresh_limit: serde_defaults::default_turn_fresh_limit(),
             session_token_limit: serde_defaults::default_session_token_limit(),
             project_root: None,

--- a/rust/src/core/config/merge.rs
+++ b/rust/src/core/config/merge.rs
@@ -209,6 +209,7 @@ impl Config {
         override_if_key_present!("compression_level", compression_level);
         override_if_key_present!("compression_aggressiveness", compression_aggressiveness);
         override_if_key_present!("terse_agent", terse_agent);
+        override_if_key_present!("behavior_nudges", behavior_nudges);
         override_if_false!(archive.enabled);
         override_if_ne!(default.archive.threshold_chars, archive.threshold_chars);
         override_if_ne!(default.archive.max_age_hours, archive.max_age_hours);

--- a/rust/src/core/config/model.rs
+++ b/rust/src/core/config/model.rs
@@ -566,6 +566,11 @@ pub struct Config {
     /// Default: 5 (suppress annotations for savings below 5%).
     #[serde(default = "serde_defaults::default_annotation_threshold_pct")]
     pub annotation_threshold_pct: u8,
+    /// In-band behavior hints (heavy full/raw reads, search→read→search
+    /// chains): "auto" (default, one hint per pattern per session) or "off".
+    /// Detections are always counted for `tools health`, hints or not.
+    #[serde(default = "serde_defaults::default_behavior_nudges")]
+    pub behavior_nudges: String,
     /// Maximum fresh tokens per single tool response (turn budget).
     /// 0 = unlimited. Default: 4096. Prevents context bloat from oversized responses.
     /// Override via LEAN_CTX_TURN_FRESH_LIMIT env var.

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -576,6 +576,14 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             ),
         );
     root.insert(
+        "behavior_nudges".into(),
+        key(
+            "String",
+            serde_json::json!("auto"),
+            "In-band behavior hints (heavy full/raw reads, search→read→search chains): auto (default, one hint per pattern per session) or off. Detections are always counted for `tools health`.",
+        ),
+    );
+    root.insert(
         "max_ram_percent".into(),
         key_with_env(
             "u8",

--- a/rust/src/core/config/serde_defaults.rs
+++ b/rust/src/core/config/serde_defaults.rs
@@ -84,3 +84,7 @@ pub(super) fn default_progressive_threshold_lines() -> u32 {
 pub(super) fn default_progressive_signatures_max() -> u32 {
     500
 }
+
+pub(super) fn default_behavior_nudges() -> String {
+    "auto".to_string()
+}

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod aggressiveness;
 pub mod attention_context;
 pub(crate) mod auto_capture;
 pub(crate) mod auto_findings;
+pub(crate) mod behavior_nudge;
 pub mod codebook;
 #[cfg(target_os = "macos")]
 pub(crate) mod codesign;

--- a/rust/src/core/tool_health.rs
+++ b/rust/src/core/tool_health.rs
@@ -97,6 +97,86 @@ pub(crate) struct KnowledgeHealth {
     pub action: String,
 }
 
+/// Measured agent-behavior signals (turn economy): how reads and tool chains
+/// actually happen, from local telemetry only.
+#[derive(Debug, Clone, Serialize, Default)]
+pub(crate) struct BehaviorHealth {
+    /// Explicit full/raw share of recorded `ctx_read` mode invocations (%),
+    /// `None` until mode telemetry exists.
+    pub heavy_read_share_pct: Option<u8>,
+    pub heavy_mode_reads: u64,
+    pub total_mode_reads: u64,
+    /// search→read→search/graph sequences one `ctx_compose` call would bundle.
+    pub chains_detected: u64,
+    pub compose_calls: u64,
+    pub hints_shown: u64,
+    pub action: String,
+}
+
+/// Share of recorded read modes above which explicit full/raw reads count as
+/// a steering problem rather than deliberate edit prep.
+const HEAVY_READ_SHARE_WARN_PCT: u8 = 40;
+
+/// Read-mode keys that participate in the heavy-read share. The CEP mode map
+/// also carries non-read instrumentation keys (register/compose/…) that must
+/// not dilute the denominator.
+fn is_read_mode(key: &str) -> bool {
+    matches!(
+        key,
+        "full"
+            | "raw"
+            | "auto"
+            | "map"
+            | "signatures"
+            | "task"
+            | "reference"
+            | "aggressive"
+            | "entropy"
+            | "diff"
+            | "delta"
+            | "fresh"
+            | "anchored"
+    ) || key.starts_with("lines:")
+        || key.starts_with("anchored:")
+        || key.starts_with("budget:")
+}
+
+/// Pure builder for the behavior section: read-mode skew from the CEP mode
+/// counters plus the nudge store's chain/heavy-read detections.
+fn behavior_health(
+    modes: &std::collections::HashMap<String, u64>,
+    nudges: &crate::core::behavior_nudge::BehaviorStore,
+    compose_calls: u64,
+) -> BehaviorHealth {
+    let total_mode_reads: u64 = modes
+        .iter()
+        .filter(|(k, _)| is_read_mode(k))
+        .map(|(_, v)| *v)
+        .sum();
+    let heavy_mode_reads: u64 = modes
+        .iter()
+        .filter(|(k, _)| matches!(k.as_str(), "full" | "raw"))
+        .map(|(_, v)| *v)
+        .sum();
+    let heavy_read_share_pct = (total_mode_reads > 0)
+        .then(|| u8::try_from(heavy_mode_reads * 100 / total_mode_reads).unwrap_or(100));
+    let action = match heavy_read_share_pct {
+        Some(pct) if pct >= HEAVY_READ_SHARE_WARN_PCT => format!(
+            "explicit full/raw dominates recorded reads ({pct}%) — signatures/map cover orientation at a fraction of the tokens; in-band nudges are counting (see behavior_nudges)"
+        ),
+        _ => String::new(),
+    };
+    BehaviorHealth {
+        heavy_read_share_pct,
+        heavy_mode_reads,
+        total_mode_reads,
+        chains_detected: nudges.chains_detected,
+        compose_calls,
+        hints_shown: nudges.hints_shown,
+        action,
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct ToolHealthReport {
     pub tool_profile: String,
@@ -127,6 +207,8 @@ pub(crate) struct ToolHealthReport {
     /// Non-lean-ctx MCP servers the client loads every session, with measured
     /// transcript usage — unused ones are pure fixed cost lean-ctx cannot see.
     pub foreign_servers: Vec<crate::core::foreign_mcp::ForeignServerEntry>,
+    /// Measured behavior signals: read-mode skew, chains vs compose, hints.
+    pub behavior: BehaviorHealth,
 }
 
 fn classify(has_usage: bool, calls: u64, schema_tokens: usize, total_calls: u64) -> ToolStatus {
@@ -306,6 +388,7 @@ pub(crate) fn build_report(
         duplicate_clients: duplicates,
         knowledge,
         foreign_servers: Vec::new(),
+        behavior: BehaviorHealth::default(),
     }
 }
 
@@ -415,6 +498,11 @@ pub(crate) fn compute(home: &Path, project: &Path) -> ToolHealthReport {
     );
     report.footprint_note = latest_footprint_note();
     report.foreign_servers = crate::core::foreign_mcp::audit(home, project);
+    report.behavior = behavior_health(
+        &crate::core::stats::load_for_display().cep.modes,
+        &crate::core::behavior_nudge::BehaviorStore::load(),
+        usage.tools.get("ctx_compose").map_or(0, |t| t.total_calls),
+    );
     report
 }
 
@@ -682,6 +770,52 @@ mod tests {
             report.foreign_servers.is_empty(),
             "pure builder adds no foreign servers"
         );
+    }
+
+    /// Behavior section: the share only counts read modes — instrumentation
+    /// keys in the CEP map (register/compose/…) must not dilute it — and the
+    /// warn threshold gates the action text.
+    #[test]
+    fn behavior_health_computes_share_from_read_modes_only() {
+        let mut modes = std::collections::HashMap::new();
+        modes.insert("full".to_string(), 50u64);
+        modes.insert("raw".to_string(), 10);
+        modes.insert("signatures".to_string(), 30);
+        modes.insert("lines:1-20".to_string(), 10);
+        modes.insert("register".to_string(), 500);
+        modes.insert("compose".to_string(), 130);
+        let store = crate::core::behavior_nudge::BehaviorStore {
+            chains_detected: 7,
+            hints_shown: 2,
+            ..Default::default()
+        };
+        let b = behavior_health(&modes, &store, 130);
+        assert_eq!(b.total_mode_reads, 100, "register/compose are not reads");
+        assert_eq!(b.heavy_mode_reads, 60);
+        assert_eq!(b.heavy_read_share_pct, Some(60));
+        assert!(b.action.contains("full/raw dominates"));
+        assert_eq!(b.chains_detected, 7);
+        assert_eq!(b.compose_calls, 130);
+    }
+
+    #[test]
+    fn behavior_health_stays_quiet_below_threshold_and_without_data() {
+        let mut modes = std::collections::HashMap::new();
+        modes.insert("full".to_string(), 10u64);
+        modes.insert("signatures".to_string(), 90);
+        let b = behavior_health(&modes, &Default::default(), 0);
+        assert_eq!(b.heavy_read_share_pct, Some(10));
+        assert!(
+            b.action.is_empty(),
+            "10% heavy reads is deliberate edit prep"
+        );
+
+        let empty = behavior_health(&std::collections::HashMap::new(), &Default::default(), 0);
+        assert_eq!(
+            empty.heavy_read_share_pct, None,
+            "no telemetry → no verdict"
+        );
+        assert!(empty.action.is_empty());
     }
 
     #[test]

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -476,6 +476,19 @@ pub(in crate::server) async fn dispatch_and_post_process(
     // and every subsequent wakeup briefing (#658).
     let findings_source = result_text.clone();
 
+    // Behavior nudge (turn economy / heavy reads, #848 follow-up): observe
+    // every call so chain detection stays complete; append the budgeted
+    // one-line hint only to plain, non-firewalled results.
+    if let Some(hint) = crate::core::behavior_nudge::observe(
+        name,
+        args,
+        crate::core::tokens::count_tokens(&result_text),
+        !machine_readable && !firewalled,
+    ) {
+        result_text.push_str("\n\n");
+        result_text.push_str(&hint);
+    }
+
     // Echo-ratio nudge (#science): when output largely repeats the task
     // description, surface a deterministic hint before footer markers (#498).
     if !machine_readable


### PR DESCRIPTION
## Summary

Stacked on #1568. Three behavior levers against token waste that `tools health` measured but nothing acted on:

### In-band behavior nudges (`core/behavior_nudge.rs`)
- Detects **heavy explicit `full`/`raw` reads** (≥1500 tok — 62% of recorded read modes at introduction) and **search→read→search/graph chains** that one `ctx_compose` call bundles.
- Appends **at most one ~30-token hint per pattern per server session**, at the moment of waste — in-conversation context outweighs static rules. New `behavior_nudges` config key (`auto`|`off`); detections are counted in a local store either way. Observation covers every call; decoration only plain, non-firewalled results, after the auto-findings snapshot.

### `tools health` Behavior section
- Explicit full/raw share of recorded CEP read modes (instrumentation keys like `register`/`compose` excluded from the denominator), chains vs `ctx_compose` adoption, hints shown. Warns at ≥40% heavy-read share.

### Measured output shaping in `gain`
- Surfaces the existing #895 holdout A/B (`proxy.output_holdout`): measured output-token reduction with 95% CI when enough paired turns exist, honest "measuring"/"not measured" status otherwise — never an estimate dressed as measurement.

## Test plan
- [x] 9 new unit tests (detection thresholds, chain window/reset/aging, compose reset, share computation incl. denominator hygiene, no-telemetry neutrality) — behavior_nudge 7/7, tool_health 22/22
- [x] `cargo clippy --all-features -- -D warnings`, `cargo fmt --check`, `gen_docs --check` (config-keys reference regenerated), `gen_registry --check` — all green
- [x] End-to-end on real machine state after dev-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)