### PR TITLE
feat(dashboard): invite design partners and SDK builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ present in the 3.10.0 artifacts.
 - Every native release target installs its wheel, passes strict package-metadata
   validation, and runs the SDK's real AgentContext lifecycle before publication.
 
+### Added — Dashboard
+
+- The local dashboard now presents a one-time, dismissible invitation for
+  companies interested in a LeanCTX design partnership or organization-wide
+  rollout, plus a direct path to the public Python SDK. It stays out of the way
+  of onboarding, authentication, and product tours; supports keyboard dismissal
+  and focus trapping; and remembers the user's choice locally.
+
 ### Security
 
 - Sessions are project-rooted and read-only by default. Write and execution

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -26,6 +26,8 @@ const COCKPIT_COMPONENT_SEARCH_JS: &str = include_str!("static/components/cockpi
 const COCKPIT_COMPONENT_COMPRESSION_JS: &str =
     include_str!("static/components/cockpit-compression.js");
 const COCKPIT_COMPONENT_TOUR_JS: &str = include_str!("static/components/cockpit-tour.js");
+const COCKPIT_COMPONENT_PARTNER_PROMO_JS: &str =
+    include_str!("static/components/cockpit-partner-promo.js");
 const COCKPIT_COMPONENT_GRAPH_JS: &str = include_str!("static/components/cockpit-graph.js");
 const COCKPIT_COMPONENT_ARCHITECTURE_JS: &str =
     include_str!("static/components/cockpit-architecture.js");

--- a/rust/src/dashboard/routes/mod.rs
+++ b/rust/src/dashboard/routes/mod.rs
@@ -41,6 +41,7 @@ fn match_component_path(path: &str) -> Option<String> {
         "/static/components/cockpit-search.js" => super::COCKPIT_COMPONENT_SEARCH_JS,
         "/static/components/cockpit-compression.js" => super::COCKPIT_COMPONENT_COMPRESSION_JS,
         "/static/components/cockpit-tour.js" => super::COCKPIT_COMPONENT_TOUR_JS,
+        "/static/components/cockpit-partner-promo.js" => super::COCKPIT_COMPONENT_PARTNER_PROMO_JS,
         "/static/components/cockpit-graph.js" => super::COCKPIT_COMPONENT_GRAPH_JS,
         "/static/components/cockpit-architecture.js" => super::COCKPIT_COMPONENT_ARCHITECTURE_JS,
         "/static/components/cockpit-explorer.js" => super::COCKPIT_COMPONENT_EXPLORER_JS,

--- a/rust/src/dashboard/static/components/cockpit-partner-promo.js
+++ b/rust/src/dashboard/static/components/cockpit-partner-promo.js
@@ -1,0 +1,223 @@
+/**
+ * One-time design-partner and SDK invitation for the local dashboard.
+ * The campaign key is versioned so future invitations can be shown once.
+ */
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'leanctx_partner_sdk_promo_v1';
+  var OVERLAY_ID = 'leanctxPartnerPromo';
+  var previousFocus = null;
+  var backgroundState = [];
+  var blockingObserver = null;
+  var openFrame = null;
+
+  function readStorage(key) {
+    try { return localStorage.getItem(key); } catch (_) { return null; }
+  }
+
+  function rememberDismissal() {
+    try { localStorage.setItem(STORAGE_KEY, 'dismissed'); } catch (_) {}
+  }
+
+  function hasBlockingDialog() {
+    var onboarding = document.getElementById('onboardOverlay');
+    var ownOverlay = document.getElementById(OVERLAY_ID);
+    var otherModal = Array.prototype.slice.call(document.querySelectorAll('[aria-modal="true"]'))
+      .some(function (dialog) {
+        return (!ownOverlay || !ownOverlay.contains(dialog)) && !dialog.closest('[hidden]');
+      });
+    return !!(
+      document.getElementById('lctxTokenGate') ||
+      document.querySelector('.tour-overlay') ||
+      (onboarding && !onboarding.hidden) ||
+      otherModal
+    );
+  }
+
+  function shouldShow() {
+    return readStorage(STORAGE_KEY) !== 'dismissed' &&
+      readStorage('lctx_onboarded') === '1' &&
+      !hasBlockingDialog();
+  }
+
+  function setBackgroundInert(overlay) {
+    backgroundState = Array.prototype.slice.call(document.body.children)
+      .filter(function (element) { return element !== overlay && element.tagName !== 'SCRIPT'; })
+      .map(function (element) {
+        var state = {
+          element: element,
+          hadInert: element.hasAttribute('inert'),
+          ariaHidden: element.getAttribute('aria-hidden')
+        };
+        element.setAttribute('inert', '');
+        element.setAttribute('aria-hidden', 'true');
+        return state;
+      });
+  }
+
+  function restoreBackground() {
+    backgroundState.forEach(function (state) {
+      if (!state.hadInert) state.element.removeAttribute('inert');
+      if (state.ariaHidden === null) state.element.removeAttribute('aria-hidden');
+      else state.element.setAttribute('aria-hidden', state.ariaHidden);
+    });
+    backgroundState = [];
+  }
+
+  function close(remember) {
+    var overlay = document.getElementById(OVERLAY_ID);
+    if (remember) rememberDismissal();
+    if (!overlay) return;
+    if (blockingObserver) blockingObserver.disconnect();
+    blockingObserver = null;
+    if (openFrame !== null) cancelAnimationFrame(openFrame);
+    openFrame = null;
+    document.removeEventListener('focusin', keepFocusInDialog, true);
+    overlay.classList.remove('show');
+    document.body.classList.remove('partner-promo-open');
+    setTimeout(function () {
+      overlay.remove();
+      restoreBackground();
+      if (!hasBlockingDialog() && previousFocus && typeof previousFocus.focus === 'function') {
+        previousFocus.focus();
+      }
+      previousFocus = null;
+    }, 180);
+  }
+
+  function dismiss() { close(true); }
+
+  function focusableElements(dialog) {
+    return Array.prototype.slice.call(
+      dialog.querySelectorAll('a[href],button:not([disabled]),[tabindex]:not([tabindex="-1"])')
+    );
+  }
+
+  function handleKeydown(event) {
+    var overlay = document.getElementById(OVERLAY_ID);
+    if (!overlay) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      dismiss();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    var dialog = overlay.querySelector('[role="dialog"]');
+    if (!dialog) return;
+    var focusable = focusableElements(dialog);
+    if (!focusable.length) return;
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    if (!dialog.contains(document.activeElement)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+    } else if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function keepFocusInDialog(event) {
+    var overlay = document.getElementById(OVERLAY_ID);
+    if (!overlay || overlay.contains(event.target)) return;
+    var dialog = overlay.querySelector('[role="dialog"]');
+    var focusable = dialog ? focusableElements(dialog) : [];
+    if (focusable.length) focusable[0].focus();
+  }
+
+  function createOverlay() {
+    var overlay = document.createElement('div');
+    overlay.id = OVERLAY_ID;
+    overlay.className = 'partner-promo-overlay';
+    overlay.innerHTML =
+      '<section class="partner-promo" role="dialog" aria-modal="true" ' +
+        'aria-labelledby="partnerPromoTitle" aria-describedby="partnerPromoDescription">' +
+        '<button type="button" class="partner-promo-close" aria-label="Dismiss invitation">&times;</button>' +
+        '<div class="partner-promo-kicker">BUILD WITH LEANCTX</div>' +
+        '<h2 id="partnerPromoTitle">Take LeanCTX further</h2>' +
+        '<p id="partnerPromoDescription" class="partner-promo-intro">' +
+          'We are looking for design partners and engineering teams ready to deploy LeanCTX in real workflows.' +
+        '</p>' +
+        '<div class="partner-promo-options">' +
+          '<article class="partner-promo-option">' +
+            '<span class="partner-promo-index" aria-hidden="true">01</span>' +
+            '<h3>Roll out LeanCTX</h3>' +
+            '<p>Work with us on integrations, governance, rollout and measurable context efficiency for your organization.</p>' +
+            '<a class="partner-promo-cta partner-promo-cta-primary" ' +
+              'href="mailto:yves@thinkery.ch?subject=LeanCTX%20design%20partner%20inquiry">' +
+              'Email yves@thinkery.ch <span aria-hidden="true">&rarr;</span></a>' +
+          '</article>' +
+          '<article class="partner-promo-option">' +
+            '<span class="partner-promo-index" aria-hidden="true">02</span>' +
+            '<h3>Build your own agent</h3>' +
+            '<p>Use the Python SDK with the local LeanCTX Engine to build custom, token-efficient agent workflows.</p>' +
+            '<a class="partner-promo-cta" href="https://github.com/Thinkery-AG/leanctx-sdk#readme" ' +
+              'target="_blank" rel="noopener noreferrer">Explore the SDK <span aria-hidden="true">&rarr;</span>' +
+              '<span class="partner-promo-sr-only"> (opens in a new tab)</span></a>' +
+          '</article>' +
+        '</div>' +
+        '<button type="button" class="partner-promo-later">Dismiss</button>' +
+      '</section>';
+    return overlay;
+  }
+
+  function show() {
+    if (!shouldShow() || document.getElementById(OVERLAY_ID)) return false;
+    previousFocus = document.activeElement;
+    var overlay = createOverlay();
+    document.body.appendChild(overlay);
+    setBackgroundInert(overlay);
+    document.body.classList.add('partner-promo-open');
+
+    overlay.querySelector('.partner-promo-close').addEventListener('click', dismiss);
+    overlay.querySelector('.partner-promo-later').addEventListener('click', dismiss);
+    overlay.querySelectorAll('.partner-promo-cta').forEach(function (link) {
+      link.addEventListener('click', dismiss);
+    });
+    overlay.addEventListener('click', function (event) {
+      if (event.target === overlay) dismiss();
+    });
+    overlay.addEventListener('keydown', handleKeydown);
+    document.addEventListener('focusin', keepFocusInDialog, true);
+    if (typeof MutationObserver !== 'undefined') {
+      blockingObserver = new MutationObserver(function () {
+        if (hasBlockingDialog()) close(false);
+      });
+      blockingObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class', 'hidden']
+      });
+    }
+
+    openFrame = requestAnimationFrame(function () {
+      openFrame = null;
+      if (document.getElementById(OVERLAY_ID) !== overlay) return;
+      overlay.classList.add('show');
+      overlay.querySelector('.partner-promo-close').focus();
+    });
+    return true;
+  }
+
+  function autoStart() {
+    setTimeout(show, 1200);
+  }
+
+  window.__leanctxPartnerPromo = {
+    dismiss: dismiss,
+    shouldShow: shouldShow,
+    show: show,
+    storageKey: STORAGE_KEY
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', autoStart, { once: true });
+  } else {
+    autoStart();
+  }
+})();

--- a/rust/src/dashboard/static/index.html
+++ b/rust/src/dashboard/static/index.html
@@ -265,6 +265,7 @@
 <script type="module" src="/static/components/cockpit-search.js"></script>
 <script type="module" src="/static/components/cockpit-compression.js"></script>
 <script src="/static/components/cockpit-tour.js"></script>
+<script src="/static/components/cockpit-partner-promo.js" defer></script>
 <script type="module" src="/static/components/cockpit-graph.js"></script>
 <script type="module" src="/static/components/cockpit-architecture.js"></script>
 <script type="module" src="/static/components/cockpit-explorer.js"></script>

--- a/rust/src/dashboard/static/style.css
+++ b/rust/src/dashboard/static/style.css
@@ -1358,6 +1358,82 @@ tr:hover td{background:var(--surface-2)}
 }
 .onboard-btn:hover{filter:brightness(1.08)}
 
+/* ---- One-time design-partner + SDK invitation ---- */
+.partner-promo-open{overflow:hidden}
+.partner-promo-overlay{
+  position:fixed;inset:0;z-index:var(--z-modal,1000);
+  display:flex;align-items:center;justify-content:center;padding:24px;
+  background:rgba(8,12,16,.76);backdrop-filter:blur(9px);-webkit-backdrop-filter:blur(9px);
+  opacity:0;transition:opacity .18s var(--ease-out);
+}
+[data-theme="light"] .partner-promo-overlay{background:rgba(245,245,240,.78)}
+.partner-promo-overlay.show{opacity:1}
+.partner-promo{
+  position:relative;width:min(680px,100%);max-height:calc(100vh - 48px);
+  max-height:calc(100dvh - 48px);overflow:auto;
+  padding:34px;background:var(--surface);border:1px solid var(--border-light);
+  border-radius:14px;box-shadow:var(--shadow-lg,0 24px 60px rgba(0,0,0,.4));
+  transform:translateY(10px) scale(.985);transition:transform .18s var(--ease-out);
+}
+.partner-promo-overlay.show .partner-promo{transform:translateY(0) scale(1)}
+.partner-promo-close{
+  position:sticky;top:0;z-index:1;float:right;width:34px;height:34px;margin:-20px -20px 0 12px;
+  border:1px solid var(--border);border-radius:50%;background:var(--bg);
+  color:var(--muted);font-size:22px;line-height:1;cursor:pointer;
+}
+.partner-promo-close:hover{border-color:var(--border-light);color:var(--text-bright)}
+.partner-promo-close:focus-visible,.partner-promo-cta:focus-visible,.partner-promo-later:focus-visible{
+  outline:2px solid var(--accent);outline-offset:3px;
+}
+.partner-promo-kicker{
+  margin-bottom:10px;color:var(--accent);font:700 10px/1 var(--mono);
+  letter-spacing:.14em;
+}
+.partner-promo h2{
+  margin:0 44px 8px 0;color:var(--text-bright);font:500 28px/1.15 var(--font-display);
+  letter-spacing:-.025em;
+}
+.partner-promo-intro{max-width:580px;margin:0 0 24px;color:var(--muted);font-size:14px;line-height:1.55}
+.partner-promo-options{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.partner-promo-option{
+  display:flex;flex-direction:column;min-height:220px;padding:20px;
+  background:var(--bg);border:1px solid var(--border);border-radius:var(--r);
+}
+.partner-promo-index{color:var(--accent);font:700 10px/1 var(--mono);letter-spacing:.08em}
+.partner-promo-option h3{margin:18px 0 8px;color:var(--text-bright);font-size:16px;font-weight:600}
+.partner-promo-option p{margin:0 0 20px;color:var(--muted);font-size:12.5px;line-height:1.55}
+.partner-promo-cta{
+  display:inline-flex;align-items:center;justify-content:space-between;gap:12px;
+  margin-top:auto;padding:10px 12px;border:1px solid var(--border-light);border-radius:7px;
+  color:var(--text-bright);font-size:12px;font-weight:600;text-decoration:none;
+  transition:border-color .15s,background .15s,color .15s;
+}
+.partner-promo-cta:hover{border-color:var(--accent);color:var(--accent);background:var(--accent-dim)}
+.partner-promo-cta-primary{border-color:var(--accent);background:var(--accent-dim);color:var(--accent)}
+.partner-promo-later{
+  display:block;margin:18px auto 0;padding:6px 10px;border:0;background:transparent;
+  color:var(--muted);font-size:11.5px;cursor:pointer;
+}
+.partner-promo-later:hover{color:var(--text-bright)}
+.partner-promo-sr-only{
+  position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+  clip:rect(0,0,0,0);white-space:nowrap;border:0;
+}
+@media(max-width:620px){
+  .partner-promo-overlay{
+    padding:max(12px,env(safe-area-inset-top)) max(12px,env(safe-area-inset-right))
+      max(12px,env(safe-area-inset-bottom)) max(12px,env(safe-area-inset-left));
+  }
+  .partner-promo{padding:26px 18px 22px}
+  .partner-promo-close{margin:-14px -6px 0 10px}
+  .partner-promo h2{font-size:23px}
+  .partner-promo-options{grid-template-columns:1fr}
+  .partner-promo-option{min-height:auto}
+}
+@media(prefers-reduced-motion:reduce){
+  .partner-promo-overlay,.partner-promo{transition:none}
+}
+
 /* Background ASCII art was visual noise behind the data — keep it off. */
 .ascii-global-bg{display:none}
 

--- a/rust/src/dashboard/tests.rs
+++ b/rust/src/dashboard/tests.rs
@@ -661,3 +661,43 @@ fn pulse_refresh_targets_only_the_active_view() {
     assert!(coordinator.contains("hasPendingUpdate"));
     assert!(!coordinator.contains("CustomEvent('lctx:refresh')"));
 }
+
+#[test]
+fn partner_promo_is_accessible_versioned_and_served() {
+    let (status, content_type, source) = super::routes::route_response(
+        "/static/components/cockpit-partner-promo.js",
+        "",
+        None,
+        None,
+        true,
+        "GET",
+        "",
+    );
+
+    assert_eq!(status, "200 OK");
+    assert_eq!(content_type, "application/javascript; charset=utf-8");
+    assert!(COCKPIT_INDEX_HTML.contains("/static/components/cockpit-partner-promo.js"));
+    assert!(source.contains("leanctx_partner_sdk_promo_v1"));
+    assert!(source.contains("aria-modal=\"true\""));
+    assert!(source.contains("aria-labelledby=\"partnerPromoTitle\""));
+    assert!(source.contains("event.key === 'Escape'"));
+    assert!(source.contains("event.key !== 'Tab'"));
+    assert!(source.contains("setBackgroundInert(overlay)"));
+    assert!(source.contains("document.addEventListener('focusin', keepFocusInDialog, true)"));
+    assert!(source.contains("new MutationObserver"));
+    assert!(source.contains("close(false)"));
+    assert!(source.contains("cancelAnimationFrame(openFrame)"));
+    assert!(source.contains("document.getElementById(OVERLAY_ID) !== overlay"));
+    assert!(source.contains("opens in a new tab"));
+    assert!(source.contains("target=\"_blank\" rel=\"noopener noreferrer\""));
+    assert!(source.contains("Thinkery-AG/leanctx-sdk#readme"));
+    assert!(
+        source.contains("mailto:yves@thinkery.ch?subject=LeanCTX%20design%20partner%20inquiry")
+    );
+    assert!(source.contains("local LeanCTX Engine"));
+
+    let rewritten = super::base_path::rewrite_asset_urls(COCKPIT_INDEX_HTML, "/dashboard");
+    assert!(rewritten.contains("src=\"/dashboard/static/components/cockpit-partner-promo.js\""));
+    assert!(super::COCKPIT_STYLE_CSS.contains("max-height:calc(100dvh - 48px)"));
+    assert!(super::COCKPIT_STYLE_CSS.contains("env(safe-area-inset-bottom)"));
+}


### PR DESCRIPTION
## Summary
- add a one-time local dashboard invitation for LeanCTX design partners and company rollouts
- direct design-partner inquiries to yves@thinkery.ch
- advertise the public Python SDK for custom token-efficient agents
- preserve onboarding/auth/tour priority, focus containment, dismissal persistence, responsive layout, and base-path routing
- document the dashboard addition in the 3.10.1 changelog

## Verification
- node --check cockpit-partner-promo.js
- cargo test --lib (10,599 tests)
- cargo clippy --all-features -- -D warnings
- cargo fmt --check
- git diff --check