### PR TITLE
test(ctx_explore): settle the index before comparing, not with a warm-up call

### DIFF
--- a/rust/src/tools/ctx_explore.rs
+++ b/rust/src/tools/ctx_explore.rs
@@ -705,17 +705,40 @@ mod tests {
             )
         };
 
-        // The fixture root is brand new, so the first call races index warm-up:
-        // it can answer from a partially-built symbol index and cite two spans
-        // where a warm call cites three (`lookup (fn)` arrives late). That is a
-        // cold-start difference, not the state accumulation #498 is about — so
-        // warm the index with a discarded call and compare two warm runs.
-        let _warm = run();
+        // #498 is about state accumulation between runs, so the index must be
+        // settled *before* the two runs being compared — otherwise the test
+        // measures index warm-up instead.
+        //
+        // The symbol half of the answer (`lookup (fn)`) comes from
+        // `graph_provider::open_or_build`, which returns `None` when the build
+        // gate is already held (another test in this binary) or when the 30s
+        // build times out under parallel load. So one run cites two spans and
+        // the next cites three — a red build about scheduling, not about
+        // determinism.
+        //
+        // A discarded warm-up call does not fix that: it enters the same racy
+        // path and offers no guarantee about the call after it. Building the
+        // graph index synchronously does — `scan` persists it, so both runs
+        // below take the `open_existing` fast path and never touch the gate.
+        let prebuilt = crate::core::graph_index::load_or_build(&root_str);
+        assert!(
+            !prebuilt.files.is_empty(),
+            "the fixture must yield a graph index; without one both runs would \
+             degrade to the same symbol-less output and the comparison would pass \
+             while proving nothing"
+        );
+
         let a = run();
         let b = run();
 
         assert_eq!(a.text, b.text, "explore output must be byte-stable");
         assert_eq!(a.tokens, b.tokens);
+        assert!(
+            a.text.contains("lookup (fn)"),
+            "the symbol citation must be present — its absence is exactly the \
+             degraded state this test used to compare against itself: {}",
+            a.text
+        );
         let locs = |o: &ExploreOutcome| -> Vec<(String, usize, usize)> {
             o.citations
                 .iter()


### PR DESCRIPTION
`handle_output_is_byte_stable_across_runs` fails under parallel load — one run cites two spans, the next three, depending on whether `lookup (fn)` appears. It took a full-suite run red while passing in isolation.

## The mechanism is not cold-start

The existing mitigation was a discarded warm-up call, on the theory that only the *first* call is cold. That is not what happens.

The symbol half of the answer comes from `graph_provider::open_or_build`, which returns `None` in two cases that have nothing to do with call order:

- the build gate is already held — by **another test in the same binary**, and
- the 30-second build times out on a loaded runner.

A warm-up call enters that same racy path and guarantees nothing about the call after it. It narrowed the window without closing it, which is why the flake survived the first fix.

## The fix

Build the graph index **synchronously** before the comparison. `scan` persists it, so both compared runs take the `open_existing` fast path and never touch the gate.

## Two assertions that matter more than the fix

Without them, this fix would leave a worse failure mode than the one it removes: if the fixture ever stops yielding symbols, *both* runs degrade identically and a byte-comparison passes while proving nothing.

So the test now requires (a) a non-empty index up front, and (b) the `lookup (fn)` citation in the output. A degraded run fails loudly instead of silently agreeing with itself.

## Verification

- the test 5× in a row → green each time
- `cargo test --lib` → 10569 passed, 0 failed
- `cargo clippy --lib --all-features -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)