### PR TITLE
release: 3.10.1 — ship the nine fixes that missed the 3.10.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 All notable changes to lean-ctx are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [3.10.1] — 2026-08-29
 
-Merged after the `v3.10.0` tag (`5b69202`), so **none of this is in the 3.10.0
-artifacts** — a user on 3.10.0 still hits every defect below.
+Patch release: the nine defect fixes below merged after the `v3.10.0` tag
+(`5b69202`) and are therefore **absent from the 3.10.0 artifacts**. 3.10.1
+carries them, plus a CI-only test fix. No new features, no behavior change
+beyond the fixes themselves.
 
 ### Fixed
 
@@ -52,6 +54,18 @@ artifacts** — a user on 3.10.0 still hits every defect below.
   removed in 3.9.20. All surfaces now name the replacements (`lean-ctx
   dashboard`, `lean-ctx cep`, `lean-ctx index watch`).
 - **Dependency** — `chacha20` 0.10.1 → 0.10.2 (0.10.1 was yanked upstream).
+
+### Internal
+
+- **Deterministic auto-detach test (#1611)** — the `auto_detached_result`
+  harness helper raced its own premise (a 10 ms soft cap against a `sleep 0.1`
+  child) and turned `main` red on macOS after a green PR run. The child now
+  blocks on a barrier file until the detach has been observed, so the path
+  under test is exercised by construction. Test-only; no shipped code involved.
+- **Post-release records (#1612)** — the `v3.10.0` artifacts were verified
+  against `SHA256SUMS` and `release-manifest.json`, and a clean-environment
+  install passed `lean-ctx doctor`; the changelog now states which fixes a
+  given tag does and does not carry.
 
 ## [3.10.0] — 2026-08-29
 

--- a/packages/lean-ctx-bin/package.json
+++ b/packages/lean-ctx-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lean-ctx-bin",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "LeanCTX \u2014 a local Context SDK for AI agents. Select, shape, reuse, recover, and measure context before inference. No Rust required.",
   "keywords": [
     "lean-ctx",

--- a/packages/pi-lean-ctx/package-lock.json
+++ b/packages/pi-lean-ctx/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-lean-ctx",
-  "version": "3.9.20",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-lean-ctx",
-      "version": "3.9.20",
+      "version": "3.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.3",

--- a/packages/pi-lean-ctx/package.json
+++ b/packages/pi-lean-ctx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-lean-ctx",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Pi Coding Agent extension — routes bash/read/grep/find/ls through lean-ctx for strong token savings. The embedded MCP bridge (on by default) adds a persistent session cache so unchanged re-reads cost ~13 tokens.",
   "keywords": [
     "pi-package",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2041,7 +2041,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lean-ctx"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["."]
 
 [package]
 name = "lean-ctx"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 autobins = false
 description = "Local context engine, CLI, MCP server, and proxy for AI agents."

--- a/tests/delivery/test_check_release_tag.py
+++ b/tests/delivery/test_check_release_tag.py
@@ -37,7 +37,7 @@ class ReleaseTagGateTests(unittest.TestCase):
                 GATE.verify_tag(tag, root)
 
     def test_current_repository_tag_matches_all_release_versions(self):
-        self.assertEqual(GATE.verify_tag("v3.10.0", ROOT), "3.10.0")
+        self.assertEqual(GATE.verify_tag("v3.10.1", ROOT), "3.10.1")
 
     def test_accepts_strict_prerelease_when_every_manifest_matches(self):
         temporary, root = self.fixture_root("3.9.11-rc.1")


### PR DESCRIPTION
Patch release. The nine defect fixes from #1603 merged **after** `v3.10.0` was tagged at `5b69202`, so the published 3.10.0 artifacts contain none of them. Anyone installing 3.10.0 today still hits #1582, #1585, #1586, #1596, #1598, #1599, #1602, #1604 and #1605. This release closes that window and adds nothing else.

## Version bump

| File | Before | After |
|---|---|---|
| `rust/Cargo.toml` + `Cargo.lock` | 3.10.0 | 3.10.1 |
| `packages/lean-ctx-bin/package.json` | 3.10.0 | 3.10.1 |
| `packages/pi-lean-ctx/package.json` | 3.10.0 | 3.10.1 |
| `packages/pi-lean-ctx/package-lock.json` | **3.9.20** | 3.10.1 |
| `tests/delivery/test_check_release_tag.py` | v3.10.0 | v3.10.1 |

The pi lock file was still on 3.9.20 — it went through the entire 3.10.0 release without failing anything, because `check-package-versions.py` reads only the two `package.json` files. Corrected here rather than left to drift.

## Pre-release gate — `docs/ga/release-checklist.md` §1

Run from this branch:

| Gate | Result |
|---|---|
| `cargo test --lib` | 10538 passed, 0 failed, 22 ignored |
| `cargo clippy --all-features -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `cargo build --release` | ok — binary reports `lean-ctx 3.10.1 (official)` |
| `leanctx-verify` tests + clippy | clean |
| `packages/python-lean-ctx` pytest | 118 passed, 3 skipped (**Preview**, unchanged) |
| `check-package-versions.py` | engine 3.10.1, both coupled packages match |
| `check-release-tag.py v3.10.1` | accepted |
| `tests/delivery/test_check_release_tag.py` | 9 tests ok |
| `check-sdk-versions.py` | `lean-ctx-python` 1.0.0 |
| `check-narrative-governance.py` | passed |
| `scripts/loc-gate.sh` | ok |
| `lean-ctx doctor`, clean HOME, release binary | 33/38 — the 5 misses are the expected "not set up yet" checks |

## v3.10.0 post-release verification, for the record

Done retroactively while preparing this (`docs/ga/release-checklist.md` §3):

- `verify-release-integrity.py verify --tag v3.10.0` → `"verified": true`, `"errors": []` across all 14 checks (manifest-tag, sbom-sha256, sbom-format, checksums-sha256, and each of the 10 artifacts)
- `release-manifest.json` ↔ `SHA256SUMS` → all 10 hashes identical, `checksums_sha256` matches
- clean-environment install of the published `aarch64-apple-darwin` artifact → `lean-ctx doctor` 33/38

No feature work, no claim promotion, no capability status change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
