### PR TITLE
fix(ctx_search): make the tool read-only so restricted modes can call it

### DIFF
--- a/docs/guides/cursor.md
+++ b/docs/guides/cursor.md
@@ -237,9 +237,11 @@ Task(subagent_type="explore", ...)  # explore is always readonly
 Task(subagent_type="generalPurpose", readonly=false, prompt="Use ctx_compose to...")
 ```
 
-lean-ctx tools declare `readOnlyHint: true` in MCP annotations. When Cursor
-starts respecting this hint (per MCP spec), readonly subagents will gain access
-to read-only lean-ctx tools (ctx_read, ctx_compose, ctx_search, etc.).
+lean-ctx's read-only tools declare `readOnlyHint: true` in MCP annotations —
+`ctx_read`, `ctx_search`, `ctx_glob`, `ctx_tree` and the rest of the inspection
+surface. When Cursor starts respecting this hint (per MCP spec), readonly
+subagents will gain access to them. `ctx_compose` is deliberately *not* in that
+set: it records co-access for the session, so it mutates state and says so.
 
 Within subagents that have MCP access:
 

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -595,7 +595,7 @@ Parameters: `action`*, `agent`
 
 ## `ctx_search`
 
-Search code: regex(pattern, default) | semantic(query) | symbol(name|handle) | reindex | find_related(file_path,line). anchored=true enables ctx_patch refs; queries batches regex searches. Run ctx_compose FIRST.
+Search code: regex(pattern, default) | semantic(query) | symbol(name|handle) | find_related(file_path,line). Read-only. anchored=true enables ctx_patch refs; queries batches regex searches. Run ctx_compose FIRST.
 
 Parameters: `action`, `anchored`, `exclude`, `exclude_pattern`, `file`, `file_path`, `handle`, `include`, `kind`, `line`, `max_results`, `mode`, `name`, `path`, `paths`, `pattern`, `queries`, `query`, `top_k`
 

--- a/rust/src/tool_defs/mod.rs
+++ b/rust/src/tool_defs/mod.rs
@@ -46,11 +46,15 @@ fn sanitize_schema(schema: Value) -> Value {
 ///
 /// Excluded from this list (despite mostly-read paths):
 /// - `ctx_compose` — calls `record_access()` (co-access / session state mutation)
-/// - `ctx_search` — `action=reindex` rebuilds persistent BM25 indexes
 pub const READONLY_TOOL_NAMES: &[&str] = &[
     "ctx_read",
     "ctx_tree",
     "ctx_glob",
+    // #1624: `ctx_search` belongs here. Its one mutating action, `reindex`,
+    // moved to `ctx_index` — annotations are per tool, so that single action
+    // was withholding the hint from every search call and locking the tool out
+    // of read-only client modes (Devin Plan mode, Cursor's restricted context).
+    "ctx_search",
     "ctx_callgraph",
     "ctx_overview",
     "ctx_expand",

--- a/rust/src/tools/registered/ctx_search.rs
+++ b/rust/src/tools/registered/ctx_search.rs
@@ -13,12 +13,17 @@ pub struct CtxSearchTool;
 /// Which search engine a `ctx_search` call routes to (#509). One tool, many
 /// engines — replacing the former `ctx_search`/`ctx_semantic_search`/`ctx_symbol`
 /// trio with a single, less ambiguous entry point.
+///
+/// Every variant is read-only (#1624). `reindex` used to live here and was the
+/// single reason `ctx_search` could not carry `readOnlyHint`, which locked the
+/// whole tool out of read-only client modes; it now belongs to `ctx_index`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SearchAction {
     Regex,
     Semantic,
     Symbol,
-    Reindex,
+    /// Accepted only to answer with the replacement call — never executed.
+    MovedReindex,
     FindRelated,
 }
 
@@ -32,7 +37,7 @@ impl SearchAction {
                 "regex" | "grep" | "pattern" => return Self::Regex,
                 "semantic" | "search" => return Self::Semantic,
                 "symbol" => return Self::Symbol,
-                "reindex" => return Self::Reindex,
+                "reindex" => return Self::MovedReindex,
                 "find_related" | "related" => return Self::FindRelated,
                 _ => {}
             }
@@ -62,14 +67,14 @@ impl McpTool for CtxSearchTool {
         tool_def(
             "ctx_search",
             "Search code: regex(pattern, default) | semantic(query) | symbol(name|handle) | \
-             reindex | find_related(file_path,line). anchored=true enables ctx_patch refs; \
+             find_related(file_path,line). Read-only. anchored=true enables ctx_patch refs; \
              queries batches regex searches. Run ctx_compose FIRST.",
             json!({
                 "type": "object",
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["regex", "semantic", "symbol", "reindex", "find_related"]
+                        "enum": ["regex", "semantic", "symbol", "find_related"]
                     },
                     "pattern": { "type": "string" },
                     "query": { "type": "string" },
@@ -124,7 +129,7 @@ impl McpTool for CtxSearchTool {
             SearchAction::Regex => handle_regex(args, ctx),
             SearchAction::Semantic => handle_semantic(args, ctx),
             SearchAction::Symbol => handle_symbol(args, ctx),
-            SearchAction::Reindex => handle_reindex(args, ctx),
+            SearchAction::MovedReindex => Err(moved_reindex_error()),
             SearchAction::FindRelated => handle_find_related(args, ctx),
         };
         if let Ok(output) = &result {
@@ -151,7 +156,7 @@ fn record_attribution_result(
         SearchAction::Regex => "regex",
         SearchAction::Semantic => "semantic",
         SearchAction::Symbol => "symbol",
-        SearchAction::Reindex => "reindex",
+        SearchAction::MovedReindex => "reindex",
         SearchAction::FindRelated => "find_related",
     };
     let query = get_str(args, "pattern")
@@ -489,22 +494,25 @@ fn handle_symbol(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOut
     })
 }
 
-/// `action=reindex` — rebuild the BM25 (or artifacts) index, routed to core.
-fn handle_reindex(args: &Map<String, Value>, ctx: &ToolContext) -> Result<ToolOutput, ErrorData> {
-    let path = resolve_path_or_root(ctx)?;
-    let workspace = get_bool(args, "workspace").unwrap_or(false);
-    let artifacts = get_bool(args, "artifacts").unwrap_or(false);
-    prime_bm25_cache(ctx);
-
-    let result = tokio::task::block_in_place(|| {
-        if artifacts {
-            crate::tools::ctx_semantic_search::handle_reindex_artifacts(&path, workspace)
-        } else {
-            crate::tools::ctx_semantic_search::handle_reindex(&path)
-        }
-    });
-
-    Ok(semantic_output(result))
+/// `action=reindex` was removed from `ctx_search` (#1624).
+///
+/// It was the one mutating path in an otherwise read-only tool, and MCP
+/// annotations are per *tool*, not per action — so its presence stripped
+/// `readOnlyHint` from `ctx_search` and made the whole tool unavailable in
+/// every read-only client mode (Devin Plan mode, Cursor's restricted contexts).
+/// Search was collateral damage for a rebuild action that `ctx_index` already
+/// owns and correctly advertises as mutating.
+///
+/// The call is answered rather than silently dropped: an agent that learned
+/// `action="reindex"` gets the exact replacement line, not "unknown action".
+fn moved_reindex_error() -> ErrorData {
+    ErrorData::invalid_params(
+        "ctx_search no longer performs reindex — it is read-only so it stays available \
+         in read-only/plan modes (#1624). Rebuild the index with \
+         ctx_index(action=\"build-full\"), or ctx_index(action=\"build\") for an \
+         incremental pass.",
+        None,
+    )
 }
 
 /// `action=find_related` — context neighbors for a source location, via core.
@@ -1019,7 +1027,82 @@ mod tests {
         );
         assert_eq!(
             SearchAction::resolve(&args(&[("action", json!("reindex"))])),
-            SearchAction::Reindex
+            SearchAction::MovedReindex
+        );
+    }
+
+    /// #1624: `ctx_search` was unusable in read-only client modes (Devin Plan
+    /// mode, Cursor's restricted contexts) because MCP annotations are per
+    /// *tool*, and the single mutating action `reindex` withheld
+    /// `readOnlyHint` from every search call. The rebuild belongs to
+    /// `ctx_index`, which already owns it and advertises itself as mutating.
+    #[test]
+    fn search_is_annotated_read_only_so_plan_mode_can_call_it() {
+        use crate::server::tool_trait::McpTool;
+        let defs = crate::tool_defs::apply_tool_annotations(vec![super::CtxSearchTool.tool_def()]);
+        let annotations = defs[0]
+            .annotations
+            .as_ref()
+            .expect("ctx_search must carry annotations at all");
+        assert_eq!(
+            annotations.read_only_hint,
+            Some(true),
+            "without readOnlyHint a read-only client mode refuses the call before dispatch"
+        );
+        assert_ne!(
+            annotations.destructive_hint,
+            Some(true),
+            "search destroys nothing"
+        );
+    }
+
+    /// The published action list must not advertise what the tool no longer
+    /// does — an enum still naming `reindex` would send agents into an error.
+    #[test]
+    fn reindex_is_gone_from_the_published_action_list() {
+        use crate::server::tool_trait::McpTool;
+        let def = super::CtxSearchTool.tool_def();
+        let schema = serde_json::to_value(&*def.input_schema).expect("schema");
+        let actions = schema["properties"]["action"]["enum"]
+            .as_array()
+            .expect("action enum")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            !actions.contains(&"reindex"),
+            "reindex must not be offered by a read-only tool: {actions:?}"
+        );
+        assert!(
+            !def.description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("reindex"),
+            "the description must not advertise it either"
+        );
+        for kept in ["regex", "semantic", "symbol", "find_related"] {
+            assert!(
+                actions.contains(&kept),
+                "the read-only actions must all survive: {actions:?}"
+            );
+        }
+    }
+
+    /// A call that still asks for `reindex` gets the replacement, not a bare
+    /// rejection: agents that learned the old spelling must be able to recover
+    /// from the error text alone.
+    #[test]
+    fn a_reindex_call_is_answered_with_the_replacement_command() {
+        let error = super::moved_reindex_error();
+        assert!(
+            error.message.contains("ctx_index(action=\"build-full\")"),
+            "the error must carry the exact replacement call: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains("read-only"),
+            "and say why it moved, so the change does not look arbitrary: {}",
+            error.message
         );
     }
 


### PR DESCRIPTION
Reported by @jh061084 in #1624. Reopened from #1627, which GitHub auto-closed when its base branch (`fix/1625-search-budget`, the #1626 stack) was deleted on merge; the branch is now rebased onto `main` and the diff is 4 files.

`tools/list` annotates `ctx_read`, `ctx_glob` and `ctx_expand` with `readOnlyHint`. `ctx_search` had no annotations at all, so a client that permits only read-only tools refuses it **before dispatch**:

```
MCP tool ctx_search on server lean-ctx is currently unavailable: only tools
annotated as read-only (readOnlyHint) can be called in the current mode.
```

## The mismatch

MCP annotates *tools*. `ctx_search` multiplexes five actions, four of which only read. The fifth — `reindex` — wrote persistent BM25 indexes, and that single action withheld the hint from every regex, semantic and symbol lookup.

Search was collateral damage for a rebuild: unavailable in exactly the mode where searching matters most and rebuilding is least welcome. The reporter's workaround was to shell out to `lean-ctx grep`, which keeps the compression but leaves the MCP surface and its session instrumentation behind.

## Why removal rather than an alias or a friendly annotation

`ctx_index` already owns index rebuilds (`status` / `build` / `build-full`) and already advertises itself as mutating. `reindex` on `ctx_search` was a **second, undeclared mutation path** into a tool whose other four actions are pure reads — so this deletes a duplicate rather than relocating work.

The alternatives, and why not:

- **Annotate `readOnlyHint: true` and keep `reindex` working.** No breaking change, but the annotation becomes false: a plan-mode client could trigger a disk-writing rebuild through a tool it was told is safe. An annotation nobody can trust is worse than one that is absent.
- **A read-only alias tool (`ctx_find`).** Also no breaking change, but it adds a tool to every agent's catalogue — a permanent per-turn context cost — plus two names for one thing.

## What a `reindex` caller sees

The action is still *recognised*, so an agent that learned the old spelling recovers from the error text alone rather than getting "unknown action":

```
ctx_search no longer performs reindex — it is read-only so it stays available in
read-only/plan modes (#1624). Rebuild the index with ctx_index(action="build-full"),
or ctx_index(action="build") for an incremental pass.
```

That is the entire cost of this change, and it is the honest one.

## Documentation

`docs/guides/cursor.md` listed `ctx_compose` among the read-only tools. It isn't — it calls `record_access()` and is deliberately excluded from `READONLY_TOOL_NAMES`. The doc now names the actual set and says why compose is not in it. Generated tool reference regenerated.

## Tests

- `search_is_annotated_read_only_so_plan_mode_can_call_it` — asserts the annotation the client actually reads, not the constant list.
- `reindex_is_gone_from_the_published_action_list` — the enum and description must not advertise what the tool no longer does, and all four read-only actions must survive.
- `a_reindex_call_is_answered_with_the_replacement_command`.

## Verification

- `cargo test --lib` → 10569 passed, 0 failed
- `cargo clippy --lib --all-features -- -D warnings`, `cargo fmt --check`, `gen_docs --check` → clean

Fixes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)