### PR TITLE
docs(engine): clarify public embedding boundaries

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,6 @@
-# Workspace root. The SDK (Track A) is an opt-in member; `default-members` keeps
-# every existing `cargo build`/`test`/`clippy`/`publish` scoped to the engine
-# crate exactly as before — build the SDK explicitly with `-p lean-ctx-sdk` or
-# the whole workspace with `--workspace`.
+# Workspace root. The Apache Rust embedding research crate is opt-in; it is not
+# the separately governed Production SDK. `default-members` keeps ordinary
+# build/test/clippy/publish commands scoped to the Engine crate.
 [workspace]
 members = [
   ".",
@@ -25,7 +24,7 @@ name = "lean-ctx"
 version = "3.9.20"
 edition = "2024"
 autobins = false
-description = "Local Context SDK for AI agents. Select, shape, reuse, recover, and measure context before inference."
+description = "Local context engine, CLI, MCP server, and proxy for AI agents."
 license = "Apache-2.0"
 repository = "https://github.com/yvgude/lean-ctx"
 homepage = "https://leanctx.com"
@@ -104,7 +103,6 @@ default = [
   # LEANCTX_PGVECTOR_URL work out of the box (both are env-gated at runtime).
   "qdrant",
   "pgvector",
-  "context_kernel",
 ]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 dev-tools = []
@@ -132,6 +130,7 @@ pgvector = ["embeddings"]
 shape-xlat = ["http-server"]
 secure-update = []
 experimental = []
+# Compatibility feature name for existing builds; Engine internals are always compiled.
 context_kernel = []
 tree-sitter = [
   "dep:tree-sitter",

--- a/rust/crates/lean-ctx-sdk/Cargo.toml
+++ b/rust/crates/lean-ctx-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
-description = "In-process embedding SDK for lean-ctx — a stable Rust façade over the context engine (Engine handle with a shared session cache, read/search/symbol surface, compression, tokenization, addon authoring/audit)."
+description = "Experimental Apache Rust façade for embedding the local lean-ctx Engine in-process."
 repository = "https://github.com/yvgude/lean-ctx"
 keywords = ["mcp", "llm", "tokens", "context", "embedding"]
 categories = ["development-tools", "api-bindings"]
@@ -16,15 +16,14 @@ name = "lean_ctx_sdk"
 path = "src/lib.rs"
 
 [dependencies]
-# Path dependency on the engine. The SDK is a *thin façade*: it re-exposes a
-# curated, stable subset behind its own types so consumers are insulated from
-# internal churn. (Surface map + workspace-split rationale: docs/rfcs/sdk-embedding-v1.md.)
+# Path dependency on the Engine. This unpublished Preview crate exposes a
+# curated low-level embedding surface; it is not the Production Product SDK.
+# (Surface map + rationale: docs/rfcs/sdk-embedding-v1.md.)
 #
 # `default-features = false` drops the engine's `jemalloc` feature so embedding
 # the SDK does NOT force a `#[global_allocator]` onto the host binary — the one
-# real embedder landmine. Every other default feature is kept verbatim because
-# the engine currently references `proxy`/`http_server`/`ort` unconditionally;
-# `tree-sitter` in particular powers the AST read modes (signatures/map).
+# real embedder landmine. The listed Engine features support the current
+# low-level read/search/symbol surface; `tree-sitter` powers AST read modes.
 lean-ctx = { path = "../..", default-features = false, features = [
   "tree-sitter",
   "embeddings",

--- a/rust/crates/lean-ctx-sdk/README.md
+++ b/rust/crates/lean-ctx-sdk/README.md
@@ -3,6 +3,8 @@
 > **Status: Preview substrate — not a supported stable public Rust SDK.** Embed
 > work is Preview; external addon authoring is Research. The only declared
 > public SDK reference path is the **Preview** Python v1/OpenAI Agents wrapper.
+> The separately governed Production SDK remains private/non-published staging;
+> it is not this Apache crate.
 > Current product scope and status are governed by
 > [`docs/internal/README.md`](../../../docs/internal/README.md).
 

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -128,6 +128,9 @@ pub mod context_deficit;
 pub mod context_field;
 pub mod context_handles;
 pub mod context_ir;
+// Accidental historical surface retained for source compatibility. Public
+// embedders should use `crate::engine::ContextEngine` or `lean-ctx-sdk`.
+#[doc(hidden)]
 pub mod context_kernel;
 pub mod context_ledger;
 pub(crate) mod context_lint;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,6 +22,7 @@ pub mod daemon_autostart;
 pub mod daemon_client;
 pub mod dashboard;
 pub mod dropin;
+/// Low-level Apache in-process tool-execution façade for Engine embedders.
 pub mod engine;
 pub mod heatmap;
 pub mod hook_handlers;


### PR DESCRIPTION
## Summary
- describe the Apache crate as the Engine/CLI/MCP/proxy, not the Production SDK
- keep `context_kernel` source-compatible but hide the accidental surface from generated docs
- classify `lean-ctx-sdk` as an experimental Apache embedding façade

## Scope
R6 only. The Production SDK remains private staging. R4E2 deterministic Run IDs and the public-source-sensitive D4 removal remain explicitly deferred.

## Verification
- patch ID matches independently reviewed R6 candidate: `65f0a36ec60599c435c221c78021245cc512988b`
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --check`
- `git diff --check`

No local full Cargo gate was repeated; authoritative PR CI is the Layer-4 gate.