### PR TITLE
docs(changelog): record the proxy rate-limit header fix in 3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ present in the 3.10.0 artifacts.
 
 ### Fixed
 
+- **Claude Code lost its plan-usage windows and near-limit warnings behind the
+  proxy (#1638, thanks @online)** — Claude Code derives both from the
+  `anthropic-ratelimit-unified-*` response headers, and the proxy's response
+  allowlist enumerated only the four legacy `requests-`/`tokens-` names. When
+  the `unified-*` family arrived upstream the allowlist stayed correct about
+  what it listed and silently dropped the rest, so `rate_limits` vanished from
+  the statusline payload and — the costlier half — the warning that a usage
+  limit is approaching could never fire. The whole `anthropic-ratelimit-*`
+  family is now relayed by prefix rather than by enumeration, which is what
+  aged badly in the first place; `request-id` and `x-should-retry` are relayed
+  too. The allowlist stays an allowlist: the proxy rewrites the body
+  (decompression, SSE re-framing), so upstream framing headers are still not
+  passed through.
 - **`ctx_search` was unusable in read-only client modes (#1624, thanks @jh061084)** —
   MCP annotates tools, but `ctx_search` multiplexes five actions and only four
   of them read. The fifth, `reindex`, wrote persistent BM25 indexes, and that


### PR DESCRIPTION
#1638 (#1639) merged before the tag is cut, so it belongs in the 3.10.1 section.

The entry leads with what the user loses — plan usage in the statusline, and the warning before a usage limit is hit — rather than with the header names, because the header list only becomes interesting once you know the consequence.

It also records *why* the fix is a prefix rule rather than eighteen added literals: enumerating the family is exactly what aged badly when Anthropic introduced `unified-*`. Someone later deciding whether to narrow it back should meet that reasoning in the changelog, not have to reconstruct it from the diff.

`check-narrative-governance.py` passes. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)