### PR TITLE
fix(mcp): upgrade Codex MCP config to include mcp arg

### DIFF
--- a/rust/src/core/editor_registry/writers/install/codex.rs
+++ b/rust/src/core/editor_registry/writers/install/codex.rs
@@ -24,7 +24,7 @@ pub(crate) fn write_codex_config(
     }
 
     let content = format!(
-        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = []\n",
+        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = [\"mcp\"]\n",
         toml_quote(binary)
     );
     crate::config_io::write_atomic_with_backup(&target.config_path, &content)?;
@@ -49,7 +49,7 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
     let mut in_env_subtable = false;
 
     let parent_block = format!(
-        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = []\n\n",
+        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = [\"mcp\"]\n\n",
         toml_quote(binary)
     );
 
@@ -64,7 +64,7 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
                 wrote_command = true;
             }
             if in_section && !wrote_args {
-                out.push_str("args = []\n");
+                out.push_str("args = [\"mcp\"]\n");
                 wrote_args = true;
             }
             in_env_subtable = trimmed == "[mcp_servers.lean-ctx.env]"
@@ -99,7 +99,12 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
                 continue;
             }
             if trimmed.starts_with("args") && trimmed.contains('=') {
-                out.push_str("args = []\n");
+                if trimmed.contains("\"mcp\"") || trimmed.contains("'mcp'") {
+                    out.push_str(line);
+                    out.push('\n');
+                } else {
+                    out.push_str("args = [\"mcp\"]\n");
+                }
                 wrote_args = true;
                 continue;
             }
@@ -114,7 +119,7 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
             out.push_str(&format!("command = {}\n", toml_quote(binary)));
         }
         if in_section && !wrote_args {
-            out.push_str("args = []\n");
+            out.push_str("args = [\"mcp\"]\n");
         }
         return out;
     }
@@ -128,6 +133,6 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
     }
     out.push_str("\n[mcp_servers.lean-ctx]\n");
     out.push_str(&format!("command = {}\n", toml_quote(binary)));
-    out.push_str("args = []\n");
+    out.push_str("args = [\"mcp\"]\n");
     out
 }

--- a/rust/src/core/editor_registry/writers/tests.rs
+++ b/rust/src/core/editor_registry/writers/tests.rs
@@ -178,7 +178,7 @@ fn upsert_codex_toml_inserts_new_section_when_missing() {
     let updated = upsert_codex_toml("[other]\nx=1\n", "lean-ctx");
     assert!(updated.contains("[mcp_servers.lean-ctx]"));
     assert!(updated.contains("command = \"lean-ctx\""));
-    assert!(updated.contains("args = []"));
+    assert!(updated.contains("args = [\"mcp\"]"));
 }
 
 #[test]
@@ -222,7 +222,7 @@ approval_mode = \"approve\"
         "parent must come before tool sub-tables:\n{updated}"
     );
     assert!(updated.contains("command = \"lean-ctx\""));
-    assert!(updated.contains("args = []"));
+    assert!(updated.contains("args = [\"mcp\"]"));
     assert!(updated.contains("approval_mode = \"approve\""));
 }
 
@@ -274,8 +274,21 @@ approval_mode = \"approve\"
         "must not duplicate parent section"
     );
     assert!(updated.contains("command = \"new\""));
-    assert!(updated.contains("args = []"));
+    assert!(updated.contains("args = [\"mcp\"]"));
     assert!(updated.contains("approval_mode = \"approve\""));
+}
+
+#[test]
+fn upsert_codex_toml_upgrades_legacy_empty_args_to_mcp() {
+    let input = "\
+[mcp_servers.lean-ctx]
+command = \"/opt/homebrew/bin/lean-ctx\"
+args = []
+startup_timeout_sec = 30
+";
+    let updated = upsert_codex_toml(input, "/opt/homebrew/bin/lean-ctx");
+    assert!(updated.contains("args = [\"mcp\"]"));
+    assert!(updated.contains("startup_timeout_sec = 30"));
 }
 
 #[test]

--- a/rust/src/doctor/integrations/codex.rs
+++ b/rust/src/doctor/integrations/codex.rs
@@ -26,7 +26,14 @@ pub(crate) fn check_codex_toml(path: &std::path::Path, binary: &str) -> NamedChe
         .and_then(|t| t.get("lean-ctx"))
         .and_then(|t| t.get("command"))
         .and_then(|c| c.as_str());
-    let ok = cmd.is_some_and(|c| cmd_matches_expected(c, binary));
+    let cmd_ok = cmd.is_some_and(|c| cmd_matches_expected(c, binary));
+    let args_ok = v
+        .get("mcp_servers")
+        .and_then(|t| t.get("lean-ctx"))
+        .and_then(|t| t.get("args"))
+        .and_then(|a| a.as_array())
+        .is_some_and(|arr| arr.iter().any(|arg| arg.as_str() == Some("mcp")));
+    let ok = cmd_ok && args_ok;
     NamedCheck {
         name: "Codex MCP".to_string(),
         ok,

--- a/rust/src/doctor/integrations/tests.rs
+++ b/rust/src/doctor/integrations/tests.rs
@@ -349,3 +349,50 @@ fn check_cursor_hooks_ok_for_bare_command() {
         "bare lean-ctx command is PATH-resolved and current"
     );
 }
+
+#[test]
+fn check_codex_toml_detects_missing_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(!check.ok);
+    assert!(check.detail.contains("missing"));
+}
+
+#[test]
+fn check_codex_toml_detects_legacy_empty_args_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n",
+    )
+    .unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(!check.ok);
+    assert!(check.detail.contains("drift"));
+}
+
+#[test]
+fn check_codex_toml_detects_missing_args_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\n").unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(!check.ok);
+    assert!(check.detail.contains("drift"));
+}
+
+#[test]
+fn check_codex_toml_ok_with_mcp_arg() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"mcp\"]\n",
+    )
+    .unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(check.ok);
+    assert!(check.detail.contains("ok"));
+}

--- a/rust/src/hooks/agents/codex.rs
+++ b/rust/src/hooks/agents/codex.rs
@@ -411,7 +411,13 @@ fn ensure_codex_mcp_server(
         lean_tbl["command"] = toml_edit::value(binary);
     }
     if !lean_tbl.contains_key("args") {
-        lean_tbl["args"] = toml_edit::value(toml_edit::Array::new());
+        let mut arr = toml_edit::Array::new();
+        arr.push("mcp");
+        lean_tbl["args"] = toml_edit::value(arr);
+    } else if let Some(arr) = lean_tbl.get_mut("args").and_then(|a| a.as_array_mut()) {
+        if arr.is_empty() {
+            arr.push("mcp");
+        }
     }
 
     // Ensure adequate timeouts: lean-ctx tools like ctx_compose can take
@@ -819,7 +825,7 @@ command = \"lean-ctx\"
             .expect("should add MCP section");
         assert!(result.contains("[mcp_servers.lean-ctx]"));
         assert!(result.contains("command = \"lean-ctx\""));
-        assert!(result.contains("args = []"));
+        assert!(result.contains("args = [\"mcp\"]"));
         assert!(result.contains("[features]\ncodex_hooks = true\n"));
     }
 
@@ -827,7 +833,7 @@ command = \"lean-ctx\"
     fn ensure_mcp_server_noop_when_already_complete() {
         // Parent + args + timeouts + an env block already carrying every desired
         // key: the upsert must be a true no-op (no churn on every session start).
-        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n\
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"mcp\"]\n\
                      startup_timeout_sec = 30\ntool_timeout_sec = 120\n\n\
                      [mcp_servers.lean-ctx.env]\nLEAN_CTX_DATA_DIR = \"/Users/user/.lean-ctx\"\n";
         assert!(
@@ -837,8 +843,18 @@ command = \"lean-ctx\"
     }
 
     #[test]
+    fn ensure_mcp_server_upgrades_empty_args_to_mcp() {
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n\
+                     startup_timeout_sec = 30\ntool_timeout_sec = 120\n\n\
+                     [mcp_servers.lean-ctx.env]\nLEAN_CTX_DATA_DIR = \"/Users/user/.lean-ctx\"\n";
+        let result = ensure_codex_mcp_server(input, "lean-ctx", &data_dir_pairs())
+            .expect("should upgrade empty args to ['mcp']");
+        assert!(result.contains("args = [\"mcp\"]"));
+    }
+
+    #[test]
     fn ensure_mcp_server_adds_timeouts() {
-        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n";
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"mcp\"]\n";
         let result = ensure_codex_mcp_server(input, "lean-ctx", &data_dir_pairs())
             .expect("should add timeouts");
         assert!(


### PR DESCRIPTION
Fixes #1595: in lean-ctx >= 3.9.20, launching the binary without arguments in environments where standard input/output behaves like an interactive terminal or PTY (such as Devin, containerized agents, or subshells) triggers the interactive quickstart rather than the stdio MCP server. Passing explicit `mcp` (`lean-ctx mcp`) bypasses this check and reliably starts the stdio MCP server regardless of TTY allocation.

However, Codex configuration (`~/.codex/config.toml`) historically wrote `args = []`. When users upgrade from 3.9.18 to 3.9.20, `lean-ctx doctor` does not flag `args = []` or missing `args` as drift, and running `lean-ctx doctor --fix`, `lean-ctx upgrade`, or `lean-ctx setup` maintained or rewrote `args = []`.

### What changed

- `rust/src/core/editor_registry/writers/install/codex.rs`:
  - New Codex configuration blocks now default to `args = ["mcp"]`.
  - `upsert_codex_toml` detects legacy empty `args = []` (or args without `"mcp"`) and updates them to `args = ["mcp"]`.
  - Preserves existing custom `args` containing `"mcp"` idempotently.
- `rust/src/hooks/agents/codex.rs`:
  - `ensure_codex_mcp_server` now upgrades missing or empty `args` to `["mcp"]`.
- `rust/src/doctor/integrations/codex.rs`:
  - `check_codex_toml` now verifies both `command` and that `args` contains `"mcp"`.
  - Flags missing or empty `args` as `drift (~/.codex/config.toml)` so `lean-ctx doctor` surfaces the issue and `lean-ctx doctor --fix` (and `setup --fix`) automatically repairs it.
- `rust/src/core/editor_registry/writers/tests.rs`:
  - Updated existing `upsert_codex_toml` assertions to expect `args = ["mcp"]`.
  - Added `upsert_codex_toml_upgrades_legacy_empty_args_to_mcp` testing input with `args = []` and verifying upgrade to `args = ["mcp"]`.
- `rust/src/hooks/agents/codex.rs`:
  - Added `ensure_mcp_server_upgrades_empty_args_to_mcp` regression test.
- `rust/src/doctor/integrations/tests.rs`:
  - Added unit tests for `check_codex_toml` covering missing files, legacy empty args drift, missing args drift, and valid configuration.

### Verification Plan

- [x] `cargo fmt --check`: passed (clean)
- [x] Regression tests added for `upsert_codex_toml`, `ensure_codex_mcp_server`, and `check_codex_toml`
- [x] CI checks running on `rey-workbench` fork for all platforms

### Contributor License Agreement

Signed via CLA bot in PR #1463.
