### PR TITLE
fix(mcp,doctor): serve MCP under a pty; explicit Codex `args = ["mcp"]`

### DIFF
--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -1,16 +1,19 @@
 // Auto-split from the former monolithic dispatch.rs. run() (the command
 // match) stays in mod.rs; standalone helpers grouped by concern.
 
-/// Short, friendly orientation shown when a human runs bare `lean-ctx` in a
-/// terminal (where the silent stdio MCP server would otherwise just hang). One
-/// obvious next step (`onboard`), not the full 150-line command reference.
+/// Short, friendly orientation shown when a human runs bare `lean-ctx` on a
+/// terminal. It goes to stderr and the stdio server starts anyway (#1595): a
+/// TTY on stdin means a human *may* be watching, never that an MCP client is
+/// absent — some clients spawn the server under a PTY. One obvious next step
+/// (`onboard`), not the full 150-line command reference.
 pub(super) fn quickstart_text() -> String {
     format!(
         "lean-ctx {version} — Context SDK for AI Agents
 
 With no arguments, lean-ctx speaks the MCP protocol on stdin/stdout — that is
-for your AI editor, not for interactive use, so it is waiting silently. You
-probably want one of these:
+for your AI editor, not for interactive use. It is doing that right now and
+will sit there waiting for JSON-RPC; press Ctrl-C to stop it. You probably
+want one of these:
 
   lean-ctx wrap cursor   One-command setup for Cursor (recommended)
   lean-ctx wrap claude   One-command setup for Claude Code
@@ -21,10 +24,6 @@ Docs: https://leanctx.com
 ",
         version = env!("CARGO_PKG_VERSION"),
     )
-}
-
-pub(super) fn print_quickstart() {
-    print!("{}", quickstart_text());
 }
 
 /// One-line capability summary under the `--help` title. The MCP-tool count is

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -821,14 +821,20 @@ pub fn run() {
         }
     }
 
-    // Bare `lean-ctx` in an interactive terminal: a human almost certainly did
-    // not mean to start a silent stdio MCP server (which just hangs waiting for
-    // JSON-RPC). Show a short quickstart instead. MCP clients pipe stdin (not a
-    // TTY) so they still get the server, and explicit `lean-ctx mcp` always
-    // serves regardless of TTY.
+    // Bare `lean-ctx` on an interactive terminal: a human almost certainly did
+    // not mean to start a silent stdio MCP server, so print the quickstart.
+    //
+    // #1595: the TTY test alone is not a safe *stop* condition. An MCP client
+    // that spawns the server under a PTY (Devin, several containerized agent
+    // runners, anything driving the child through `script`/`expect`) hands it a
+    // terminal on stdin and is then answered with the quickstart instead of a
+    // server — the connection simply never comes up, with no error to see.
+    // A TTY tells us a human *might* be watching; it never tells us a client is
+    // not. So the guidance goes to stderr, which MCP clients log rather than
+    // parse, and the server starts either way: the human reads what is going on
+    // and presses Ctrl-C, the client completes its handshake on stdout.
     if args.len() == 1 && std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        print_quickstart();
-        return;
+        eprint!("{}", quickstart_text());
     }
 
     if let Err(e) = run_mcp_server() {

--- a/rust/src/core/editor_registry/writers/install/codex.rs
+++ b/rust/src/core/editor_registry/writers/install/codex.rs
@@ -24,7 +24,7 @@ pub(crate) fn write_codex_config(
     }
 
     let content = format!(
-        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = []\n",
+        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = [\"mcp\"]\n",
         toml_quote(binary)
     );
     crate::config_io::write_atomic_with_backup(&target.config_path, &content)?;
@@ -49,7 +49,7 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
     let mut in_env_subtable = false;
 
     let parent_block = format!(
-        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = []\n\n",
+        "[mcp_servers.lean-ctx]\ncommand = {}\nargs = [\"mcp\"]\n\n",
         toml_quote(binary)
     );
 
@@ -64,7 +64,7 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
                 wrote_command = true;
             }
             if in_section && !wrote_args {
-                out.push_str("args = []\n");
+                out.push_str("args = [\"mcp\"]\n");
                 wrote_args = true;
             }
             in_env_subtable = trimmed == "[mcp_servers.lean-ctx.env]"
@@ -99,7 +99,12 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
                 continue;
             }
             if trimmed.starts_with("args") && trimmed.contains('=') {
-                out.push_str("args = []\n");
+                if trimmed.contains("\"mcp\"") || trimmed.contains("'mcp'") {
+                    out.push_str(line);
+                    out.push('\n');
+                } else {
+                    out.push_str("args = [\"mcp\"]\n");
+                }
                 wrote_args = true;
                 continue;
             }
@@ -114,7 +119,7 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
             out.push_str(&format!("command = {}\n", toml_quote(binary)));
         }
         if in_section && !wrote_args {
-            out.push_str("args = []\n");
+            out.push_str("args = [\"mcp\"]\n");
         }
         return out;
     }
@@ -128,6 +133,6 @@ pub(crate) fn upsert_codex_toml(existing: &str, binary: &str) -> String {
     }
     out.push_str("\n[mcp_servers.lean-ctx]\n");
     out.push_str(&format!("command = {}\n", toml_quote(binary)));
-    out.push_str("args = []\n");
+    out.push_str("args = [\"mcp\"]\n");
     out
 }

--- a/rust/src/core/editor_registry/writers/tests.rs
+++ b/rust/src/core/editor_registry/writers/tests.rs
@@ -178,7 +178,7 @@ fn upsert_codex_toml_inserts_new_section_when_missing() {
     let updated = upsert_codex_toml("[other]\nx=1\n", "lean-ctx");
     assert!(updated.contains("[mcp_servers.lean-ctx]"));
     assert!(updated.contains("command = \"lean-ctx\""));
-    assert!(updated.contains("args = []"));
+    assert!(updated.contains("args = [\"mcp\"]"));
 }
 
 #[test]
@@ -222,7 +222,7 @@ approval_mode = \"approve\"
         "parent must come before tool sub-tables:\n{updated}"
     );
     assert!(updated.contains("command = \"lean-ctx\""));
-    assert!(updated.contains("args = []"));
+    assert!(updated.contains("args = [\"mcp\"]"));
     assert!(updated.contains("approval_mode = \"approve\""));
 }
 
@@ -274,8 +274,21 @@ approval_mode = \"approve\"
         "must not duplicate parent section"
     );
     assert!(updated.contains("command = \"new\""));
-    assert!(updated.contains("args = []"));
+    assert!(updated.contains("args = [\"mcp\"]"));
     assert!(updated.contains("approval_mode = \"approve\""));
+}
+
+#[test]
+fn upsert_codex_toml_upgrades_legacy_empty_args_to_mcp() {
+    let input = "\
+[mcp_servers.lean-ctx]
+command = \"/opt/homebrew/bin/lean-ctx\"
+args = []
+startup_timeout_sec = 30
+";
+    let updated = upsert_codex_toml(input, "/opt/homebrew/bin/lean-ctx");
+    assert!(updated.contains("args = [\"mcp\"]"));
+    assert!(updated.contains("startup_timeout_sec = 30"));
 }
 
 #[test]

--- a/rust/src/core/editor_registry/writers/tests.rs
+++ b/rust/src/core/editor_registry/writers/tests.rs
@@ -170,7 +170,11 @@ args = ["x"]
 
     let content = std::fs::read_to_string(&path).unwrap();
     assert!(content.contains(r#"command = "new""#));
-    assert!(content.contains("args = []"));
+    // The pre-existing `args = ["x"]` names no entry point that starts the
+    // stdio server, so the writer replaces it with the explicit one. An `args`
+    // list that already contains `mcp` is preserved verbatim
+    // (`upsert_codex_toml_preserves_custom_args_containing_mcp`).
+    assert!(content.contains(r#"args = ["mcp"]"#));
 }
 
 #[test]
@@ -289,6 +293,22 @@ startup_timeout_sec = 30
     let updated = upsert_codex_toml(input, "/opt/homebrew/bin/lean-ctx");
     assert!(updated.contains("args = [\"mcp\"]"));
     assert!(updated.contains("startup_timeout_sec = 30"));
+}
+
+#[test]
+fn upsert_codex_toml_preserves_custom_args_containing_mcp() {
+    // A user who added their own flag alongside `mcp` has a working entry
+    // point; rewriting it to a bare `["mcp"]` would silently drop their flag.
+    let input = "\
+[mcp_servers.lean-ctx]
+command = \"/opt/homebrew/bin/lean-ctx\"
+args = [\"mcp\", \"--verbose\"]
+";
+    let updated = upsert_codex_toml(input, "/opt/homebrew/bin/lean-ctx");
+    assert!(
+        updated.contains("args = [\"mcp\", \"--verbose\"]"),
+        "custom args carrying `mcp` must survive verbatim: {updated}"
+    );
 }
 
 #[test]

--- a/rust/src/doctor/integrations/codex.rs
+++ b/rust/src/doctor/integrations/codex.rs
@@ -26,7 +26,14 @@ pub(crate) fn check_codex_toml(path: &std::path::Path, binary: &str) -> NamedChe
         .and_then(|t| t.get("lean-ctx"))
         .and_then(|t| t.get("command"))
         .and_then(|c| c.as_str());
-    let ok = cmd.is_some_and(|c| cmd_matches_expected(c, binary));
+    let cmd_ok = cmd.is_some_and(|c| cmd_matches_expected(c, binary));
+    let args_ok = v
+        .get("mcp_servers")
+        .and_then(|t| t.get("lean-ctx"))
+        .and_then(|t| t.get("args"))
+        .and_then(|a| a.as_array())
+        .is_some_and(|arr| arr.iter().any(|arg| arg.as_str() == Some("mcp")));
+    let ok = cmd_ok && args_ok;
     NamedCheck {
         name: "Codex MCP".to_string(),
         ok,

--- a/rust/src/doctor/integrations/codex.rs
+++ b/rust/src/doctor/integrations/codex.rs
@@ -27,12 +27,24 @@ pub(crate) fn check_codex_toml(path: &std::path::Path, binary: &str) -> NamedChe
         .and_then(|t| t.get("command"))
         .and_then(|c| c.as_str());
     let cmd_ok = cmd.is_some_and(|c| cmd_matches_expected(c, binary));
-    let args_ok = v
+    // `args` is optional by design. A bare `lean-ctx` invocation starts the
+    // stdio server just as `lean-ctx mcp` does (`cli/dispatch/server.rs`
+    // matches `None | Some("mcp")`), so a missing key and `args = []` are both
+    // working configurations — reporting them as drift would push a `--fix`
+    // that rewrites a functional file into a semantically identical one, the
+    // same failure mode as #1596. New installs are written with the explicit
+    // `["mcp"]`; only an `args` value that replaces the entry point with
+    // something else is real drift.
+    let args_ok = match v
         .get("mcp_servers")
         .and_then(|t| t.get("lean-ctx"))
         .and_then(|t| t.get("args"))
-        .and_then(|a| a.as_array())
-        .is_some_and(|arr| arr.iter().any(|arg| arg.as_str() == Some("mcp")));
+    {
+        None => true,
+        Some(args) => args
+            .as_array()
+            .is_some_and(|arr| arr.is_empty() || arr.iter().any(|arg| arg.as_str() == Some("mcp"))),
+    };
     let ok = cmd_ok && args_ok;
     NamedCheck {
         name: "Codex MCP".to_string(),

--- a/rust/src/doctor/integrations/tests.rs
+++ b/rust/src/doctor/integrations/tests.rs
@@ -349,3 +349,50 @@ fn check_cursor_hooks_ok_for_bare_command() {
         "bare lean-ctx command is PATH-resolved and current"
     );
 }
+
+#[test]
+fn check_codex_toml_detects_missing_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(!check.ok);
+    assert!(check.detail.contains("missing"));
+}
+
+#[test]
+fn check_codex_toml_detects_legacy_empty_args_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n",
+    )
+    .unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(!check.ok);
+    assert!(check.detail.contains("drift"));
+}
+
+#[test]
+fn check_codex_toml_detects_missing_args_drift() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\n").unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(!check.ok);
+    assert!(check.detail.contains("drift"));
+}
+
+#[test]
+fn check_codex_toml_ok_with_mcp_arg() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"mcp\"]\n",
+    )
+    .unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(check.ok);
+    assert!(check.detail.contains("ok"));
+}

--- a/rust/src/doctor/integrations/tests.rs
+++ b/rust/src/doctor/integrations/tests.rs
@@ -360,7 +360,11 @@ fn check_codex_toml_detects_missing_file() {
 }
 
 #[test]
-fn check_codex_toml_detects_legacy_empty_args_drift() {
+fn check_codex_toml_accepts_legacy_empty_args() {
+    // The pre-3.9.20 writers emitted `args = []`, and that config still works:
+    // a bare `lean-ctx` starts the stdio server. Calling it drift would give
+    // every existing Codex user a red check and a `--fix` that rewrites a
+    // working file — the #1596 failure mode.
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
     std::fs::write(
@@ -369,15 +373,30 @@ fn check_codex_toml_detects_legacy_empty_args_drift() {
     )
     .unwrap();
     let check = check_codex_toml(&path, "lean-ctx");
-    assert!(!check.ok);
-    assert!(check.detail.contains("drift"));
+    assert!(check.ok);
+    assert!(check.detail.contains("ok"));
 }
 
 #[test]
-fn check_codex_toml_detects_missing_args_drift() {
+fn check_codex_toml_accepts_absent_args() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
     std::fs::write(&path, "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\n").unwrap();
+    let check = check_codex_toml(&path, "lean-ctx");
+    assert!(check.ok);
+    assert!(check.detail.contains("ok"));
+}
+
+#[test]
+fn check_codex_toml_flags_args_that_replace_the_entry_point() {
+    // Neither bare nor `mcp`: this one really would not start the server.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"dashboard\"]\n",
+    )
+    .unwrap();
     let check = check_codex_toml(&path, "lean-ctx");
     assert!(!check.ok);
     assert!(check.detail.contains("drift"));

--- a/rust/src/hooks/agents/codex.rs
+++ b/rust/src/hooks/agents/codex.rs
@@ -411,7 +411,13 @@ fn ensure_codex_mcp_server(
         lean_tbl["command"] = toml_edit::value(binary);
     }
     if !lean_tbl.contains_key("args") {
-        lean_tbl["args"] = toml_edit::value(toml_edit::Array::new());
+        let mut arr = toml_edit::Array::new();
+        arr.push("mcp");
+        lean_tbl["args"] = toml_edit::value(arr);
+    } else if let Some(arr) = lean_tbl.get_mut("args").and_then(|a| a.as_array_mut()) {
+        if arr.is_empty() {
+            arr.push("mcp");
+        }
     }
 
     // Ensure adequate timeouts: lean-ctx tools like ctx_compose can take
@@ -819,7 +825,7 @@ command = \"lean-ctx\"
             .expect("should add MCP section");
         assert!(result.contains("[mcp_servers.lean-ctx]"));
         assert!(result.contains("command = \"lean-ctx\""));
-        assert!(result.contains("args = []"));
+        assert!(result.contains("args = [\"mcp\"]"));
         assert!(result.contains("[features]\ncodex_hooks = true\n"));
     }
 
@@ -827,7 +833,7 @@ command = \"lean-ctx\"
     fn ensure_mcp_server_noop_when_already_complete() {
         // Parent + args + timeouts + an env block already carrying every desired
         // key: the upsert must be a true no-op (no churn on every session start).
-        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n\
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"mcp\"]\n\
                      startup_timeout_sec = 30\ntool_timeout_sec = 120\n\n\
                      [mcp_servers.lean-ctx.env]\nLEAN_CTX_DATA_DIR = \"/Users/user/.lean-ctx\"\n";
         assert!(
@@ -837,8 +843,18 @@ command = \"lean-ctx\"
     }
 
     #[test]
+    fn ensure_mcp_server_upgrades_empty_args_to_mcp() {
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n\
+                     startup_timeout_sec = 30\ntool_timeout_sec = 120\n\n\
+                     [mcp_servers.lean-ctx.env]\nLEAN_CTX_DATA_DIR = \"/Users/user/.lean-ctx\"\n";
+        let result = ensure_codex_mcp_server(input, "lean-ctx", &data_dir_pairs())
+            .expect("should upgrade empty args to ['mcp']");
+        assert!(result.contains("args = [\"mcp\"]"));
+    }
+
+    #[test]
     fn ensure_mcp_server_adds_timeouts() {
-        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = []\n";
+        let input = "[mcp_servers.lean-ctx]\ncommand = \"lean-ctx\"\nargs = [\"mcp\"]\n";
         let result = ensure_codex_mcp_server(input, "lean-ctx", &data_dir_pairs())
             .expect("should add timeouts");
         assert!(

--- a/rust/tests/suite/mcp_pty_startup_1595.rs
+++ b/rust/tests/suite/mcp_pty_startup_1595.rs
@@ -1,0 +1,149 @@
+//! Bare `lean-ctx` must serve MCP even when stdin is a terminal (GH #1595).
+//!
+//! `run()` prints the quickstart when stdin is a TTY, on the assumption that a
+//! terminal means a human. That assumption is one-directional: several MCP
+//! clients (Devin, containerized agent runners, anything driving the child
+//! through `script`/`expect`) spawn the server under a PTY, and those clients
+//! were answered with the quickstart instead of a server — the connection
+//! never came up and nothing in the client's log said why. The reporter's
+//! workaround was to add `args = ["mcp"]`, which bypasses the TTY branch.
+//!
+//! The guarantee this pins: with a PTY on stdin/stdout and no subcommand, an
+//! `initialize` handshake is answered. The quickstart may still be printed —
+//! on stderr, where a client logs rather than parses it.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const HANDSHAKE_DEADLINE: Duration = Duration::from_secs(30);
+
+/// A pty pair with echo disabled — otherwise the master reads back every byte
+/// the test writes and the response is buried in its own request.
+fn openpty_pair() -> (OwnedFd, OwnedFd) {
+    let mut master: libc::c_int = -1;
+    let mut slave: libc::c_int = -1;
+    let mut termios: libc::termios = unsafe { std::mem::zeroed() };
+    // Sane defaults for a line-oriented pty, minus ECHO.
+    termios.c_iflag = libc::ICRNL;
+    termios.c_oflag = libc::OPOST | libc::ONLCR;
+    termios.c_cflag = libc::CREAD | libc::CS8;
+    termios.c_lflag = libc::ICANON;
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            &raw mut termios,
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+    unsafe { (OwnedFd::from_raw_fd(master), OwnedFd::from_raw_fd(slave)) }
+}
+
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "pty allocation and HOME-override isolation are Unix-only"
+)]
+fn bare_invocation_serves_mcp_over_a_pty() {
+    let bin = env!("CARGO_BIN_EXE_lean-ctx");
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().join("home");
+    let data = tmp.path().join("data");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&data).unwrap();
+    std::fs::create_dir_all(project.join(".git")).unwrap();
+
+    let (master, slave) = openpty_pair();
+    let child_stdin = slave.try_clone().expect("dup pty slave for stdin");
+    let child_stdout = slave.try_clone().expect("dup pty slave for stdout");
+
+    // No subcommand on purpose: this is the shape #1595 reports.
+    let mut child = Command::new(bin)
+        .current_dir(&project)
+        .env("HOME", &home)
+        .env("LEAN_CTX_DATA_DIR", &data)
+        .env("CODEX_HOME", home.join(".codex"))
+        .env("LEAN_CTX_HEADLESS", "1")
+        .env_remove("LEAN_CTX_PROJECT_ROOT")
+        .env_remove("CLAUDE_PROJECT_DIR")
+        .env_remove("WORKSPACE_FOLDER_PATHS")
+        .stdin(Stdio::from(child_stdin))
+        .stdout(Stdio::from(child_stdout))
+        // The quickstart lands here. A client logs stderr; it must never reach
+        // the JSON-RPC channel.
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn bare lean-ctx on a pty");
+    // The parent must not keep the slave open, or reads on the master block
+    // forever after the child exits instead of reporting EOF.
+    drop(slave);
+
+    let reader_fd = master.try_clone().expect("dup pty master for reading");
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader = std::thread::spawn(move || {
+        let file = unsafe { std::fs::File::from_raw_fd(reader_fd.as_raw_fd()) };
+        std::mem::forget(reader_fd);
+        for line in BufReader::new(file).lines() {
+            match line {
+                Ok(l) => {
+                    if tx.send(l).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut writer = std::fs::File::from(master.try_clone().expect("dup pty master for writing"));
+    let init = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "pty-client", "version": "1" }
+        }
+    });
+    writeln!(writer, "{init}").expect("write initialize into the pty");
+    writer.flush().ok();
+
+    let until = Instant::now() + HANDSHAKE_DEADLINE;
+    let mut response: Option<serde_json::Value> = None;
+    while let Some(remaining) = until.checked_duration_since(Instant::now()) {
+        let Ok(line) = rx.recv_timeout(remaining) else {
+            break;
+        };
+        // Skip the quickstart if it ever reappears on stdout, and any log line:
+        // only a JSON-RPC result answers the handshake.
+        if !line.contains("\"result\"") {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+            if value["id"] == serde_json::json!(1) {
+                response = Some(value);
+                break;
+            }
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    drop(writer);
+    drop(master);
+    let _ = reader.join();
+
+    let response = response.expect(
+        "bare `lean-ctx` under a pty answered no initialize response — the TTY branch swallowed \
+         the server again (#1595); an MCP client that allocates a pty cannot connect",
+    );
+    assert!(
+        response["result"]["serverInfo"]["name"].is_string(),
+        "initialize must return serverInfo; got: {response}"
+    );
+}

--- a/rust/tests/suite/mod.rs
+++ b/rust/tests/suite/mod.rs
@@ -54,6 +54,8 @@ mod mcp_fast_initialize_669;
 mod mcp_manifest_up_to_date;
 mod mcp_optout_281;
 mod mcp_preinit_method_not_found_1454;
+#[cfg(unix)]
+mod mcp_pty_startup_1595;
 mod metrics_contract;
 mod ocla_wire_contract_suite;
 mod onboard_doctor_clean;


### PR DESCRIPTION
Supersedes #1597 by @reysilvaa, whose commit is preserved here with their authorship — I could not push to their fork (403), so the branch lives in this repo instead. Also fixes the root cause their report uncovered.

## What @reysilvaa got right

`args = ["mcp"]` really is the correct default, and their writer changes land unchanged: `write_codex_config`, `upsert_codex_toml` and `ensure_codex_mcp_server` now emit it, matching what the Copilot writer already did.

## What I changed in their patch

**1. The red test.** `codex_toml_upserts_existing_section` still asserted `args = []` and was taking down Test (ubuntu-latest), Test (windows-latest) and Coverage. Fixed, plus a companion test for the behaviour the writer deliberately preserves: `args = ["mcp", "--verbose"]` survives verbatim instead of being flattened.

**2. `args = []` is not drift.** Their `check_codex_toml` required the `mcp` argument, which would have turned every existing Codex installation red. Both `args = []` and an absent `args` start the stdio server (`cli/dispatch/server.rs` matches `None | Some("mcp")`), so the doctor would have reported a working config as broken and `--fix` would have rewritten it into a semantically identical file — the #1596 failure mode, hitting far more users than the change helps. The check now accepts absent / empty / `mcp`-carrying args and flags only an args array that replaces the entry point (`["dashboard"]`).

## The root cause — and my earlier review was wrong about it

I told @reysilvaa and the reporter of #1595 that bare invocation still serves MCP, and showed a probe to prove it. **That probe was wrong**: I piped stdin. The reporter's environment gives the process a *PTY*, and `cli/dispatch/mod.rs` treats a TTY on stdin as "a human is here", prints the quickstart and exits.

Reproduced against the shipped 3.10.1 binary:

```
stdin = pipe          →  "lean-ctx v3.10.1 MCP server starting"   ✓
stdin = pty (bare)    →  quickstart text, process exits           ✗
stdin = pty + "mcp"   →  server starts                            ✓
```

So the report was accurate and `args = ["mcp"]` was a real workaround, not a cosmetic one. Devin, containerized agent runners, and anything driving the child through `script`/`expect` allocate a PTY; every one of them silently failed to connect, with nothing in the logs to explain it.

**The fix**: a TTY tells us a human *may* be watching — it never tells us a client is absent. The quickstart now goes to **stderr** (which MCP clients log rather than parse) and the server starts either way. The human reads what is happening and presses Ctrl-C; the client completes its handshake on stdout. The quickstart text says so instead of claiming the process "is waiting silently".

`rust/tests/suite/mcp_pty_startup_1595.rs` allocates a real pty with `openpty` (echo off), spawns the binary with **no subcommand**, and requires an `initialize` response. It fails against the previous behaviour.

## Verification

- `cargo test --lib` → 10546 passed, 0 failed
- `cargo clippy --lib --all-features -- -D warnings` → clean
- `cargo fmt --check` → clean
- new pty integration test passes; removing the fix makes it fail

Fixes #1595
Closes #1597

Co-authored-by: reysilvaa <reynaldsilva123@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
