### PR TITLE
test(call_tool): make the auto-detach reproduction deterministic (fixes red main on macOS)

### DIFF
--- a/rust/src/server/call_tool/tests.rs
+++ b/rust/src/server/call_tool/tests.rs
@@ -181,21 +181,50 @@ mod shell_outcome_tests {
         )
     }
 
+    /// Drive a command through the auto-detach path *deterministically*.
+    ///
+    /// The 10 ms foreground window used to be held open by the caller's own
+    /// `sleep 0.1`, which assumes the child is spawned, scheduled and still
+    /// running 10 ms later. On a loaded macOS runner that assumption broke and
+    /// the helper panicked with "the reproduction must exercise the
+    /// auto-detached path" — a flake in the harness, not a defect in the code
+    /// under test. The child now blocks on a barrier file until the test
+    /// releases it, exactly like `auto_detached_pipeline_result` below, so the
+    /// detach is guaranteed no matter how the runner schedules us.
     #[cfg(not(windows))]
     fn auto_detached_result(command: &str) -> CallToolResult {
+        let release_dir = tempfile::tempdir().expect("create auto-detach barrier directory");
+        let release_path = release_dir.path().join("release");
+        let mut extra_env = std::collections::HashMap::new();
+        extra_env.insert(
+            "LCTX_TEST_RELEASE_PATH".to_string(),
+            release_path.to_string_lossy().into_owned(),
+        );
+        let guarded_command =
+            format!("while [ ! -e \"$LCTX_TEST_RELEASE_PATH\" ]; do sleep 0.01; done; {command}");
         let detached = crate::server::background_shell::run_foreground_or_detach(
-            command.to_string(),
+            guarded_command,
             ".".to_string(),
-            std::collections::HashMap::default(),
+            extra_env,
             Some(10_000),
             std::time::Duration::from_millis(10),
             None,
         );
-        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
-        else {
-            panic!("the reproduction must exercise the auto-detached path");
+        let job_id = match detached {
+            crate::server::background_shell::ForegroundResult::Detached { job_id } => job_id,
+            // Diagnostic on purpose: if this ever fires on CI we need to see
+            // *why* the child never reached the soft cap. A failed spawn or a
+            // missing `sleep` shows up here as an exit code and a shell error
+            // rather than as an unexplained timing story.
+            crate::server::background_shell::ForegroundResult::Finished { output, exit_code } => {
+                panic!(
+                    "the reproduction must exercise the auto-detached path; the child \
+                     finished inside the soft cap instead (exit {exit_code}): {output}"
+                )
+            }
         };
         let _job = BackgroundJobGuard::new(job_id.clone());
+        std::fs::write(&release_path, b"release").expect("release auto-detached child");
 
         let mut terminal = false;
         for _ in 0..240 {
@@ -244,9 +273,18 @@ mod shell_outcome_tests {
             std::time::Duration::from_millis(10),
             None,
         );
-        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
-        else {
-            panic!("the reproduction must exercise the auto-detached path");
+        let job_id = match detached {
+            crate::server::background_shell::ForegroundResult::Detached { job_id } => job_id,
+            // Diagnostic on purpose: if this ever fires on CI we need to see
+            // *why* the child never reached the soft cap. A failed spawn or a
+            // missing `sleep` shows up here as an exit code and a shell error
+            // rather than as an unexplained timing story.
+            crate::server::background_shell::ForegroundResult::Finished { output, exit_code } => {
+                panic!(
+                    "the reproduction must exercise the auto-detached path; the child \
+                     finished inside the soft cap instead (exit {exit_code}): {output}"
+                )
+            }
         };
         let job = BackgroundJobGuard::new(job_id.clone());
         std::fs::write(release_path, b"release").expect("release auto-detached child");
@@ -287,9 +325,18 @@ mod shell_outcome_tests {
             std::time::Duration::from_millis(10),
             None,
         );
-        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
-        else {
-            panic!("the reproduction must exercise the auto-detached path");
+        let job_id = match detached {
+            crate::server::background_shell::ForegroundResult::Detached { job_id } => job_id,
+            // Diagnostic on purpose: if this ever fires on CI we need to see
+            // *why* the child never reached the soft cap. A failed spawn or a
+            // missing `sleep` shows up here as an exit code and a shell error
+            // rather than as an unexplained timing story.
+            crate::server::background_shell::ForegroundResult::Finished { output, exit_code } => {
+                panic!(
+                    "the reproduction must exercise the auto-detached path; the child \
+                     finished inside the soft cap instead (exit {exit_code}): {output}"
+                )
+            }
         };
         let _job = BackgroundJobGuard::new(job_id.clone());
 
@@ -511,9 +558,18 @@ mod shell_outcome_tests {
             std::time::Duration::from_millis(10),
             None,
         );
-        let crate::server::background_shell::ForegroundResult::Detached { job_id } = detached
-        else {
-            panic!("the reproduction must exercise the auto-detached path");
+        let job_id = match detached {
+            crate::server::background_shell::ForegroundResult::Detached { job_id } => job_id,
+            // Diagnostic on purpose: if this ever fires on CI we need to see
+            // *why* the child never reached the soft cap. A failed spawn or a
+            // missing `sleep` shows up here as an exit code and a shell error
+            // rather than as an unexplained timing story.
+            crate::server::background_shell::ForegroundResult::Finished { output, exit_code } => {
+                panic!(
+                    "the reproduction must exercise the auto-detached path; the child \
+                     finished inside the soft cap instead (exit {exit_code}): {output}"
+                )
+            }
         };
         let _job = BackgroundJobGuard::new(job_id.clone());
 


### PR DESCRIPTION
Main went red on `ea0e5284bf` ([run 33248005217](https://github.com/yvgude/lean-ctx/actions/runs/33248005217), `Test (macos-latest)` → `CI Green`) with:

```
panicked at src/server/call_tool/tests.rs:196:13:
the reproduction must exercise the auto-detached path
```

No production code is involved. The failing assertion is a **test-harness race** that predates the merged content — the same commit was 29/29 green on PR #1603.

## What raced

`auto_detached_result` drove `run_foreground_or_detach` with a 10 ms soft cap and a `sleep 0.1` child, then asserted the result was `Detached`. That holds only if the child is spawned, scheduled *and still running* when the cap check fires. On a loaded macOS runner it isn't always: the child completes first, `ForegroundResult::Finished` comes back, and the `let … else` panics — with a message that says the premise broke and nothing about why.

## The fix

Remove the timing assumption rather than widen it. The child now blocks on a barrier file until the test writes it, which only happens *after* the detach has been observed:

```rust
let guarded_command =
    format!("while [ ! -e \"$LCTX_TEST_RELEASE_PATH\" ]; do sleep 0.01; done; {command}");
```

It cannot finish inside the soft cap by construction, so the detach branch is guaranteed regardless of scheduling. `auto_detached_pipeline_result` already worked exactly this way; this brings the plain helper in line with it instead of leaving two different reliability levels in one file.

The four identical `let … else` sites become a `match` whose `Finished` arm prints the exit code and the captured output. If detachment ever fails for a real reason — a failed spawn, a missing `sleep` on some runner image — the failure will say what the child actually did.

## Verification

- `cargo test --lib shell_outcome_tests` → 31 passed, 0 failed
- `cargo test --lib` → 10537 passed, 1 failed: `tools::ctx_explore::tests::handle_output_is_byte_stable_across_runs`, which passes in isolation and is unrelated to this file — a separate pre-existing flake, not something this PR introduces or claims to fix
- `cargo clippy --lib --all-features -- -D warnings` → clean
- `cargo fmt --check` → clean
- `scripts/loc-gate.sh` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
