### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -268,8 +268,8 @@ Index-time file filters: declare the retrieval corpus explicitly (BM25 + graph +
 
 Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable.
 
-- `api_key` (string, default `""`) — API key for OpenRouter or Anthropic backends
-- `backend` (enum: ollama | openrouter | anthropic, default `ollama`) — LLM backend provider
+- `api_key` (string, default `""`) — API key for OpenRouter, OrcaRouter or Anthropic backends
+- `backend` (enum: ollama | openrouter | orcarouter | anthropic, default `ollama`) — LLM backend provider
 - `enabled` (bool, default `false`) — Enable optional LLM enhancements (query expansion, contradiction explanation)
 - `model` (string, default `llama3.2`) — Model name for the selected backend
 - `timeout_secs` (u64, default `10`) — HTTP timeout for LLM requests

--- a/rust/src/core/config/schema/sections_advanced.rs
+++ b/rust/src/core/config/schema/sections_advanced.rs
@@ -635,7 +635,7 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
     llm_keys.insert(
         "backend".into(),
         key_enum(
-            &["ollama", "openrouter", "anthropic"],
+            &["ollama", "openrouter", "orcarouter", "anthropic"],
             "ollama",
             "LLM backend provider",
         ),
@@ -653,7 +653,7 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         key(
             "string",
             serde_json::json!(""),
-            "API key for OpenRouter or Anthropic backends",
+            "API key for OpenRouter, OrcaRouter or Anthropic backends",
         ),
     );
     llm_keys.insert(

--- a/rust/src/core/context_kernel/provider_normalization.rs
+++ b/rust/src/core/context_kernel/provider_normalization.rs
@@ -177,6 +177,7 @@ fn canonical_provider(provider: &str) -> String {
         "anthropic" | "claude" | "bedrock" => "anthropic".to_owned(),
         "gemini" | "google" | "google_ai" => "gemini".to_owned(),
         "openrouter" => "openrouter".to_owned(),
+        "orcarouter" => "orcarouter".to_owned(),
         other => other.to_owned(),
     }
 }
@@ -342,6 +343,11 @@ pub fn normalize_provider(
             usage.provider = String::from("openrouter");
             usage
         }
+        "orcarouter" => {
+            let mut usage = normalize_openai(value, requested_model, retries);
+            usage.provider = String::from("orcarouter");
+            usage
+        }
         "anthropic" => normalize_anthropic(value, requested_model, retries),
         "gemini" => normalize_gemini(value, requested_model, retries),
         _ => {
@@ -486,7 +492,7 @@ mod tests {
 
     use super::{
         NormalizedUsage, decimal_to_micros, normalize_anthropic, normalize_gemini,
-        normalize_openai, normalize_stream,
+        normalize_openai, normalize_provider, normalize_stream,
     };
 
     #[test]
@@ -536,6 +542,26 @@ mod tests {
         assert_eq!(gemini.fresh_input_tokens, Some(90));
         assert_eq!(gemini.output_tokens, Some(25));
         assert_eq!(gemini.reasoning_tokens, Some(5));
+    }
+
+    #[test]
+    fn orcarouter_uses_openai_shape_and_keeps_provider() {
+        let usage = normalize_provider(
+            "orcarouter",
+            &json!({
+                "model": "openai/gpt-oss-120b",
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "cost": 0.00000392
+                }
+            }),
+            None,
+            0,
+        );
+        assert_eq!(usage.provider, "orcarouter");
+        assert_eq!(usage.fresh_input_tokens, Some(100));
+        assert_eq!(usage.output_tokens, Some(20));
     }
 
     #[test]

--- a/rust/src/core/context_kernel/provider_parity.rs
+++ b/rust/src/core/context_kernel/provider_parity.rs
@@ -4,11 +4,12 @@ use serde_json::Value;
 
 use super::token_envelope::{ProviderKind, TokenEnvelope};
 
-const SUPPORTED: [ProviderKind; 7] = [
+const SUPPORTED: [ProviderKind; 8] = [
     ProviderKind::OpenAi,
     ProviderKind::Anthropic,
     ProviderKind::Gemini,
     ProviderKind::OpenRouter,
+    ProviderKind::OrcaRouter,
     ProviderKind::Bedrock,
     ProviderKind::Azure,
     ProviderKind::Local,
@@ -34,6 +35,8 @@ pub fn detect_provider(base_url: &str) -> ProviderKind {
         ProviderKind::Azure
     } else if url.contains("openrouter.ai") {
         ProviderKind::OpenRouter
+    } else if url.contains("orcarouter.ai") {
+        ProviderKind::OrcaRouter
     } else if url.contains("localhost") || url.contains("127.0.0.1") || url.contains("0.0.0.0") {
         ProviderKind::Local
     } else {
@@ -77,6 +80,7 @@ pub fn envelope_from_usage(provider: ProviderKind, model: &str, usage: &Value) -
             ProviderKind::OpenAi
             | ProviderKind::Azure
             | ProviderKind::OpenRouter
+            | ProviderKind::OrcaRouter
             | ProviderKind::Local
             | ProviderKind::Unknown => (
                 token(usage, &["prompt_tokens"]),
@@ -110,6 +114,7 @@ pub const fn provider_display_name(kind: ProviderKind) -> &'static str {
         ProviderKind::Bedrock => "Bedrock",
         ProviderKind::Azure => "Azure",
         ProviderKind::OpenRouter => "OpenRouter",
+        ProviderKind::OrcaRouter => "OrcaRouter",
         ProviderKind::Local => "Local",
         ProviderKind::Unknown => "Unknown",
     }
@@ -170,6 +175,11 @@ pub mod tests {
         detect_localhost,
         "http://localhost:11434",
         ProviderKind::Local
+    );
+    detect_test!(
+        detect_orcarouter,
+        "https://api.orcarouter.ai/v1",
+        ProviderKind::OrcaRouter
     );
     detect_test!(detect_unknown, "https://example.com", ProviderKind::Unknown);
 

--- a/rust/src/core/context_kernel/token_envelope.rs
+++ b/rust/src/core/context_kernel/token_envelope.rs
@@ -13,6 +13,8 @@ pub enum ProviderKind {
     Gemini,
     /// OpenRouter gateway.
     OpenRouter,
+    /// OrcaRouter gateway.
+    OrcaRouter,
     /// Amazon Bedrock.
     Bedrock,
     /// Azure OpenAI Service.
@@ -87,6 +89,7 @@ pub(crate) fn parse_provider(label: &str) -> ProviderKind {
         "anthropic" => ProviderKind::Anthropic,
         "gemini" | "google" => ProviderKind::Gemini,
         "openrouter" => ProviderKind::OpenRouter,
+        "orcarouter" => ProviderKind::OrcaRouter,
         "bedrock" => ProviderKind::Bedrock,
         "azure" | "azure_openai" => ProviderKind::Azure,
         "local" => ProviderKind::Local,
@@ -300,6 +303,7 @@ mod tests {
     fn parse_provider_aliases_and_unknown() {
         assert_eq!(parse_provider("google"), ProviderKind::Gemini);
         assert_eq!(parse_provider("openrouter"), ProviderKind::OpenRouter);
+        assert_eq!(parse_provider("orcarouter"), ProviderKind::OrcaRouter);
         assert_eq!(parse_provider("local"), ProviderKind::Local);
         assert_eq!(parse_provider("other"), ProviderKind::Unknown);
     }

--- a/rust/src/core/llm_enhance.rs
+++ b/rust/src/core/llm_enhance.rs
@@ -3,7 +3,7 @@
 //! Deterministic by default — LLM calls are opt-in and always fall back to
 //! the deterministic pipeline on failure, timeout, or when disabled.
 //!
-//! Supported backends: Ollama (local), OpenRouter, Claude (Anthropic).
+//! Supported backends: Ollama (local), OpenRouter, OrcaRouter, Claude (Anthropic).
 
 use std::time::Duration;
 
@@ -39,6 +39,7 @@ pub enum LlmBackend {
     #[default]
     Ollama,
     OpenRouter,
+    OrcaRouter,
     Anthropic,
 }
 
@@ -50,6 +51,7 @@ impl LlmConfig {
         match self.backend {
             LlmBackend::Ollama => "http://localhost:11434".to_string(),
             LlmBackend::OpenRouter => "https://openrouter.ai/api".to_string(),
+            LlmBackend::OrcaRouter => "https://api.orcarouter.ai".to_string(),
             LlmBackend::Anthropic => "https://api.anthropic.com".to_string(),
         }
     }
@@ -58,6 +60,7 @@ impl LlmConfig {
         match self.backend {
             LlmBackend::Ollama => None,
             LlmBackend::OpenRouter => std::env::var("OPENROUTER_API_KEY").ok(),
+            LlmBackend::OrcaRouter => std::env::var("ORCAROUTER_API_KEY").ok(),
             LlmBackend::Anthropic => std::env::var("ANTHROPIC_API_KEY").ok(),
         }
     }
@@ -67,6 +70,26 @@ impl LlmConfig {
             Duration::from_secs(self.timeout_secs)
         } else {
             DEFAULT_TIMEOUT
+        }
+    }
+
+    /// Env var holding the backend's API key, used in error messages.
+    fn api_key_env_name(&self) -> &'static str {
+        match self.backend {
+            LlmBackend::Ollama => "OLLAMA_API_KEY",
+            LlmBackend::OpenRouter => "OPENROUTER_API_KEY",
+            LlmBackend::OrcaRouter => "ORCAROUTER_API_KEY",
+            LlmBackend::Anthropic => "ANTHROPIC_API_KEY",
+        }
+    }
+
+    /// Lowercase backend name for error context.
+    fn backend_name(&self) -> &'static str {
+        match self.backend {
+            LlmBackend::Ollama => "ollama",
+            LlmBackend::OpenRouter => "openrouter",
+            LlmBackend::OrcaRouter => "orcarouter",
+            LlmBackend::Anthropic => "anthropic",
         }
     }
 }
@@ -152,7 +175,7 @@ pub fn enhance_observation(entity: &str, deterministic: &str) -> String {
     }
 }
 
-/// Low-level LLM call. Supports Ollama, OpenRouter, and Anthropic.
+/// Low-level LLM call. Supports Ollama, OpenRouter, OrcaRouter, and Anthropic.
 fn call_llm(cfg: &LlmConfig, prompt: &str) -> Result<String, String> {
     let truncated = if prompt.len() > MAX_PROMPT_CHARS {
         &prompt[..prompt.floor_char_boundary(MAX_PROMPT_CHARS)]
@@ -162,7 +185,7 @@ fn call_llm(cfg: &LlmConfig, prompt: &str) -> Result<String, String> {
 
     match cfg.backend {
         LlmBackend::Ollama => call_ollama(cfg, truncated),
-        LlmBackend::OpenRouter => call_openai_compatible(cfg, truncated),
+        LlmBackend::OpenRouter | LlmBackend::OrcaRouter => call_openai_compatible(cfg, truncated),
         LlmBackend::Anthropic => call_anthropic(cfg, truncated),
     }
 }
@@ -205,7 +228,9 @@ fn call_ollama(cfg: &LlmConfig, prompt: &str) -> Result<String, String> {
 }
 
 fn call_openai_compatible(cfg: &LlmConfig, prompt: &str) -> Result<String, String> {
-    let key = cfg.api_key().ok_or("OPENROUTER_API_KEY not set")?;
+    let key = cfg
+        .api_key()
+        .ok_or_else(|| format!("{} not set", cfg.api_key_env_name()))?;
     let url = format!("{}/v1/chat/completions", cfg.effective_base_url());
     let body = serde_json::json!({
         "model": cfg.model,
@@ -220,7 +245,7 @@ fn call_openai_compatible(cfg: &LlmConfig, prompt: &str) -> Result<String, Strin
         .header("Authorization", &format!("Bearer {key}"))
         .header("Content-Type", "application/json")
         .send(payload.as_slice())
-        .map_err(|e| format!("openrouter: {e}"))?;
+        .map_err(|e| format!("{}: {e}", cfg.backend_name()))?;
 
     let text = resp
         .into_body()
@@ -297,5 +322,12 @@ pub mod tests {
             ..Default::default()
         };
         assert!(cfg.effective_base_url().contains("openrouter"));
+
+        let cfg = LlmConfig {
+            backend: LlmBackend::OrcaRouter,
+            ..Default::default()
+        };
+        assert!(cfg.effective_base_url().contains("orcarouter"));
+        assert_eq!(cfg.api_key_env_name(), "ORCAROUTER_API_KEY");
     }
 }

--- a/rust/src/proxy/usage_parity.rs
+++ b/rust/src/proxy/usage_parity.rs
@@ -12,6 +12,7 @@ pub fn provider_kind_from_label(label: &str) -> ProviderKind {
         "Bedrock" => ProviderKind::Bedrock,
         "Azure" => ProviderKind::Azure,
         _ if label.to_ascii_lowercase().contains("openrouter") => ProviderKind::OpenRouter,
+        _ if label.to_ascii_lowercase().contains("orcarouter") => ProviderKind::OrcaRouter,
         _ => ProviderKind::Unknown,
     }
 }
@@ -79,6 +80,18 @@ mod tests {
     #[test]
     fn kind_from_unknown() {
         assert_eq!(provider_kind_from_label("Other"), ProviderKind::Unknown);
+    }
+
+    #[test]
+    fn kind_from_orcarouter_label() {
+        assert_eq!(
+            provider_kind_from_label("OrcaRouter"),
+            ProviderKind::OrcaRouter
+        );
+        assert_eq!(
+            provider_kind_from_label("orcarouter"),
+            ProviderKind::OrcaRouter
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

LeanCTX describes itself as an **AI Value Gate for AI coding agents** — it sits on the wire path between your agent and the model, compressing and metering every request. It is model-agnostic ("swap OpenAI/Anthropic/Gemini freely"), and its universal provider registry already treats OpenAI-compatible gateways such as OpenRouter as first-class citizens.

This PR adds **OrcaRouter** the same way: as a *named* provider that mirrors the existing OpenRouter wiring, rather than something a user has to bolt on as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means lean-ctx users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Parallel to the existing OpenRouter wiring

Every change below is the OrcaRouter twin of an existing OpenRouter branch:

| File | OpenRouter (existing) | OrcaRouter (this PR) |
|---|---|---|
| `rust/src/core/llm_enhance.rs` | `LlmBackend::OpenRouter` → base URL `https://openrouter.ai/api`, `OPENROUTER_API_KEY`, OpenAI chat-completions path | `LlmBackend::OrcaRouter` → base URL `https://api.orcarouter.ai`, `ORCAROUTER_API_KEY`, same `call_openai_compatible` path |
| `rust/src/core/context_kernel/token_envelope.rs` | `ProviderKind::OpenRouter` | `ProviderKind::OrcaRouter` + `parse_provider` entry |
| `rust/src/core/context_kernel/provider_parity.rs` | URL detect `openrouter.ai`, OpenAI-dialect usage mapping, display name "OpenRouter" | URL detect `orcarouter.ai`, same OpenAI-dialect mapping (incl. `usage.cost`), display name "OrcaRouter" |
| `rust/src/core/context_kernel/provider_normalization.rs` | `canonical_provider("openrouter")` → OpenAI shape, keeps provider label | `canonical_provider("orcarouter")` → same |
| `rust/src/proxy/usage_parity.rs` | label containing "openrouter" → `ProviderKind::OpenRouter` | label containing "orcarouter" → `ProviderKind::OrcaRouter` |
| `rust/src/core/config/schema/sections_advanced.rs` | `llm.backend` enum includes `openrouter` | enum includes `orcarouter` |
| `docs/reference/generated/config-keys.md` | backend enum + api-key description | synced (generated reference) |

## Test plan

- [ ] `cd rust && cargo fmt --check` — **passed**
- [ ] `cd rust && cargo test -- --test-threads=1` — *not runnable in this container* (no C toolchain / cargo network unavailable); CI will run the full suite
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — *same environment limitation*
- [x] Live API check against OrcaRouter with the real gateway key:
  - `GET /v1/models` → **200** (models listed in `vendor/model` form, e.g. `anthropic/claude-fable-5`, `orcarouter/auto`)
  - `POST /v1/chat/completions` → **200**, OpenAI-shaped response whose `usage` carries `cost`, `cost_details`, `prompt_tokens_details.cached_tokens` and `cache_write_tokens` — exactly the OpenRouter usage dialect the lean-ctx OpenAI absorbers already parse

## Notes for reviewers

- Risk areas / edge cases: none beyond the mirrored OpenRouter branches; `usage.include` opt-in injection stays OpenRouter-only (OrcaRouter already reports billed `usage.cost` without it).
- Backwards compatibility: additive only — new enum variants, new config enum value, no existing behavior changes. Existing stored `ProviderKind` values deserialize unchanged.
- Docs updated: `docs/reference/generated/config-keys.md` synced with the schema change.

## Contributor License Agreement

I have read the CLA Document and I hereby sign the CLA.

---

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
