### PR TITLE
fix(proxy): relay the whole anthropic-ratelimit family to the client

### DIFF
--- a/rust/src/proxy/forward/headers.rs
+++ b/rust/src/proxy/forward/headers.rs
@@ -106,10 +106,17 @@ pub(crate) const FORWARDED_HEADERS: &[&str] = &[
     "openai-version",
     "x-models-etag",
     "x-reasoning-included",
-    "anthropic-ratelimit-requests-limit",
-    "anthropic-ratelimit-requests-remaining",
-    "anthropic-ratelimit-tokens-limit",
-    "anthropic-ratelimit-tokens-remaining",
+    // #1638: `anthropic-ratelimit-*` is covered by the prefix rule in
+    // `is_forwarded_response_header` rather than enumerated here. Enumeration
+    // is what broke: the four legacy `requests-`/`tokens-` names were listed,
+    // and when Anthropic introduced the `unified-*` family the allowlist
+    // silently kept dropping them.
+    //
+    // `request-id` and `x-should-retry` are client-side state too — the first
+    // is what a user quotes to Anthropic support, the second tells the SDK
+    // whether a failure is worth retrying.
+    "request-id",
+    "x-should-retry",
     "retry-after",
     "x-ratelimit-limit-requests",
     "x-ratelimit-remaining-requests",
@@ -122,5 +129,19 @@ pub(crate) fn is_forwarded_response_header(name: &str) -> bool {
     FORWARDED_HEADERS.contains(&name)
         || name.starts_with("x-codex-")
         || name.starts_with("x-ratelimit-")
+        // #1638: the whole `anthropic-ratelimit-*` family, by prefix.
+        //
+        // Claude Code derives its plan-usage windows *only* from
+        // `anthropic-ratelimit-unified-5h-utilization` and its siblings. With
+        // them dropped, `rate_limits` vanishes from the statusline payload —
+        // and, less visibly but far worse, the near-limit warning machinery
+        // reads the same state, so a user behind the proxy is never told they
+        // are approaching a limit.
+        //
+        // A prefix rather than eighteen more literals: these headers carry
+        // client-side state, and the family grows upstream on Anthropic's
+        // schedule, not ours. Enumerating it means going quiet again the next
+        // time it grows.
+        || name.starts_with("anthropic-ratelimit-")
         || crate::proxy::bedrock::is_bedrock_response_header(name)
 }

--- a/rust/src/proxy/forward/tests.rs
+++ b/rust/src/proxy/forward/tests.rs
@@ -738,6 +738,86 @@ fn forwards_codex_state_response_headers() {
     }
 }
 
+/// #1638: Claude Code fills its plan-usage windows *only* from the
+/// `anthropic-ratelimit-unified-*` response headers. The allowlist enumerated
+/// the four legacy `requests-`/`tokens-` names, so when the `unified-*` family
+/// arrived upstream the proxy silently dropped all of it: `rate_limits`
+/// disappeared from the statusline payload, and — the part that actually
+/// matters — the near-limit warning machinery reads the same state, so a user
+/// behind the proxy was never warned before hitting a limit.
+///
+/// The names below are the full family as parsed by Claude Code 2.1.236,
+/// quoted from the report. They are asserted individually rather than through
+/// the prefix, so narrowing the rule back to an enumeration fails here.
+#[test]
+fn forwards_the_whole_anthropic_ratelimit_family() {
+    for required in [
+        "anthropic-ratelimit-unified-status",
+        "anthropic-ratelimit-unified-reset",
+        "anthropic-ratelimit-unified-5h-utilization",
+        "anthropic-ratelimit-unified-5h-reset",
+        "anthropic-ratelimit-unified-5h-surpassed-threshold",
+        "anthropic-ratelimit-unified-7d-utilization",
+        "anthropic-ratelimit-unified-7d-reset",
+        "anthropic-ratelimit-unified-7d-surpassed-threshold",
+        "anthropic-ratelimit-unified-grace-status",
+        "anthropic-ratelimit-unified-grace-5h-utilization",
+        "anthropic-ratelimit-unified-grace-7d-utilization",
+        "anthropic-ratelimit-unified-overage-status",
+        "anthropic-ratelimit-unified-overage-utilization",
+        "anthropic-ratelimit-unified-overage-reset",
+        "anthropic-ratelimit-unified-overage-period",
+        "anthropic-ratelimit-unified-representative-claim",
+        "anthropic-ratelimit-unified-fallback",
+        "anthropic-ratelimit-unified-upgrade-paths",
+        // The legacy names the allowlist used to carry explicitly must keep
+        // working — the prefix replaced the enumeration, not the coverage.
+        "anthropic-ratelimit-requests-limit",
+        "anthropic-ratelimit-requests-remaining",
+        "anthropic-ratelimit-tokens-limit",
+        "anthropic-ratelimit-tokens-remaining",
+    ] {
+        assert!(
+            is_forwarded_response_header(required),
+            "response header `{required}` carries the client's own quota state \
+             and must reach it"
+        );
+    }
+}
+
+/// Also reported in #1638: without `request-id` a user cannot correlate a
+/// failed request with Anthropic support, and `x-should-retry` is what tells
+/// an SDK whether a failure is worth retrying at all.
+#[test]
+fn forwards_request_correlation_and_retry_headers() {
+    for required in ["request-id", "x-should-retry", "retry-after"] {
+        assert!(
+            is_forwarded_response_header(required),
+            "response header `{required}` must reach the client"
+        );
+    }
+}
+
+/// The fix widens one family; it must not turn the allowlist into a
+/// pass-through. Hop-by-hop and framing headers stay out — the proxy rewrites
+/// the body (decompression, SSE re-framing), so relaying the upstream's
+/// framing would describe a response that no longer exists.
+#[test]
+fn the_allowlist_stays_an_allowlist() {
+    for denied in [
+        "transfer-encoding",
+        "connection",
+        "content-length",
+        "server",
+        "set-cookie",
+    ] {
+        assert!(
+            !is_forwarded_response_header(denied),
+            "`{denied}` must not be relayed"
+        );
+    }
+}
+
 #[test]
 fn chatgpt_responses_use_openai_responses_holdout_key() {
     let _iso = crate::core::data_dir::isolated_data_dir();


### PR DESCRIPTION
Reported by @online in #1638, with a diagnosis that turned out to be exactly right.

Claude Code behind `lean-ctx proxy` shows no plan usage in its statusline, and — the part that actually costs the user something — its **near-limit warnings never fire**. Both read the same state, and that state arrives exclusively in `anthropic-ratelimit-unified-*` *response* headers.

## Confirmed in the code, not inferred

`FORWARDED_HEADERS` (`proxy/forward/headers.rs:94`) is a response **allowlist**. It carried the four legacy `anthropic-ratelimit-requests-*` / `-tokens-*` names, and there is a prefix rule for `x-ratelimit-` — but **none for `anthropic-ratelimit-`**. So when Anthropic introduced the `unified-*` family, the allowlist stayed correct about what it listed and silently wrong about what mattered.

Both response paths share the predicate — `transport.rs:117` (streaming) and `:199` (buffered) — so every response was affected regardless of status code.

That also settles the one thing the reporter explicitly could not observe. They had no successful 200 trace, said so plainly, and inferred the drop from a 401 probe. The allowlist makes it unconditional: there is no status-dependent branch.

## The fix

A family rule, not eighteen more literals:

```rust
|| name.starts_with("anthropic-ratelimit-")
```

Enumeration is precisely what broke here. These headers carry client-side state and the family grows on Anthropic's schedule, not ours — listing it by hand means going quiet again the next time it grows. The four legacy entries are removed from the list because the prefix subsumes them.

`request-id` and `x-should-retry` are added for the same reason (point 3 of the report): the first is what a user quotes to Anthropic support, the second tells an SDK whether a failure is worth retrying. `retry-after` was already forwarded.

## What I did *not* do

The report offered "pass through everything the proxy does not deliberately rewrite" as the safer default. I did not take it: the proxy **does** rewrite the body — decompression, SSE re-framing — so relaying the upstream's `transfer-encoding` or `content-length` would describe a response that no longer exists. `the_allowlist_stays_an_allowlist` pins that boundary so the next widening has to argue for itself.

## Tests

- `forwards_the_whole_anthropic_ratelimit_family` — all 18 `unified-*` names quoted from the report, plus the 4 legacy ones, asserted **individually** rather than through the prefix, so narrowing the rule back to an enumeration fails loudly.
- `forwards_request_correlation_and_retry_headers`
- `the_allowlist_stays_an_allowlist`

## Verification

- `cargo test --lib` → 10576 passed, 0 failed
- `cargo clippy --lib --all-features -- -D warnings`, `cargo fmt --check` → clean

Fixes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)