### PR TITLE
fix(pi-lean-ctx,ci): honest extension footer (#1578) + flaky-test hardening (#1536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   flags it with the reclaimable size. `.claude/rules/*.md` project files are
   now included in the fixed-cost scan.
 
+### Fixed
+
+- **pi-lean-ctx footer no longer fabricates "N → N (0%)"** (#1578) — the
+  extension now parses the CLI's real marker formats (savings banner incl.
+  abbreviated counts and mode/detail parts, reason bracket, saved brackets)
+  and renders one honest footer; when nothing was measured it emits no footer
+  instead of measuring the compressed text against itself.
+- **Flaky CI hardening** (#1536) — `health_latency` runs best-of-3 with a
+  doubled budget under the perf gate; the Windows descendant-pipe formatter
+  test waits up to 30 s for PowerShell cold-start on loaded runners.
+
 ## [3.9.20] — 2026-08-25
 
 ### Fixed — triage (community incident, 3.9.19)

--- a/packages/pi-lean-ctx/extensions/footer.ts
+++ b/packages/pi-lean-ctx/extensions/footer.ts
@@ -1,0 +1,135 @@
+import type { CompressionStats } from "./types.js";
+
+/**
+ * Pure footer/marker logic for the Pi extension (#1578).
+ *
+ * Lives in its own module (no Pi-runtime imports) so it can be unit-tested:
+ * importing `index.ts` drags in `@earendil-works/pi-coding-agent`, whose
+ * nested undici cannot load under vitest's Node environment.
+ */
+
+export function estimateTokens(text: string) {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Parses a CLI token count that may be abbreviated the way the savings banner
+ * abbreviates: "917", "1,474", "17.0k", "1.2M" (#1578).
+ */
+function parseTokenCount(raw: string): number {
+  const cleaned = raw.replace(/,/g, "");
+  const scale = cleaned.endsWith("M") ? 1_000_000 : cleaned.endsWith("k") ? 1_000 : 1;
+  const digits = scale === 1 ? cleaned : cleaned.slice(0, -1);
+  const value = Number.parseFloat(digits);
+  return Number.isFinite(value) && value > 0 ? Math.round(value * scale) : 0;
+}
+
+function clampStats(original: number, compressed: number): CompressionStats {
+  const orig = Math.max(0, original);
+  const comp = Math.max(0, Math.min(orig, compressed));
+  const saved = Math.max(0, orig - comp);
+  const percentSaved = orig > 0 ? Math.round((saved / orig) * 100) : 0;
+  return { originalTokens: orig, compressedTokens: comp, percentSaved };
+}
+
+export function parseLeanCtxOutput(text: string) {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  let stats: CompressionStats | undefined;
+  const kept: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // CLI marker formats (#1578). The Rust CLI emits several footer shapes:
+    //   ─── 917 → 239 tok (↓~70%) ───              savings banner (numbers may
+    //     be abbreviated to 17.0k / 1.2M, percent exact or quantized, optional
+    //     "| mode: … | …" parts)
+    //   [lean-ctx: 17001→1474 tok, verbatim truncated]  reason bracket
+    //   [lean-ctx: 12 tok saved (3%)] / [12 tok saved]  saved brackets
+    // Parse them all; the pre-#1578 regexes matched none of these, so stats
+    // stayed undefined and the fabricated fallback printed "N → N (0%)".
+    const bannerMatch = trimmed.match(
+      /^─+\s*([\d.,]+[kM]?)\s*→\s*([\d.,]+[kM]?)\s*tok\s*\(↓~?\d+%\)(?:\s*\|[^─]*)?\s*─+\s*$/,
+    );
+    if (bannerMatch) {
+      stats = clampStats(parseTokenCount(bannerMatch[1]), parseTokenCount(bannerMatch[2]));
+      continue;
+    }
+
+    const shellMatch = trimmed.match(
+      /^\[lean-ctx:\s*([\d.,]+[kM]?)\s*→\s*([\d.,]+[kM]?)\s*tok(?:,\s*[^\]]*)?\]$/,
+    );
+    if (shellMatch) {
+      stats = clampStats(parseTokenCount(shellMatch[1]), parseTokenCount(shellMatch[2]));
+      continue;
+    }
+
+    const savedMatch = trimmed.match(/^\[(?:lean-ctx:\s*)?(\d+)\s+tok saved(?:\s+\((\d+)%\))?\]$/);
+    if (savedMatch) {
+      const saved = Number(savedMatch[1]);
+      const pct = savedMatch[2] ? Number(savedMatch[2]) : 0;
+      if (pct > 0) {
+        const original = Math.round((saved * 100) / pct);
+        stats = clampStats(original, Math.max(0, original - saved));
+      } else {
+        stats = clampStats(saved, saved);
+      }
+      continue;
+    }
+
+    kept.push(line);
+  }
+
+  return { text: kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd(), stats };
+}
+
+function formatFooter(stats: CompressionStats) {
+  const pct = stats.percentSaved > 0 ? `-${stats.percentSaved}%` : "0%";
+  return `Compressed ${stats.originalTokens} → ${stats.compressedTokens} tokens (${pct})`;
+}
+
+export function withFooter(text: string, opts?: {
+  originalText?: string;
+  limit?: number;
+  always?: boolean;
+  preferEstimate?: boolean;
+  suppressIfNoSaving?: boolean;
+}) {
+  const parsed = parseLeanCtxOutput(text);
+  const limited = limitLines(parsed.text, opts?.limit);
+
+  let stats = parsed.stats;
+  if (opts?.originalText !== undefined && (opts.preferEstimate || !stats)) {
+    stats = clampStats(estimateTokens(opts.originalText), estimateTokens(limited.text));
+  }
+  // #1578: never fabricate stats. The old `always` fallback measured the
+  // already-compressed text against itself, so it could only ever print
+  // "N → N tokens (0%)". No parsed marker and no original text ⇒ no footer.
+  if (!stats) return { text: limited.text, stats: undefined, truncated: limited.truncated };
+
+  // On tiny files compression cannot beat the envelope, so a "0%" footer would
+  // be pure overhead — larger payload than the source for no gain (#361). Keep
+  // the computed stats for telemetry (`details.compression`) but drop the
+  // visible footer when nothing was actually saved.
+  if (opts?.suppressIfNoSaving && stats.percentSaved <= 0) {
+    return { text: limited.text, stats, truncated: limited.truncated };
+  }
+
+  const footer = formatFooter(stats);
+  const base = limited.text.trimEnd();
+  return {
+    text: base ? `${base}\n\n${footer}` : footer,
+    stats,
+    truncated: limited.truncated,
+  };
+}
+
+function limitLines(text: string, limit?: number) {
+  if (!limit || limit <= 0) return { text, truncated: false };
+  const lines = text.split("\n");
+  if (lines.length <= limit) return { text, truncated: false };
+  return {
+    text: lines.slice(0, limit).join("\n") + `\n\n[Output truncated to ${limit} lines]`,
+    truncated: true,
+  };
+}

--- a/packages/pi-lean-ctx/extensions/index.ts
+++ b/packages/pi-lean-ctx/extensions/index.ts
@@ -26,7 +26,7 @@ import { extname, resolve } from "node:path";
 import { homedir, platform } from "node:os";
 import { McpBridge } from "./mcp-bridge.js";
 import { loadPiConfig, resolvePiShellPath, resolveSuppressedBuiltins } from "./config.js";
-import type { CompressionStats } from "./types.js";
+import { withFooter } from "./footer.js";
 
 const BRIDGE_STARTUP_TIMEOUT_MS = 10_000;
 
@@ -193,103 +193,6 @@ async function readSlice(path: string, offset?: number, limit?: number) {
     maxBytes: DEFAULT_MAX_BYTES,
   });
   return { text: truncation.content, lines: lines.length, truncated: truncation.truncated };
-}
-
-function estimateTokens(text: string) {
-  return Math.ceil(text.length / 4);
-}
-
-function clampStats(original: number, compressed: number): CompressionStats {
-  const orig = Math.max(0, original);
-  const comp = Math.max(0, Math.min(orig, compressed));
-  const saved = Math.max(0, orig - comp);
-  const percentSaved = orig > 0 ? Math.round((saved / orig) * 100) : 0;
-  return { originalTokens: orig, compressedTokens: comp, percentSaved };
-}
-
-function parseLeanCtxOutput(text: string) {
-  const lines = text.replace(/\r\n/g, "\n").split("\n");
-  let stats: CompressionStats | undefined;
-  const kept: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    const shellMatch = trimmed.match(/^\[lean-ctx:\s*(\d+)\s*→\s*(\d+)\s*tok,\s*-?(\d+)%\]$/);
-    if (shellMatch) {
-      stats = clampStats(Number(shellMatch[1]), Number(shellMatch[2]));
-      continue;
-    }
-
-    const savedMatch = trimmed.match(/^\[(\d+)\s+tok saved(?:\s+\((\d+)%\))?\]$/);
-    if (savedMatch) {
-      const saved = Number(savedMatch[1]);
-      const pct = savedMatch[2] ? Number(savedMatch[2]) : 0;
-      if (pct > 0) {
-        const original = Math.round((saved * 100) / pct);
-        stats = clampStats(original, Math.max(0, original - saved));
-      } else {
-        stats = clampStats(saved, saved);
-      }
-      continue;
-    }
-
-    kept.push(line);
-  }
-
-  return { text: kept.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd(), stats };
-}
-
-function formatFooter(stats: CompressionStats) {
-  const pct = stats.percentSaved > 0 ? `-${stats.percentSaved}%` : "0%";
-  return `Compressed ${stats.originalTokens} → ${stats.compressedTokens} tokens (${pct})`;
-}
-
-function withFooter(text: string, opts?: {
-  originalText?: string;
-  limit?: number;
-  always?: boolean;
-  preferEstimate?: boolean;
-  suppressIfNoSaving?: boolean;
-}) {
-  const parsed = parseLeanCtxOutput(text);
-  const limited = limitLines(parsed.text, opts?.limit);
-
-  let stats = parsed.stats;
-  if (opts?.originalText !== undefined && (opts.preferEstimate || !stats)) {
-    stats = clampStats(estimateTokens(opts.originalText), estimateTokens(limited.text));
-  }
-  if (!stats && opts?.always) {
-    const tokens = estimateTokens(limited.text);
-    stats = clampStats(tokens, tokens);
-  }
-  if (!stats) return { text: limited.text, stats: undefined, truncated: limited.truncated };
-
-  // On tiny files compression cannot beat the envelope, so a "0%" footer would
-  // be pure overhead — larger payload than the source for no gain (#361). Keep
-  // the computed stats for telemetry (`details.compression`) but drop the
-  // visible footer when nothing was actually saved.
-  if (opts?.suppressIfNoSaving && stats.percentSaved <= 0) {
-    return { text: limited.text, stats, truncated: limited.truncated };
-  }
-
-  const footer = formatFooter(stats);
-  const base = limited.text.trimEnd();
-  return {
-    text: base ? `${base}\n\n${footer}` : footer,
-    stats,
-    truncated: limited.truncated,
-  };
-}
-
-function limitLines(text: string, limit?: number) {
-  if (!limit || limit <= 0) return { text, truncated: false };
-  const lines = text.split("\n");
-  if (lines.length <= limit) return { text, truncated: false };
-  return {
-    text: lines.slice(0, limit).join("\n") + `\n\n[Output truncated to ${limit} lines]`,
-    truncated: true,
-  };
 }
 
 function replaceTabs(text: string) {

--- a/packages/pi-lean-ctx/test/footer.test.ts
+++ b/packages/pi-lean-ctx/test/footer.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { parseLeanCtxOutput, withFooter } from "../extensions/footer.js";
+
+// #1578: the extension footer reported "Compressed N → N tokens (0%)" on every
+// call because parseLeanCtxOutput matched none of the CLI's real marker
+// formats and the `always` fallback then measured the already-compressed text
+// against itself. These tests pin the real formats and the no-fabrication rule.
+describe("parseLeanCtxOutput (#1578)", () => {
+  it("parses the savings banner and strips it from the text", () => {
+    const text = "✔︎ Bottle tesseract (5.5.3)\n─── 917 → 239 tok (↓~70%) ───";
+    const { text: kept, stats } = parseLeanCtxOutput(text);
+    expect(stats).toEqual({ originalTokens: 917, compressedTokens: 239, percentSaved: 74 });
+    expect(kept).not.toContain("───");
+  });
+
+  it("parses abbreviated banner counts (17.0k, thousands separators)", () => {
+    const { stats } = parseLeanCtxOutput("─── 17.0k → 1,474 tok (↓91%) ───");
+    expect(stats?.originalTokens).toBe(17000);
+    expect(stats?.compressedTokens).toBe(1474);
+  });
+
+  it("parses banners carrying mode/detail parts", () => {
+    const { stats } = parseLeanCtxOutput("─── 4,200 → 840 tok (↓80%) | mode: full | cached ───");
+    expect(stats?.originalTokens).toBe(4200);
+    expect(stats?.compressedTokens).toBe(840);
+  });
+
+  it("parses the reason bracket without a percentage", () => {
+    const { stats } = parseLeanCtxOutput("[lean-ctx: 17001→1474 tok, verbatim truncated]");
+    expect(stats).toEqual({ originalTokens: 17001, compressedTokens: 1474, percentSaved: 91 });
+  });
+
+  it("parses saved brackets with and without the lean-ctx prefix", () => {
+    expect(parseLeanCtxOutput("[lean-ctx: 12 tok saved (3%)]").stats?.originalTokens).toBe(400);
+    expect(parseLeanCtxOutput("[0 tok saved]").stats?.percentSaved).toBe(0);
+  });
+});
+
+describe("withFooter (#1578)", () => {
+  it("never fabricates a 0% footer when no marker matched", () => {
+    const out = withFooter("plain output with no lean-ctx marker", { always: true });
+    expect(out.stats).toBeUndefined();
+    expect(out.text).not.toContain("Compressed");
+  });
+
+  it("re-renders a parsed banner as the single extension footer", () => {
+    const out = withFooter("body\n─── 917 → 239 tok (↓~70%) ───", { always: true });
+    expect(out.text).toContain("Compressed 917 → 239 tokens (-74%)");
+    expect(out.text.match(/tok/g)?.length).toBe(1);
+  });
+});

--- a/rust/src/core/context_kernel/perf_benchmark.rs
+++ b/rust/src/core/context_kernel/perf_benchmark.rs
@@ -63,14 +63,23 @@ mod tests {
         assert_eq!(evidence_hook::evidence_report().tool_calls, 10_000);
     }
 
+    /// #1536: a flat 50 ms wall-clock budget was not reliably attainable on
+    /// loaded shared runners even under the serialized perf gate. Best-of-3
+    /// with a doubled budget keeps the regression signal — a real latency
+    /// regression fails all three attempts — without burning a CI cycle on
+    /// scheduler noise.
     #[test]
     fn health_latency() {
         let _guard = isolated();
-        let started = Instant::now();
-        for _ in 0..100 {
-            std::hint::black_box(health::kernel_health());
+        let mut best = Duration::MAX;
+        for _ in 0..3 {
+            let started = Instant::now();
+            for _ in 0..100 {
+                std::hint::black_box(health::kernel_health());
+            }
+            best = best.min(started.elapsed());
         }
-        assert!(!timing_enforced() || started.elapsed() < Duration::from_millis(50));
+        assert!(!timing_enforced() || best < Duration::from_millis(100));
     }
 
     #[test]

--- a/rust/src/lsp/format/mod.rs
+++ b/rust/src/lsp/format/mod.rs
@@ -653,8 +653,11 @@ mod tests {
             dir.path().to_str().unwrap(),
         )
         .expect("formatter process must spawn");
+        // #1536: PowerShell cold-start on a loaded Windows runner can exceed
+        // 5 s. The poll is bounded either way, so the generous ceiling only
+        // costs wall-clock time in the case where the test is about to fail.
         assert!(
-            wait_for_path(&ready, Duration::from_secs(5)),
+            wait_for_path(&ready, Duration::from_secs(30)),
             "formatter descendant must start"
         );
         let error = wait_for_command_formatter(process, Duration::from_millis(250))


### PR DESCRIPTION
## Summary

Two community-reported problems fixed:

### #1578 — pi-lean-ctx footer fabricated "Compressed N → N tokens (0%)"
- `parseLeanCtxOutput` matched **none** of the CLI's real marker formats (verified against 141 MB of transcripts in the report). It now parses all of them: the savings banner `─── 917 → 239 tok (↓~70%) ───` (incl. abbreviated `17.0k`/`1.2M` counts and `| mode: … | …` parts), the reason bracket `[lean-ctx: 17001→1474 tok, verbatim truncated]`, and the saved brackets `[lean-ctx: N tok saved (P%)]` / `[N tok saved]`.
- The `always` fallback that measured the already-compressed text against itself is gone: **no measurement ⇒ no footer**, never a fabricated 0%.
- Pure footer logic extracted to `extensions/footer.ts` so it is unit-testable (importing `index.ts` drags in the Pi runtime, whose nested undici cannot load under vitest). 7 new tests pin the formats + the no-fabrication rule.

### #1536 — flaky CI hardening
- `health_latency`: best-of-3 with a doubled budget under the perf gate — a real latency regression still fails all three attempts; scheduler noise no longer burns a CI cycle.
- Windows descendant-pipe formatter test: bounded poll widened to 30 s for PowerShell cold-start on loaded runners.

Closes #1578. Closes #1536.

## Test plan
- [x] pi-lean-ctx: `tsc --noEmit` + vitest 46/46 (7 new footer tests)
- [x] `cargo test --lib health_latency` green; Windows test covered by the cross-compile gate
- [x] `scripts/preflight.sh fast` (6 passed; base github/main — the stale GitLab origin/main flagged an upstream workflow file outside this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)