### PR TITLE
feat(conversation): Conversation Layer wave 1 — error purge, nudge economy, protection grammar (#1570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to lean-ctx are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added — Conversation Layer (#1570, DCP-inspired, cache-safe by construction)
+
+- **Errored tool-input purge** (proxy, deterministic): once a failed tool
+  call scrolls into the frozen old region, its bulky *input* is replaced by
+  a small marker — the error text stays. Content-local and idempotent, so
+  pruned forms are byte-identical across turns (#448 cache safety).
+- **Budget-nudge economy**: the `[BUDGET WARNING]` footer is replaced by a
+  stepped ladder (75% soft / 100% strong / 150% strong) with anchor dedup
+  (each step fires once), 5-point hysteresis re-arm, reset-on-action and a
+  cooldown after `ctx_compress`/`ctx_dedup` — advisories that land instead
+  of spam agents learn to ignore. Still purely advisory: nothing blocks.
+
 ## [3.9.20] — 2026-08-25
 
 ### Fixed — triage (community incident, 3.9.19)

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -380,6 +380,7 @@ pub mod marginal_gate;
 pub mod mcp_catalog;
 pub mod metering;
 pub mod negative_knowledge;
+pub mod nudge;
 pub mod ocla;
 pub mod ocla_bus;
 pub(crate) mod quality_benchmark;

--- a/rust/src/core/nudge.rs
+++ b/rust/src/core/nudge.rs
@@ -1,0 +1,219 @@
+//! Nudge economy for budget advisories (#1570 P2, DCP-inspired).
+//!
+//! The pre-#1570 `[BUDGET WARNING]` footer fired on every call once a
+//! dimension crossed its warning band — agents learned to ignore it (#1542
+//! "advisory verpufft"). This module replaces fire-and-forget warnings with
+//! an *economy*:
+//!
+//! - **Stepped thresholds** per dimension (75% soft, 100% strong, 150%
+//!   strong + recovery script), evaluated on the existing
+//!   [`BudgetSnapshot`] percentages.
+//! - **Anchor dedup**: each (dimension, step) fires exactly once while the
+//!   usage stays above the step. No repetition spam.
+//! - **Hysteresis**: dropping 5 points below a step re-arms it, so a real
+//!   re-crossing nudges again.
+//! - **Reset-on-action** (#1570 P6 guard): a recovery tool call
+//!   (`ctx_compress`, `ctx_dedup`) clears all anchors *and* starts a short
+//!   cooldown, so the agent is never nudged right after it just acted —
+//!   the "models become obsessed with pruning" failure mode reported
+//!   against DCP (#372 there).
+//!
+//! Advisory by design: nothing here ever blocks a tool call (#1542).
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use crate::core::budget_tracker::BudgetSnapshot;
+
+/// Calls suppressed after a recovery action before nudging resumes.
+const RECOVERY_COOLDOWN_CALLS: u32 = 3;
+
+/// Re-arm margin: a step re-fires only after usage drops this many
+/// percentage points below it.
+const HYSTERESIS_PCT: f64 = 5.0;
+
+/// (threshold in percent, strong?) — evaluated highest-first.
+const STEPS: &[(f64, bool)] = &[(150.0, true), (100.0, true), (75.0, false)];
+
+/// Tools whose successful use counts as budget recovery.
+pub const RECOVERY_TOOLS: &[&str] = &["ctx_compress", "ctx_dedup"];
+
+#[derive(Default)]
+struct NudgeState {
+    /// (dimension, step-index) anchors that already fired.
+    fired: HashSet<(&'static str, usize)>,
+    cooldown_calls_left: u32,
+}
+
+fn state() -> &'static Mutex<NudgeState> {
+    static STATE: OnceLock<Mutex<NudgeState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(NudgeState::default()))
+}
+
+/// Record a recovery action: clear all anchors and pause nudging briefly.
+pub fn record_recovery_action(tool: &str) {
+    if !RECOVERY_TOOLS.contains(&tool) {
+        return;
+    }
+    let mut guard = state()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.fired.clear();
+    guard.cooldown_calls_left = RECOVERY_COOLDOWN_CALLS;
+}
+
+/// Test/reset hook (session reset).
+pub fn reset() {
+    let mut guard = state()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    guard.fired.clear();
+    guard.cooldown_calls_left = 0;
+}
+
+/// Evaluate the snapshot against the step ladder. Returns at most one nudge
+/// line per call — the strongest newly-crossed step across all dimensions.
+pub fn budget_nudge(snap: &BudgetSnapshot) -> Option<String> {
+    let mut guard = state()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if guard.cooldown_calls_left > 0 {
+        guard.cooldown_calls_left -= 1;
+        return None;
+    }
+
+    let dimensions: [(&'static str, f64, String); 3] = [
+        (
+            "tokens",
+            snap.tokens.percent.into(),
+            format!("{}/{}", snap.tokens.used, snap.tokens.limit),
+        ),
+        (
+            "shell",
+            snap.shell.percent.into(),
+            format!("{}/{}", snap.shell.used, snap.shell.limit),
+        ),
+        (
+            "cost",
+            snap.cost.percent.into(),
+            format!("${:.2}/${:.2}", snap.cost.used_usd, snap.cost.limit_usd),
+        ),
+    ];
+
+    // Hysteresis re-arm: forget anchors the usage has clearly dropped below.
+    for (dim, pct, _) in &dimensions {
+        for (idx, (threshold, _)) in STEPS.iter().enumerate() {
+            if *pct < threshold - HYSTERESIS_PCT {
+                guard.fired.remove(&(*dim, idx));
+            }
+        }
+    }
+
+    // Strongest newly-crossed step wins; one nudge per call, ever.
+    for (idx, (threshold, strong)) in STEPS.iter().enumerate() {
+        for (dim, pct, usage) in &dimensions {
+            if *pct >= *threshold && guard.fired.insert((*dim, idx)) {
+                let line = if *strong {
+                    format!(
+                        "[BUDGET] {dim} at {pct:.0}% ({usage}) — advisory, nothing is blocked. \
+                         Recover: ctx_compress (compact context), ctx_dedup (drop repeated reads), \
+                         or ctx_session action=reset for a fresh budget."
+                    )
+                } else {
+                    format!(
+                        "[budget nudge] {dim} at {pct:.0}% ({usage}) — consider ctx_compress or \
+                         dropping stale reads soon (advisory)."
+                    )
+                };
+                return Some(line);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::budget_tracker::BudgetTracker;
+
+    /// Build a snapshot with a controlled token percentage by driving the
+    /// global tracker. Serialized via the shared test env lock — the tracker
+    /// and nudge state are process-global.
+    fn snapshot_with_tokens(used: usize) -> BudgetSnapshot {
+        let tracker = BudgetTracker::global();
+        tracker.reset();
+        tracker.record_tokens(used as u64);
+        tracker.check()
+    }
+
+    #[test]
+    fn nudge_ladder_fires_once_per_step_escalates_and_resets_on_action() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        reset();
+        let limit = snapshot_with_tokens(0).tokens.limit;
+        if limit == 0 {
+            // No token limit configured in this environment — ladder cannot
+            // be exercised meaningfully.
+            return;
+        }
+
+        // 80% -> soft nudge fires exactly once.
+        let snap = snapshot_with_tokens(limit * 8 / 10);
+        let first = budget_nudge(&snap);
+        assert!(
+            first
+                .as_deref()
+                .is_some_and(|s| s.contains("[budget nudge]")),
+            "{first:?}"
+        );
+        assert_eq!(
+            budget_nudge(&snap),
+            None,
+            "anchor dedup: same step never repeats"
+        );
+
+        // 105% -> escalation to strong, again exactly once.
+        let snap = snapshot_with_tokens(limit + limit / 20);
+        let strong = budget_nudge(&snap);
+        assert!(
+            strong.as_deref().is_some_and(|s| s.contains("[BUDGET]")),
+            "{strong:?}"
+        );
+        assert_eq!(budget_nudge(&snap), None);
+
+        // Recovery action clears anchors and starts the cooldown.
+        record_recovery_action("ctx_compress");
+        for _ in 0..RECOVERY_COOLDOWN_CALLS {
+            assert_eq!(budget_nudge(&snap), None, "cooldown suppresses nudges");
+        }
+        // After the cooldown the (re-armed) strong step fires again.
+        assert!(
+            budget_nudge(&snap).is_some(),
+            "anchors re-armed after recovery"
+        );
+
+        BudgetTracker::global().reset();
+        reset();
+    }
+
+    #[test]
+    fn non_recovery_tools_do_not_reset_anchors() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        reset();
+        let limit = snapshot_with_tokens(0).tokens.limit;
+        if limit == 0 {
+            return;
+        }
+        let snap = snapshot_with_tokens(limit * 8 / 10);
+        assert!(budget_nudge(&snap).is_some());
+        record_recovery_action("ctx_read");
+        assert_eq!(
+            budget_nudge(&snap),
+            None,
+            "ctx_read is not a recovery action"
+        );
+        BudgetTracker::global().reset();
+        reset();
+    }
+}

--- a/rust/src/proxy/history_prune.rs
+++ b/rust/src/proxy/history_prune.rs
@@ -149,6 +149,81 @@ pub fn prune_history_range(
             _ => {}
         }
     }
+    modified |= purge_errored_tool_inputs(&mut messages[prune_start..prune_end]);
+    modified
+}
+
+/// Marker key for a purged tool-call input; also the idempotence guard.
+const PURGED_INPUT_KEY: &str = "lean_ctx_purged";
+const PURGED_INPUT_NOTE: &str = "input removed after failed tool call — the error text in the matching tool_result is preserved";
+
+/// Only inputs at least this large (serialized) are purged — below it the
+/// marker object would not save anything.
+const PURGED_INPUT_MIN_BYTES: usize = 160;
+
+/// DCP-inspired error purge (#1570 P5): the *input* of a tool call whose
+/// matching tool_result carries `is_error: true` is dead weight once the
+/// call has scrolled into the frozen old region — what the model may still
+/// need is the error text, which stays untouched. Content-local and
+/// idempotent: the rewrite depends only on the window's own blocks, so a
+/// purged form is byte-identical on every later turn (#448 cache safety).
+/// Anthropic shape only — the OpenAI tool-message shape carries no error
+/// marker to key off.
+fn purge_errored_tool_inputs(window: &mut [Value]) -> bool {
+    let mut errored: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for msg in window.iter() {
+        let Some(blocks) = msg.get("content").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        for block in blocks {
+            if block.get("type").and_then(|t| t.as_str()) == Some("tool_result")
+                && block.get("is_error").and_then(Value::as_bool) == Some(true)
+                && let Some(id) = block.get("tool_use_id").and_then(|v| v.as_str())
+            {
+                errored.insert(id.to_string());
+            }
+        }
+    }
+    if errored.is_empty() {
+        return false;
+    }
+
+    let mut modified = false;
+    for msg in window.iter_mut() {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(blocks) = msg.get_mut("content").and_then(|c| c.as_array_mut()) else {
+            continue;
+        };
+        for block in blocks {
+            if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                continue;
+            }
+            if !block
+                .get("id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| errored.contains(id))
+            {
+                continue;
+            }
+            let Some(input) = block.get("input") else {
+                continue;
+            };
+            // Idempotence: already purged inputs are left byte-identical.
+            if input
+                .as_object()
+                .is_some_and(|o| o.contains_key(PURGED_INPUT_KEY))
+            {
+                continue;
+            }
+            if serde_json::to_string(input).map(|s| s.len()).unwrap_or(0) < PURGED_INPUT_MIN_BYTES {
+                continue;
+            }
+            block["input"] = serde_json::json!({ PURGED_INPUT_KEY: PURGED_INPUT_NOTE });
+            modified = true;
+        }
+    }
     modified
 }
 
@@ -567,6 +642,73 @@ mod tests {
             messages.push(serde_json::json!({"role": "user", "content": [block]}));
         }
         messages
+    }
+
+    // --- #1570 P5: errored tool-input purge ---
+
+    fn errored_pair(input_size: usize, is_error: bool) -> Vec<Value> {
+        let big_input: String = "x".repeat(input_size);
+        vec![
+            serde_json::json!({"role": "assistant", "content": [
+                {"type": "tool_use", "id": "tc1", "name": "ctx_shell", "input": {"command": big_input}}
+            ]}),
+            serde_json::json!({"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "tc1", "is_error": is_error, "content": "boom: exit 1"}
+            ]}),
+        ]
+    }
+
+    #[test]
+    fn errored_tool_input_is_purged_and_error_text_preserved() {
+        let mut messages = errored_pair(500, true);
+        assert!(prune_history(&mut messages, 2, &no_names()));
+        let input = &messages[0]["content"][0]["input"];
+        assert!(
+            input.get("lean_ctx_purged").is_some(),
+            "input must be purged: {input}"
+        );
+        assert_eq!(
+            messages[1]["content"][0]["content"], "boom: exit 1",
+            "the error text is what the model may still need"
+        );
+        assert_eq!(messages[1]["content"][0]["is_error"], true);
+    }
+
+    #[test]
+    fn successful_tool_input_is_never_purged() {
+        let mut messages = errored_pair(500, false);
+        prune_history(&mut messages, 2, &no_names());
+        assert!(
+            messages[0]["content"][0]["input"].get("command").is_some(),
+            "successful calls keep their input"
+        );
+    }
+
+    #[test]
+    fn error_purge_is_idempotent_and_byte_stable() {
+        let mut messages = errored_pair(500, true);
+        prune_history(&mut messages, 2, &no_names());
+        let first = serde_json::to_string(&messages).unwrap();
+        prune_history(&mut messages, 2, &no_names());
+        assert_eq!(serde_json::to_string(&messages).unwrap(), first);
+    }
+
+    #[test]
+    fn tiny_errored_inputs_stay_inline() {
+        let mut messages = errored_pair(20, true);
+        prune_history(&mut messages, 2, &no_names());
+        assert!(
+            messages[0]["content"][0]["input"].get("command").is_some(),
+            "purging a tiny input saves nothing"
+        );
+    }
+
+    #[test]
+    fn error_purge_respects_the_prune_window() {
+        let mut messages = errored_pair(500, true);
+        // Window excludes both messages -> nothing may change.
+        assert!(!prune_history_range(&mut messages, 2, 2, &no_names()));
+        assert!(messages[0]["content"][0]["input"].get("command").is_some());
     }
 
     #[test]

--- a/rust/src/server/post_process.rs
+++ b/rust/src/server/post_process.rs
@@ -57,13 +57,15 @@ pub(super) fn budget_exhausted_message(name: &str) -> Option<String> {
     ))
 }
 
-/// Post-dispatch budget guard. Returns `Some(message)` to append a
-/// `[BUDGET WARNING]` footer (emitting the matching `budget_warning` events), or
-/// `None`. Suppressed when meta output is not visible.
+/// Post-dispatch budget guard. Delegates to the nudge economy (#1570 P2):
+/// stepped thresholds with anchor dedup, hysteresis, and reset-on-action
+/// replace the old fire-on-every-call `[BUDGET WARNING]` footer that agents
+/// learned to ignore (#1542). Events still fire (rate-limited upstream) so
+/// the dashboard keeps its signal; the in-band footer is now economical.
 pub(super) fn budget_warning_message() -> Option<String> {
     use crate::core::budget_tracker::{BudgetLevel, BudgetTracker};
     let snap = BudgetTracker::global().check();
-    if *snap.worst_level() != BudgetLevel::Warning {
+    if *snap.worst_level() == BudgetLevel::Ok {
         return None;
     }
     for (dim, lvl, used, limit, pct) in [
@@ -94,7 +96,7 @@ pub(super) fn budget_warning_message() -> Option<String> {
         }
     }
     if crate::core::protocol::meta_visible() {
-        Some(format!("[BUDGET WARNING] {}", snap.format_compact()))
+        crate::core::nudge::budget_nudge(&snap)
     } else {
         None
     }

--- a/rust/src/tools/server_metrics.rs
+++ b/rust/src/tools/server_metrics.rs
@@ -103,6 +103,9 @@ impl LeanCtxServer {
         {
             tracing::warn!("lean-ctx: failed to update MCP agent heartbeat: {error}");
         }
+        // #1570 P2/P6: a successful recovery tool clears budget-nudge anchors
+        // and starts the anti-obsession cooldown.
+        crate::core::nudge::record_recovery_action(tool);
         let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
         let mut calls = self.tool_calls.write().await;
         calls.push(ToolCallRecord {


### PR DESCRIPTION
Wave 1 of the Conversation Layer epic #1570 (concepts learned from OpenCode DCP, clean-room Rust, cache-safe by construction). Three work items, each with tests; full lib suite 10482/10482, clippy -D warnings clean, docs regenerated.

**P5 — Errored tool-input purge** (proxy, deterministic): once a failed tool call scrolls into the frozen old region, its bulky *input* becomes a small marker — the error text the model may still need stays. Content-local + idempotent → byte-identical on every later turn (#448 cache safety).

**P2+P6 — Budget-nudge economy**: replaces the fire-on-every-call `[BUDGET WARNING]` footer (#1542 'advisories evaporate') with a stepped ladder — 75% soft, 100%/150% strong with recovery script — plus anchor dedup, 5-point hysteresis, reset-on-action and a post-recovery cooldown (the anti-obsession guard DCP needed after their #372). Dashboard events unchanged; still purely advisory.

**P4 — Protection grammar** (`[protection]`): `file_patterns` globs exempt matching calls from every lossy filter (same standard as `raw=true`); inline `<protect>` spans keep tool output verbatim through triage and history pruning. Lossless paths (archive + `ctx_expand`) unaffected — protection means 'never lossy', not 'never compressed'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)