### PR TITLE
fix(hooks): stop replace mode from rejecting other MCP servers' tools

### DIFF
--- a/rust/src/hook_handlers/deny.rs
+++ b/rust/src/hook_handlers/deny.rs
@@ -78,6 +78,15 @@ fn should_allow(tool_name: &str, file_path: Option<&str>) -> bool {
         return true;
     }
 
+    // Replace mode can only redirect what it can replace. A tool from another
+    // MCP server (`jira_get_issue`, `github_create_pull_request`, …) has no
+    // `ctx_*` equivalent, and hosts that route MCP calls through PreToolUse
+    // deliver those here alongside the native ones. Denying them breaks the
+    // user's other servers for no compression benefit whatsoever.
+    if !is_replaceable_native_tool(tool_name) {
+        return true;
+    }
+
     // Shadow-only surface: hooks compress native tools transparently,
     // so the deny guard must not block them.
     if is_shadow_only_surface() {
@@ -109,6 +118,49 @@ fn should_allow(tool_name: &str, file_path: Option<&str>) -> bool {
 
 fn is_lean_ctx_tool(tool_name: &str) -> bool {
     tool_name.starts_with("ctx_") || tool_name == "shell"
+}
+
+/// Native tools replace mode can actually redirect to a `ctx_*` equivalent.
+///
+/// The deny guard used to be "allow `ctx_*`, deny everything else", which is
+/// only correct on a host that filters by matcher before invoking the hook.
+/// Devin routes *every* MCP call through the same PreToolUse pipeline (#1329),
+/// so tools from OTHER MCP servers arrived here too — and were rejected with
+/// "Use the equivalent ctx_* tool", naming an equivalent that does not exist:
+///
+///     Calling jira_get_issue from atlassian-mcp-server
+///     Output: Tool rejected: Use the equivalent ctx_* tool — replace mode is active.
+///
+/// lean-ctx has nothing to offer instead of a Jira read, so denying it removes
+/// a capability from the user's stack and gives back nothing. Replace mode's
+/// scope is the native read/search/shell surface it can genuinely replace;
+/// everything else passes through.
+///
+/// The read names mirror Claude's `REDIRECT_MATCHER`; the shell names come from
+/// `hook_handlers::is_shell_tool`, the same list the rewrite hook uses, so the
+/// two guards cannot drift apart.
+fn is_replaceable_native_tool(tool_name: &str) -> bool {
+    super::is_shell_tool(tool_name)
+        || matches!(
+            tool_name,
+            "Read"
+                | "read"
+                | "ReadFile"
+                | "read_file"
+                | "View"
+                | "view"
+                | "Grep"
+                | "grep"
+                | "Search"
+                | "search"
+                | "Glob"
+                | "glob"
+                | "ListFiles"
+                | "list_files"
+                | "ListDirectory"
+                | "list_directory"
+                | "list_dir"
+        )
 }
 
 fn is_mcp_server_reachable() -> bool {
@@ -557,6 +609,72 @@ fn read_stdin_with_timeout() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A user with the Atlassian MCP server got every Jira call rejected:
+    ///
+    ///     Calling jira_get_issue from atlassian-mcp-server
+    ///     Tool rejected: Use the equivalent ctx_* tool — replace mode is active.
+    ///
+    /// There is no equivalent — lean-ctx does not read Jira. The guard was
+    /// "deny everything that is not ctx_*", which is safe only on a host that
+    /// filters by matcher first; Devin routes all MCP traffic through the same
+    /// PreToolUse pipeline, so foreign servers were caught in it.
+    #[test]
+    fn foreign_mcp_tools_are_not_replaceable() {
+        for tool in [
+            "jira_get_issue",
+            "jira_search",
+            "confluence_get_page",
+            "github_create_pull_request",
+            "mcp__atlassian__jira_get_issue",
+            "atlassian-mcp-server:jira_get_issue",
+            "browser_navigate",
+            "slack_post_message",
+        ] {
+            assert!(
+                !is_replaceable_native_tool(tool),
+                "{tool} has no ctx_* equivalent; denying it removes a capability \
+                 and gives nothing back"
+            );
+        }
+    }
+
+    /// The other half of the contract: narrowing the guard must not let the
+    /// native surface through, or replace mode silently stops replacing.
+    #[test]
+    fn the_native_read_and_shell_surface_stays_replaceable() {
+        for tool in [
+            "Read",
+            "read",
+            "ReadFile",
+            "read_file",
+            "View",
+            "Grep",
+            "grep",
+            "Search",
+            "Glob",
+            "glob",
+            "list_dir",
+            "ListDirectory",
+        ] {
+            assert!(
+                is_replaceable_native_tool(tool),
+                "{tool} is the native read surface replace mode exists for"
+            );
+        }
+        for shell in [
+            "Bash",
+            "bash",
+            "Shell",
+            "run_terminal_command",
+            "powershell",
+        ] {
+            assert!(
+                is_replaceable_native_tool(shell),
+                "{shell} must stay covered — the list is shared with the rewrite hook"
+            );
+        }
+    }
 
     #[test]
     fn is_write_tool_recognizes_all_variants() {

--- a/rust/src/hook_handlers/deny.rs
+++ b/rust/src/hook_handlers/deny.rs
@@ -59,14 +59,14 @@ pub fn handle_deny() {
         return;
     }
 
-    if should_allow(&tool_name, file_path.as_deref()) {
+    if should_allow(&tool_name, file_path.as_deref(), &stdin_payload) {
         print_allow();
     } else {
         print_smart_deny(&tool_name, &stdin_payload);
     }
 }
 
-fn should_allow(tool_name: &str, file_path: Option<&str>) -> bool {
+fn should_allow(tool_name: &str, file_path: Option<&str>, payload: &str) -> bool {
     if super::is_disabled() {
         return true;
     }
@@ -78,11 +78,15 @@ fn should_allow(tool_name: &str, file_path: Option<&str>) -> bool {
         return true;
     }
 
-    // Replace mode can only redirect what it can replace. A tool from another
-    // MCP server (`jira_get_issue`, `github_create_pull_request`, …) has no
-    // `ctx_*` equivalent, and hosts that route MCP calls through PreToolUse
-    // deliver those here alongside the native ones. Denying them breaks the
-    // user's other servers for no compression benefit whatsoever.
+    // #1631: the same pipeline delivers every OTHER MCP server's tools too, and
+    // replace mode has no `ctx_*` equivalent to offer for a Jira read or a Slack
+    // post. Denying them removed capabilities from the user's stack and gave
+    // nothing back. Provenance decides first, because the native names below are
+    // ordinary words a foreign server may legitimately use.
+    if is_mcp_call(tool_name, payload) {
+        return true;
+    }
+
     if !is_replaceable_native_tool(tool_name) {
         return true;
     }
@@ -117,7 +121,33 @@ fn should_allow(tool_name: &str, file_path: Option<&str>) -> bool {
 }
 
 fn is_lean_ctx_tool(tool_name: &str) -> bool {
-    tool_name.starts_with("ctx_") || tool_name == "shell"
+    tool_name.starts_with("ctx_")
+        || tool_name.starts_with("mcp__lean-ctx__")
+        || tool_name == "shell"
+}
+
+/// Whether this payload describes a call to *some* MCP server rather than one
+/// of the host's own native tools.
+///
+/// Two signals, both structural rather than name-based:
+/// - Windsurf/Devin `pre_mcp_tool_use` nests the name under
+///   `tool_info.mcp_tool_name` (#1407) and names the server beside it;
+/// - Claude Code spells MCP tools `mcp__<server>__<tool>`, the convention
+///   `edit_health` and `observe` already key off.
+///
+/// This matters beyond tidiness: a name allowlist alone would still reject a
+/// foreign server that happens to expose a tool called `search`, `read` or
+/// `view` — common words that collide with the native surface. Provenance does
+/// not collide.
+fn is_mcp_call(tool_name: &str, payload: &str) -> bool {
+    if tool_name.starts_with("mcp__") {
+        return true;
+    }
+    serde_json::from_str::<serde_json::Value>(payload).is_ok_and(|json| {
+        json.get("tool_info")
+            .and_then(|ti| ti.get("mcp_tool_name"))
+            .is_some()
+    })
 }
 
 /// Native tools replace mode can actually redirect to a `ctx_*` equivalent.
@@ -128,8 +158,10 @@ fn is_lean_ctx_tool(tool_name: &str) -> bool {
 /// so tools from OTHER MCP servers arrived here too — and were rejected with
 /// "Use the equivalent ctx_* tool", naming an equivalent that does not exist:
 ///
-///     Calling jira_get_issue from atlassian-mcp-server
-///     Output: Tool rejected: Use the equivalent ctx_* tool — replace mode is active.
+/// ```text
+/// Calling jira_get_issue from atlassian-mcp-server
+/// Output: Tool rejected: Use the equivalent ctx_* tool — replace mode is active.
+/// ```
 ///
 /// lean-ctx has nothing to offer instead of a Jira read, so denying it removes
 /// a capability from the user's stack and gives back nothing. Replace mode's
@@ -138,7 +170,9 @@ fn is_lean_ctx_tool(tool_name: &str) -> bool {
 ///
 /// The read names mirror Claude's `REDIRECT_MATCHER`; the shell names come from
 /// `hook_handlers::is_shell_tool`, the same list the rewrite hook uses, so the
-/// two guards cannot drift apart.
+/// two guards cannot drift apart. This is the *second* line of defence —
+/// `is_mcp_call` settles provenance first, because these names are ordinary
+/// words another server may well use.
 fn is_replaceable_native_tool(tool_name: &str) -> bool {
     super::is_shell_tool(tool_name)
         || matches!(
@@ -612,8 +646,10 @@ mod tests {
 
     /// A user with the Atlassian MCP server got every Jira call rejected:
     ///
-    ///     Calling jira_get_issue from atlassian-mcp-server
-    ///     Tool rejected: Use the equivalent ctx_* tool — replace mode is active.
+    /// ```text
+    /// Calling jira_get_issue from atlassian-mcp-server
+    /// Tool rejected: Use the equivalent ctx_* tool — replace mode is active.
+    /// ```
     ///
     /// There is no equivalent — lean-ctx does not read Jira. The guard was
     /// "deny everything that is not ctx_*", which is safe only on a host that
@@ -824,14 +860,53 @@ mod tests {
         );
     }
 
+    /// The hole a name-based allowlist leaves open: a foreign MCP server whose
+    /// tool is called `search`, `read` or `view` collides with the native
+    /// surface, so the name alone cannot decide. Provenance can — and both
+    /// hosts that route MCP through this hook announce it.
+    #[test]
+    fn foreign_mcp_calls_are_allowed_even_when_the_name_collides() {
+        let devin = r#"{"tool_info":{"mcp_tool_name":"search","server":"atlassian-mcp-server"}}"#;
+        assert!(
+            is_mcp_call("search", devin),
+            "tool_info.mcp_tool_name marks the call as MCP whatever the tool is called"
+        );
+        assert!(
+            should_allow("search", None, devin),
+            "another server's `search` must not be answered with 'use ctx_search'"
+        );
+        assert!(
+            should_allow("read", None, r#"{"tool_info":{"mcp_tool_name":"read"}}"#),
+            "same for a foreign `read`"
+        );
+
+        // Claude Code's spelling for the identical situation.
+        assert!(is_mcp_call("mcp__atlassian__jira_get_issue", "{}"));
+        assert!(should_allow("mcp__atlassian__jira_get_issue", None, "{}"));
+
+        // A native call carries neither marker and stays in scope.
+        assert!(!is_mcp_call("Read", r#"{"tool_name":"Read"}"#));
+        assert!(!is_mcp_call("Grep", "{}"));
+    }
+
+    /// lean-ctx's own tools reach this hook under both spellings — bare
+    /// `ctx_read` from Devin, `mcp__lean-ctx__ctx_read` from Claude Code, the
+    /// form `edit_health` and `observe` already recognise.
+    #[test]
+    fn lean_ctx_tools_are_recognised_under_both_spellings() {
+        assert!(is_lean_ctx_tool("ctx_read"));
+        assert!(is_lean_ctx_tool("mcp__lean-ctx__ctx_read"));
+        assert!(!is_lean_ctx_tool("mcp__atlassian__jira_get_issue"));
+    }
+
     #[test]
     fn should_allow_lean_ctx_tools() {
-        assert!(should_allow("ctx_tree", None));
-        assert!(should_allow("ctx_read", Some("/tmp/test.rs")));
-        assert!(should_allow("ctx_search", None));
-        assert!(should_allow("ctx_shell", None));
-        assert!(should_allow("ctx_compose", None));
-        assert!(should_allow("shell", None));
+        assert!(should_allow("ctx_tree", None, "{}"));
+        assert!(should_allow("ctx_read", Some("/tmp/test.rs"), "{}"));
+        assert!(should_allow("ctx_search", None, "{}"));
+        assert!(should_allow("ctx_shell", None, "{}"));
+        assert!(should_allow("ctx_compose", None, "{}"));
+        assert!(should_allow("shell", None, "{}"));
     }
 
     #[test]
@@ -848,10 +923,11 @@ mod tests {
     fn should_allow_claude_auto_memory_paths() {
         assert!(should_allow(
             "Read",
-            Some("/home/jules/.claude/projects/-slug/memory/MEMORY.md")
+            Some("/home/jules/.claude/projects/-slug/memory/MEMORY.md"),
+            "{}"
         ));
         assert!(
-            !should_allow("Read", Some("/home/jules/project/src/main.rs")),
+            !should_allow("Read", Some("/home/jules/project/src/main.rs"), "{}"),
             "ordinary project files stay denied under replace deny hooks"
         );
     }


### PR DESCRIPTION
Reported via Discord with a screenshot: a user running the Atlassian MCP server alongside lean-ctx had **every** Jira call rejected.

```
Calling jira_get_issue from atlassian-mcp-server
  Raw Input: { "issue_key": "CORE-55989", "fields": "description,attachment" }
  Output: Tool rejected: Use the equivalent ctx_* tool — lean-ctx replace mode is active.
```

They asked how to add other MCP tools to lean-ctx's allowlist. There is no such setting, and there should not need to be — **there is no equivalent `ctx_*` tool.** lean-ctx does not read Jira. The message points at a replacement that does not exist, and the only escape was `LEAN_CTX_REPLACE_MODE=0`, i.e. giving up replace mode entirely.

## Cause

`should_allow()` in `hook_handlers/deny.rs` was deny-by-default. Past the `ctx_*` and write-tool exemptions, *anything* fell through to a deny — it never asked whether the tool was one replace mode could actually redirect.

That is safe only on a host that filters by matcher before invoking the hook. Claude Code has `REDIRECT_MATCHER` and never routes foreign MCP calls to it. Devin routes **every** MCP call through the same PreToolUse pipeline — which is exactly why the `is_lean_ctx_tool` exemption had to be added in #1329 — so every other MCP server the user had configured landed in the guard.

`handle_deny` already documents the intended scope: *"the deny hook's scope is native tools only."* The code just did not agree with the comment.

## Impact

Any user on a host that routes MCP through PreToolUse, running replace mode **plus any other MCP server** — Atlassian, GitHub, Slack, Playwright, in-house. Installing lean-ctx silently disabled the rest of their stack, and the error message sent them looking for an allowlist that does not exist.

## Fix

`is_replaceable_native_tool` — the native read surface (mirroring Claude's `REDIRECT_MATCHER`) plus the shell dialects from `hook_handlers::is_shell_tool`. Sharing that second list with the rewrite hook means the two guards cannot drift apart. Everything else passes through.

**The trade-off, stated rather than buried:** an unrecognised *native* read tool name now passes uncompressed instead of being blocked. A missed compression on one unknown tool is a far smaller failure than disabling every other MCP server a user has installed.

## Tests

- `foreign_mcp_tools_are_not_replaceable` — the reporter's `jira_get_issue` plus namespaced spellings (`mcp__atlassian__jira_get_issue`, `atlassian-mcp-server:jira_get_issue`) and other common servers.
- `the_native_read_and_shell_surface_stays_replaceable` — the other half of the contract: narrowing the guard must not let the native surface through, or replace mode silently stops replacing.

## Verification

- `cargo test --lib` → 10571 passed, 0 failed
- `cargo clippy --lib --all-features -- -D warnings`, `cargo fmt --check` → clean

Fixes #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)