### PR TITLE
fix(cli): give `lean-ctx call` a session, tool_calls and ledger handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ present in the 3.10.0 artifacts.
 
 ### Fixed
 
+- **One-shot CLI tool calls could abort before dispatch** — `lean-ctx call`
+  created an incomplete tool context, so read, shell, session, knowledge,
+  handoff, ledger, fill, metrics, workflow, and multi-read calls could fail
+  with a missing-handle error even though the same tools worked over MCP. The
+  CLI now loads the bounded project session and persisted context ledger and
+  supplies empty per-process call history, enabling custom agents to use the
+  registered tools safely without running a long-lived MCP connection.
 - **Claude Code lost its plan-usage windows and near-limit warnings behind the
   proxy (#1638, thanks @online)** — Claude Code derives both from the
   `anthropic-ratelimit-unified-*` response headers, and the proxy's response

--- a/docs/ga/release-checklist.md
+++ b/docs/ga/release-checklist.md
@@ -105,19 +105,27 @@ release assets, and verification commands.
 - [ ] The history policy gate passes.
 
   ```bash
-  python scripts/history-policy-gate.py
+  python3 scripts/history-policy-gate.py gate --root . \
+    --policy security/history-policy-v1.json \
+    --output /tmp/leanctx-history-delta-evidence.json
   ```
 
 - [ ] Branch protection is verified.
 
+  Export a GitHub token with repository-administration read access as
+  `GITHUB_TOKEN` before running this check and the secret-expiry check below.
+
   ```bash
-  python scripts/verify-branch-protection.py
+  python3 scripts/verify-branch-protection.py verify
   ```
 
 - [ ] Secret expiry is checked.
 
   ```bash
-  python scripts/check-secret-expiry.py
+  python3 scripts/check-secret-expiry.py check \
+    --policy security/secret-rotation-policy-v1.json \
+    --repo yvgude/lean-ctx \
+    --output /tmp/leanctx-secret-rotation-report.json
   ```
 
 - [ ] The working tree contains only intentional release changes.

--- a/docs/ga/release-checklist.md
+++ b/docs/ga/release-checklist.md
@@ -5,9 +5,9 @@
 > managed-service, control-plane, or Research capability deployment. Delivery
 > order and capability status are governed by the
 > [OSS Vision Delivery Plan](../internal/execution/OSS-VISION-DELIVERY-PLAN.md)
-> and the [internal canonical entry point](../internal/README.md). Use the root
-> [`DEPLOY_CHECKLIST.md`](../../DEPLOY_CHECKLIST.md) for the local Runtime release
-> boundary.
+> and the [internal canonical entry point](../internal/README.md). This document
+> is the public local Runtime release boundary; maintainer-only operator notes do
+> not replace or weaken any gate below.
 
 ## Overview
 

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -127,7 +127,33 @@ fn parse_args(args: &[String]) -> Result<CallArgs, CallError> {
     })
 }
 
+/// Load the project's most recent session for a one-shot `lean-ctx call`.
+///
+/// Index-based, never a full scan: `load_latest_for_project_root` parses
+/// every file in the session store (measured: 160 files / 14.2 MB on one
+/// developer machine) before filtering on project root, and `lean-ctx call`
+/// is a short-lived subprocess that consumers spawn in loops.
+///
+/// Read-only. Nothing writes this session back. Persistence belongs to the
+/// MCP server (`server/post_dispatch.rs`, `prepare_save` -> `write_to_disk`);
+/// a write from a one-shot subprocess would be last-writer-wins against a
+/// live server holding the same session file.
+///
+/// Every failure degrades silently to an empty default session — no sessions
+/// directory (the first-run case, not an error), no index for this root, an
+/// id the store no longer has, malformed JSON, or a broad/unsafe root
+/// rejected by `normalized_safe_project_root`. An empty session is a fully
+/// valid context; it costs the task focus that steers `ctx_read` filtering,
+/// nothing else.
+fn oneshot_session(project_root: &str) -> crate::core::session::SessionState {
+    crate::core::session::SessionState::load_recent_for_project_root(project_root, 1)
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+}
+
 fn oneshot_ctx(project_root: String, resolved_paths: HashMap<String, String>) -> ToolContext {
+    let session = oneshot_session(&project_root);
     ToolContext {
         project_root,
         resolved_paths,
@@ -138,6 +164,18 @@ fn oneshot_ctx(project_root: String, resolved_paths: HashMap<String, String>) ->
             crate::core::cache::SessionCache::default(),
         ))),
         bm25_cache: Some(std::sync::Arc::new(std::sync::Mutex::new(None))),
+        // Same class of omission as `cache` above: without these three,
+        // ten registered tools abort with "<handle> not available".
+        // `session` is read-only (see `oneshot_session`); `tool_calls` and
+        // `ledger` start empty because a one-shot process has no history.
+        session: Some(std::sync::Arc::new(tokio::sync::RwLock::new(session))),
+        tool_calls: Some(std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new()))),
+        ledger: Some(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::core::context_ledger::ContextLedger::default(),
+        ))),
+        // Every remaining handle stays None deliberately: no registered tool
+        // aborts on their absence, and each would pull in server state a
+        // one-shot process has no basis to fabricate.
         ..Default::default()
     }
 }
@@ -290,5 +328,58 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn oneshot_ctx_supplies_session_tool_calls_and_ledger() {
+        let data = tempfile::tempdir().expect("data dir");
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
+        let project = tempfile::tempdir().expect("project dir");
+
+        let ctx = oneshot_ctx(project.path().to_string_lossy().to_string(), HashMap::new());
+
+        assert!(ctx.session.is_some(), "session handle missing");
+        assert!(ctx.tool_calls.is_some(), "tool_calls handle missing");
+        assert!(ctx.ledger.is_some(), "ledger handle missing");
+    }
+
+    #[test]
+    fn oneshot_session_without_an_index_returns_a_default() {
+        let data = tempfile::tempdir().expect("data dir");
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
+        let project = tempfile::tempdir().expect("project dir");
+
+        let session = oneshot_session(&project.path().to_string_lossy());
+
+        assert!(
+            session.task.is_none(),
+            "expected a default session for a root with no index"
+        );
+    }
+
+    #[test]
+    fn ctx_read_via_call_no_longer_aborts_on_a_missing_session() {
+        let data = tempfile::tempdir().expect("data dir");
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
+        let project = tempfile::tempdir().expect("project dir");
+        let file = project.path().join("sample.rs");
+        std::fs::write(&file, b"pub fn sample() -> u32 { 7 }\n").expect("write sample");
+
+        let args = vec![
+            "ctx_read".to_string(),
+            "--project-root".to_string(),
+            project.path().to_string_lossy().to_string(),
+            "--json".to_string(),
+            format!(
+                r#"{{"path": {}, "mode": "signatures"}}"#,
+                serde_json::to_string(file.to_string_lossy().as_ref()).expect("encode path")
+            ),
+        ];
+
+        let out = run_call(&args).expect("ctx_read should dispatch, not abort");
+        assert!(
+            out.contains("sample"),
+            "ctx_read output missing the file's symbol:\n{out}"
+        );
     }
 }

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -134,10 +134,15 @@ fn parse_args(args: &[String]) -> Result<CallArgs, CallError> {
 /// developer machine) before filtering on project root, and `lean-ctx call`
 /// is a short-lived subprocess that consumers spawn in loops.
 ///
-/// Read-only. Nothing writes this session back. Persistence belongs to the
-/// MCP server (`server/post_dispatch.rs`, `prepare_save` -> `write_to_disk`);
-/// a write from a one-shot subprocess would be last-writer-wins against a
-/// live server holding the same session file.
+/// This function only READS — it never writes the session back, and there is
+/// no implicit post-dispatch save (that belongs to the MCP server,
+/// `server/post_dispatch.rs`). It is NOT an invariant that a one-shot call
+/// leaves the session untouched: five actions reachable via `lean-ctx call`
+/// persist it on purpose — `ctx_session` `save`/`reset`/`import` and
+/// `ctx_handoff` `pull`/`import`. `write_to_disk`
+/// (`core/session/persistence.rs`) skips a write when the on-disk version is
+/// strictly newer, but an equal-version write still lands, so such a call
+/// racing a live server on the same session can still clobber it.
 ///
 /// Every failure degrades silently to an empty default session — no sessions
 /// directory (the first-run case, not an error), no index for this root, an
@@ -166,12 +171,18 @@ fn oneshot_ctx(project_root: String, resolved_paths: HashMap<String, String>) ->
         bm25_cache: Some(std::sync::Arc::new(std::sync::Mutex::new(None))),
         // Same class of omission as `cache` above: without these three,
         // ten registered tools abort with "<handle> not available".
-        // `session` is read-only (see `oneshot_session`); `tool_calls` and
-        // `ledger` start empty because a one-shot process has no history.
+        // `tool_calls` genuinely starts empty — it is in-process turn history
+        // a fresh subprocess cannot have. The ledger is the opposite: it is
+        // persisted state, so it is loaded from disk exactly as the MCP server
+        // does (`tools/server_lifecycle.rs`). An empty ledger here would not be
+        // a clean slate but data loss — tools that hold this handle write it
+        // straight back (`ctx_control` saves unconditionally, `ctx_ledger`
+        // reset/evict likewise), truncating the user's real, global
+        // `state_dir()/context_ledger.json` while every action silently no-ops.
         session: Some(std::sync::Arc::new(tokio::sync::RwLock::new(session))),
         tool_calls: Some(std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new()))),
         ledger: Some(std::sync::Arc::new(tokio::sync::RwLock::new(
-            crate::core::context_ledger::ContextLedger::default(),
+            crate::core::context_ledger::ContextLedger::load(),
         ))),
         // Every remaining handle stays None deliberately: no registered tool
         // aborts on their absence, and each would pull in server state a
@@ -456,6 +467,62 @@ mod tests {
             files_before,
             session_file_names(&sessions),
             "a one-shot call created or removed a session file"
+        );
+    }
+
+    /// Regression: a one-shot call must never truncate the user's global
+    /// context ledger (`state_dir()/context_ledger.json`, ONE non-project-scoped
+    /// file rewritten wholesale). `oneshot_ctx` briefly handed tools a
+    /// `ContextLedger::default()`; every ledger-holding tool writes that handle
+    /// straight back — `ctx_control` saves unconditionally — so a single
+    /// `lean-ctx call ctx_control` erased the real ledger.
+    ///
+    /// Isolation: `state_dir()` resolves through `paths::category_dir`, whose
+    /// explicit `LEAN_CTX_STATE_DIR` override wins even under `#[cfg(test)]`
+    /// (`LEAN_CTX_DATA_DIR` does NOT govern it). Pointing it at a tempdir is
+    /// what keeps this test off the developer's real `~/.local/state/lean-ctx`.
+    #[test]
+    fn a_one_shot_call_never_truncates_the_global_ledger() {
+        let state = tempfile::tempdir().expect("state dir");
+        crate::test_env::set_var("LEAN_CTX_STATE_DIR", state.path());
+        let data = tempfile::tempdir().expect("data dir");
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
+        let project = tempfile::tempdir().expect("project dir");
+        let marker_file = project.path().join("LEDGER_SEED_MARKER.rs");
+        std::fs::write(&marker_file, b"pub fn seeded() -> u32 { 1 }\n").expect("write marker");
+
+        // Seed an entry a `ContextLedger::default()` could never carry.
+        let mut seeded = crate::core::context_ledger::ContextLedger::new();
+        seeded.record(&marker_file.to_string_lossy(), "full", 4_000, 1_000);
+        seeded.save();
+
+        let ledger_file = state.path().join("context_ledger.json");
+        let before = std::fs::read_to_string(&ledger_file).expect("seeded ledger file");
+        assert!(
+            before.contains("LEDGER_SEED_MARKER"),
+            "precondition: the seed never reached {}",
+            ledger_file.display()
+        );
+
+        // ctx_control writes back whatever ledger `oneshot_ctx` gave it.
+        let args = vec![
+            "ctx_control".to_string(),
+            "--project-root".to_string(),
+            project.path().to_string_lossy().to_string(),
+            "--json".to_string(),
+            r#"{"action": "list"}"#.to_string(),
+        ];
+        run_call(&args).expect("ctx_control should dispatch");
+
+        let after = crate::core::context_ledger::ContextLedger::load();
+        assert!(
+            after
+                .entries
+                .iter()
+                .any(|entry| entry.path.contains("LEDGER_SEED_MARKER")),
+            "a one-shot call truncated the global ledger — {} entries survived; file now:\n{}",
+            after.entries.len(),
+            std::fs::read_to_string(&ledger_file).unwrap_or_default()
         );
     }
 }

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -343,6 +343,7 @@ mod tests {
 
     #[test]
     fn oneshot_ctx_supplies_session_tool_calls_and_ledger() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let data = tempfile::tempdir().expect("data dir");
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
         let project = tempfile::tempdir().expect("project dir");
@@ -356,6 +357,7 @@ mod tests {
 
     #[test]
     fn oneshot_session_without_an_index_returns_a_default() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let data = tempfile::tempdir().expect("data dir");
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
         let project = tempfile::tempdir().expect("project dir");
@@ -370,6 +372,7 @@ mod tests {
 
     #[test]
     fn ctx_read_via_call_no_longer_aborts_on_a_missing_session() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let data = tempfile::tempdir().expect("data dir");
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
         let project = tempfile::tempdir().expect("project dir");
@@ -406,6 +409,7 @@ mod tests {
 
     #[test]
     fn an_indexed_session_loads_and_a_one_shot_call_never_writes_it_back() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let data = tempfile::tempdir().expect("data dir");
         crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
         let project = tempfile::tempdir().expect("project dir");
@@ -483,6 +487,7 @@ mod tests {
     /// what keeps this test off the developer's real `~/.local/state/lean-ctx`.
     #[test]
     fn a_one_shot_call_never_truncates_the_global_ledger() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
         let state = tempfile::tempdir().expect("state dir");
         crate::test_env::set_var("LEAN_CTX_STATE_DIR", state.path());
         let data = tempfile::tempdir().expect("data dir");

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -382,4 +382,80 @@ mod tests {
             "ctx_read output missing the file's symbol:\n{out}"
         );
     }
+
+    fn session_file_names(dir: &std::path::Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .expect("sessions dir")
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn an_indexed_session_loads_and_a_one_shot_call_never_writes_it_back() {
+        let data = tempfile::tempdir().expect("data dir");
+        crate::test_env::set_var("LEAN_CTX_DATA_DIR", data.path());
+        let project = tempfile::tempdir().expect("project dir");
+        let root = project.path().to_string_lossy().to_string();
+
+        // Seed one session through the public API. `write_to_disk` is what
+        // populates the project index that `oneshot_session` reads back.
+        // Struct-update syntax, not `default()` + field assignment: the latter
+        // trips `clippy::field_reassign_with_default` and the gate is `-D warnings`.
+        let mut seeded = crate::core::session::SessionState {
+            project_root: Some(root.clone()),
+            task: Some(crate::core::session::TaskInfo {
+                description: "seeded task description".to_string(),
+                intent: None,
+                progress_pct: None,
+            }),
+            ..Default::default()
+        };
+        let seeded_id = seeded.id.clone();
+        seeded
+            .prepare_save()
+            .expect("prepare_save")
+            .write_to_disk()
+            .expect("write_to_disk");
+
+        // Half 1 — the index lookup resolves that session, not a default.
+        let loaded = oneshot_session(&root);
+        assert_eq!(
+            loaded.task.as_ref().map(|task| task.description.as_str()),
+            Some("seeded task description"),
+            "oneshot_session did not resolve the seeded session through the index"
+        );
+
+        // Half 2 — a one-shot call that mutates the session writes nothing back.
+        let sessions = data.path().join("sessions");
+        let seeded_path = sessions.join(format!("{seeded_id}.json"));
+        let before = std::fs::read(&seeded_path).expect("seeded session file");
+        let files_before = session_file_names(&sessions);
+
+        let args = vec![
+            "ctx_session".to_string(),
+            "--project-root".to_string(),
+            root,
+            "--json".to_string(),
+            r#"{"action": "task", "value": "a different task"}"#.to_string(),
+        ];
+        let out = run_call(&args).expect("ctx_session action=task should run to completion");
+        assert!(
+            out.contains("Task set"),
+            "ctx_session did not report success:\n{out}"
+        );
+
+        assert_eq!(
+            before,
+            std::fs::read(&seeded_path).expect("seeded session file"),
+            "a one-shot call rewrote the seeded session file"
+        );
+        assert_eq!(
+            files_before,
+            session_file_names(&sessions),
+            "a one-shot call created or removed a session file"
+        );
+    }
 }

--- a/rust/src/core/sandbox_landlock.rs
+++ b/rust/src/core/sandbox_landlock.rs
@@ -3,14 +3,14 @@ use std::process::Command;
 
 /// Describes which filesystem paths the Landlock sandbox should allow.
 /// Deny-all by default; explicitly listed paths get read or read+write access.
-pub struct LandlockRuleset {
+pub(crate) struct LandlockRuleset {
     pub read_paths: Vec<String>,
     pub read_write_paths: Vec<String>,
     pub interpreter: String,
 }
 
 impl LandlockRuleset {
-    pub fn new(allowed_read_paths: &[&Path], interpreter_path: &str) -> Self {
+    pub(crate) fn new(allowed_read_paths: &[&Path], interpreter_path: &str) -> Self {
         let mut read_paths = vec![
             "/usr".to_string(),
             "/lib".to_string(),
@@ -37,12 +37,12 @@ impl LandlockRuleset {
     }
 
     #[cfg(test)]
-    pub fn contains_read_path(&self, path: &str) -> bool {
+    pub(crate) fn contains_read_path(&self, path: &str) -> bool {
         self.read_paths.iter().any(|p| p == path)
     }
 
     #[cfg(test)]
-    pub fn contains_rw_path(&self, path: &str) -> bool {
+    pub(crate) fn contains_rw_path(&self, path: &str) -> bool {
         self.read_write_paths.iter().any(|p| p == path)
     }
 }
@@ -245,7 +245,7 @@ mod landlock_sys {
 // Public API
 // ---------------------------------------------------------------------------
 
-pub fn execute_sandboxed(
+pub(crate) fn execute_sandboxed(
     interpreter: &str,
     args: &[&str],
     allowed_read_paths: &[&Path],


### PR DESCRIPTION
## Summary

`lean-ctx call` built its `ToolContext` with `session`, `tool_calls` and `ledger`
left at `None`. Ten registered tools read those handles through
`ok_or_else(|| internal_error("<handle> not available"))` and abort outright, so
dispatching any of them through the one-shot CLI path failed where the same tool
succeeds over MCP: `ctx_read`, `ctx_multi_read`, `ctx_shell`, `ctx_session`,
`ctx_knowledge`, `ctx_handoff`, `ctx_ledger`, `ctx_fill`, `ctx_metrics`,
`ctx_workflow`.

This PR populates the three handles, each for a different reason:

* **`session`** — loaded from the project's most recent indexed session via
  `SessionState::load_recent_for_project_root(root, 1)`. Index-based on purpose:
  `load_latest_for_project_root` parses every file in the session store before
  filtering on project root, and `lean-ctx call` is a short-lived subprocess that
  consumers spawn in loops. Every failure path (no session directory, no index for
  this root, stale id, malformed JSON, unsafe root) degrades silently to an empty
  default session — a fully valid context that only costs the task focus steering
  `ctx_read` filtering.
* **`tool_calls`** — genuinely empty. It is in-process turn history that a fresh
  subprocess cannot have.
* **`ledger`** — `ContextLedger::load()`, exactly as the MCP server does in
  `tools/server_lifecycle.rs`. **Not `default()`.** The ledger is persisted state,
  and handing an empty one to a tool that writes it straight back is data loss, not
  a clean slate: `ctx_control` (`tools/registered/ctx_control.rs:44`) branches on
  `ctx.ledger.is_some()`, and the `Some` arm calls `ledger.save()` unconditionally
  at line 66. `save()` → `save_for_agent("default")` → `atomic_write_json` over
  `state_dir()/context_ledger.json`, which is one global, non-project-scoped file.
  With an empty handle every `ctx_control` invocation would silently no-op *and*
  truncate the user's real ledger. `ctx_ledger` `reset`/`evict` take the same path.

The one-shot path only ever **reads** the session — there is no implicit
post-dispatch save (that belongs to `server/post_dispatch.rs`). That is documented
at the function, together with the honest caveat that it is *not* an invariant:
five actions reachable through `lean-ctx call` persist the session on purpose
(`ctx_session` `save`/`reset`/`import`, `ctx_handoff` `pull`/`import`), and
`write_to_disk` only skips a write when the on-disk version is strictly newer — an
equal-version write still lands, so such a call racing a live server on the same
session can still clobber it.

The final commit is an unrelated lint cleanup, kept separate so it can be dropped:
`core/mod.rs:476` declares `pub(crate) mod sandbox_landlock`, so that module's
`pub` items are unreachable from outside the crate and `unreachable_pub`
(`Cargo.toml:340`) denies them under the CI clippy gate. The sibling
`sandbox_seatbelt.rs` already uses `pub(crate)` throughout, including its own
`execute_sandboxed`; all callers are crate-internal (`core/sandbox.rs:348,364`).

## Test plan

- [x] `cd rust && cargo test -- --test-threads=1` — **lib target green: 10559 passed, 0 failed, 23 ignored** (347 s). The integration target `tests/main.rs` has 3 failures on my machine, all proven pre-existing: I reverted `call_cmd.rs` and `sandbox_landlock.rs` to `main`, rebuilt, and reran them — identical panics, same messages. They are local-environment artefacts, not regressions:
  - `suite::ctx_read_lmd_md_raw::ctx_read_lmd_md_returns_raw_source` — `path escapes project root: /tmp/.tmpXXXXXX/d.lmd.md (root: <repo>)`. The fixture is a `tempfile::tempdir()` under `/tmp`, which lies outside the project root, and `jail_path_with_roots` denies it: neither `allow_paths`, `extra_roots`, `state_dir()` nor `read_only_roots` covers the system temp dir. Reproduced with `XDG_CONFIG_HOME` pointed at an empty directory, so it is not a local-config artefact. It drives `lean-ctx read`, a code path this branch does not touch.
  - `suite::efficiency_ux_scenarios::integration_workflow::scenario_multimode_read_workflow`
  - `suite::efficiency_ux_scenarios::zstd_bypass::scenario_map_mode_uses_compressed_cache` — both expect `F1=… [unchanged … view · fresh=true to re-emit]` and get the `→ … unchanged (ref:…), already in context` form instead; a cache-stub formatting expectation, unrelated to this branch.

  Separately, `suite::lock_contention_hardening::bounded_read_under_write_contention_returns_none` did not finish in the serialized full run on my machine, but passes in 10 s in isolation — the shared process-global state the template's own note warns about, under load.
- [ ] `cd rust && cargo clippy --all-targets --all-features -- -D warnings` — **fails, pre-existing.** 7919 warnings, all in the `lib test` target, 7707 of them `clippy::unwrap_used` in test code across the whole crate. Zero are attributable to this branch: the three in files it touches (`sandbox_landlock.rs:417`, `call_cmd.rs:324`, `call_cmd.rs:326`) all come from `6f8697ef4`, which is an ancestor of `main`. `unreachable_pub` count is **0** after the last commit. The gate CI actually runs — `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines` (`.github/workflows/ci.yml:217`, no `--all-targets`) — is green.
- [x] `cd rust && cargo fmt --check`
- [ ] No cookbook/packages changes.

Five new tests in `rust/src/cli/call_cmd.rs`:

| test | what it pins |
|---|---|
| `oneshot_session_without_an_index_returns_a_default` | the no-index path yields an empty session rather than panicking |
| `oneshot_ctx_supplies_session_tool_calls_and_ledger` | all three handles are `Some` |
| `ctx_read_via_call_no_longer_aborts_on_a_missing_session` | the actual user-visible regression, end to end |
| `an_indexed_session_loads_and_a_one_shot_call_never_writes_it_back` | index lookup resolves, and the store is byte-identical afterwards |
| `a_one_shot_call_never_truncates_the_global_ledger` | the data-loss case above |

The last two were verified load-bearing by mutation rather than assumed: reverting
`ContextLedger::load()` to `default()` fails the ledger test, and removing the
session seeding makes the non-persistence assertion vacuous (an empty store
satisfies it even if the code tried to save and failed).

## Notes for reviewers

* **Risk areas / edge cases:** Raising a handle from `None` to `Some` is never
  purely additive — it flips the fallback branch at every consumer. `ctx_control`
  is the one where that flip is load-bearing, and it is the reason `ledger` is
  `load()`. Reviewers should sanity-check the other nine tools for the same shape.
* **Backwards compatibility:** No signature, flag or output changes. Tools that
  worked through `lean-ctx call` behave identically; the ten that aborted now run.
  Session and ledger files are read with the same loaders the MCP server uses.
* **Known gaps, stated rather than hidden:** only `ctx_read` is covered end to end
  — the other nine tools are not individually tested. Nor is `ctx_session`
  `save`/`reset` persistence, which is the actual boundary of the "read-only"
  claim above.
* **Splitting:** the `sandbox_landlock` lint commit is deliberately last and
  self-contained. Drop it with a single `git revert` if you would rather have it as
  its own PR.
* **Docs updated:** none — the design spec lives outside the repo.
