### PR TITLE
fix: OpenCode config safety (#1585,#1586), policy-aware drift (#1596,#1598,#1599), verbatim turn budget (#1582), config/CLI/dispatch honesty (#1605,#1604,#1602)

### DIFF
--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -266,12 +266,12 @@ Index-time file filters: declare the retrieval corpus explicitly (BM25 + graph +
 
 ## `[llm]`
 
-Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable.
+Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable. Credentials come from the environment — OPENROUTER_API_KEY or ANTHROPIC_API_KEY — not from this file.
 
-- `api_key` (string, default `""`) — API key for OpenRouter or Anthropic backends
 - `backend` (enum: ollama | openrouter | anthropic, default `ollama`) — LLM backend provider
+- `base_url` (string, default `""`) — Override the backend's base URL (empty = the backend's own default)
 - `enabled` (bool, default `false`) — Enable optional LLM enhancements (query expansion, contradiction explanation)
-- `model` (string, default `llama3.2`) — Model name for the selected backend
+- `model` (string, default `qwen2.5-coder:1.5b`) — Model name for the selected backend
 - `timeout_secs` (u64, default `10`) — HTTP timeout for LLM requests
 
 ## `[loop_detection]`

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3043,7 +3043,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/rust/src/cli/completions/spec.rs
+++ b/rust/src/cli/completions/spec.rs
@@ -1426,11 +1426,13 @@ pub static COMMAND_TREE: &[CommandNode] = &[
     CommandNode {
         name: "watch",
         aliases: &[],
-        description: "Watch for file changes",
+        // #1602: removed in 3.9.20; kept only as a signpost to `dashboard`,
+        // so it must not be completed as if it were a working command.
+        description: "Removed — see `lean-ctx dashboard`",
         subcommands: &[],
         flags: &[],
         positional: None,
-        hidden: false,
+        hidden: true,
     },
     CommandNode {
         name: "yolo",
@@ -1570,5 +1572,26 @@ mod tests {
             .expect("benchmark command must be registered");
         assert!(benchmark.flags.iter().any(|flag| flag.long == "--real"));
         assert!(benchmark.flags.iter().any(|flag| flag.long == "--json"));
+    }
+
+    /// #1602: `watch` was removed in 3.9.20, but the completion spec still
+    /// offered it — under a third description ("Watch for file changes") that
+    /// matched neither the removed TUI nor `index watch`. A removed command
+    /// must not be advertised as a working one.
+    #[test]
+    fn removed_watch_command_is_not_advertised() {
+        let watch = COMMAND_TREE
+            .iter()
+            .find(|node| node.name == "watch")
+            .expect("watch stays in the tree as a signpost to `dashboard`");
+        assert!(
+            watch.hidden,
+            "a removed command must not be completed as a working one"
+        );
+        assert!(
+            watch.description.contains("Removed"),
+            "the description must say the command is gone, got: {}",
+            watch.description
+        );
     }
 }

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -92,8 +92,12 @@ GITHUB:  https://github.com/yvgude/lean-ctx
     )
 }
 
-pub(super) fn print_help() {
-    println!(
+/// The full command reference (`lean-ctx help all`). Split out of
+/// [`print_help`] the way [`concise_help_text`] is split out of
+/// [`print_help_concise`], so tests can assert what the reference advertises
+/// — a removed command listed here is how #1602 reached a user.
+pub(super) fn full_help_text() -> String {
+    format!(
         "lean-ctx {version} — Context SDK for AI Agents
 
 {banner}
@@ -165,7 +169,6 @@ COMMANDS:
     verify-cache [path] [--json]   Inspect local session-cache re-read behavior
     prove [--format table|json|markdown] [--output FILE]  Generate Decision Loop evidence report
     health [path] [--json] [--gate]  Code-health report: cognitive complexity, naming, navigability score + token tax
-    watch                          Live TUI dashboard (real-time event stream)
     dashboard [--port=N] [--host=H] [--base-path=/prefix] [--open=browser|none|vscode]  Open web dashboard (default: http://localhost:3333)
     serve [--host H] [--port N]    MCP over HTTP (Streamable HTTP, local-first)
     proxy start [--port=4444] [--detach]  API proxy: compress tool_results before LLM API
@@ -393,5 +396,28 @@ GITHUB:  https://github.com/yvgude/lean-ctx
         version = env!("CARGO_PKG_VERSION"),
         banner = capability_banner(),
         rc_file = crate::shell_hook::shell_rc_file(),
-    );
+    )
+}
+
+pub(super) fn print_help() {
+    println!("{}", full_help_text());
+}
+
+#[cfg(test)]
+mod tests {
+    /// #1602: `lean-ctx help all` advertised "watch — Live TUI dashboard
+    /// (real-time event stream)" for a command removed in 3.9.20, which then
+    /// exited 1 with a bare removal notice. The reference lists what works.
+    #[test]
+    fn full_help_does_not_advertise_the_removed_tui_dashboard() {
+        let text = super::full_help_text();
+        assert!(
+            !text.contains("Live TUI dashboard"),
+            "`help all` must not list the removed TUI dashboard"
+        );
+        assert!(
+            text.contains("dashboard [--port=N]"),
+            "the web dashboard — the actual replacement — must still be listed"
+        );
+    }
 }

--- a/rust/src/cli/dispatch/network/mod.rs
+++ b/rust/src/cli/dispatch/network/mod.rs
@@ -208,13 +208,23 @@ pub(super) fn cmd_dashboard(rest: &[String]) {
     ));
 }
 
+/// #1602: the live TUI dashboard went away with the dead-module cleanup in
+/// 3.9.20 (de96cc5b), but every surface kept advertising it — `help all` as
+/// "Live TUI dashboard", the completion spec as "Watch for file changes", and
+/// `watch --help` as if it still ran — while the command itself exited 1 with
+/// a bare removal notice and no way forward. The listings are gone; the
+/// command stays as a signpost, because the muscle memory outlives the
+/// feature. Both paths now say the same thing and name the replacement.
 pub(super) fn cmd_watch(rest: &[String]) {
+    const NOTICE: &str = "`lean-ctx watch` (live TUI dashboard) was removed in 3.9.20.\n\
+         Use `lean-ctx dashboard` for the same event stream in the web UI \
+         (http://localhost:3333), or `lean-ctx cep` for the metrics as text.\n\
+         For the codebase index watcher, the command is `lean-ctx index watch`.";
     if rest.iter().any(|a| a == "--help" || a == "-h") {
-        println!("Usage: lean-ctx watch");
-        println!("  Live TUI dashboard (real-time event stream).");
+        println!("{NOTICE}");
         return;
     }
-    eprintln!("The live TUI dashboard has been removed.");
+    eprintln!("{NOTICE}");
     std::process::exit(1);
 }
 

--- a/rust/src/core/config/defaults.rs
+++ b/rust/src/core/config/defaults.rs
@@ -166,6 +166,7 @@ impl Default for Config {
             annotation_threshold_pct: serde_defaults::default_annotation_threshold_pct(),
             behavior_nudges: serde_defaults::default_behavior_nudges(),
             turn_fresh_limit: serde_defaults::default_turn_fresh_limit(),
+            turn_fresh_limit_verbatim: serde_defaults::default_turn_fresh_limit_verbatim(),
             session_token_limit: serde_defaults::default_session_token_limit(),
             project_root: None,
             lsp: std::collections::HashMap::new(),

--- a/rust/src/core/config/logic.rs
+++ b/rust/src/core/config/logic.rs
@@ -208,6 +208,24 @@ impl Config {
             .unwrap_or(self.turn_fresh_limit)
     }
 
+    /// Effective turn budget for an explicitly verbatim response (#1582).
+    ///
+    /// 0 = unlimited. Never below `turn_fresh_limit_effective()`: raising the
+    /// ordinary budget above the verbatim one must not make `raw=true` deliver
+    /// *less* than a compressed read of the same file. An unlimited ordinary
+    /// budget stays unlimited here.
+    pub fn turn_fresh_limit_verbatim_effective(&self) -> usize {
+        let ordinary = self.turn_fresh_limit_effective();
+        if ordinary == 0 {
+            return 0;
+        }
+        let verbatim = std::env::var("LEAN_CTX_TURN_FRESH_LIMIT_VERBATIM")
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(self.turn_fresh_limit_verbatim);
+        resolve_verbatim_limit(ordinary, verbatim)
+    }
+
     /// Whether progressive disclosure is active. Default true. The env var
     /// `LEAN_CTX_PROGRESSIVE_DISCLOSURE` overrides the config field.
     pub fn progressive_disclosure_effective(&self) -> bool {
@@ -633,5 +651,39 @@ impl Config {
             }
         }
         out
+    }
+}
+
+/// Resolve the verbatim turn budget from the two configured limits (#1582).
+///
+/// Pure so the precedence rules are testable without touching process env:
+/// `0` means unlimited, and the verbatim budget is never smaller than the
+/// ordinary one.
+fn resolve_verbatim_limit(ordinary: usize, verbatim: usize) -> usize {
+    if verbatim == 0 {
+        return 0;
+    }
+    verbatim.max(ordinary)
+}
+
+#[cfg(test)]
+mod verbatim_budget_tests {
+    use super::resolve_verbatim_limit;
+
+    #[test]
+    fn verbatim_budget_is_larger_than_the_ordinary_backstop() {
+        assert_eq!(resolve_verbatim_limit(4096, 32_768), 32_768);
+    }
+
+    #[test]
+    fn zero_means_unlimited_verbatim_reads() {
+        assert_eq!(resolve_verbatim_limit(4096, 0), 0);
+    }
+
+    #[test]
+    fn a_raised_ordinary_budget_is_never_undercut() {
+        // Someone who sets turn_fresh_limit = 64k must not get *less* content
+        // back from an explicit raw read than from a compressed one.
+        assert_eq!(resolve_verbatim_limit(65_536, 32_768), 65_536);
     }
 }

--- a/rust/src/core/config/model.rs
+++ b/rust/src/core/config/model.rs
@@ -576,6 +576,16 @@ pub struct Config {
     /// Override via LEAN_CTX_TURN_FRESH_LIMIT env var.
     #[serde(default = "serde_defaults::default_turn_fresh_limit")]
     pub turn_fresh_limit: usize,
+    /// Turn budget for a response the caller explicitly asked to be verbatim
+    /// (`ctx_read` with `raw=true` or `mode="raw"`). 0 = unlimited.
+    /// Default: 32768. Override via LEAN_CTX_TURN_FRESH_LIMIT_VERBATIM.
+    ///
+    /// The ordinary `turn_fresh_limit` is a compression backstop for output the
+    /// agent did not size itself. A verbatim read is the documented recovery
+    /// path out of compression (#1582); capping it at the same 4096 tokens made
+    /// that path unreachable for any file above ~16 KB.
+    #[serde(default = "serde_defaults::default_turn_fresh_limit_verbatim")]
+    pub turn_fresh_limit_verbatim: usize,
     /// Maximum cumulative fresh tokens per session. 0 = unlimited.
     /// Default: 200000. Progressive compression kicks in at 50/75/90%.
     /// Override via LEAN_CTX_SESSION_TOKEN_LIMIT env var.

--- a/rust/src/core/config/schema/mod.rs
+++ b/rust/src/core/config/schema/mod.rs
@@ -315,4 +315,51 @@ mod tests {
             "permission_inheritance must default to On so IDE permission rules are honored out of the box"
         );
     }
+
+    /// #1605: the `[llm]` schema was hand-written with literal defaults and had
+    /// drifted from `LlmConfig` — it named an `api_key` key that no field backs
+    /// (so `config set llm.api_key <secret>` printed "Updated" and then dropped
+    /// the value in the serde round-trip), advertised `llama3.2` as the model
+    /// default, and omitted `base_url` entirely. Every `[llm]` schema key must
+    /// name a real serialised field, and its default must be the struct's.
+    #[test]
+    fn llm_schema_keys_match_the_llm_config_struct() {
+        let schema = ConfigSchema::generate();
+        let section = schema
+            .sections
+            .get("llm")
+            .expect("[llm] section must exist in the schema");
+        let defaults = serde_json::to_value(crate::core::llm_enhance::LlmConfig::default())
+            .expect("LlmConfig serialises");
+        let defaults = defaults.as_object().expect("LlmConfig is a struct");
+
+        for (key, entry) in &section.keys {
+            let actual = defaults.get(key).unwrap_or_else(|| {
+                panic!(
+                    "schema key `llm.{key}` has no field on LlmConfig — \
+                     `config set llm.{key} <v>` would report a save that serde discards"
+                )
+            });
+            // `Option<String>` serialises as null; the schema shows an empty string.
+            let expected = if actual.is_null() {
+                serde_json::json!("")
+            } else {
+                actual.clone()
+            };
+            assert_eq!(
+                entry.default, expected,
+                "schema default for `llm.{key}` has drifted from LlmConfig::default()"
+            );
+        }
+
+        assert!(
+            schema.lookup("llm.api_key").is_none(),
+            "`llm.api_key` is not a config field — the credential comes from \
+             OPENROUTER_API_KEY / ANTHROPIC_API_KEY, so `config set` must reject it"
+        );
+        assert!(
+            schema.lookup("llm.base_url").is_some(),
+            "`llm.base_url` is a real field and must be settable"
+        );
+    }
 }

--- a/rust/src/core/config/schema/sections_advanced.rs
+++ b/rust/src/core/config/schema/sections_advanced.rs
@@ -623,20 +623,31 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
             },
         );
 
+    // #1605: these defaults are derived from `cfg.llm`, never written out by
+    // hand. The literal copies that used to live here had drifted from
+    // `LlmConfig`: `model` advertised `llama3.2` while the struct defaulted to
+    // `qwen2.5-coder:1.5b`, `base_url` was missing, and `api_key` named a field
+    // that does not exist — so `config set llm.api_key …` reported a save that
+    // was silently discarded. The key is gone; the environment variables that
+    // actually supply the credential are named in the section description.
     let mut llm_keys = BTreeMap::new();
     llm_keys.insert(
         "enabled".into(),
         key(
             "bool",
-            serde_json::json!(false),
+            serde_json::json!(cfg.llm.enabled),
             "Enable optional LLM enhancements (query expansion, contradiction explanation)",
         ),
     );
+    let backend_default = serde_json::to_value(cfg.llm.backend.clone())
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| "ollama".to_string());
     llm_keys.insert(
         "backend".into(),
         key_enum(
             &["ollama", "openrouter", "anthropic"],
-            "ollama",
+            &backend_default,
             "LLM backend provider",
         ),
     );
@@ -644,28 +655,28 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         "model".into(),
         key(
             "string",
-            serde_json::json!("llama3.2"),
+            serde_json::json!(cfg.llm.model),
             "Model name for the selected backend",
         ),
     );
     llm_keys.insert(
-        "api_key".into(),
+        "base_url".into(),
         key(
             "string",
-            serde_json::json!(""),
-            "API key for OpenRouter or Anthropic backends",
+            serde_json::json!(cfg.llm.base_url.clone().unwrap_or_default()),
+            "Override the backend's base URL (empty = the backend's own default)",
         ),
     );
     llm_keys.insert(
         "timeout_secs".into(),
         key(
             "u64",
-            serde_json::json!(10),
+            serde_json::json!(cfg.llm.timeout_secs),
             "HTTP timeout for LLM requests",
         ),
     );
     sections.insert("llm".into(), SectionSchema {
-            description: "Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable.".into(),
+            description: "Optional LLM enhancement settings (query expansion, contradiction explanation). Deterministic fallback when disabled or unreachable. Credentials come from the environment — OPENROUTER_API_KEY or ANTHROPIC_API_KEY — not from this file.".into(),
             keys: llm_keys,
         });
 

--- a/rust/src/core/config/serde_defaults.rs
+++ b/rust/src/core/config/serde_defaults.rs
@@ -73,6 +73,10 @@ pub(super) fn default_turn_fresh_limit() -> usize {
     4096
 }
 
+pub(super) fn default_turn_fresh_limit_verbatim() -> usize {
+    32_768
+}
+
 pub(super) fn default_session_token_limit() -> usize {
     200_000
 }

--- a/rust/src/core/editor_registry/detect.rs
+++ b/rust/src/core/editor_registry/detect.rs
@@ -9,24 +9,11 @@ use super::paths::{
 use super::types::{ConfigType, EditorTarget};
 
 pub fn build_targets(home: &Path) -> Vec<EditorTarget> {
-    #[cfg(windows)]
-    let opencode_cfg = if let Ok(appdata) = std::env::var("APPDATA") {
-        PathBuf::from(appdata)
-            .join("opencode")
-            .join("opencode.json")
-    } else {
-        home.join(".config/opencode/opencode.json")
-    };
-    #[cfg(not(windows))]
-    let opencode_cfg = home.join(".config/opencode/opencode.json");
-
-    #[cfg(windows)]
-    let opencode_detect = opencode_cfg
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| home.join(".config/opencode"));
-    #[cfg(not(windows))]
-    let opencode_detect = home.join(".config/opencode");
+    // #1585: honour an existing opencode.jsonc instead of creating a competing
+    // opencode.json next to it.
+    let opencode_dir = crate::core::opencode_config::config_dir(home);
+    let opencode_cfg = crate::core::opencode_config::resolve_in_dir(&opencode_dir).path;
+    let opencode_detect = opencode_dir;
 
     let mut targets = vec![
         EditorTarget {

--- a/rust/src/core/jsonc.rs
+++ b/rust/src/core/jsonc.rs
@@ -6,7 +6,12 @@ use serde_json::Value;
 /// This makes lean-ctx tolerant of the JSONC dialect that editors like VS Code
 /// use for `settings.json` / `mcp.json` (comments + trailing commas are valid
 /// there but rejected by strict JSON). See issue #311.
+///
+/// A single leading UTF-8 BOM is also accepted. Windows editors emit it
+/// routinely, serde_json rejects it, and callers used to read that rejection as
+/// "config is corrupt" and scaffold a fresh one over the user's file (#1586).
 pub fn parse_jsonc(input: &str) -> Result<Value, serde_json::Error> {
+    let input = input.strip_prefix('\u{feff}').unwrap_or(input);
     let stripped = strip_json_comments(input);
     let cleaned = strip_trailing_commas(&stripped);
     serde_json::from_str(&cleaned)
@@ -120,6 +125,19 @@ fn strip_trailing_commas(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn leading_bom_is_accepted() {
+        // #1586: Windows editors save configs BOM-prefixed. serde_json rejects
+        // that, and callers read the rejection as "file is corrupt".
+        let v = parse_jsonc("\u{feff}{\n  // hi\n  \"a\": 1,\n}").expect("BOM config must parse");
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn only_one_leading_bom_is_stripped() {
+        assert!(parse_jsonc("\u{feff}\u{feff}{\"a\":1}").is_err());
+    }
 
     #[test]
     fn strips_line_comments() {

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -445,6 +445,7 @@ pub mod multi_repo;
 pub(crate) mod nc_compress;
 pub mod ocp;
 pub mod openapi;
+pub mod opencode_config;
 pub(crate) mod output_echo;
 pub(crate) mod owasp_alignment;
 pub(crate) mod path_locks;

--- a/rust/src/core/opencode_config.rs
+++ b/rust/src/core/opencode_config.rs
@@ -54,19 +54,16 @@ pub fn resolve_in_dir(dir: &Path) -> Resolved {
     }
 }
 
-/// Resolve OpenCode's global config directory for this platform.
+/// Resolve OpenCode's global config directory.
+///
+/// `~/.config/opencode` on every platform — OpenCode uses the XDG layout on
+/// Windows too, and so does the rest of lean-ctx: the rules file, skills,
+/// detection and uninstall all address `home/.config/opencode`. Special-casing
+/// `%APPDATA%` here would point the MCP writer and doctor at a directory the
+/// uninstaller never visits and the rules writer never fills — and would make
+/// every caller that passes a test home write to the real user profile.
 pub fn config_dir(home: &Path) -> PathBuf {
-    #[cfg(windows)]
-    {
-        if let Ok(appdata) = std::env::var("APPDATA") {
-            return PathBuf::from(appdata).join("opencode");
-        }
-        home.join(".config/opencode")
-    }
-    #[cfg(not(windows))]
-    {
-        home.join(".config/opencode")
-    }
+    home.join(".config/opencode")
 }
 
 /// Resolve the global OpenCode config for a given home directory.
@@ -119,6 +116,18 @@ mod tests {
         let r = resolve_in_dir(dir.path());
         assert_eq!(r.path.file_name().unwrap(), "opencode.json");
         assert!(!r.ambiguous);
+    }
+
+    #[test]
+    fn config_dir_stays_under_the_given_home_on_every_platform() {
+        // Windows CI caught this the hard way: a `%APPDATA%` branch here made
+        // the config resolver ignore its `home` argument, so five tests shared
+        // the runner's real profile and contaminated each other — and in
+        // production it would have split the config away from the rules file,
+        // detection and uninstall, which all use `home/.config/opencode`.
+        let home = Path::new("/tmp/leanctx-home-probe");
+        assert_eq!(config_dir(home), home.join(".config/opencode"));
+        assert!(config_dir(home).starts_with(home));
     }
 
     #[test]

--- a/rust/src/core/opencode_config.rs
+++ b/rust/src/core/opencode_config.rs
@@ -1,0 +1,135 @@
+//! Single source of truth for locating OpenCode's global config file.
+//!
+//! OpenCode accepts both `opencode.json` and `opencode.jsonc`. lean-ctx used to
+//! hardcode `opencode.json` in every writer, so a user whose config was
+//! `opencode.jsonc` got a *second*, competing global config containing nothing
+//! but the lean-ctx MCP entry and shadow-mode denies — their providers, models
+//! and foreign MCP servers appeared to vanish (#1585).
+//!
+//! Resolution rule, applied by `init`, `setup`, doctor, the shadow-mode
+//! permission updater and uninstall alike:
+//!
+//! 1. exactly one of the two exists → that file
+//! 2. both exist → `opencode.json` (OpenCode's own default name), reported via
+//!    [`Resolved::ambiguous`] so callers can warn instead of silently picking
+//! 3. neither exists → `opencode.json`, to be created
+
+use std::path::{Path, PathBuf};
+
+/// Where the OpenCode config lives, plus whether the choice was ambiguous.
+pub struct Resolved {
+    /// The file to read and write.
+    pub path: PathBuf,
+    /// Both `opencode.json` and `opencode.jsonc` exist on disk.
+    pub ambiguous: bool,
+}
+
+impl Resolved {
+    /// Display form for CLI output, e.g. `~/.config/opencode/opencode.jsonc`.
+    pub fn display(&self, home: &Path) -> String {
+        self.path.strip_prefix(home).map_or_else(
+            |_| self.path.display().to_string(),
+            |rest| format!("~/{}", rest.display()),
+        )
+    }
+}
+
+/// Resolve the config inside an OpenCode config directory.
+pub fn resolve_in_dir(dir: &Path) -> Resolved {
+    let json = dir.join("opencode.json");
+    let jsonc = dir.join("opencode.jsonc");
+    match (json.exists(), jsonc.exists()) {
+        (false, true) => Resolved {
+            path: jsonc,
+            ambiguous: false,
+        },
+        (true, true) => Resolved {
+            path: json,
+            ambiguous: true,
+        },
+        _ => Resolved {
+            path: json,
+            ambiguous: false,
+        },
+    }
+}
+
+/// Resolve OpenCode's global config directory for this platform.
+pub fn config_dir(home: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            return PathBuf::from(appdata).join("opencode");
+        }
+        home.join(".config/opencode")
+    }
+    #[cfg(not(windows))]
+    {
+        home.join(".config/opencode")
+    }
+}
+
+/// Resolve the global OpenCode config for a given home directory.
+pub fn resolve(home: &Path) -> Resolved {
+    resolve_in_dir(&config_dir(home))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn touch(p: &Path) {
+        std::fs::write(p, "{}").unwrap();
+    }
+
+    #[test]
+    fn picks_the_only_file_that_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        touch(&dir.path().join("opencode.jsonc"));
+        let r = resolve_in_dir(dir.path());
+        assert_eq!(r.path.file_name().unwrap(), "opencode.jsonc");
+        assert!(!r.ambiguous);
+    }
+
+    #[test]
+    fn plain_json_is_used_when_it_is_the_one_present() {
+        let dir = tempfile::tempdir().unwrap();
+        touch(&dir.path().join("opencode.json"));
+        let r = resolve_in_dir(dir.path());
+        assert_eq!(r.path.file_name().unwrap(), "opencode.json");
+        assert!(!r.ambiguous);
+    }
+
+    #[test]
+    fn both_present_prefers_json_and_reports_ambiguity() {
+        let dir = tempfile::tempdir().unwrap();
+        touch(&dir.path().join("opencode.json"));
+        touch(&dir.path().join("opencode.jsonc"));
+        let r = resolve_in_dir(dir.path());
+        assert_eq!(r.path.file_name().unwrap(), "opencode.json");
+        assert!(
+            r.ambiguous,
+            "callers must be able to warn instead of silently choosing"
+        );
+    }
+
+    #[test]
+    fn neither_present_targets_json_for_creation() {
+        let dir = tempfile::tempdir().unwrap();
+        let r = resolve_in_dir(dir.path());
+        assert_eq!(r.path.file_name().unwrap(), "opencode.json");
+        assert!(!r.ambiguous);
+    }
+
+    #[test]
+    fn jsonc_is_never_shadowed_by_a_file_we_would_create() {
+        // The #1585 regression: a user with only opencode.jsonc must not end up
+        // with lean-ctx writing a competing opencode.json.
+        let dir = tempfile::tempdir().unwrap();
+        touch(&dir.path().join("opencode.jsonc"));
+        assert_eq!(
+            resolve_in_dir(dir.path()).path,
+            dir.path().join("opencode.jsonc")
+        );
+    }
+}

--- a/rust/src/doctor/common.rs
+++ b/rust/src/doctor/common.rs
@@ -365,26 +365,16 @@ pub(super) fn mcp_config_locations(home: &std::path::Path) -> Vec<McpLocation> {
     });
 
     {
-        #[cfg(unix)]
-        let opencode_cfg = home.join(".config").join("opencode").join("opencode.json");
-        #[cfg(unix)]
-        let opencode_display = "~/.config/opencode/opencode.json";
-
-        #[cfg(windows)]
-        let opencode_cfg = if let Ok(appdata) = std::env::var("APPDATA") {
-            std::path::PathBuf::from(appdata)
-                .join("opencode")
-                .join("opencode.json")
-        } else {
-            home.join(".config").join("opencode").join("opencode.json")
-        };
-        #[cfg(windows)]
-        let opencode_display = "%APPDATA%/opencode/opencode.json";
+        // #1585: OpenCode accepts opencode.json and opencode.jsonc. Doctor must
+        // inspect the file the user actually has, not the name we happen to
+        // prefer, or it reports "not configured" for a working setup.
+        let resolved = crate::core::opencode_config::resolve(home);
+        let opencode_display = resolved.display(home);
 
         locations.push(McpLocation {
             name: "OpenCode",
             display: opencode_display.into(),
-            path: opencode_cfg,
+            path: resolved.path,
         });
     }
 

--- a/rust/src/doctor/integrations/editors.rs
+++ b/rust/src/doctor/integrations/editors.rs
@@ -97,7 +97,14 @@ pub(crate) fn integration_generic(
     }
 
     if let Some(rules_path) = rules_path_for(target.name, home) {
-        checks.push(check_rules_file(&rules_path));
+        // #1596: honour rules_injection / rules_scope — an intentionally absent
+        // rules file is not drift.
+        let cfg = crate::core::config::Config::load();
+        checks.push(check_rules_file_for_policy(
+            &rules_path,
+            cfg.rules_injection_effective(),
+            cfg.rules_scope_effective(),
+        ));
     }
 
     // #593: Windsurf is wired through MCP + dedicated rules + Cascade hooks, but

--- a/rust/src/doctor/integrations/wiring.rs
+++ b/rust/src/doctor/integrations/wiring.rs
@@ -180,7 +180,55 @@ pub(crate) fn cmd_matches_expected(cmd: &str, portable: &str) -> bool {
     {
         return true;
     }
+    // #1598: the generated bash wrappers hold an MSYS-style path
+    // (`/c/Users/Max/.cargo/bin/lean-ctx.exe`) because that is what bash needs,
+    // while the expected binary is native (`C:\Users\Max\…`). Byte comparison
+    // calls a correct wrapper stale and sends Windows users into a
+    // `setup --fix` loop that rewrites the file to a byte-identical result.
+    if same_windows_path(cmd, portable) {
+        return true;
+    }
+    if let Some(resolved) = resolve_lean_ctx_binary()
+        && same_windows_path(cmd, &resolved.to_string_lossy())
+    {
+        return true;
+    }
     false
+}
+
+/// Whether two strings name the same Windows file across the MSYS/native
+/// spelling divide: `/c/Users/Max/x.exe` ≡ `C:\Users\Max\x.exe` (#1598).
+///
+/// Returns `false` for anything that is not drive-qualified in one of the two
+/// forms, so ordinary Unix paths are never conflated.
+fn same_windows_path(a: &str, b: &str) -> bool {
+    fn canon(s: &str) -> Option<String> {
+        let s = s.trim().trim_matches('"');
+        let bytes = s.as_bytes();
+        // `X:\…` / `X:/…`  →  drive + remainder after the colon
+        // `/x/…` (MSYS)     →  drive + remainder after the drive letter
+        let (drive, rest) =
+            if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+                (bytes[0], &s[2..])
+            } else if bytes.len() >= 3
+                && bytes[0] == b'/'
+                && bytes[1].is_ascii_alphabetic()
+                && bytes[2] == b'/'
+            {
+                (bytes[1], &s[2..])
+            } else {
+                return None;
+            };
+        Some(format!(
+            "{}:{}",
+            drive.to_ascii_lowercase() as char,
+            rest.replace('\\', "/").to_ascii_lowercase()
+        ))
+    }
+    match (canon(a), canon(b)) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
 }
 
 /// Collect the `lean-ctx` binary tokens that appear immediately before a
@@ -232,6 +280,41 @@ pub(crate) fn check_rules_file(path: &std::path::Path) -> NamedCheck {
         } else {
             format!("missing ({})", path.display())
         },
+    }
+}
+
+/// Rules-file health that respects the configured rules policy (#1596).
+///
+/// A missing global rules file is only drift when lean-ctx was actually asked to
+/// write one. With `rules_injection = "off"` — or `rules_scope = "project"`,
+/// which keeps global files out by design — the file is absent on purpose, and
+/// reporting the integration as unhealthy for it sends users chasing a
+/// non-problem. Claude Code's dedicated check already reasoned this way; this
+/// gives every other editor (Cline, Cline CLI, Roo, Windsurf, …) the same rule.
+pub(crate) fn check_rules_file_for_policy(
+    path: &std::path::Path,
+    injection: crate::core::config::RulesInjection,
+    scope: crate::core::config::RulesScope,
+) -> NamedCheck {
+    use crate::core::config::{RulesInjection, RulesScope};
+
+    if path.exists() {
+        return check_rules_file(path);
+    }
+    let intentional = match injection {
+        RulesInjection::Off => Some("rules injection off (intentionally not installed)"),
+        _ if scope == RulesScope::Project => {
+            Some("project scope (global rules intentionally absent)")
+        }
+        _ => None,
+    };
+    match intentional {
+        Some(detail) => NamedCheck {
+            name: "Rules file".to_string(),
+            ok: true,
+            detail: detail.to_string(),
+        },
+        None => check_rules_file(path),
     }
 }
 
@@ -331,5 +414,111 @@ pub(crate) fn rules_path_for(name: &str, home: &std::path::Path) -> Option<std::
         "Pi Coding Agent" => Some(home.join(".pi/rules/lean-ctx.md")),
         "Crush" => Some(home.join(".config/crush/rules/lean-ctx.md")),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::{RulesInjection, RulesScope};
+
+    // --- #1598: MSYS vs native Windows spelling of the same wrapper binary ---
+
+    #[test]
+    fn msys_and_native_windows_paths_are_the_same_binary() {
+        assert!(same_windows_path(
+            "/c/Users/Max/.cargo/bin/lean-ctx.exe",
+            r"C:\Users\Max\.cargo\bin\lean-ctx.exe"
+        ));
+    }
+
+    #[test]
+    fn drive_letter_and_separators_compare_case_insensitively() {
+        assert!(same_windows_path(
+            "/d/Tools/lean-ctx.exe",
+            r"D:\tools\LEAN-CTX.exe"
+        ));
+        assert!(same_windows_path("C:/x/lean-ctx.exe", r"c:\x\lean-ctx.exe"));
+    }
+
+    #[test]
+    fn different_windows_paths_still_differ() {
+        assert!(!same_windows_path(
+            "/c/Users/Max/.cargo/bin/lean-ctx.exe",
+            r"C:\Users\Other\.cargo\bin\lean-ctx.exe"
+        ));
+    }
+
+    #[test]
+    fn plain_unix_paths_are_never_conflated() {
+        // No drive qualification on either side -> the comparison must abstain
+        // rather than invent an equivalence.
+        assert!(!same_windows_path(
+            "/usr/local/bin/lean-ctx",
+            "/opt/lean-ctx"
+        ));
+        assert!(!same_windows_path(
+            "/usr/local/bin/lean-ctx",
+            "/usr/local/bin/lean-ctx"
+        ));
+    }
+
+    #[test]
+    fn wrapper_written_for_bash_is_not_reported_stale() {
+        let native = r"C:\Users\Max\.cargo\bin\lean-ctx.exe";
+        let bash = crate::hooks::to_bash_compatible_path(native);
+        assert_eq!(bash, "/c/Users/Max/.cargo/bin/lean-ctx.exe");
+        assert!(
+            cmd_matches_expected(&bash, native),
+            "the wrapper we generate ourselves must pass our own staleness check"
+        );
+    }
+
+    // --- #1596: an intentionally absent rules file is not drift ---
+
+    #[test]
+    fn missing_rules_file_is_drift_when_injection_is_on() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lean-ctx.md");
+        let c = check_rules_file_for_policy(&path, RulesInjection::Dedicated, RulesScope::Global);
+        assert!(!c.ok);
+        assert!(c.detail.starts_with("missing"));
+    }
+
+    #[test]
+    fn missing_rules_file_is_healthy_when_injection_is_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lean-ctx.md");
+        let c = check_rules_file_for_policy(&path, RulesInjection::Off, RulesScope::Global);
+        assert!(
+            c.ok,
+            "rules_injection=off means the file is absent by design"
+        );
+        assert!(c.detail.contains("injection off"));
+    }
+
+    #[test]
+    fn missing_global_rules_file_is_healthy_in_project_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lean-ctx.md");
+        let c = check_rules_file_for_policy(&path, RulesInjection::Shared, RulesScope::Project);
+        assert!(c.ok);
+        assert!(c.detail.contains("project scope"));
+    }
+
+    #[test]
+    fn present_rules_file_is_healthy_under_every_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lean-ctx.md");
+        std::fs::write(&path, "rules").unwrap();
+        for (inj, scope) in [
+            (RulesInjection::Off, RulesScope::Global),
+            (RulesInjection::Shared, RulesScope::Project),
+            (RulesInjection::Dedicated, RulesScope::Both),
+        ] {
+            let c = check_rules_file_for_policy(&path, inj, scope);
+            assert!(c.ok);
+            assert!(c.detail.contains("lean-ctx.md"));
+        }
     }
 }

--- a/rust/src/hooks/agents/opencode.rs
+++ b/rust/src/hooks/agents/opencode.rs
@@ -1,11 +1,30 @@
 use super::super::{HookMode, mcp_server_quiet_mode, resolve_binary_path};
 use crate::core::config::{Config, RulesInjection, RulesScope};
 
+/// The JSON document a config update starts from (#1586).
+///
+/// `Err` means "leave the file alone": an existing config we cannot parse is
+/// never replaced with a fresh lean-ctx-only scaffold. Starting from an empty
+/// object there wiped providers, models, plugins and foreign MCP entries — and
+/// the command still reported success. Only a genuinely absent file may start
+/// empty.
+fn starting_document(file_existed: bool, content: &str) -> Result<serde_json::Value, String> {
+    match crate::core::jsonc::parse_jsonc(content) {
+        Ok(v) => Ok(v),
+        Err(e) if file_existed => Err(e.to_string()),
+        Err(_) => Ok(serde_json::Value::Object(serde_json::Map::new())),
+    }
+}
+
 pub(crate) fn install_opencode_hook_with_mode(mode: HookMode) {
     let binary = resolve_binary_path();
     let home = crate::core::home::resolve_home_dir().unwrap_or_default();
-    let config_path = home.join(".config/opencode/opencode.json");
-    let display_path = "~/.config/opencode/opencode.json";
+    // #1585: write into the user's existing opencode.jsonc when that is the file
+    // they actually have, rather than creating a competing opencode.json.
+    let resolved = crate::core::opencode_config::resolve(&home);
+    let display_path = resolved.display(&home);
+    let display_path = display_path.as_str();
+    let config_path = resolved.path;
 
     if let Some(parent) = config_path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -37,8 +56,17 @@ pub(crate) fn install_opencode_hook_with_mode(mode: HookMode) {
     };
     let has_lean_ctx = content.contains("lean-ctx");
 
-    let mut json = crate::core::jsonc::parse_jsonc(&content)
-        .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
+    let mut json = match starting_document(file_existed, &content) {
+        Ok(v) => v,
+        Err(e) => {
+            if !mcp_server_quiet_mode() {
+                eprintln!(
+                    "  \x1b[33m!\x1b[0m OpenCode config at {display_path} could not be parsed ({e}) — left untouched. Fix the file, then re-run."
+                );
+            }
+            return;
+        }
+    };
     let Some(obj) = json.as_object_mut() else {
         return;
     };
@@ -122,7 +150,9 @@ pub(crate) fn install_opencode_hook_with_mode(mode: HookMode) {
 }
 
 fn opencode_config_path(home: &std::path::Path) -> std::path::PathBuf {
-    home.join(".config/opencode/opencode.json")
+    // #1585: resolve .json/.jsonc instead of hardcoding one name, so
+    // registration and unregistration touch the same file the installer wrote.
+    crate::core::opencode_config::resolve(home).path
 }
 
 /// Add the dedicated rules file to opencode.json `instructions[]` (idempotent).
@@ -133,9 +163,20 @@ fn register_opencode_instructions(home: &std::path::Path) {
         .into_owned();
 
     let mut json = match std::fs::read_to_string(&config_path) {
-        Ok(content) => crate::core::jsonc::parse_jsonc(&content).unwrap_or_else(
-            |_| serde_json::json!({ "$schema": "https://opencode.ai/config.json" }),
-        ),
+        // #1586: same rule as the installer — an existing config we cannot parse
+        // is left alone, never overwritten with a fresh scaffold.
+        Ok(content) => match starting_document(true, &content) {
+            Ok(v) => v,
+            Err(e) => {
+                if !mcp_server_quiet_mode() {
+                    eprintln!(
+                        "  \x1b[33m!\x1b[0m OpenCode config at {} could not be parsed ({e}) — instructions[] not registered.",
+                        config_path.display()
+                    );
+                }
+                return;
+            }
+        },
         Err(_) => serde_json::json!({ "$schema": "https://opencode.ai/config.json" }),
     };
 
@@ -636,5 +677,94 @@ mod shadow_permission_tests {
             json.get("permissions").is_none(),
             "'permissions' (plural) should not exist"
         );
+    }
+}
+
+/// #1585 / #1586: the OpenCode global config must survive a lean-ctx install.
+#[cfg(test)]
+mod config_preservation_tests {
+    use super::*;
+
+    const REAL_WORLD: &str = r#"{
+  // my setup
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-opus-4",
+  "provider": {
+    "anthropic": { "options": { "apiKey": "{env:ANTHROPIC_API_KEY}" } }
+  },
+  "plugin": ["my-plugin"],
+  "permission": { "bash": "ask" },
+  "mcp": {
+    "other-tool": { "type": "local", "command": ["other"], "enabled": true }
+  },
+}"#;
+
+    #[test]
+    fn unparseable_existing_config_is_never_replaced_by_a_scaffold() {
+        // The #1586 regression: this used to yield an empty object, which the
+        // installer then wrote back over the user's file.
+        let broken = r#"{ "model": "x" "provider": {} }"#;
+        let err = starting_document(true, broken)
+            .expect_err("a config we cannot parse must abort the write, not reset it");
+        assert!(!err.is_empty(), "the user needs to know what was wrong");
+    }
+
+    #[test]
+    fn absent_config_may_start_from_an_empty_object() {
+        let v = starting_document(false, "").expect("a missing file is created from scratch");
+        assert_eq!(v, serde_json::json!({}));
+    }
+
+    #[test]
+    fn jsonc_comments_and_trailing_commas_still_parse() {
+        let v = starting_document(true, REAL_WORLD).expect("JSONC is valid OpenCode config");
+        assert_eq!(v["model"], "anthropic/claude-opus-4");
+        assert!(v["mcp"]["other-tool"]["enabled"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn bom_prefixed_config_parses_instead_of_being_reset() {
+        // Windows editors emit a UTF-8 BOM. serde_json rejects it, and that
+        // rejection used to be read as "corrupt, scaffold a fresh one".
+        let with_bom = format!("\u{feff}{REAL_WORLD}");
+        let v = starting_document(true, &with_bom)
+            .expect("a BOM is an encoding artefact, not a corrupt config");
+        assert_eq!(v["model"], "anthropic/claude-opus-4");
+        assert_eq!(v["plugin"][0], "my-plugin");
+    }
+
+    #[test]
+    fn user_content_survives_the_lean_ctx_mcp_insertion() {
+        let mut v = starting_document(true, REAL_WORLD).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        obj.entry("mcp")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .unwrap()
+            .insert("lean-ctx".to_string(), serde_json::json!({"enabled": true}));
+
+        assert_eq!(v["model"], "anthropic/claude-opus-4");
+        assert!(v["provider"]["anthropic"]["options"]["apiKey"].is_string());
+        assert_eq!(v["plugin"][0], "my-plugin");
+        assert_eq!(v["permission"]["bash"], "ask");
+        assert!(
+            v["mcp"]["other-tool"]["enabled"].as_bool().unwrap(),
+            "a foreign MCP server must not be dropped"
+        );
+        assert!(v["mcp"]["lean-ctx"]["enabled"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn config_path_follows_the_users_jsonc_file() {
+        // #1585: with only opencode.jsonc present we must not create a second,
+        // competing opencode.json.
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_dir = dir.path().join(".config/opencode");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        std::fs::write(cfg_dir.join("opencode.jsonc"), REAL_WORLD).unwrap();
+
+        let resolved = crate::core::opencode_config::resolve_in_dir(&cfg_dir);
+        assert_eq!(resolved.path, cfg_dir.join("opencode.jsonc"));
+        assert!(!cfg_dir.join("opencode.json").exists());
     }
 }

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -1119,7 +1119,18 @@ pub(in crate::server) async fn dispatch_and_post_process(
     // This applies uniformly to every tool, including raw shell output and
     // explicit full reads. Oversized archivable responses retain their
     // ctx_expand handle from the archive stage above.
-    let budget_limit = crate::core::config::Config::load().turn_fresh_limit_effective();
+    //
+    // #1582: a read the caller explicitly asked to be verbatim gets the larger
+    // verbatim budget. `raw=true` is what every compression annotation and the
+    // server instructions name as the way back to the original bytes; holding
+    // it to the same 4096-token backstop as an unrequested response made that
+    // documented recovery path silently unreachable above ~16 KB.
+    let cfg = crate::core::config::Config::load();
+    let budget_limit = if verbatim_requested(name, args) {
+        cfg.turn_fresh_limit_verbatim_effective()
+    } else {
+        cfg.turn_fresh_limit_effective()
+    };
     if budget_limit > 0 {
         let (budgeted, action) = crate::core::budget::apply_turn_budget(&result_text, budget_limit);
         if let crate::core::budget::BudgetAction::Truncated {
@@ -1206,6 +1217,32 @@ pub(super) fn triage_bypass_requested(
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false)
         })
+}
+
+/// Whether the caller explicitly asked for the original bytes (#1582).
+///
+/// Deliberately narrower than [`triage_bypass_requested`]: only `raw = true` and
+/// `mode = "raw"` count. Those two are the escape hatch every compression
+/// annotation points at, so they earn the larger verbatim turn budget. `full`,
+/// `lines:`, `anchored` and friends stay on the ordinary budget — they are
+/// routine reads, not a request to defeat compression, and exempting them would
+/// turn the backstop off for most traffic.
+pub(super) fn verbatim_requested(
+    name: &str,
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> bool {
+    if !matches!(name, "ctx_read" | "ctx_shell") {
+        return false;
+    }
+    args.is_some_and(|args| {
+        args.get("raw")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+            || args
+                .get("mode")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|mode| mode == "raw")
+    })
 }
 
 /// Applies task triage at the native dispatch chokepoint. If no profile is
@@ -1335,7 +1372,10 @@ fn record_decision_loop(
 
 #[cfg(test)]
 mod savings_tests {
-    use super::{apply_task_triage_filter, compression_tracker_tokens, triage_bypass_requested};
+    use super::{
+        apply_task_triage_filter, compression_tracker_tokens, triage_bypass_requested,
+        verbatim_requested,
+    };
 
     #[test]
     fn test_tracker_in_pipeline() {
@@ -1415,5 +1455,44 @@ mod savings_tests {
 
         let shell = serde_json::Map::new();
         assert!(!triage_bypass_requested("ctx_shell", Some(&shell)));
+    }
+
+    fn args(pairs: &[(&str, serde_json::Value)]) -> serde_json::Map<String, serde_json::Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn raw_true_and_mode_raw_are_explicit_verbatim_requests() {
+        let raw_flag = args(&[("raw", serde_json::Value::Bool(true))]);
+        let raw_mode = args(&[("mode", serde_json::Value::String("raw".to_owned()))]);
+        assert!(verbatim_requested("ctx_read", Some(&raw_flag)));
+        assert!(verbatim_requested("ctx_read", Some(&raw_mode)));
+        assert!(verbatim_requested("ctx_shell", Some(&raw_flag)));
+    }
+
+    #[test]
+    fn ordinary_reads_stay_on_the_ordinary_budget() {
+        // #1582 raises the cap for an explicit escape hatch, not for the
+        // everyday modes — otherwise the backstop is off for most traffic.
+        for mode in ["full", "auto", "lines:1-40", "anchored", "signatures"] {
+            let a = args(&[("mode", serde_json::Value::String(mode.to_owned()))]);
+            assert!(
+                !verbatim_requested("ctx_read", Some(&a)),
+                "mode={mode} must not claim the verbatim budget"
+            );
+        }
+        let off = args(&[("raw", serde_json::Value::Bool(false))]);
+        assert!(!verbatim_requested("ctx_read", Some(&off)));
+        assert!(!verbatim_requested("ctx_read", None));
+    }
+
+    #[test]
+    fn other_tools_never_claim_the_verbatim_budget() {
+        let raw_flag = args(&[("raw", serde_json::Value::Bool(true))]);
+        assert!(!verbatim_requested("ctx_search", Some(&raw_flag)));
+        assert!(!verbatim_requested("ctx_compose", Some(&raw_flag)));
     }
 }

--- a/rust/src/server/dispatch/mod.rs
+++ b/rust/src/server/dispatch/mod.rs
@@ -112,7 +112,27 @@ impl LeanCtxServer {
                                 None,
                             ));
                         }
-                        None
+                        // #1604: agents also *flatten* the call —
+                        // ctx_call(name="ctx_edit", path=…, old_string=…) —
+                        // and the inner tool then answered "path is required",
+                        // naming a parameter the caller demonstrably supplied.
+                        // That message sent one reporter hunting a marshalling
+                        // bug through three identical retries and a hand-rolled
+                        // stdio probe. `name` is the only key ctx_call reserves,
+                        // so a flattened call is unambiguous: forward the rest.
+                        let flattened: serde_json::Map<String, Value> = args
+                            .map(|m| {
+                                m.iter()
+                                    .filter(|(k, _)| k.as_str() != "name")
+                                    .map(|(k, v)| (k.clone(), v.clone()))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        if flattened.is_empty() {
+                            None
+                        } else {
+                            Some(flattened)
+                        }
                     }
                     Some(Value::Object(map)) => Some(map.clone()),
                     Some(_) => {
@@ -830,6 +850,81 @@ mod tests {
             !err.message.contains("did you mean"),
             "no confident suggestion for garbage: {}",
             err.message
+        );
+    }
+
+    /// #1604: `ctx_call(name="ctx_edit", path=…, old_string=…)` — the inner
+    /// tool's arguments flattened onto the ctx_call envelope instead of nested
+    /// under `arguments` — used to reach the inner tool with NO arguments, so
+    /// it answered "path is required" about a parameter the caller had just
+    /// supplied. `name` is the only key ctx_call reserves, so the rest is
+    /// forwarded. The nested form and the #658 misspelling guard are unchanged.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ctx_call_forwards_flattened_inner_arguments() {
+        let server = crate::tools::create_server();
+        fn msg(
+            r: Result<
+                (
+                    String,
+                    usize,
+                    Option<ShellOutcome>,
+                    Option<Vec<ContentBlock>>,
+                ),
+                ErrorData,
+            >,
+        ) -> String {
+            match r {
+                Ok((text, ..)) => text,
+                Err(e) => e.message.to_string(),
+            }
+        }
+
+        // `ctx_read` on purpose: it is on every built-in role's allowlist, so a
+        // sibling test that leaves a non-default role in the global slot cannot
+        // turn these assertions into `[ROLE DENIED]`. Its missing-argument error
+        // is also the exact one from the report.
+        //
+        // Control: genuinely no arguments — the inner tool's own error stands.
+        let mut bare = serde_json::Map::new();
+        bare.insert("name".into(), Value::String("ctx_read".into()));
+        let bare = msg(server.dispatch_tool("ctx_call", Some(&bare), false).await);
+        assert!(
+            bare.contains("path is required"),
+            "an argument-less inner call must still say what is missing: {bare}"
+        );
+
+        // Flattened: the same message would be a lie — the caller passed it.
+        let mut flat = serde_json::Map::new();
+        flat.insert("name".into(), Value::String("ctx_read".into()));
+        flat.insert("path".into(), Value::String("Cargo.toml".into()));
+        let flat = msg(server.dispatch_tool("ctx_call", Some(&flat), false).await);
+        assert!(
+            !flat.contains("path is required"),
+            "flattened arguments must reach the inner tool: {flat}"
+        );
+
+        // Nested form: unchanged.
+        let mut nested = serde_json::Map::new();
+        nested.insert("name".into(), Value::String("ctx_read".into()));
+        nested.insert(
+            "arguments".into(),
+            serde_json::json!({ "path": "Cargo.toml" }),
+        );
+        let nested = msg(server.dispatch_tool("ctx_call", Some(&nested), false).await);
+        assert!(
+            !nested.contains("path is required"),
+            "nested arguments must keep working: {nested}"
+        );
+
+        // #658 guard: an `args`/`params` wrapper is a typo, not a flat call —
+        // forwarding it would hand the inner tool a bogus `args` parameter.
+        let mut typo = serde_json::Map::new();
+        typo.insert("name".into(), Value::String("ctx_read".into()));
+        typo.insert("args".into(), serde_json::json!({ "path": "Cargo.toml" }));
+        let typo = msg(server.dispatch_tool("ctx_call", Some(&typo), false).await);
+        assert!(
+            typo.contains("unknown key 'args'"),
+            "the #658 misspelling hint must survive: {typo}"
         );
     }
 }

--- a/rust/src/server/server_handler.rs
+++ b/rust/src/server/server_handler.rs
@@ -259,11 +259,6 @@ impl ServerHandler for LeanCtxServer {
         crate::core::client_capabilities::set_detected(&client_caps);
 
         let session = self.session.read().await.clone();
-        let instructions = crate::instructions::build_instructions_with_client_and_session(
-            CrpMode::effective(),
-            &name,
-            &session,
-        );
 
         let capabilities = server_capabilities(client_caps.resources, client_caps.prompts);
 
@@ -273,9 +268,23 @@ impl ServerHandler for LeanCtxServer {
         // GH #1447: Antigravity/Gemini CLI disconnect when the initialize
         // response contains `instructions`. The MCP spec marks it optional,
         // but these clients fail on any unexpected field in the JSON envelope.
-        if matches!(client_caps.client_id.as_str(), "antigravity" | "gemini-cli") {
+        //
+        // GH #1599: `rules_injection = "off"` means the user has opted out of
+        // lean-ctx steering their agent. The initialize `instructions` field is
+        // that same steering block delivered over a different channel, so
+        // honouring the setting in the files but still shipping ~780 tokens of
+        // "ALWAYS use ctx_*, NEVER use native Read/Grep" on every session start
+        // makes the setting look broken. Off means off, on every channel.
+        let injection_off = crate::core::config::Config::load().rules_injection_effective()
+            == crate::core::config::RulesInjection::Off;
+        if injection_off || matches!(client_caps.client_id.as_str(), "antigravity" | "gemini-cli") {
             Ok(result)
         } else {
+            let instructions = crate::instructions::build_instructions_with_client_and_session(
+                CrpMode::effective(),
+                &name,
+                &session,
+            );
             Ok(result.with_instructions(instructions))
         }
     }

--- a/rust/src/setup/mcp.rs
+++ b/rust/src/setup/mcp.rs
@@ -310,16 +310,9 @@ pub(crate) fn agent_mcp_targets(
             ConfigType::McpJson,
         ),
         "opencode" => {
-            #[cfg(windows)]
-            let opencode_path = if let Ok(appdata) = std::env::var("APPDATA") {
-                std::path::PathBuf::from(appdata)
-                    .join("opencode")
-                    .join("opencode.json")
-            } else {
-                home.join(".config/opencode/opencode.json")
-            };
-            #[cfg(not(windows))]
-            let opencode_path = home.join(".config/opencode/opencode.json");
+            // #1585: write into the user's existing opencode.jsonc when that is
+            // the file they have, instead of creating a competing opencode.json.
+            let opencode_path = crate::core::opencode_config::resolve(home).path;
             push(
                 &mut targets,
                 "OpenCode",
@@ -583,16 +576,9 @@ pub fn disable_agent_mcp(agent: &str, overwrite_invalid: bool) -> Result<(), Str
             ConfigType::McpJson,
         ),
         "opencode" => {
-            #[cfg(windows)]
-            let opencode_path = if let Ok(appdata) = std::env::var("APPDATA") {
-                std::path::PathBuf::from(appdata)
-                    .join("opencode")
-                    .join("opencode.json")
-            } else {
-                home.join(".config/opencode/opencode.json")
-            };
-            #[cfg(not(windows))]
-            let opencode_path = home.join(".config/opencode/opencode.json");
+            // #1585: write into the user's existing opencode.jsonc when that is
+            // the file they have, instead of creating a competing opencode.json.
+            let opencode_path = crate::core::opencode_config::resolve(home.as_ref()).path;
             push(
                 &mut targets,
                 "OpenCode",

--- a/rust/src/uninstall/agents.rs
+++ b/rust/src/uninstall/agents.rs
@@ -350,7 +350,13 @@ pub(super) fn remove_mcp_configs(home: &Path, dry_run: bool) -> bool {
                 .join("config.toml"),
         ),
         ("Grok", home.join(".grok/config.toml")),
+        // #1585: OpenCode accepts either name. Uninstall visits both so a
+        // lean-ctx entry is never left behind in the file we did not install to.
         ("OpenCode", home.join(".config/opencode/opencode.json")),
+        (
+            "OpenCode (jsonc)",
+            home.join(".config/opencode/opencode.jsonc"),
+        ),
         ("Qwen Code", home.join(".qwen/settings.json")),
         ("Qwen Code (legacy)", home.join(".qwen/mcp.json")),
         ("Trae", home.join(".trae/mcp.json")),
@@ -649,7 +655,7 @@ pub(super) fn remove_rules_files(home: &Path, dry_run: bool) -> bool {
     // Always attempt regardless of the current rules_injection mode, since a prior
     // dedicated install could have left these behind.
     if dry_run {
-        let opencode_cfg = home.join(".config/opencode/opencode.json");
+        let opencode_cfg = crate::core::opencode_config::resolve(home).path;
         if fs::read_to_string(&opencode_cfg)
             .is_ok_and(|c| c.contains("lean-ctx") && c.contains("instructions"))
         {


### PR DESCRIPTION
Six field-reported defects, each with regression tests. Branch is cut from `github/main` (`5a90893092`), so the diff is 16 files — not the whole lineage.

## What was wrong

**#1586 — an OpenCode config could be silently replaced by a lean-ctx-only scaffold.**
Both writers (`install_opencode_hook_with_mode` and `register_opencode_instructions`) started from an empty object whenever `parse_jsonc` failed, wiping providers, models, plugins and foreign MCP entries — and the command still reported success. They now fail closed: an existing config that will not parse is left untouched and the reason is printed. `parse_jsonc` also tolerates a single leading UTF-8 BOM, which Windows editors emit routinely and `serde_json` rejects — that rejection was one of the ways a healthy config got read as "corrupt".

**#1585 — OpenCode accepts both `opencode.json` and `opencode.jsonc`.**
lean-ctx hardcoded one name per call site, so install, doctor, setup and uninstall could each target a different file than the user actually has. New `core::opencode_config` resolver (exactly one exists → that file; both → `.json`, flagged ambiguous; neither → `.json` for creation) is now the single source of truth for all of them. Uninstall visits both names so a lean-ctx entry is never orphaned in the file we did not install to.

**#1596 — intentionally absent rules files were reported as drift.**
A missing global rules file counted as unhealthy even when `rules_injection = "off"` or `rules_scope = "project"` made its absence deliberate. Claude Code's dedicated check already reasoned this way; `check_rules_file_for_policy` gives Cline, Cline CLI, Roo, Windsurf and the rest the same rule.

**#1598 — Windows `setup --fix` loop.**
The generated bash wrappers hold an MSYS path (`/c/Users/Max/.cargo/bin/lean-ctx.exe`) because that is what bash needs, while the expected binary is native (`C:\Users\Max\…`). Byte comparison called a correct wrapper stale and sent Windows users into a `setup --fix` loop that rewrote the file to a byte-identical result. `same_windows_path` compares the two spellings; anything not drive-qualified in one of those two forms returns `false`, so ordinary Unix paths are never conflated.

**#1599 — `rules_injection = "off"` was only half honoured.**
That setting is an opt-out from lean-ctx steering the agent. The initialize `instructions` field is the same steering block delivered over a different channel, so honouring the setting in the files while still shipping ~780 tokens of "ALWAYS use ctx_*, NEVER use native Read/Grep" on every session start made the setting look broken. Off is now off on every channel. The existing #1447 carve-out for Antigravity/Gemini CLI is unchanged.

**#1582 — the documented recovery path out of compression did not work.**
The turn budget (#1306) capped every response at 4096 tokens, including a read the caller explicitly asked to be verbatim. `raw=true` is exactly what the compression annotations and the server instructions name as the way back to the original bytes, so that path was silently unreachable for any file above ~16 KB.

Explicit verbatim requests (`raw=true` or `mode="raw"`, on `ctx_read` and `ctx_shell`) now use a separate `turn_fresh_limit_verbatim` — default 32768, env `LEAN_CTX_TURN_FRESH_LIMIT_VERBATIM`, `0` = unlimited, and never below the ordinary limit so raising `turn_fresh_limit` can't make a raw read deliver *less* than a compressed one. Everyday modes keep the 4096-token backstop: exempting `full`, `lines:`, `anchored` and friends would switch the backstop off for most traffic, and their truncation banner already points at a working `lines=` recovery.

## Measured, not asserted

235 KB / 6000-line markdown file, driven through the stdio server:

| request | before | after |
|---|---|---|
| `{mode:"raw", raw:true}` | 4052 tokens / 462 lines | **32740 tokens / 3722 lines** |
| `{mode:"raw"}` | 4052 tokens | **32740 tokens** |
| `{mode:"full"}` | 4052 tokens | 4052 tokens (unchanged, banner intact) |

Side note for the original report: a truncation banner *is* emitted on this build (`[… truncated at ~N of M tokens — use ctx_read with lines= …]`). The defect was the ceiling ignoring an explicit verbatim request, not a missing banner.

## Verification

- `cargo test --lib` → **10508 passed, 0 failed**, 22 ignored
- `cargo clippy --lib --all-features` → clean
- `scripts/preflight.sh fast` → 7/8. The one failure is `git diff --check` evaluated over the divergent merge-base (`437132fa`, 3466 pre-existing files from the other lineage); `git diff --check` on this branch's own changes is empty.

New tests: 6 in `hooks::agents::opencode::config_preservation_tests`, 9 in `doctor::integrations::wiring::tests`, 5 in `core::opencode_config`, 3 in `core::config::logic::verbatim_budget_tests`, 3 in `server::call_tool::pipeline::savings_tests`, 2 in `core::jsonc::tests`.

### #1605 — `config set llm.api_key` reported a save it discarded

The `[llm]` schema block was hand-written with literal defaults instead of being derived from `cfg.llm`, and had drifted three ways: an `api_key` key no struct field backs (so `set_by_key` wrote it into the TOML table and the `Config` round-trip silently dropped it — after the CLI printed "Updated"), a `model` default of `llama3.2` against the struct's `qwen2.5-coder:1.5b`, and a missing `base_url`. Defaults now come from `cfg.llm.*` like the neighbouring `[decision_loop]` block, `api_key` is gone (`config set llm.api_key …` fails with `Unknown config key`; the section description names `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY`), and `llm_schema_keys_match_the_llm_config_struct` guards the class so the next drift fails in CI instead of eating a secret. `config-keys.md` regenerated.

### #1604 — `ctx_call` answered "path is required" about a parameter the caller supplied

The envelope parser accepted the inner arguments only under `arguments` (plus the #658 guard that turns an `args`/`params`/`parameters`/`arg` wrapper into a "did you mean `arguments`" hint). Agents also *flatten* the call — `ctx_call(name="ctx_edit", path=…, old_string=…)` — and that reached the inner tool with no arguments at all, so the inner tool complained about its own first required parameter. Probing a shipped 3.9.20 binary shows the signature: flattened `ctx_glob` → "pattern is required", flattened `ctx_edit` → "path is required" — the message follows whichever tool you name, which is what an argument-less forward looks like, not the registry-ordering bug the report suspected. `name` is the only key `ctx_call` reserves, so a flattened call is unambiguous and the rest is now forwarded; nested calls and the #658 hint are unchanged. With arguments arriving, an inner tool that genuinely isn't registered now reaches the existing `Unknown tool: …` + nearest-match path (#712), which is what the reporter asked for. `ctx_call_forwards_flattened_inner_arguments` pins all four shapes; it drives `ctx_read` deliberately, because that tool is on every built-in role's allowlist and so a sibling test leaving a non-default role in the global slot can't turn the assertions into `[ROLE DENIED]`.

### #1602 — `lean-ctx watch` was still advertised after its removal

The TUI went with the dead-module cleanup in 3.9.20 (de96cc5b), but `--help`, the completion spec and `watch --help` all still described it as a working command, while bare `watch` exited 1 with "The live TUI dashboard has been removed." and named no replacement. All four surfaces now carry the same notice and point at `lean-ctx dashboard` (web UI, same event stream), `lean-ctx cep` (metrics as text) and `lean-ctx index watch` (the index watcher). `watch --help` → stdout, exit 0; bare `watch` → stderr, exit 1. The completion entry is hidden rather than deleted, with a "Removed — see `lean-ctx dashboard`" description. Guarded by `full_help_does_not_advertise_the_removed_tui_dashboard` and `removed_watch_command_is_not_advertised`.

Fixes #1582
Fixes #1585
Fixes #1586
Fixes #1596
Fixes #1598
Fixes #1599
Fixes #1602
Fixes #1604
Fixes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)

