### PR TITLE
fix(agents): name the path and operation when registry directory creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ beyond the fixes themselves.
 
 ### Fixed
 
+- **Agent-bus registration errors named no path (#1619, thanks @GrimmiMeloni)** —
+  a sandbox or filesystem policy denies exactly one directory, and the failure
+  arrived as `agent bus registration is required before tool execution: File
+  exists (os error 17)`: no path, no operation, nothing to allow-list. The
+  reporter had to guess `~/.local/share/lean-ctx/agents`. Directory creation
+  for the agent registry and the agent diary now names both the operation and
+  the resolved path (`create agent registry directory /…/agents: …`), as the
+  neighbouring registry-read, lock and persist errors already did.
 - **A bare `lean-ctx` refused to serve MCP under a pty (#1595)** — the startup
   path treated a terminal on stdin as proof that a human was there, printed the
   quickstart and exited. MCP clients that spawn the server under a pty (Devin,

--- a/rust/src/core/agents/diary.rs
+++ b/rust/src/core/agents/diary.rs
@@ -117,10 +117,14 @@ impl AgentDiary {
 
     pub(crate) fn save(&self) -> Result<(), String> {
         let dir = diary_dir()?;
-        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        // Same reasoning as #1619: name the path and the operation, or a
+        // sandbox denial reads as an unattributable "Operation not permitted".
+        std::fs::create_dir_all(&dir)
+            .map_err(|error| format!("create agent diary directory {}: {error}", dir.display()))?;
         let path = dir.join(format!("{}.json", sanitize_filename(&self.agent_id)));
         let json = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-        std::fs::write(&path, json).map_err(|e| e.to_string())
+        std::fs::write(&path, json)
+            .map_err(|error| format!("write agent diary {}: {error}", path.display()))
     }
 
     pub(crate) fn load(agent_id: &str) -> Option<Self> {

--- a/rust/src/core/agents/persistence.rs
+++ b/rust/src/core/agents/persistence.rs
@@ -66,11 +66,20 @@ fn identity_index_path() -> Result<PathBuf, String> {
     Ok(agents_dir()?.join("process-identities.json"))
 }
 
+/// Create the agent-registry directory, naming the path and the operation on
+/// failure (#1619). A bare `File exists (os error 17)` or `Operation not
+/// permitted` tells a user nothing they can act on; sandboxes and filesystem
+/// policies deny exactly one path, and that path is the whole diagnosis.
+pub(super) fn create_agents_dir(dir: &std::path::Path) -> Result<(), String> {
+    std::fs::create_dir_all(dir)
+        .map_err(|error| format!("create agent registry directory {}: {error}", dir.display()))
+}
+
 pub(super) fn mutate_persistent<T>(
     mutate: impl FnOnce(&mut AgentRegistry) -> T,
 ) -> Result<T, String> {
     let dir = agents_dir()?;
-    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    create_agents_dir(&dir)?;
     let _lock = FileLock::acquire(&dir.join("registry.lock"))?;
     let path = dir.join("registry.json");
     let mut registry = load_registry_file(&path)?.unwrap_or_default();

--- a/rust/src/core/agents/registry.rs
+++ b/rust/src/core/agents/registry.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 #[cfg(test)]
 use super::diary::{AgentDiary, DiaryEntryType, truncate};
 use super::persistence::{
-    FileLock, ProcessIdentityIndex, agents_dir, generate_short_id, load_registry_file,
-    mutate_persistent, save_registry_file,
+    FileLock, ProcessIdentityIndex, agents_dir, create_agents_dir, generate_short_id,
+    load_registry_file, mutate_persistent, save_registry_file,
 };
 use super::{AgentEntry, AgentRegistry, AgentStatus, LogicalSessionPresence, ScratchpadEntry};
 use crate::core::a2a::message::{MessagePriority, PrivacyLevel};
@@ -616,7 +616,7 @@ impl AgentRegistry {
 
     pub(crate) fn save(&self) -> Result<(), String> {
         let dir = agents_dir()?;
-        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        create_agents_dir(&dir)?;
 
         let lock_path = dir.join("registry.lock");
         let _lock = FileLock::acquire(&lock_path)?;
@@ -650,7 +650,7 @@ impl AgentRegistry {
     /// latest on-disk state.
     pub(crate) fn mutate_locked<T>(f: impl FnOnce(&mut Self) -> T) -> Result<(Self, T), String> {
         let dir = agents_dir()?;
-        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        create_agents_dir(&dir)?;
 
         let lock_path = dir.join("registry.lock");
         let _lock = FileLock::acquire(&lock_path)?;
@@ -1256,6 +1256,33 @@ mod presence_tests {
 
         assert!(error.contains("agent registry is corrupt"));
         assert_eq!(std::fs::read_to_string(registry_path).unwrap(), corrupt);
+    }
+
+    /// #1619: a sandbox or filesystem policy denies exactly one path, and the
+    /// error was reported as a bare `File exists (os error 17)` — no path, no
+    /// operation, nothing to allow-list. The reporter had to guess
+    /// `~/.local/share/lean-ctx/agents` to unblock themselves.
+    #[test]
+    fn agents_dir_creation_failure_names_the_path_and_operation() {
+        let isolated = crate::core::data_dir::isolated_data_dir();
+        // A plain file where the directory belongs reproduces the reported
+        // EEXIST without needing a sandbox.
+        let blocker = isolated.path().join("agents");
+        std::fs::write(&blocker, b"not a directory").expect("blocking file");
+
+        let error = AgentRegistry::mutate_locked(|registry| {
+            let _ = registry.register_process("mcp", Some("context-engine"), "/project", 101);
+        })
+        .expect_err("a file in place of the agents directory must fail");
+
+        assert!(
+            error.contains("create agent registry directory"),
+            "the failing operation must be named; got: {error}"
+        );
+        assert!(
+            error.contains(&blocker.display().to_string()),
+            "the conflicting path must be in the message so it can be allow-listed; got: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Reported by @GrimmiMeloni in #1619. A sandboxed MCP process was told:

```
agent bus registration is required before tool execution: File exists (os error 17)
```

Everything actionable is missing. No path — so there is nothing to add to a sandbox allow-list. No operation — so it is not even clear which file the process was reaching for. The reporter unblocked themselves by *guessing* `~/.local/share/lean-ctx/agents`.

## Before / after

```
before:  agent bus registration is required before tool execution:
         File exists (os error 17)

after:   agent bus registration is required before tool execution:
         create agent registry directory /Users/…/.local/share/lean-ctx/agents:
         File exists (os error 17)
```

## Why it read that way

The four `create_dir_all` call sites on this path each carried a bare `.map_err(|e| e.to_string())`, which throws away the one piece of context the caller cannot reconstruct. They now go through `create_agents_dir`; the diary writer gets the same treatment for its directory and its file write.

Worth noting: the *neighbouring* errors in that module have named their path all along — the registry read (`agent registry is corrupt at …`), the lock (`agent registry lock …`), the persist step (`persist agent registry …`). Only directory creation did not, which is exactly why the first failure a sandboxed user hits was the least informative one.

## Test

`agents_dir_creation_failure_names_the_path_and_operation` reproduces the reported EEXIST by putting a plain file where the directory belongs — no sandbox needed — and asserts on both halves of the message, so a future refactor cannot quietly drop the path again.

## Verification

- `cargo test --lib` → 10547 passed, 0 failed
- `cargo clippy --lib --all-features -- -D warnings` → clean
- `cargo fmt --check`, `scripts/loc-gate.sh`, `check-narrative-governance.py` → clean

Included in the 3.10.1 changelog section, since the tag has not been cut yet.

Fixes #1619

🤖 Generated with [Claude Code](https://claude.com/claude-code)