### PR TITLE
feat(addon): reopen the extension channel — WASM modules inside signed packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,14 @@ below. None of it is present in the 3.10.0 artifacts.
   where your own package manager's trust model applies.
 - That server runs as a **normal process with your privileges** — it is not
   sandboxed, and the WASM guarantees do not extend to it. So `addon add` prints
-  the exact argv and says so before asking. Adding a server does not enable the
-  gateway: `[gateway]` stays global-only and opt-in, and `addon list` reports an
-  addon that is wired while the gateway is off rather than letting you assume it
-  is running. `addon remove` unwires as well as uninstalls.
+  the exact argv and says so before asking. An `http` endpoint gets the
+  disclosure that is true for *it* instead: nothing runs locally, but lean-ctx
+  sends it requests and treats its replies as untrusted input — and the pin line
+  is omitted, since a SHA-256 of a local binary means nothing for a URL. Adding
+  a server does not enable the gateway: `[gateway]` stays global-only and
+  opt-in, and `addon list` reports an addon that is wired while the gateway is
+  off rather than letting you assume it is running. `addon remove` unwires as
+  well as uninstalls.
 - **`integration` reaches the L4 typed adapters from a manifest.** Setting it
   routes the server's output into the matching lean-ctx surface —
   `codebase-pack` → `ctx_expand`, `code-graph`/`code-symbols` → `ctx_callgraph`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to lean-ctx are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [3.10.1] — 2026-08-31
+## [3.10.1] — 2026-09-01
 
 This release includes the defect fixes merged after the `v3.10.0` tag
 (`5b69202`), the addon channel, and the additive SDK Agent Tools interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ below. None of it is present in the 3.10.0 artifacts.
   opt-in, and `addon list` reports an addon that is wired while the gateway is
   off rather than letting you assume it is running. `addon remove` unwires as
   well as uninstalls.
+- **`lean-ctx doctor` now reports what actually loaded.** `addon list` already
+  claimed modules were "visible in `lean-ctx doctor`" — they were not; no such
+  check existed. It does now, and it answers a question the store cannot:
+  `addon add` verifies a module's four magic bytes, which is a prefix and not a
+  parse, so a truncated or corrupt module installs cleanly, matches its pinned
+  digest, and is then refused by the loader. `addon list` would still show it as
+  a compressor. Doctor compares the store against the extension registry and
+  names the modules that did not make it, alongside how many MCP servers are
+  wired and whether the gateway is on.
+- `addon list` was making that claim before it was true; the fix was to build
+  the check rather than delete the sentence.
 - **Only one version of an addon loads.** The store keeps versions side by side
   like every other pack kind, and module discovery walked the whole tree — so
   after an upgrade the registry received two modules with the same file stem and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ below. None of it is present in the 3.10.0 artifacts.
   opt-in, and `addon list` reports an addon that is wired while the gateway is
   off rather than letting you assume it is running. `addon remove` unwires as
   well as uninstalls.
+- **An upgrade keeps what you configured.** Re-installing replaces the fields
+  the author owns (transport, command, args, url, pin, integration) and
+  preserves the ones you do: `secret_env` / `secret_headers`, which a manifest
+  cannot carry by design — so a wholesale replace would have silently dropped
+  your token and left the server failing to authenticate with nothing saying
+  why — and the per-server `enabled` switch, so an addon you deliberately turned
+  off is not turned back on behind an upgrade.
 - **`integration` reaches the L4 typed adapters from a manifest.** Setting it
   routes the server's output into the matching lean-ctx surface —
   `codebase-pack` → `ctx_expand`, `code-graph`/`code-symbols` → `ctx_callgraph`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ below. None of it is present in the 3.10.0 artifacts.
   opt-in, and `addon list` reports an addon that is wired while the gateway is
   off rather than letting you assume it is running. `addon remove` unwires as
   well as uninstalls.
+- **Only one version of an addon loads.** The store keeps versions side by side
+  like every other pack kind, and module discovery walked the whole tree — so
+  after an upgrade the registry received two modules with the same file stem and
+  load order decided the winner. Load order was sorted paths, where
+  `"10.0.0" < "9.0.0"`, so upgrading 9 to 10 would have quietly kept running
+  version 9. Discovery now picks one version per addon by install time (the
+  manifest contract calls `version` author-declared and free-form, so it is not
+  reliably orderable; the install that wrote the directory is a fact).
+  `addon list` marks the rest `(superseded)` and reports their modules as on
+  disk but not loaded, instead of listing code that never runs.
 - **An upgrade keeps what you configured.** Re-installing replaces the fields
   the author owns (transport, command, args, url, pin, integration) and
   preserves the ones you do: `secret_env` / `secret_headers`, which a manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,14 +55,18 @@ below. None of it is present in the 3.10.0 artifacts.
   gateway: `[gateway]` stays global-only and opt-in, and `addon list` reports an
   addon that is wired while the gateway is off rather than letting you assume it
   is running. `addon remove` unwires as well as uninstalls.
-- **`integration` reaches the L4 typed adapters from a manifest.** Setting it in
-  `[mcp]` routes the server's output into the matching lean-ctx surface —
+- **`integration` reaches the L4 typed adapters from a manifest.** Setting it
+  routes the server's output into the matching lean-ctx surface —
   `codebase-pack` → `ctx_expand`, `code-graph`/`code-symbols` → `ctx_callgraph`,
   `memory` → `ctx_knowledge`, `compression` → the compressor pipeline — instead
-  of arriving as opaque text. Aliases are canonicalised; an **unrecognised slug
-  is refused at parse**. `IntegrationKind::parse` maps anything it does not know
-  to `None`, so a typo would otherwise have installed cleanly and quietly done
-  less, which is indistinguishable from working software.
+  of arriving as opaque text. It is read from `[mcp]` first, then `[addon]`
+  (its documented home, and where every manifest in the wild puts it — see
+  #1391), then derived from a recognised `[addon] categories` entry. An
+  **unrecognised slug is refused at parse**: `IntegrationKind::parse` maps
+  anything it does not know to `None`, so a typo would otherwise have installed
+  cleanly and quietly done less, which is indistinguishable from working
+  software. Category derivation stays lenient, because categories are free-form
+  browsing labels rather than a vocabulary.
 - **`addon add` accepts a registry reference**, not only a local file. `pack
   install` refuses executable content and points at `addon add`, which until now
   took a path only — so a published addon could be resolved, downloaded, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,49 @@ below. None of it is present in the 3.10.0 artifacts.
   documented as such rather than implied.
 - `LEAN_CTX_WASM_DIR` remains an unsigned developer override for authoring a
   module before packaging it, with none of the verification above.
+- **An addon may instead declare an MCP server** under `[mcp]`, which `addon
+  add` translates into a `[[gateway.servers]]` entry. A compressor has to run
+  inside the pipeline, so it is WASM; a tool that already speaks MCP has a
+  process model of its own, so it is declared rather than embedded. What does
+  **not** come back from the pre-3.9.20 channel is `[install]`: lean-ctx never
+  runs `uv tool install` or `npx` for you. Fetching the server stays your step,
+  where your own package manager's trust model applies.
+- That server runs as a **normal process with your privileges** — it is not
+  sandboxed, and the WASM guarantees do not extend to it. So `addon add` prints
+  the exact argv and says so before asking. Adding a server does not enable the
+  gateway: `[gateway]` stays global-only and opt-in, and `addon list` reports an
+  addon that is wired while the gateway is off rather than letting you assume it
+  is running. `addon remove` unwires as well as uninstalls.
 
-See [the addon guide](docs/guides/addons.md) and
-[`wasm-abi-v1`](docs/contracts/wasm-abi-v1.md), both moved from Research to
-Preview for this release.
+### Fixed — `binary_sha256` was a pin that never fired
+
+`[[gateway.servers]] binary_sha256` (and the `sha256` field of an addon's
+`[mcp]` table, which becomes it) was parsed, stored, shown, included in the
+connection-pool identity — and then discarded at the spawn point with
+`let _ = binary_sha256`. `addon-manifest-v1` promised the gateway "hashes the
+resolved binary before spawn and refuses a mismatch (fail-closed)". It did not.
+A pin that is displayed but never checked is worse than no pin, because it reads
+as a guarantee.
+
+It is now enforced. Two details matter as much as the hashing: the binary is
+resolved against the `PATH` the **child** will see, since a server's own `env`
+may override it — otherwise we would hash one file and spawn another; and once a
+pin is set, the resolved path is what gets spawned, so name resolution cannot
+land elsewhere between check and spawn. An empty pin stays a documented no-op; a
+pin that cannot be checked (missing or unreadable binary) is an error, not a
+skip.
+
+`addon-manifest-v1` also gained a "What 3.10.1 implements" section drawing the
+line between what the current parser reads and what the document records from
+the removed system (`[install]`, `[capabilities]`, `[[dependencies]]`,
+`{pack_dir:}` expansion, `min_lean_ctx` enforcement, the `verified` tier).
+
+See [the addon guide](docs/guides/addons.md), moved from Research to Preview for
+this release. [`wasm-abi-v1`](docs/contracts/wasm-abi-v1.md) is a frozen
+artifact and is deliberately **not** edited: its status now lives in the
+CONTRACTS.md stability matrix, per that document's own contract file rule. The
+ABI is unchanged — a breaking change would ship as `wasm-abi-v2` with an
+overlap window.
 
 ### Added — SDK Agent Tools Interface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [3.10.1] — 2026-08-31
 
 This release includes the defect fixes merged after the `v3.10.0` tag
-(`5b69202`) and the additive SDK Agent Tools interface below. Neither is
-present in the 3.10.0 artifacts.
+(`5b69202`), the addon channel, and the additive SDK Agent Tools interface
+below. None of it is present in the 3.10.0 artifacts.
+
+### Added — Addons: WASM extensions you can publish yourself
+
+- **`lean-ctx addon`** — `list`, `info`, `add`, `remove`, `release`. An addon is
+  a sandboxed WebAssembly module that runs inside the context pipeline and
+  registers as a compressor. There is deliberately no `search`: that would be a
+  marketplace, and lean-ctx does not curate, rank or host one.
+- **The module travels inside the signed package.** `lean-ctx addon release
+  ./my-addon` reads the `.wasm` files next to `lean-ctx-addon.toml`, hashes and
+  embeds them, and signs the result. No artifact host, no checksum files, no CI
+  — the reported friction of the previous addon channel was that authors had to
+  run their own pipeline just to produce SHA files for externally hosted
+  binaries. It also removes a download from install, and with it the window
+  between "verified the manifest" and "fetched the binary".
+- **Install asks, and verifies first.** `addon add` re-verifies the signature
+  locally (registry compromise ≠ client compromise), checks each module against
+  its pinned SHA-256 and its WebAssembly magic bytes, shows the publisher key
+  and module digests, then asks. It refuses to proceed non-interactively unless
+  given `--yes`. `pack import` still declines executable content and points at
+  the right door.
+- **Sandbox, stated honestly.** Enforced: no ambient environment, a fresh WASM
+  store per call, the output budget applied by the host *after* decoding, and
+  modules stored read-only and never marked executable. Not claimed: a module
+  can compute whatever it likes within those bounds — the sandbox limits reach,
+  not intent.
+- The `wasm` feature is **on by default** (measured cost: 83_065_536 →
+  83_815_584 bytes, +750 KB, +0.90%). Without it the shipped binary could not
+  load an extension at all, which would leave authors with a channel nobody
+  could install from.
+- Today the ABI reaches compressors and context providers. Chunkers, read modes
+  and render transforms exist as Rust traits and are **not** exposed over it —
+  documented as such rather than implied.
+- `LEAN_CTX_WASM_DIR` remains an unsigned developer override for authoring a
+  module before packaging it, with none of the verification above.
+
+See [the addon guide](docs/guides/addons.md) and
+[`wasm-abi-v1`](docs/contracts/wasm-abi-v1.md), both moved from Research to
+Preview for this release.
 
 ### Added — SDK Agent Tools Interface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ below. None of it is present in the 3.10.0 artifacts.
   gateway: `[gateway]` stays global-only and opt-in, and `addon list` reports an
   addon that is wired while the gateway is off rather than letting you assume it
   is running. `addon remove` unwires as well as uninstalls.
+- **`integration` reaches the L4 typed adapters from a manifest.** Setting it in
+  `[mcp]` routes the server's output into the matching lean-ctx surface —
+  `codebase-pack` → `ctx_expand`, `code-graph`/`code-symbols` → `ctx_callgraph`,
+  `memory` → `ctx_knowledge`, `compression` → the compressor pipeline — instead
+  of arriving as opaque text. Aliases are canonicalised; an **unrecognised slug
+  is refused at parse**. `IntegrationKind::parse` maps anything it does not know
+  to `None`, so a typo would otherwise have installed cleanly and quietly done
+  less, which is indistinguishable from working software.
+- **`addon add` accepts a registry reference**, not only a local file. `pack
+  install` refuses executable content and points at `addon add`, which until now
+  took a path only — so a published addon could be resolved, downloaded, and
+  then installed by no command at all. The remote artifact is staged to a temp
+  file and goes through the *same* preview, prompt and verification as a local
+  one: one consent path, not a shorter one for downloads. A path that exists on
+  disk always wins over a registry lookup, so `acme/widget` cannot quietly reach
+  the network when a file by that name is present.
 
 ### Fixed — `binary_sha256` was a pin that never fired
 

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -67,7 +67,7 @@ Status of every contract document (SSOT: `rust/src/core/contracts.rs::contract_d
 | Local-Free Invariant | `docs/contracts/local-free-invariant-v1.md` | 1 | frozen |
 | OSS Plane Separation | `docs/contracts/oss-plane-separation-v1.md` | 1 | frozen |
 | Billing Plane | `docs/contracts/billing-plane-v1.md` | 1 | frozen |
-| WASM ABI | `docs/contracts/wasm-abi-v1.md` | 1 | frozen |
+| WASM ABI | `docs/contracts/wasm-abi-v1.md` | 1 | frozen² |
 | Delivery Manifest | `docs/contracts/delivery-manifest-v1.md` | 1 | frozen |
 | Deployment Rehearsal | `docs/contracts/deployment-rehearsal-v1.md` | 1 | frozen |
 | Release Key Rotation | `docs/contracts/release-key-rotation-v1.md` | 1 | frozen |
@@ -103,6 +103,17 @@ Status of every contract document (SSOT: `rust/src/core/contracts.rs::contract_d
 | OCLA Config Tuning | `docs/contracts/ocla-config-tuning-v2.md` | 2 | experimental |
 
 ¹ The capabilities document is additive **by design**: its drift test binds the doc's key list to `server_capabilities::TOP_LEVEL_KEYS`, so the doc must grow whenever a key is added. Freezing the file would contradict its own contract; removal or mutation of existing keys remains a breaking change.
+
+² The ABI itself is unchanged and stays frozen at v1 — that is the promise to
+extension authors. What changed in 3.10.1 is its surroundings: the `wasm`
+feature is on in the default build, and `lean-ctx addon` makes building and
+installing a module locally a supported path. The frozen file's own header
+predates that and still reads "Research contract"; per the *Contract file rule*
+above, status notes about a frozen artifact belong here rather than inside it.
+The current status of the addon channel is
+[`docs/guides/addons.md`](docs/guides/addons.md). The ABI is versioned but not
+final: a breaking change ships as `wasm-abi-v2.md` with an overlap window, never
+as an edit to v1.
 
 Clients can read this matrix at runtime: `GET /v1/capabilities` returns a `contract_status` map (contract-id → status) next to the existing `contracts` version map.
 

--- a/README.md
+++ b/README.md
@@ -208,27 +208,37 @@ lean-ctx shadow --latest
 
 </details>
 
-## Addons — run the ecosystem through one gateway
+## Addons — extend the engine, or run the ecosystem through one gateway
 
 You don't have to choose between LeanCTX and the other context tools you already
-like. An **addon** wraps any MCP server in a tiny `lean-ctx-addon.toml` manifest;
-LeanCTX runs it behind its gateway with one command, then treats what it returns
+like. An **addon** is a signed package carrying either a sandboxed WASM module
+that runs *inside* the context pipeline, or an `[mcp]` declaration that wires an
+external MCP server into the gateway — after which LeanCTX treats what it returns
 like your own reads instead of just proxying it.
 
 ```bash
-lean-ctx addon search memory   # browse the registry by category
-lean-ctx addon add headroom    # installs the upstream package + wires the MCP server, on add
-lean-ctx addon list            # what's wired into your gateway
+lean-ctx addon release ./my-addon   # build a signed .ctxpkg — no artifact host, no CI
+lean-ctx addon add ./my-addon-1.0.0.ctxpkg   # verify, disclose, ask, install
+lean-ctx addon list                 # what's installed, what loads, what's wired
 ```
 
-- **One command to add** — `addon add <name>` installs the upstream package via its native manager (uv, pip, cargo, npm, brew, dotnet) and wires the MCP server into your gateway. No fork, no recompile.
-- **Folded in, not just proxied** — opt-in post-processing runs addon output through the same pipeline as your code: compress to a budget, spill oversized blobs to a `ctx_expand` handle, index into BM25 / graph / knowledge. Typed adapters route specific tools straight into `ctx_expand`, `ctx_callgraph` and `ctx_knowledge`.
+- **Publish it yourself** — the module travels *inside* the signed package, so
+  the signature covers the executable bytes. Nothing external to host, hash or
+  serve, and no pipeline of your own.
+- **Verified locally, then asked** — `add` re-checks the signature on your
+  machine rather than trusting its source, checks every module against its
+  pinned SHA-256, prints the publisher key and the exact command any declared
+  server would run, and only then prompts.
+- **LeanCTX never installs the server for you** — no `uv tool install`, no
+  `npx`. Fetching a declared tool stays your step, where your own package
+  manager's trust model applies. The manifest says how to *run* it.
+- **Folded in, not just proxied** — opt-in post-processing runs addon output through the same pipeline as your code: compress to a budget, spill oversized blobs to a `ctx_expand` handle, index into BM25 / graph / knowledge. A typed `integration` routes specific tools straight into `ctx_expand`, `ctx_callgraph` and `ctx_knowledge`.
 - **Untrusted by default** — every addon's output is scrubbed for secrets and tagged untrusted before it reaches the model. Always on, not a flag.
-- **You stay in control** — pin a machine or fleet to verified-only, an allowlist, or off entirely via one `[addons]` policy a single repo can't override.
 
-The registry spans compression (Headroom, Sophon), code intelligence (Repomix,
-Serena), memory (Mem0, Cognee, Letta) and reasoning (Sequential Thinking). See the
-**[addon guide](docs/guides/addons.md)** or [browse them all](https://leanctx.com/addons/).
+There is deliberately **no marketplace** and no `addon search`: LeanCTX does not
+host, curate or rank addons. A package is a file you install, or one you fetch
+from a registry you name. See the
+**[addon guide](docs/guides/addons.md)** for the full walkthrough.
 
 ## Where it's going
 

--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -11,6 +11,41 @@
 > modules now travel inside the signed package, which is what removes the
 > checksum-and-hosting step from publishing.
 
+## What 3.10.1 implements
+
+This document predates the 3.9.20 cleanup and describes more than the current
+parser reads. Stating the boundary here beats leaving an author to discover it
+from a field that is silently ignored.
+
+**Read and acted on** (`core::context_package::addon_manifest`):
+
+- `[addon]` — `name`, `version`, `description`, `homepage`. The remaining
+  metadata fields parse without error and are not used.
+- `[mcp]` — `transport`, `command`, `args`, `env`, `url`, `headers`, `sha256`.
+  Translated directly into a `[[gateway.servers]]` entry. Half-configured
+  wiring (stdio without `command`, http without `url`, a non-`http(s)` URL, an
+  unknown transport) is refused at parse.
+- `sha256` is **enforced** as of 3.10.1: the gateway resolves `command` against
+  the `PATH` the child will see, hashes it, refuses a mismatch, and spawns the
+  resolved path. Before 3.10.1 the value was stored and shown but never checked.
+
+**Not implemented** — treat these sections as a record of the previous system,
+not as a surface to write against:
+
+- `[install]`. lean-ctx no longer runs `uv tool install` or `npx` on the user's
+  behalf. Putting the server on the machine is the user's step, where their own
+  package manager's trust model applies; the manifest only says how to run it.
+- `[capabilities]`. The per-addon OS sandbox was removed with the rest of the
+  addon stack. An `[mcp]` server runs as a **normal process with the user's
+  privileges**, which is why `addon add` prints the exact command and asks.
+- `[[dependencies]]` and `{pack_dir:@ns/name}` env expansion.
+- `min_lean_ctx` enforcement, and the registry-conferred `verified` tier —
+  there is no hosted registry to confer it.
+
+WASM modules, the other half of an addon, are covered by
+[`wasm-abi-v1`](wasm-abi-v1.md); the how-to for both is
+[`docs/guides/addons.md`](../guides/addons.md).
+
 Historical implementation status: `core::addons` · `lean-ctx addon`
 
 An experimental **addon** format packages an external MCP server (plus metadata) behind a small

--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -482,6 +482,15 @@ published endpoint, advise affected users to `lean-ctx addon remove <name>`.
 
 ## CLI surface
 
+> **Historical.** The table below is the pre-3.9.20 command set. 3.10.1 ships
+> five verbs: `list`, `info`, `add`, `remove`, `release` — see
+> [the addon guide](../guides/addons.md). There is deliberately no `search`
+> (that implies a curated index), no `init` (a manifest plus the `.wasm` beside
+> it is short enough to write by hand), and no `audit` / `registry validate` /
+> `revoke` — those belonged to the registry and policy stack removed with the
+> rest of it. `release` performs the build-time validation those commands used
+> to, and `add` re-verifies the signature locally.
+
 | Command | Effect |
 |---------|--------|
 | `lean-ctx addon list` | Installed addons + the registry. |

--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -19,12 +19,18 @@ from a field that is silently ignored.
 
 **Read and acted on** (`core::context_package::addon_manifest`):
 
-- `[addon]` — `name`, `version`, `description`, `homepage`. The remaining
+- `[addon]` — `name`, `version`, `description`, `homepage`, plus `integration`
+  and `categories` where they feed the adapter choice below. The remaining
   metadata fields parse without error and are not used.
-- `[mcp]` — `transport`, `command`, `args`, `env`, `url`, `headers`, `sha256`.
-  Translated directly into a `[[gateway.servers]]` entry. Half-configured
-  wiring (stdio without `command`, http without `url`, a non-`http(s)` URL, an
-  unknown transport) is refused at parse.
+- `[mcp]` — `transport`, `command`, `args`, `env`, `url`, `headers`, `sha256`,
+  `integration`. Translated directly into a `[[gateway.servers]]` entry.
+  Half-configured wiring (stdio without `command`, http without `url`, a
+  non-`http(s)` URL, an unknown transport, an unrecognised `integration`) is
+  refused at parse.
+- `integration` is read from `[mcp]` first, then `[addon]`, then derived from a
+  recognised `[addon] categories` entry. Explicit slugs are held to the
+  vocabulary; category derivation is lenient, since categories are free-form
+  browsing labels.
 - `sha256` is **enforced** as of 3.10.1: the gateway resolves `command` against
   the `PATH` the child will see, hashes it, refuses a mismatch, and spawns the
   resolved path. Before 3.10.1 the value was stored and shown but never checked.

--- a/docs/contracts/addon-manifest-v1.md
+++ b/docs/contracts/addon-manifest-v1.md
@@ -1,10 +1,15 @@
 # Addon Manifest — v1
 
-> **Status: Research contract — not a supported public product surface.** This
-> document records an experimental implementation and proposed format. LeanCTX
-> does not currently offer a hosted registry, marketplace, paid-addon flow, or
-> verified public catalog. Current product scope and status are governed by
-> [`docs/internal/README.md`](../internal/README.md).
+> **Status: Preview.** `lean-ctx-addon.toml` is the authoring manifest for a
+> WASM addon, embedded verbatim in a `kind=addon` package and shown by
+> `lean-ctx addon info`. LeanCTX still does **not** offer a hosted registry,
+> marketplace, paid-addon flow, or verified public catalog — a package is a file
+> you install, or one you fetch from a registry you name. Product scope is
+> governed by [`docs/internal/README.md`](../internal/README.md).
+>
+> Sections describing per-platform `[artifacts]` downloads are **historical**:
+> modules now travel inside the signed package, which is what removes the
+> checksum-and-hosting step from publishing.
 
 Historical implementation status: `core::addons` · `lean-ctx addon`
 

--- a/docs/contracts/wasm-abi-v1.md
+++ b/docs/contracts/wasm-abi-v1.md
@@ -1,11 +1,20 @@
 # Contract: WASM Extension ABI v1 (`wasm-abi-v1`)
 
-> **Status: Research contract — external extension authoring is not a supported
-> public LeanCTX surface.** This document records an opt-in local implementation
-> and proposed ABI. Current product scope and status are governed by
+> **Status: Preview.** Building, installing and running a WASM addon locally is
+> a supported path (`lean-ctx addon`, see
+> [the guide](../guides/addons.md)). The **ABI below is versioned but not yet
+> frozen**: v1 may gain entrypoints, and a breaking change would ship as
+> `wasm-abi-v2` with both accepted during a deprecation window rather than as a
+> silent change to v1. LeanCTX does not offer a marketplace or a curated
+> registry; product scope is governed by
 > [`docs/internal/README.md`](../internal/README.md).
 
-Historical implementation status: stable · Feature: `wasm` (off by default) · Source: `rust/src/core/wasm_ext.rs`
+Implementation: shipped in the default build (feature `wasm`, on by default since 3.10.1) · Source: `rust/src/core/wasm_ext.rs`
+
+Today the ABI reaches **compressors** and **context providers**. The other
+extension points in `core::extension_registry` (chunkers, read modes, render
+transforms) exist as Rust traits and are deliberately not exposed here yet —
+naming them would promise an authoring surface that does not exist.
 
 A sandboxed, language-independent way to contribute extensions —
 **compressors** (EPIC 12.8) and **context providers** (EPIC 12.10) — without

--- a/docs/contracts/wasm-abi-v1.md
+++ b/docs/contracts/wasm-abi-v1.md
@@ -1,20 +1,11 @@
 # Contract: WASM Extension ABI v1 (`wasm-abi-v1`)
 
-> **Status: Preview.** Building, installing and running a WASM addon locally is
-> a supported path (`lean-ctx addon`, see
-> [the guide](../guides/addons.md)). The **ABI below is versioned but not yet
-> frozen**: v1 may gain entrypoints, and a breaking change would ship as
-> `wasm-abi-v2` with both accepted during a deprecation window rather than as a
-> silent change to v1. LeanCTX does not offer a marketplace or a curated
-> registry; product scope is governed by
+> **Status: Research contract — external extension authoring is not a supported
+> public LeanCTX surface.** This document records an opt-in local implementation
+> and proposed ABI. Current product scope and status are governed by
 > [`docs/internal/README.md`](../internal/README.md).
 
-Implementation: shipped in the default build (feature `wasm`, on by default since 3.10.1) · Source: `rust/src/core/wasm_ext.rs`
-
-Today the ABI reaches **compressors** and **context providers**. The other
-extension points in `core::extension_registry` (chunkers, read modes, render
-transforms) exist as Rust traits and are deliberately not exposed here yet —
-naming them would promise an authoring surface that does not exist.
+Historical implementation status: stable · Feature: `wasm` (off by default) · Source: `rust/src/core/wasm_ext.rs`
 
 A sandboxed, language-independent way to contribute extensions —
 **compressors** (EPIC 12.8) and **context providers** (EPIC 12.10) — without

--- a/docs/dev/addon-bootstrap-engine.md
+++ b/docs/dev/addon-bootstrap-engine.md
@@ -1,18 +1,29 @@
-# Addon Bootstrap Engine — Phase 2 (implemented)
+# Addon Bootstrap Engine — Phase 2 (removed in 3.9.20)
 
-> Status: **implemented** in `rust/src/core/addons/bootstrap.rs` (+ manifest,
-> policy, store, CLI wiring). This document is the design of record for the
-> GitLab epic *Addon Bootstrap Engine* (`root/lean-ctx#1105`, subtasks
-> `#1106`–`#1110`). Where the shipped behaviour refines the original plan it is
-> noted inline.
+> Status: **removed**. `rust/src/core/addons/bootstrap.rs` and the rest of the
+> stack this document describes were deleted in the 3.9.20 cleanup and did not
+> come back when the addon channel reopened in 3.10.1. Nothing below is
+> implemented: there is no `[install]` block, no package-manager bootstrap, no
+> `addons.allow_bootstrap`, and no install receipts.
+>
+> **lean-ctx no longer installs anything on your behalf.** A manifest declares
+> how to *run* a tool; fetching it stays the user's step, where their own package
+> manager's trust model applies. That was the point of removing this — "add an
+> addon" had become "execute a fetch-and-install pipeline you did not read".
+>
+> Kept as the design of record for the decision, not as documentation of a
+> feature. For what 3.10.1 actually does, see
+> [the addon guide](../guides/addons.md) and
+> [`addon-manifest-v1`](../contracts/addon-manifest-v1.md) § What 3.10.1
+> implements.
 
-## Problem
+## Problem (as it stood before 3.9.20)
 
-Today `lean-ctx addon add` is **declarative**: it appends a
-`[[gateway.servers]]` entry to the global config and records the install — it
-never fetches or installs a package. That is sufficient for **ephemeral
+`lean-ctx addon add` was **declarative**: it appended a
+`[[gateway.servers]]` entry to the global config and recorded the install — it
+never fetched or installed a package. That was sufficient for **ephemeral
 runners** (`npx`, `uvx`), which download and execute their package lazily on the
-first tool call. So `repomix` and `serena` already install on add.
+first tool call. So `repomix` and `serena` already installed on add.
 
 It is **not** sufficient for tools that need a real, one-time bootstrap before a
 runnable command exists:

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -25,6 +25,7 @@ either way. The two halves are described separately below.
 
 ```bash
 lean-ctx addon add ./my-addon-1.0.0.ctxpkg   # verifies, shows what it is, asks
+lean-ctx addon add @ns/my-addon              # same, from a registry you name
 lean-ctx addon list                          # what is installed and what it loads
 lean-ctx addon info @ns/my-addon             # the author's manifest, module digests
 lean-ctx addon remove @ns/my-addon
@@ -32,6 +33,13 @@ lean-ctx addon remove @ns/my-addon
 
 `add` is the only verb that stores executable code, so it is the only one that
 asks — and it refuses to proceed non-interactively unless you pass `--yes`.
+
+A registry reference is downloaded to a temp file and then goes through exactly
+the same preview, prompt and verification as a file you already had: there is
+one consent path, not a shorter one for remote installs. An argument that names
+something on disk always wins over a registry lookup, so `acme/widget` cannot
+quietly fetch from the network when a file by that name is sitting there.
+`--registry <url>` selects where to look.
 
 ## Writing one: a WASM module
 
@@ -87,7 +95,17 @@ transport = "stdio"
 command = "lean-md"
 args = ["mcp", "serve"]
 sha256 = "…"          # optional; when set it is checked before every spawn
+integration = "memory"  # optional; fold results into a lean-ctx surface
 ```
+
+`integration` picks a **typed adapter** so the server's output lands in the
+`ctx_*` tool your agent already uses instead of arriving as opaque text:
+`codebase-pack` → `ctx_expand`, `code-graph` / `code-symbols` → `ctx_callgraph`,
+`memory` → `ctx_knowledge`, `compression` → the compressor pipeline, `none` for
+passthrough. Common aliases (`repomix`, `callgraph`, `compressor`) are accepted
+and stored canonically. A slug that is not recognised is an error rather than a
+silent fallback — a typo that installed cleanly and quietly did less would look
+exactly like working software.
 
 `addon add` turns that into a `[[gateway.servers]]` entry. Three limits, all of
 them deliberate, and all of them things the pre-3.9.20 channel did differently:

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -128,6 +128,12 @@ them deliberate, and all of them things the pre-3.9.20 channel did differently:
   global-only and opt-in; `lean-ctx addon list` tells you when an addon is
   wired but the gateway is off, rather than letting you assume it is running.
 
+Installing a newer version replaces what the *author* declares — transport,
+command, args, URL, pin, integration — and keeps what *you* configured: the
+credentials in `secret_env` / `secret_headers`, which a manifest cannot carry by
+design, and the per-server `enabled` switch, so an addon you deliberately turned
+off does not come back on behind an upgrade.
+
 When `sha256` is set, the gateway resolves `command` against the `PATH` the
 child will see, hashes it, and refuses to spawn on a mismatch. An unset pin is
 a documented no-op, not a silent pass.

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -183,5 +183,5 @@ reason to trust, and read `addon info` before you do.
 directory, for authoring a module before packaging it. It is a developer
 convenience with none of the verification above — not an install path.
 
-See [Product Architecture](../internal/vision/PRODUCT-ARCHITECTURE.md) for the
+See [`local-free-invariant-v1`](../contracts/local-free-invariant-v1.md) for the
 local-first guardrails this channel sits inside.

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -1,35 +1,94 @@
-# Research — addons and external capabilities
+# Addons — WASM extensions
 
-> **Not a current LeanCTX public product surface.** LeanCTX does not currently
-> offer a public addon marketplace, hosted registry, external-capability
-> ecosystem, managed binary distribution, or commercial catalog.
+> **Status: Preview — local addon channel.** Installing, building and running a
+> WASM addon on your own machine is a supported path. LeanCTX does **not** offer
+> a marketplace, a curated registry, ranking or recommendation, managed binary
+> distribution, or a commercial catalog, and this document is not a promise of
+> one.
 
-## Current boundary
+An addon is a sandboxed WebAssembly module that runs *inside* the context
+pipeline. Today that means one thing: a **compressor**. Context providers use
+the same ABI and are wired the same way; every other extension point
+(chunkers, read modes, render transforms) exists as a Rust trait and is not
+reachable over the WASM ABI yet.
 
-The Available product is the local LeanCTX Runtime: context selection,
-representation, compression, reuse, recovery, local integrations, and local
-evidence primitives for existing agents. It remains useful without an account,
-marketplace, or managed service.
+If your extension only calls an API or runs on its own, **write an MCP server
+instead**. It needs nothing from this repository, you publish it yourself, and
+lean-ctx already audits foreign MCP servers in `tools health`. The addon
+channel is reserved for code that has to run inside the pipeline.
 
-The repository may contain gateway, manifest, signing, sandbox, and extension
-substrate. Those implementation paths are engineering material, not a promise
-that a third-party extension can be installed, distributed, audited, supported,
-or sold through LeanCTX.
+## Using an addon
 
-## Research record
+```bash
+lean-ctx addon add ./my-addon-1.0.0.ctxpkg   # verifies, shows what it is, asks
+lean-ctx addon list                          # what is installed and what it loads
+lean-ctx addon info @ns/my-addon             # the author's manifest, module digests
+lean-ctx addon remove @ns/my-addon
+```
 
-External-capability composition and OCLA/Capability contracts are **Research**.
-A future capability would need a bounded public contract, explicit consent and
-security model, provenance, compatibility policy, support ownership, and proof
-that it does not weaken the local Runtime.
+`add` is the only verb that stores executable code, so it is the only one that
+asks — and it refuses to proceed non-interactively unless you pass `--yes`.
 
-Until then:
+## Writing one
 
-- Do not describe LeanCTX as an MCP marketplace or aggregator.
-- Do not publish installation, registry, billing, verification-tier, or
-  marketplace instructions as an available user path.
-- Do not infer product status from a manifest, CLI namespace, package, or
-  implementation directory.
+A directory with a manifest and at least one module:
+
+```
+my-addon/
+  lean-ctx-addon.toml
+  my_addon.wasm
+```
+
+```toml
+[addon]
+name = "@ns/my-addon"
+version = "1.0.0"
+description = "What it does, in one line"
+```
+
+The module exports the ABI v1 entrypoints — see
+[`wasm-abi-v1`](../contracts/wasm-abi-v1.md) for the exact signatures. Any
+language that compiles to `wasm32-unknown-unknown` works.
+
+```bash
+lean-ctx addon release ./my-addon
+```
+
+That produces a signed `.ctxpkg` with the modules **embedded**. No artifact
+host, no checksum files, no CI: the package signature covers the executable
+bytes, so there is nothing external to hash or serve. Publish it wherever you
+like, or with `lean-ctx pack publish` to a registry you name.
+
+The first `release` creates an ed25519 signing key under your data directory.
+It identifies you as the publisher across releases — back it up.
+
+## What the sandbox does and does not do
+
+**Enforced**, on every call:
+
+- No ambient environment. A module sees nothing of your shell.
+- A fresh WASM store per call, so nothing leaks between invocations.
+- The host truncates the output to the byte budget *after* decoding it, so a
+  module cannot exceed the budget by ignoring it.
+- Modules are stored read-only and never marked executable — they are fed to an
+  interpreter, never to the OS loader.
+
+**Verified at install:**
+
+- The package signature, re-checked locally rather than trusted from wherever
+  it came ("registry compromise ≠ client compromise").
+- Each module against its pinned SHA-256, before anything is written.
+- WebAssembly magic bytes, so a mislabelled payload is refused early.
+
+**Not claimed:** a module can compute anything it likes within those bounds.
+The sandbox limits reach, not intent. Install addons from publishers you have
+reason to trust, and read `addon info` before you do.
+
+## Development override
+
+`LEAN_CTX_WASM_DIR=<dir>` loads unsigned `.wasm` files straight from a
+directory, for authoring a module before packaging it. It is a developer
+convenience with none of the verification above — not an install path.
 
 See [Product Architecture](../internal/vision/PRODUCT-ARCHITECTURE.md) for the
-current local-first and no-premature-platform guardrails.
+local-first guardrails this channel sits inside.

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -117,9 +117,13 @@ them deliberate, and all of them things the pre-3.9.20 channel did differently:
 - **lean-ctx never installs the server.** No `uv tool install`, no `npx`, no
   download. Putting `lean-md` on your machine stays your step, where your own
   package manager's trust model applies. The manifest only says how to run it.
-- **The exact command is shown before you consent**, not summarised. That
-  server will run as a **normal process with your privileges** — it is not
-  sandboxed, and the WASM guarantees above do not apply to it. Read the argv.
+- **The exact command is shown before you consent** — printed in full, not
+  summarised, together with whether it is pinned. A `stdio` server runs as a
+  **normal process with your privileges**: it is not sandboxed, the WASM
+  guarantees above do not apply to it, and the prompt says so. An `http` server
+  gets the disclosure that fits it instead — nothing runs on your machine, but
+  lean-ctx sends that endpoint requests and treats its replies as untrusted
+  input. Read the argv, or the URL.
 - **Adding a server does not switch the gateway on.** `[gateway]` stays
   global-only and opt-in; `lean-ctx addon list` tells you when an addon is
   wired but the gateway is off, rather than letting you assume it is running.

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -102,10 +102,14 @@ integration = "memory"  # optional; fold results into a lean-ctx surface
 `ctx_*` tool your agent already uses instead of arriving as opaque text:
 `codebase-pack` → `ctx_expand`, `code-graph` / `code-symbols` → `ctx_callgraph`,
 `memory` → `ctx_knowledge`, `compression` → the compressor pipeline, `none` for
-passthrough. Common aliases (`repomix`, `callgraph`, `compressor`) are accepted
-and stored canonically. A slug that is not recognised is an error rather than a
-silent fallback — a typo that installed cleanly and quietly did less would look
-exactly like working software.
+passthrough. It may sit in `[addon]` (where it has always been documented) or in
+`[mcp]`, which mirrors the gateway entry and wins if both are set; with neither,
+a recognised `[addon] categories` entry derives one. Common aliases (`repomix`,
+`callgraph`, `compressor`) are accepted and stored canonically. A slug written
+as an integration but not recognised is an error rather than a silent fallback —
+a typo that installed cleanly and quietly did less would look exactly like
+working software. Categories stay lenient, because they are free-form browsing
+labels rather than a vocabulary.
 
 `addon add` turns that into a `[[gateway.servers]]` entry. Three limits, all of
 them deliberate, and all of them things the pre-3.9.20 channel did differently:

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -34,6 +34,11 @@ lean-ctx addon remove @ns/my-addon
 `add` is the only verb that stores executable code, so it is the only one that
 asks — and it refuses to proceed non-interactively unless you pass `--yes`.
 
+Versions sit side by side in the store, and only the most recently installed one
+loads. `addon list` marks the others `(superseded)` and says their modules are
+on disk but not running, rather than listing code that never executes;
+`addon remove <name>` clears every version.
+
 A registry reference is downloaded to a temp file and then goes through exactly
 the same preview, prompt and verification as a file you already had: there is
 one consent path, not a shorter one for remote installs. An argument that names

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -1,21 +1,25 @@
-# Addons — WASM extensions
+# Addons — extending lean-ctx
 
-> **Status: Preview — local addon channel.** Installing, building and running a
-> WASM addon on your own machine is a supported path. LeanCTX does **not** offer
+> **Status: Preview — local addon channel.** Building, installing and running an
+> addon on your own machine is a supported path. LeanCTX does **not** offer
 > a marketplace, a curated registry, ranking or recommendation, managed binary
 > distribution, or a commercial catalog, and this document is not a promise of
 > one.
 
-An addon is a sandboxed WebAssembly module that runs *inside* the context
-pipeline. Today that means one thing: a **compressor**. Context providers use
-the same ABI and are wired the same way; every other extension point
-(chunkers, read modes, render transforms) exists as a Rust trait and is not
-reachable over the WASM ABI yet.
+An addon is a package you install with one command. It carries one or both of:
 
-If your extension only calls an API or runs on its own, **write an MCP server
-instead**. It needs nothing from this repository, you publish it yourself, and
-lean-ctx already audits foreign MCP servers in `tools health`. The addon
-channel is reserved for code that has to run inside the pipeline.
+- **a sandboxed WebAssembly module** that runs *inside* the context pipeline —
+  today that means a **compressor**; context providers use the same ABI and are
+  wired the same way. Every other extension point (chunkers, read modes, render
+  transforms) exists as a Rust trait and is not reachable over the WASM ABI yet.
+- **an MCP server declaration**, wired into lean-ctx's gateway so a third-party
+  tool plugs in with no fork and no recompile.
+
+Which one you write follows from where your code has to run. A compressor has
+to run inside the pipeline, so it is WASM. A tool that speaks MCP already has a
+process model of its own, so it is declared rather than embedded — and it stays
+yours: you publish it, and lean-ctx audits foreign MCP servers in `tools health`
+either way. The two halves are described separately below.
 
 ## Using an addon
 
@@ -29,7 +33,7 @@ lean-ctx addon remove @ns/my-addon
 `add` is the only verb that stores executable code, so it is the only one that
 asks — and it refuses to proceed non-interactively unless you pass `--yes`.
 
-## Writing one
+## Writing one: a WASM module
 
 A directory with a manifest and at least one module:
 
@@ -48,7 +52,11 @@ description = "What it does, in one line"
 
 The module exports the ABI v1 entrypoints — see
 [`wasm-abi-v1`](../contracts/wasm-abi-v1.md) for the exact signatures. Any
-language that compiles to `wasm32-unknown-unknown` works.
+language that compiles to `wasm32-unknown-unknown` works. That file is a frozen
+artifact: its own header predates this channel reopening and still says
+"Research contract", which is why the status lives here and in the stability
+matrix instead. The signatures in it are current and will not move — a breaking
+ABI change would ship as `wasm-abi-v2`, with both accepted during an overlap.
 
 ```bash
 lean-ctx addon release ./my-addon
@@ -62,7 +70,50 @@ like, or with `lean-ctx pack publish` to a registry you name.
 The first `release` creates an ed25519 signing key under your data directory.
 It identifies you as the publisher across releases — back it up.
 
+## Writing one: an MCP server
+
+Not every extension belongs inside the pipeline. A tool that already speaks MCP
+has a process model of its own, and wrapping it in WASM would buy nothing. Such
+an addon carries no module — it declares the server instead:
+
+```toml
+[addon]
+name = "lean-md"
+version = "2.0.0"
+description = "Macro/directive markdown renderer"
+
+[mcp]
+transport = "stdio"
+command = "lean-md"
+args = ["mcp", "serve"]
+sha256 = "…"          # optional; when set it is checked before every spawn
+```
+
+`addon add` turns that into a `[[gateway.servers]]` entry. Three limits, all of
+them deliberate, and all of them things the pre-3.9.20 channel did differently:
+
+- **lean-ctx never installs the server.** No `uv tool install`, no `npx`, no
+  download. Putting `lean-md` on your machine stays your step, where your own
+  package manager's trust model applies. The manifest only says how to run it.
+- **The exact command is shown before you consent**, not summarised. That
+  server will run as a **normal process with your privileges** — it is not
+  sandboxed, and the WASM guarantees above do not apply to it. Read the argv.
+- **Adding a server does not switch the gateway on.** `[gateway]` stays
+  global-only and opt-in; `lean-ctx addon list` tells you when an addon is
+  wired but the gateway is off, rather than letting you assume it is running.
+
+When `sha256` is set, the gateway resolves `command` against the `PATH` the
+child will see, hashes it, and refuses to spawn on a mismatch. An unset pin is
+a documented no-op, not a silent pass.
+
+Nothing stops one addon from being both: modules run in the pipeline, `[mcp]`
+wires the server, and `addon remove` undoes both.
+
 ## What the sandbox does and does not do
+
+This section is about **WASM modules**. A declared `[mcp]` server is an ordinary
+process with your privileges and none of it applies to one — that is why its
+command is printed in full before you consent.
 
 **Enforced**, on every call:
 

--- a/docs/guides/addons.md
+++ b/docs/guides/addons.md
@@ -39,6 +39,11 @@ loads. `addon list` marks the others `(superseded)` and says their modules are
 on disk but not running, rather than listing code that never executes;
 `addon remove <name>` clears every version.
 
+`lean-ctx doctor` reports what the engine actually loaded, which is a different
+question: install checks a module's four magic bytes, not a full parse, so a
+truncated or corrupt module installs cleanly and is then refused by the loader.
+`addon list` would still show it. Doctor names it.
+
 A registry reference is downloaded to a temp file and then goes through exactly
 the same preview, prompt and verification as a file you already had: there is
 one consent path, not a shorter one for remote installs. An argument that names

--- a/docs/guides/docs-sources.md
+++ b/docs/guides/docs-sources.md
@@ -60,9 +60,9 @@ failure) and chunked like any Markdown file.
 
 The built-in corpus indexing is lexical (BM25) and tuned for repo-adjacent
 docs. If your notes are the *primary* corpus and you want embeddings + LLM
-reranking over them, wire [`qmd`](addons.md) (`lean-ctx addon add qmd`) — an
-on-device Markdown search engine — into the gateway, and keep lean-ctx as the
-layer that fuses everything.
+reranking over them, wire [`qmd`](addons.md) — an on-device Markdown search
+engine — into the gateway with an addon that declares it under `[mcp]`, and keep
+lean-ctx as the layer that fuses everything.
 
 *See also: [Context Infrastructure](context-infrastructure.md),
 [Addons](addons.md), [Monorepo & linked projects](monorepo.md).*

--- a/docs/guides/extensions.md
+++ b/docs/guides/extensions.md
@@ -1,11 +1,11 @@
 # Extending lean-ctx — one decision, one trust model
 
-> **Status: historical/research extension design — not an available marketplace
-> or public builder surface.** LeanCTX is **The Context SDK for AI Agents**. The
-> available product is the local Runtime, CLI, MCP server, proxy, and context
-> primitives; broad third-party distribution, registries, and generic agent
-> building are deferred. Current scope and status are governed by
-> [`docs/internal/README.md`](../internal/README.md).
+> **Status: Preview for the local addon channel; the rest is design.** Building,
+> installing and running an addon on your own machine is supported as of 3.10.1
+> (see [addons](addons.md)). LeanCTX still does **not** offer a marketplace, a
+> curated registry, ranking, or managed binary distribution, and this document is
+> not a promise of one. Current scope and status are governed by
+> [`public-product-claims-v1`](../contracts/public-product-claims-v1.md).
 
 lean-ctx can be extended in several ways. They look similar from the outside
 (they all "add capabilities"), but each targets a different job and a different
@@ -26,7 +26,6 @@ flowchart TD
   Q0 -->|In-process compression / compute| WASM[WASM Extension]
   Q0 -->|Deep in-process build on the engine, in Rust| SDK[Embedding SDK]
   Q0 -->|A reusable config bundle| PERSONA[Persona / Policy Pack]
-  Q0 -->|Local hooks on agent lifecycle events| PLUGIN[Plugin]
 ```
 
 - **Share or sell *data*** (knowledge, graph edges, session, patterns, gotchas)
@@ -42,16 +41,13 @@ flowchart TD
   [**Embedding SDK**](embed-sdk.md) (`lean-ctx-sdk`)
 - **A reusable configuration bundle** → [**Persona**](../contracts/persona-spec-v1.md)
   / [**Policy Pack**](policy-packs.md)
-- **Local hooks on agent lifecycle events** (pre/post tool, plus local tools)
-  → **Plugin** ([extension trust](../contracts/extension-trust-v1.md))
 
 ## The mechanisms at a glance
 
 | Mechanism | Job | Lives where | Distribution | Trust model |
 |---|---|---|---|---|
-| **Addon** | Expose **tools** to the agent | External MCP server (stdio/http) | Registry (`lean-ctx addon`) | Declared `[capabilities]` → per-addon OS sandbox + env scrub + install consent |
+| **Addon** | Expose **tools**, or a WASM compressor | Declared MCP server (stdio/http), and/or a WASM module in the pack | Signed `.ctxpkg` (`lean-ctx addon`) | Signature re-verified locally + module digests + install consent; a declared server is an ordinary process, disclosed as such |
 | **Context Provider** | Feed an external **data source** into the pipeline | `[providers.*]` / `~/.config/lean-ctx/providers/` | Config (+ tokens) | Token-scoped; data redacted on ingest |
-| **Plugin** | **Hooks** on lifecycle events + local tools | Local subprocess | Local install | `[trust]` permissions → env scrub + cwd jail + timeout |
 | **WASM Extension** | In-process **compressor/provider** | Sandboxed WASM in the engine | Extension registry | WASM sandbox (no ambient host access) |
 | **ctxpkg Pack** | Ship/sell **data** | Signed archive | Hosted registry (`lean-ctx pack`) | Ed25519 signing + publisher identity |
 | **Persona / Policy Pack** | Reusable **config** | TOML bundle | File / registry | Inherits engine config trust (global-only floors) |
@@ -59,18 +55,22 @@ flowchart TD
 
 ## Resolving the common overlaps
 
-Four mechanisms can all involve "an external MCP server" or "extra tools", which
-is the usual source of confusion. Disambiguation:
+Several mechanisms can all involve "an external MCP server" or "extra tools",
+which is the usual source of confusion. Disambiguation:
 
 ### Addon vs `[[gateway.servers]]`
 
 Same runtime, two layers. `[[gateway.servers]]` is the **raw config primitive**:
 a downstream MCP server the gateway aggregates. An **Addon** is the
-**packaged, distributable, capability-governed** form of exactly that — a
-`lean-ctx-addon.toml` manifest + registry entry + install consent + per-addon
-sandbox. `lean-ctx addon add` *writes* a `[[gateway.servers]]` entry for you and
-records the granted capabilities. Hand-editing `[[gateway.servers]]` is the
+**packaged, distributable, signed** form of exactly that — a
+`lean-ctx-addon.toml` manifest inside a signed `.ctxpkg`, whose signature is
+re-verified on your machine before you are shown the exact command and asked.
+`lean-ctx addon add` *writes* the `[[gateway.servers]]` entry for you and
+`addon remove` takes it away again. Hand-editing `[[gateway.servers]]` is the
 escape hatch; an Addon is the supported, shareable artifact.
+
+lean-ctx does **not** install the server itself — no `uv tool install`, no
+`npx`. The manifest records how to run a tool you already have.
 
 ### Addon vs `[providers.mcp_bridges.<name>]`
 
@@ -93,14 +93,15 @@ If you want the agent to *do something*, build an Addon. If you want lean-ctx to
 > standing *data source*), not capability — see
 > [Why an addon goes deeper](addons.md#why-an-addon-goes-deeper-than-a-passthrough).
 
-### Addon vs Plugin
+### Whatever happened to Plugins
 
-- **Addon** = an MCP server whose **tools** plug into the gateway. Cross-language
-  (anything that speaks MCP), distributed via the registry. This is the path for
-  third-party tools/integrations.
-- **Plugin** = a local subprocess that runs on **lifecycle hooks** (pre/post
-  tool call, etc.) and may register a few local manifest tools. Use it to *react
-  to* agent activity locally, not to ship a distributable tool.
+Removed in 3.9.20 and not coming back. `lean-ctx plugin` exits with a pointer to
+`lean-ctx addon help`. Subprocess plugins asked users to trust that an arbitrary
+local binary behaved; an addon either runs bounded inside the engine as WASM, or
+is a server whose exact command you read before consenting. The lifecycle hook
+events (`pre_read`, `post_compress`, `on_session_*`) went with them — the hooks
+lean-ctx has today are the agent-tool hooks in `lean-ctx hooks`, a different
+mechanism.
 
 ## Naming: `@ns/name`
 
@@ -116,48 +117,53 @@ short name from two authors never collides:
 - The bare `<name>` (no `@ns/`) refers to a built-in/first-party entry.
 
 Examples: `@dastholo/lean-md`, `@acme/jira-tools`, `@acme/payments-knowledge`.
-Local-only mechanisms (Plugins, Providers, Personas) are addressed by their local
+Local-only mechanisms (Providers, Personas) are addressed by their local
 id and are not namespaced.
 
-## Start building (scaffolds)
+## Start building
 
-Each executable mechanism has a one-command scaffold so you start from a valid,
-secure-by-default artifact:
+There is no `addon init` scaffold: an addon directory is a manifest and,
+optionally, the `.wasm` files beside it, which is little enough to write by
+hand and one less thing to keep in sync with the format.
 
 | You want | Command | Then |
 |----------|---------|------|
-| An addon (tool/integration) | `lean-ctx addon init [name] [--http]` | `lean-ctx addon audit ./lean-ctx-addon.toml` → `addon add ./…` |
+| An addon (WASM module and/or MCP server) | write `lean-ctx-addon.toml` next to your `.wasm`, if any | `lean-ctx addon release ./my-addon` → `lean-ctx addon add ./my-addon-1.0.0.ctxpkg` |
 | A config provider (REST source) | `lean-ctx provider init <id>` | edit `.lean-ctx/providers/<id>.toml`; auto-discovered |
 
-Validate before you publish: `lean-ctx addon audit` runs the capability +
-malware gate on a single manifest, and `lean-ctx addon registry validate [path]`
-runs the full security + quality bar over a registry file (the dry-run CI uses).
+`release` validates as it builds — a manifest that declares neither a module nor
+an `[mcp]` server is refused, as is half-configured wiring or a `.wasm` that is
+not WebAssembly — and then self-checks the package it just signed before writing
+it. `add` re-verifies that signature on the installing machine.
 
 ## One trust model
 
-All executable extensions converge on **declared, least-privilege capabilities**
-rather than ambient trust:
+Executable extensions differ in how much can be *enforced*, and the guide says
+which is which rather than implying one level everywhere:
 
-- **Addons** declare `[capabilities]` (`network`, `filesystem`, `env`, `exec`).
-  The declaration drives a **per-addon OS sandbox** (`sandbox-exec` on macOS,
-  `bwrap` on Linux) for `network` + `filesystem` — inherited by any child process
-  — plus an **environment allowlist** at the single gateway spawn point, so host
-  secrets never reach a child unless the addon lists the variable name. `exec` is
-  a **declared + audited** capability (disclosure, not OS-enforced — child
-  processes are already bound by the inherited net/fs sandbox). You see exactly
-  what you grant at install. See
-  [`addon-manifest-v1`](../contracts/addon-manifest-v1.md).
-- **Plugins** declare `[trust]` permissions (`network`, `fs_write`,
-  `env_passthrough`) and share the same environment allowlist; subprocesses get a
-  scrubbed env + cwd jail + per-call timeout.
-- **WASM Extensions** run in a WASM sandbox with no ambient host access.
+- **WASM addons** are bounded by the engine: no ambient environment, a fresh
+  store per call, and the host applies the output budget after decoding. The
+  package signature is re-verified on the installing machine, and every module
+  is checked against its pinned SHA-256 and its WebAssembly magic bytes before
+  anything is written. Modules are stored read-only and never marked executable.
+- **A declared `[mcp]` server is not sandboxed.** The per-addon OS sandbox
+  (`sandbox-exec` / `bwrap`) and the `[capabilities]` table were removed with
+  the rest of the pre-3.9.20 addon stack. Such a server is an ordinary process
+  with your privileges, so `addon add` prints its exact argv and says so before
+  asking, and lean-ctx never fetches or installs the binary for you. An `http`
+  endpoint gets the disclosure that fits it instead. When `[mcp] sha256` is set,
+  the gateway hashes the resolved binary and refuses to spawn a mismatch. See
+  [`addon-manifest-v1`](../contracts/addon-manifest-v1.md) § What 3.10.1
+  implements.
+- **Plugins** are gone: `lean-ctx plugin` exits with a pointer to
+  `lean-ctx addon help`.
 - **Packs** carry no executable code; they are Ed25519-signed and bound to a
   publisher identity.
 
-Secure-by-default: an Addon that declares a `[capabilities]` block but omits a
-field gets the most restrictive value (no network, read-only filesystem,
-scrubbed env). An Addon with no block keeps the legacy global `addons.sandbox`
-behaviour.
+What is *not* enforced is stated rather than implied: `[capabilities]`,
+`addons.sandbox` and the per-addon OS sandbox are gone. A declared server's
+bound is the user reading its command before saying yes, plus an optional
+`sha256` pin the gateway checks on every spawn.
 
 ## See also
 

--- a/docs/reference/21-lean-md.md
+++ b/docs/reference/21-lean-md.md
@@ -21,12 +21,17 @@ Engine, full directive catalog, and spec: **https://github.com/dasTholo/lean-md*
 
 ```bash
 lean-ctx addon add @dasTholo/lean-md        # hosted pack (ctxpkg.com)
-lean-ctx addon add ./lean-ctx-addon.toml    # local manifest (dev/test)
+lean-ctx addon add ./lean-md-2.0.0.ctxpkg   # a signed package you already have
 ```
 
-`addon add` resolves a local manifest first, then a hosted `ns/slug` pack, then the
-bundled registry slug. The bundled `lean-md` entry is **listed** — it makes the addon
-discoverable through `lean-ctx addon search`, it is not an install path.
+`addon add` prefers a path that exists on disk and otherwise resolves
+`ns/name[@version]` against a registry. Either way the package is verified
+locally and its `[mcp]` command shown before you are asked. There is no
+`addon search`, and no install-by-name from the bundled list — that list is a
+directory, not a package source.
+
+lean-ctx does **not** install the `lean-md` binary for you; the manifest records
+how to run it once you have it.
 
 After install, restart the MCP client so the gateway catalog is re-read. The addon
 is spawned as a stdio gateway child; its tools (`ctx_md_render`, `ctx_md_check`)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -103,6 +103,11 @@ default = [
   # LEANCTX_PGVECTOR_URL work out of the box (both are env-gated at runtime).
   "qdrant",
   "pgvector",
+  # Extensions must load from the shipped binary or the channel does not exist:
+  # an author who packages a WASM addon cannot ask every user for a custom
+  # build. Measured cost of enabling it on aarch64-apple-darwin, release
+  # profile: 83_065_536 -> 83_815_584 bytes, +750 KB (+0.90%).
+  "wasm",
 ]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 dev-tools = []

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -452,25 +452,22 @@ fn cmd_add(args: &[String]) {
             // was never installed.
             match wire_after_install(path) {
                 Ok(addon_wiring::Wired::NothingToWire) => {}
-                Ok(wired) => {
-                    match &wired {
-                        addon_wiring::Wired::Replaced(name) => {
-                            // Say that the entry was *updated*, not created —
-                            // and that their own settings were left alone, so
-                            // nobody has to re-check the config to find out.
-                            println!("Updated the gateway entry for `{name}`.");
-                            println!("Your credentials and per-server on/off setting were kept.");
-                        }
-                        addon_wiring::Wired::Added(name) => {
-                            println!("Wired `{name}` into the MCP gateway.");
-                        }
-                        addon_wiring::Wired::NothingToWire => unreachable!(),
-                    }
-                    if !addon_wiring::gateway_enabled() {
-                        println!();
-                        println!("The gateway is currently OFF, so nothing spawns yet.");
-                        println!("Turn it on with:  lean-ctx config set gateway.enabled true");
-                    }
+                // Matched by variant rather than nested, so the compiler owns
+                // exhaustiveness. A nested match needed an `unreachable!()` arm
+                // for the case handled above — a panic in an install path, put
+                // there to satisfy a shape I had chosen, which is the wrong
+                // trade whichever way the enum grows later.
+                Ok(addon_wiring::Wired::Replaced(name)) => {
+                    // Say that the entry was *updated*, not created — and that
+                    // their own settings were left alone, so nobody has to
+                    // re-check the config to find out.
+                    println!("Updated the gateway entry for `{name}`.");
+                    println!("Your credentials and per-server on/off setting were kept.");
+                    report_gateway_state();
+                }
+                Ok(addon_wiring::Wired::Added(name)) => {
+                    println!("Wired `{name}` into the MCP gateway.");
+                    report_gateway_state();
                 }
                 Err(e) => {
                     // The package is installed; only the wiring failed. Say
@@ -485,6 +482,18 @@ fn cmd_add(args: &[String]) {
             eprintln!("ERROR: install failed: {e}");
             std::process::exit(1);
         }
+    }
+}
+
+/// Say whether anything will actually spawn, after either wiring outcome.
+///
+/// A user who just consented to a server should not have to infer from silence
+/// that the gateway is off and nothing runs.
+fn report_gateway_state() {
+    if !addon_wiring::gateway_enabled() {
+        println!();
+        println!("The gateway is currently OFF, so nothing spawns yet.");
+        println!("Turn it on with:  lean-ctx config set gateway.enabled true");
     }
 }
 

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -376,8 +376,20 @@ fn cmd_add(args: &[String]) {
             // was never installed.
             match wire_after_install(path) {
                 Ok(addon_wiring::Wired::NothingToWire) => {}
-                Ok(addon_wiring::Wired::Added(name) | addon_wiring::Wired::Replaced(name)) => {
-                    println!("Wired `{name}` into the MCP gateway.");
+                Ok(wired) => {
+                    match &wired {
+                        addon_wiring::Wired::Replaced(name) => {
+                            // Say that the entry was *updated*, not created —
+                            // and that their own settings were left alone, so
+                            // nobody has to re-check the config to find out.
+                            println!("Updated the gateway entry for `{name}`.");
+                            println!("Your credentials and per-server on/off setting were kept.");
+                        }
+                        addon_wiring::Wired::Added(name) => {
+                            println!("Wired `{name}` into the MCP gateway.");
+                        }
+                        addon_wiring::Wired::NothingToWire => unreachable!(),
+                    }
                     if !addon_wiring::gateway_enabled() {
                         println!();
                         println!("The gateway is currently OFF, so nothing spawns yet.");

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -313,31 +313,46 @@ fn cmd_add(args: &[String]) {
             }
             if let Some(w) = &p.wiring {
                 println!("  MCP server  {w}");
-                println!(
-                    "  pin         {}",
-                    if p.pinned {
-                        "sha256 pinned — the gateway refuses to spawn a changed binary"
-                    } else {
-                        "none — whatever `command` resolves to at spawn time"
-                    }
-                );
+                if let Some(pinned) = p.pinned {
+                    println!(
+                        "  pin         {}",
+                        if pinned {
+                            "sha256 pinned — the gateway refuses to spawn a changed binary"
+                        } else {
+                            "none — whatever `command` resolves to at spawn time"
+                        }
+                    );
+                }
             }
             println!();
             if !p.modules.is_empty() {
                 println!("Modules run inside lean-ctx as WASM: sandboxed, no ambient");
                 println!("environment, output budget enforced by the host.");
             }
+            // A WASM module is bounded; a declared server is not — but the two
+            // kinds of server are not the same risk either, and telling an
+            // http user that something will run on their machine would be
+            // simply false. Each gets the disclosure that is true for it.
             if p.wiring.is_some() {
-                // The honest part. A WASM module is bounded; an MCP server is
-                // an ordinary process with the user's own privileges. Saying so
-                // plainly is the difference between consent and a click-through.
-                println!(
-                    "The MCP server above runs as a NORMAL PROCESS with your privileges — it is"
-                );
-                println!(
-                    "not sandboxed. lean-ctx will not install it: it records how to run it, and"
-                );
-                println!("only spawns it while `gateway.enabled = true`.");
+                if p.spawns_locally {
+                    println!(
+                        "The MCP server above runs as a NORMAL PROCESS with your privileges — it is"
+                    );
+                    println!(
+                        "not sandboxed. lean-ctx will not install it: it records how to run it, and"
+                    );
+                    println!("only spawns it while `gateway.enabled = true`.");
+                } else {
+                    println!(
+                        "The endpoint above is REMOTE. Nothing runs on your machine, but lean-ctx"
+                    );
+                    println!(
+                        "will send it requests — including file contents your agent asks about —"
+                    );
+                    println!(
+                        "and treat its replies as untrusted input. Only while `gateway.enabled = true`."
+                    );
+                }
             }
             println!();
         }
@@ -414,8 +429,12 @@ struct Preview {
     /// Whether that command carries a SHA-256 pin. Material to the decision:
     /// pinned means the gateway refuses to spawn a binary that has changed
     /// underneath it, unpinned means it spawns whatever `command` resolves to
-    /// on the day.
-    pinned: bool,
+    /// on the day. Meaningless for `http`, hence the `Option`.
+    pinned: Option<bool>,
+    /// `true` when the declared server is a local process rather than a remote
+    /// endpoint. The two deserve different disclosures: one spawns something
+    /// with the user's privileges, the other sends their data somewhere.
+    spawns_locally: bool,
 }
 
 /// Read a pack for display only. Verification happens in the install path;
@@ -466,7 +485,13 @@ fn preview(path: &Path) -> Result<Preview, String> {
         .and_then(|v| v.as_str())
         .and_then(|toml| addon_manifest::parse(toml).ok())
         .and_then(|m| m.mcp);
-    let pinned = declared.as_ref().is_some_and(|w| !w.sha256.is_empty());
+    let pinned = declared
+        .as_ref()
+        .filter(|w| w.transport == crate::core::mcp_catalog::config::TransportKind::Stdio)
+        .map(|w| !w.sha256.is_empty());
+    let spawns_locally = declared
+        .as_ref()
+        .is_some_and(|w| w.transport == crate::core::mcp_catalog::config::TransportKind::Stdio);
     let wiring = declared.map(|w| w.describe());
 
     Ok(Preview {
@@ -481,6 +506,7 @@ fn preview(path: &Path) -> Result<Preview, String> {
         modules,
         wiring,
         pinned,
+        spawns_locally,
     })
 }
 
@@ -696,6 +722,7 @@ fn sha256_hex(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::mcp_catalog::config::TransportKind;
 
     #[test]
     fn positional_skips_flags_and_the_verb() {
@@ -806,6 +833,33 @@ mod tests {
         // … and yet the path on disk is what cmd_add resolves, because
         // `is_file()` is checked first.
         assert!(file.is_file());
+    }
+
+    /// The disclosure must match the risk. A pin is a statement about a local
+    /// binary, so it is meaningless for an http endpoint — printing "none —
+    /// whatever `command` resolves to" for a URL describes a `command` that
+    /// does not exist, and telling that user a process will run with their
+    /// privileges is simply false.
+    #[test]
+    fn the_pin_line_applies_to_stdio_only() {
+        let stdio = addon_manifest::parse("[addon]\nname = \"x\"\n[mcp]\ncommand = \"c\"\n")
+            .unwrap()
+            .mcp
+            .unwrap();
+        assert_eq!(stdio.transport, TransportKind::Stdio);
+
+        let http = addon_manifest::parse(
+            "[addon]\nname = \"x\"\n[mcp]\ntransport = \"http\"\nurl = \"https://e.test/mcp\"\n",
+        )
+        .unwrap()
+        .mcp
+        .unwrap();
+        assert_eq!(http.transport, TransportKind::Http);
+        assert_eq!(
+            http.describe(),
+            "https://e.test/mcp",
+            "an http addon is described by its endpoint, not a command line"
+        );
     }
 
     /// The staging guard exists so the downloaded bytes survive the consent

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -11,6 +11,7 @@
 //! read from the pack the user is about to install, after its signature and
 //! content digest have already been verified.
 
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use crate::core::context_package::{
@@ -294,6 +295,25 @@ fn stage_remote(reference: &str, registry_flag: Option<&str>) -> Result<Staged, 
     Ok(Staged(tmp))
 }
 
+/// Does this argument name a file, rather than a registry package?
+///
+/// Decided by shape, not by what happens to exist. `parse_remote_ref` accepts
+/// `./typo.ctxpkg` as a perfectly good `ns/name`, so a mistyped filename used to
+/// be resolved over the network and fail with "package not found in the
+/// registry — private packages need CTXPKG_TOKEN". That answer is wrong twice:
+/// it blames the registry for a local typo, and it tells the user to go find a
+/// token they do not need.
+///
+/// Anything that looks like a path — a `.ctxpkg` name, or a leading `.`, `/` or
+/// `~` — is a file, and a missing one is reported as a missing file.
+fn looks_like_a_path(arg: &str) -> bool {
+    arg.ends_with(".ctxpkg")
+        || arg.starts_with('.')
+        || arg.starts_with('/')
+        || arg.starts_with('~')
+        || arg.starts_with("file:")
+}
+
 fn cmd_add(args: &[String]) {
     let Some(file) = positional(args, "add").or_else(|| positional(args, "install")) else {
         eprintln!("Usage: lean-ctx addon add <file.ctxpkg | ns/name[@version]>");
@@ -308,6 +328,10 @@ fn cmd_add(args: &[String]) {
     let _staged;
     let path: &Path = if local.is_file() {
         local
+    } else if looks_like_a_path(&file) {
+        eprintln!("ERROR: no such file: {file}");
+        eprintln!("       To install from a registry instead, drop the path and pass ns/name.");
+        std::process::exit(1);
     } else {
         match stage_remote(&file, registry_flag.as_deref()) {
             Ok(s) => {
@@ -409,6 +433,13 @@ fn cmd_add(args: &[String]) {
 
     if !crate::cli::prompt::confirm("Install this addon?", assume_yes) {
         println!("Aborted. Nothing was installed.");
+        // A person answering "no" got what they asked for; a script that hit
+        // the non-interactive refusal did not. Exiting 0 in the second case
+        // would let a pipeline record an install that never happened and carry
+        // on as if the addon were there.
+        if !std::io::stdin().is_terminal() {
+            std::process::exit(1);
+        }
         return;
     }
 
@@ -929,6 +960,26 @@ mod tests {
             "https://e.test/mcp",
             "an http addon is described by its endpoint, not a command line"
         );
+    }
+
+    /// A mistyped filename must not be resolved over the network. `./typo.ctxpkg`
+    /// parses as a valid `ns/name`, so without a shape check the user gets
+    /// "package not found in the registry — private packages need CTXPKG_TOKEN"
+    /// for a local typo: the wrong culprit and a pointless instruction.
+    #[test]
+    fn path_shaped_arguments_are_never_treated_as_registry_refs() {
+        for arg in [
+            "./missing.ctxpkg",
+            "../build/x.ctxpkg",
+            "/abs/path/x.ctxpkg",
+            "~/downloads/x.ctxpkg",
+            "demo__squeeze-1.0.0.ctxpkg",
+        ] {
+            assert!(looks_like_a_path(arg), "should be a path: {arg}");
+        }
+        for arg in ["acme/widget", "acme/widget@1.2.0", "widget"] {
+            assert!(!looks_like_a_path(arg), "should be a registry ref: {arg}");
+        }
     }
 
     /// The staging guard exists so the downloaded bytes survive the consent

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -13,7 +13,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::core::context_package::{LocalRegistry, addons, content::DocumentBlob};
+use crate::core::context_package::{
+    LocalRegistry, addon_manifest, addon_wiring, addons, content::DocumentBlob,
+};
 
 pub(crate) fn cmd_addon(args: &[String]) {
     let sub = args
@@ -68,6 +70,8 @@ struct Installed {
     version: String,
     dir: PathBuf,
     modules: Vec<PathBuf>,
+    /// The `[mcp]` command line, when the addon declares one.
+    wiring: Option<String>,
 }
 
 /// Read the store rather than the package index.
@@ -100,11 +104,16 @@ fn installed_addons() -> Vec<Installed> {
                 .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("wasm"))
                 .collect();
             modules.sort();
+            let wiring = std::fs::read_to_string(dir.join("lean-ctx-addon.toml"))
+                .ok()
+                .and_then(|t| addon_manifest::parse(&t).ok())
+                .and_then(|m| m.mcp.map(|w| w.describe()));
             out.push(Installed {
                 name: display_name.clone(),
                 version: version_entry.file_name().to_string_lossy().into_owned(),
                 dir,
                 modules,
+                wiring,
             });
         }
     }
@@ -131,14 +140,21 @@ fn cmd_list() {
             .filter_map(|m| m.file_stem().map(|s| s.to_string_lossy().into_owned()))
             .collect();
         println!("  {}@{}", a.name, a.version);
-        if names.is_empty() {
-            println!("    (no modules — nothing is loaded from this addon)");
-        } else {
+        if !names.is_empty() {
             println!("    compressors: {}", names.join(", "));
+        }
+        if let Some(w) = a.wiring.as_deref() {
+            println!("    MCP server:  {w}");
+        }
+        if names.is_empty() && a.wiring.is_none() {
+            println!("    (nothing is loaded from this addon)");
         }
     }
     println!();
     println!("Modules register as compressors and are visible in `lean-ctx doctor`.");
+    if !addon_wiring::gateway_enabled() {
+        println!("The MCP gateway is OFF — declared servers are recorded but not spawned.");
+    }
 }
 
 fn cmd_info(args: &[String]) {
@@ -219,9 +235,34 @@ fn cmd_add(args: &[String]) {
                     &digest[..16]
                 );
             }
+            if let Some(w) = &p.wiring {
+                println!("  MCP server  {w}");
+                println!(
+                    "  pin         {}",
+                    if p.pinned {
+                        "sha256 pinned — the gateway refuses to spawn a changed binary"
+                    } else {
+                        "none — whatever `command` resolves to at spawn time"
+                    }
+                );
+            }
             println!();
-            println!("Addon modules run inside lean-ctx as WASM: sandboxed, no ambient");
-            println!("environment, output budget enforced by the host.");
+            if !p.modules.is_empty() {
+                println!("Modules run inside lean-ctx as WASM: sandboxed, no ambient");
+                println!("environment, output budget enforced by the host.");
+            }
+            if p.wiring.is_some() {
+                // The honest part. A WASM module is bounded; an MCP server is
+                // an ordinary process with the user's own privileges. Saying so
+                // plainly is the difference between consent and a click-through.
+                println!(
+                    "The MCP server above runs as a NORMAL PROCESS with your privileges — it is"
+                );
+                println!(
+                    "not sandboxed. lean-ctx will not install it: it records how to run it, and"
+                );
+                println!("only spawns it while `gateway.enabled = true`.");
+            }
             println!();
         }
         Err(e) => {
@@ -238,7 +279,28 @@ fn cmd_add(args: &[String]) {
     match registry.install_addon_from_file(path) {
         Ok(manifest) => {
             println!("Installed {}@{}", manifest.name, manifest.version);
-            println!("Its modules load on the next lean-ctx start.");
+
+            // Wiring happens after the package is stored: if the store write
+            // fails there must be no gateway entry pointing at an addon that
+            // was never installed.
+            match wire_after_install(path) {
+                Ok(addon_wiring::Wired::NothingToWire) => {}
+                Ok(addon_wiring::Wired::Added(name) | addon_wiring::Wired::Replaced(name)) => {
+                    println!("Wired `{name}` into the MCP gateway.");
+                    if !addon_wiring::gateway_enabled() {
+                        println!();
+                        println!("The gateway is currently OFF, so nothing spawns yet.");
+                        println!("Turn it on with:  lean-ctx config set gateway.enabled true");
+                    }
+                }
+                Err(e) => {
+                    // The package is installed; only the wiring failed. Say
+                    // exactly that rather than implying the whole install broke.
+                    eprintln!("WARNING: installed, but could not wire the MCP server: {e}");
+                    eprintln!("         Re-run `lean-ctx addon add` after fixing it.");
+                }
+            }
+            println!("Modules load on the next lean-ctx start.");
         }
         Err(e) => {
             eprintln!("ERROR: install failed: {e}");
@@ -247,12 +309,37 @@ fn cmd_add(args: &[String]) {
     }
 }
 
+/// Parse the just-installed package's manifest and apply its `[mcp]` wiring.
+///
+/// Reads the package file again rather than threading the manifest out of the
+/// installer: the file is the same one that was verified moments ago, and this
+/// keeps the wiring step independent of the storage path's signature.
+fn wire_after_install(path: &Path) -> Result<addon_wiring::Wired, String> {
+    let json = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let value: serde_json::Value = serde_json::from_str(&json).map_err(|e| e.to_string())?;
+    let toml_text = value
+        .get("content")
+        .and_then(|c| c.get("addon"))
+        .and_then(|a| a.get("manifest_toml"))
+        .and_then(|v| v.as_str())
+        .ok_or("package has no addon manifest")?;
+    let manifest = addon_manifest::parse(toml_text)?;
+    addon_wiring::register(&manifest)
+}
+
 struct Preview {
     name: String,
     version: String,
     description: String,
     signed: Option<String>,
     modules: Vec<(String, String, usize)>,
+    /// The command or URL the addon asks lean-ctx to run, if any.
+    wiring: Option<String>,
+    /// Whether that command carries a SHA-256 pin. Material to the decision:
+    /// pinned means the gateway refuses to spawn a binary that has changed
+    /// underneath it, unpinned means it spawns whatever `command` resolves to
+    /// on the day.
+    pinned: bool,
 }
 
 /// Read a pack for display only. Verification happens in the install path;
@@ -296,6 +383,16 @@ fn preview(path: &Path) -> Result<Preview, String> {
         })
         .unwrap_or_default();
 
+    let declared = value
+        .get("content")
+        .and_then(|c| c.get("addon"))
+        .and_then(|a| a.get("manifest_toml"))
+        .and_then(|v| v.as_str())
+        .and_then(|toml| addon_manifest::parse(toml).ok())
+        .and_then(|m| m.mcp);
+    let pinned = declared.as_ref().is_some_and(|w| !w.sha256.is_empty());
+    let wiring = declared.map(|w| w.describe());
+
     Ok(Preview {
         name: str_at("name"),
         version: str_at("version"),
@@ -306,6 +403,8 @@ fn preview(path: &Path) -> Result<Preview, String> {
             .and_then(|v| v.as_str())
             .map(|k| format!("signed by {}…", &k[..k.len().min(16)])),
         modules,
+        wiring,
+        pinned,
     })
 }
 
@@ -342,6 +441,22 @@ fn cmd_remove(args: &[String]) {
     // Also drop the index row so `pack list` does not keep advertising it.
     if let Ok(registry) = LocalRegistry::open() {
         let _ = registry.remove(&matches[0].name, None);
+    }
+
+    // And the gateway entry, by the manifest's own addon name — which is the
+    // gateway server name, and is not always the package name.
+    for a in &matches {
+        let manifest_path = a.dir.join("lean-ctx-addon.toml");
+        let wired_name = std::fs::read_to_string(&manifest_path)
+            .ok()
+            .and_then(|t| addon_manifest::parse(&t).ok())
+            .map(|m| m.addon.name)
+            .unwrap_or_else(|| a.name.trim_start_matches('@').to_string());
+        match addon_wiring::unregister(&wired_name) {
+            Ok(true) => println!("Unwired `{wired_name}` from the MCP gateway."),
+            Ok(false) => {}
+            Err(e) => eprintln!("WARNING: could not update the gateway config: {e}"),
+        }
     }
 
     if removed > 0 {

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -40,23 +40,27 @@ pub(crate) fn cmd_addon(args: &[String]) {
 
 fn print_usage() {
     println!(
-        "lean-ctx addon — WASM extensions loaded into the context pipeline
+        "lean-ctx addon — extensions: WASM modules and declared MCP servers
 
-  list                    Installed addons and the modules they load
+  list                    Installed addons, the modules they load, what they wire
   info <name>             The author's manifest and module digests
-  add <file.ctxpkg>       Verify, ask, then install
-  remove <name>           Remove an addon and its modules
+  add <pkg | ns/name>     Verify, show, ask, then install (file or registry ref)
+  remove <name>           Remove an addon, its modules and its gateway entry
   release <dir>           Build a signed .ctxpkg from a directory
 
-An addon directory holds `lean-ctx-addon.toml` and one or more `.wasm`
-modules. `release` embeds the modules in the package and signs it, so
-publishing needs no artifact host, no checksum files and no CI.
+An addon directory holds `lean-ctx-addon.toml` and, for a WASM addon, one or
+more `.wasm` modules. `release` embeds the modules in the package and signs it,
+so publishing needs no artifact host, no checksum files and no CI.
 
-Extensions run in a WASM sandbox: no ambient environment, a fresh store per
-call, and the host enforces the output budget after decoding. Only what a
-module returns can affect lean-ctx.
+WASM modules run in a sandbox: no ambient environment, a fresh store per call,
+and the host enforces the output budget after decoding. Only what a module
+returns can affect lean-ctx.
 
-Docs: docs/contracts/wasm-abi-v1.md"
+A manifest may instead declare an MCP server under `[mcp]`. That server is an
+ordinary process with your privileges — not sandboxed — so `add` prints the
+exact command before asking, and lean-ctx never installs the binary for you.
+
+Docs: docs/guides/addons.md · contracts: wasm-abi-v1, addon-manifest-v1"
     );
 }
 
@@ -200,13 +204,85 @@ fn cmd_info(args: &[String]) {
     }
 }
 
+/// A downloaded package, deleted when this guard drops.
+///
+/// The staging file must outlive the consent prompt: the whole point is that
+/// the user sees the digests of the exact bytes that will be installed, so the
+/// remote path and the local path have to converge on one file before anything
+/// is shown.
+struct Staged(std::path::PathBuf);
+
+impl Drop for Staged {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.0).ok();
+    }
+}
+
+/// Fetch `ns/name[@version]` from a package registry into a temp file.
+///
+/// `pack install` refuses executable content and points at `addon add`, which
+/// until now only accepted a local path — so a published addon could be
+/// resolved, downloaded and then not installed by any command. This closes that
+/// loop without adding a second consent path: the artifact lands on disk and
+/// then goes through exactly the same preview, prompt and verification as a
+/// file the user already had.
+fn stage_remote(reference: &str, registry_flag: Option<&str>) -> Result<Staged, String> {
+    use crate::core::context_package::remote;
+
+    let parsed = remote::parse_remote_ref(reference)
+        .ok_or_else(|| format!("'{reference}' is not a file, nor a valid ns/name[@version]"))?;
+    let base = remote::registry_base(registry_flag);
+    let token = remote::publish_token(None);
+    let (ns, name) = (&parsed.namespace, &parsed.name);
+
+    println!("Resolving @{ns}/{name} via {base} …");
+    let versions = remote::fetch_versions(&base, ns, name, token.as_deref())?;
+    let info = remote::select_version(&versions, parsed.version.as_deref())?;
+    if info.yanked {
+        eprintln!(
+            "WARNING: @{ns}/{name}@{} is YANKED — continuing only because the version \
+             was pinned explicitly",
+            info.version
+        );
+    }
+    let bytes = remote::download_verified(&base, ns, name, info, token.as_deref())?;
+    println!(
+        "Downloaded @{ns}/{name}@{} ({} bytes, sha256 verified against the index)",
+        info.version,
+        bytes.len()
+    );
+
+    let tmp = std::env::temp_dir().join(format!("ctxpkg-addon-{}.ctxpkg", std::process::id()));
+    std::fs::write(&tmp, &bytes).map_err(|e| format!("stage artifact: {e}"))?;
+    Ok(Staged(tmp))
+}
+
 fn cmd_add(args: &[String]) {
     let Some(file) = positional(args, "add").or_else(|| positional(args, "install")) else {
-        eprintln!("Usage: lean-ctx addon add <file.ctxpkg>");
+        eprintln!("Usage: lean-ctx addon add <file.ctxpkg | ns/name[@version]>");
         std::process::exit(2);
     };
-    let path = Path::new(&file);
     let assume_yes = args.iter().any(|a| a == "--yes" || a == "-y");
+    let registry_flag = flag_value(args, "--registry");
+
+    // A local file wins over a remote lookup: an argument that names something
+    // on disk must never silently reach the network instead.
+    let local = Path::new(&file);
+    let _staged;
+    let path: &Path = if local.is_file() {
+        local
+    } else {
+        match stage_remote(&file, registry_flag.as_deref()) {
+            Ok(s) => {
+                _staged = s;
+                &_staged.0
+            }
+            Err(e) => {
+                eprintln!("ERROR: {e}");
+                std::process::exit(1);
+            }
+        }
+    };
 
     let registry = match LocalRegistry::open() {
         Ok(r) => r,
@@ -667,5 +743,44 @@ mod tests {
         std::fs::write(dir.path().join("lean-ctx-addon.toml"), "[addon]\n").unwrap();
         let err = build_release(dir.path(), None).expect_err("must refuse");
         assert!(err.contains("name is required"), "{err}");
+    }
+
+    /// An argument that names something on disk must never reach the network.
+    /// A file called `foo/bar` in the working directory also parses as a valid
+    /// `ns/name` reference, and resolving that remotely instead would install
+    /// something other than what the user pointed at.
+    #[test]
+    fn a_local_file_is_preferred_over_a_remote_reference() {
+        use crate::core::context_package::remote;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ns_dir = dir.path().join("acme");
+        std::fs::create_dir(&ns_dir).unwrap();
+        let file = ns_dir.join("widget");
+        std::fs::write(&file, b"{}").unwrap();
+
+        // The name is a well-formed remote ref …
+        assert!(
+            remote::parse_remote_ref("acme/widget").is_some(),
+            "precondition: this parses as a registry reference"
+        );
+        // … and yet the path on disk is what cmd_add resolves, because
+        // `is_file()` is checked first.
+        assert!(file.is_file());
+    }
+
+    /// The staging guard exists so the downloaded bytes survive the consent
+    /// prompt and are gone afterwards — a leftover .ctxpkg in the temp dir is
+    /// executable content nobody is tracking.
+    #[test]
+    fn staged_artifacts_are_deleted_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("staged.ctxpkg");
+        std::fs::write(&path, b"{}").unwrap();
+        {
+            let _guard = Staged(path.clone());
+            assert!(path.is_file(), "available while the guard lives");
+        }
+        assert!(!path.exists(), "removed when the guard drops");
     }
 }

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -76,6 +76,11 @@ struct Installed {
     modules: Vec<PathBuf>,
     /// The `[mcp]` command line, when the addon declares one.
     wiring: Option<String>,
+    /// Whether this is the version whose modules actually load. The store keeps
+    /// versions side by side, so after an upgrade two rows share a name and
+    /// only one of them is live — printing both as if they both ran would be a
+    /// listing that disagrees with the running system.
+    active: bool,
 }
 
 /// Read the store rather than the package index.
@@ -98,6 +103,20 @@ fn installed_addons() -> Vec<Installed> {
         let Ok(versions) = std::fs::read_dir(name_entry.path()) else {
             continue;
         };
+        // Which version is live is decided by the loader, not restated here —
+        // the same mtime rule, read from the same directories, so the listing
+        // and the running system cannot drift apart.
+        let active_dir = std::fs::read_dir(name_entry.path()).ok().and_then(|v| {
+            v.flatten()
+                .filter(|e| e.path().is_dir())
+                .max_by_key(|e| {
+                    e.metadata()
+                        .and_then(|m| m.modified())
+                        .unwrap_or(std::time::UNIX_EPOCH)
+                })
+                .map(|e| e.path())
+        });
+
         for version_entry in versions.flatten().filter(|e| e.path().is_dir()) {
             let dir = version_entry.path();
             let mut modules: Vec<PathBuf> = std::fs::read_dir(&dir)
@@ -112,12 +131,14 @@ fn installed_addons() -> Vec<Installed> {
                 .ok()
                 .and_then(|t| addon_manifest::parse(&t).ok())
                 .and_then(|m| m.mcp.map(|w| w.describe()));
+            let active = active_dir.as_ref().is_some_and(|a| *a == dir);
             out.push(Installed {
                 name: display_name.clone(),
                 version: version_entry.file_name().to_string_lossy().into_owned(),
                 dir,
                 modules,
                 wiring,
+                active,
             });
         }
     }
@@ -137,15 +158,28 @@ fn cmd_list() {
 
     println!("Installed addons ({}):", installed.len());
     println!();
+    let superseded = installed.iter().any(|a| !a.active);
     for a in &installed {
         let names: Vec<String> = a
             .modules
             .iter()
             .filter_map(|m| m.file_stem().map(|s| s.to_string_lossy().into_owned()))
             .collect();
-        println!("  {}@{}", a.name, a.version);
+        println!(
+            "  {}@{}{}",
+            a.name,
+            a.version,
+            if a.active { "" } else { "   (superseded)" }
+        );
         if !names.is_empty() {
-            println!("    compressors: {}", names.join(", "));
+            // Only the active version's modules reach the registry, so saying
+            // "compressors:" for a superseded row would name code that never
+            // runs.
+            if a.active {
+                println!("    compressors: {}", names.join(", "));
+            } else {
+                println!("    modules on disk, not loaded: {}", names.join(", "));
+            }
         }
         if let Some(w) = a.wiring.as_deref() {
             println!("    MCP server:  {w}");
@@ -156,6 +190,9 @@ fn cmd_list() {
     }
     println!();
     println!("Modules register as compressors and are visible in `lean-ctx doctor`.");
+    if superseded {
+        println!("Superseded versions stay on disk; `addon remove <name>` clears them all.");
+    }
     if !addon_wiring::gateway_enabled() {
         println!("The MCP gateway is OFF — declared servers are recorded but not spawned.");
     }

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -344,7 +344,15 @@ fn cmd_add(args: &[String]) {
             );
             for (module, digest, bytes) in &p.modules {
                 println!(
-                    "  module      {module}  ({bytes} bytes, sha256 {})",
+                    "  module      {module}  ({}, sha256 {})",
+                    // No size rather than a wrong one: if the blob will not
+                    // decode, the install is about to refuse it anyway, and
+                    // inventing a number here would be the only place that
+                    // pretended otherwise.
+                    bytes.map_or_else(
+                        || "size unavailable — payload does not decode".to_string(),
+                        |n| format!("{n} bytes")
+                    ),
                     &digest[..16]
                 );
             }
@@ -472,7 +480,7 @@ struct Preview {
     version: String,
     description: String,
     signed: Option<String>,
-    modules: Vec<(String, String, usize)>,
+    modules: Vec<(String, String, Option<usize>)>,
     /// The command or URL the addon asks lean-ctx to run, if any.
     wiring: Option<String>,
     /// Whether that command carries a SHA-256 pin. Material to the decision:
@@ -511,6 +519,18 @@ fn preview(path: &Path) -> Result<Preview, String> {
         .map(|arr| {
             arr.iter()
                 .map(|m| {
+                    // The size must be the size of the *module*, not of its
+                    // zstd+base64 body. A reader checking the prompt against
+                    // their own file — the whole point of showing a size next
+                    // to a digest — would otherwise see a number that matches
+                    // nothing, and one that disagrees with `addon info`.
+                    // Decoding also verifies the blob against its digest, so a
+                    // corrupt payload is caught before the question is asked
+                    // rather than after the answer.
+                    let decoded = serde_json::from_value::<DocumentBlob>(m.clone())
+                        .ok()
+                        .and_then(|b| b.decode_verified().ok())
+                        .map(|plain| plain.len());
                     (
                         m.get("path")
                             .and_then(|v| v.as_str())
@@ -520,7 +540,7 @@ fn preview(path: &Path) -> Result<Preview, String> {
                             .and_then(|v| v.as_str())
                             .unwrap_or(&"?".repeat(64))
                             .to_string(),
-                        m.get("body").and_then(|v| v.as_str()).map_or(0, str::len),
+                        decoded,
                     )
                 })
                 .collect()

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -1,0 +1,556 @@
+//! `lean-ctx addon` — the extension surface.
+//!
+//! Five verbs, deliberately: `list`, `info`, `add`, `remove`, `release`.
+//!
+//! There is no `search`. Search implies an index someone curates, and that is
+//! a marketplace — explicitly out of scope. An addon arrives as a file or from
+//! a registry the user names; lean-ctx does not rank or recommend.
+//!
+//! `add` is the one verb that stores executable code, so it is the only one
+//! that asks. Everything the prompt shows — publisher key, module digests — is
+//! read from the pack the user is about to install, after its signature and
+//! content digest have already been verified.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::context_package::{LocalRegistry, addons, content::DocumentBlob};
+
+pub(crate) fn cmd_addon(args: &[String]) {
+    let sub = args
+        .iter()
+        .find(|a| !a.starts_with('-') && a.as_str() != "addon" && a.as_str() != "addons")
+        .map(String::as_str);
+
+    match sub {
+        Some("list" | "ls") | None => cmd_list(),
+        Some("info") => cmd_info(args),
+        Some("add" | "install") => cmd_add(args),
+        Some("remove" | "rm" | "uninstall") => cmd_remove(args),
+        Some("release") => cmd_release(args),
+        Some("help" | "--help" | "-h") => print_usage(),
+        Some(other) => {
+            eprintln!("lean-ctx addon: unknown subcommand '{other}'");
+            print_usage();
+            std::process::exit(1);
+        }
+    }
+}
+
+fn print_usage() {
+    println!(
+        "lean-ctx addon — WASM extensions loaded into the context pipeline
+
+  list                    Installed addons and the modules they load
+  info <name>             The author's manifest and module digests
+  add <file.ctxpkg>       Verify, ask, then install
+  remove <name>           Remove an addon and its modules
+  release <dir>           Build a signed .ctxpkg from a directory
+
+An addon directory holds `lean-ctx-addon.toml` and one or more `.wasm`
+modules. `release` embeds the modules in the package and signs it, so
+publishing needs no artifact host, no checksum files and no CI.
+
+Extensions run in a WASM sandbox: no ambient environment, a fresh store per
+call, and the host enforces the output budget after decoding. Only what a
+module returns can affect lean-ctx.
+
+Docs: docs/contracts/wasm-abi-v1.md"
+    );
+}
+
+fn store_root() -> Option<PathBuf> {
+    addons::store_root().ok()
+}
+
+/// One installed addon as it exists on disk.
+struct Installed {
+    name: String,
+    version: String,
+    dir: PathBuf,
+    modules: Vec<PathBuf>,
+}
+
+/// Read the store rather than the package index.
+///
+/// The store is what the extension registry actually loads, so listing it
+/// cannot disagree with reality — an index row whose files are missing would
+/// otherwise be reported as an installed addon that does nothing.
+fn installed_addons() -> Vec<Installed> {
+    let Some(root) = store_root() else {
+        return Vec::new();
+    };
+    let addons_root = addons::addons_root(&root);
+    let Ok(names) = std::fs::read_dir(&addons_root) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for name_entry in names.flatten().filter(|e| e.path().is_dir()) {
+        let display_name = name_entry.file_name().to_string_lossy().replace("__", "/");
+        let Ok(versions) = std::fs::read_dir(name_entry.path()) else {
+            continue;
+        };
+        for version_entry in versions.flatten().filter(|e| e.path().is_dir()) {
+            let dir = version_entry.path();
+            let mut modules: Vec<PathBuf> = std::fs::read_dir(&dir)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("wasm"))
+                .collect();
+            modules.sort();
+            out.push(Installed {
+                name: display_name.clone(),
+                version: version_entry.file_name().to_string_lossy().into_owned(),
+                dir,
+                modules,
+            });
+        }
+    }
+    out.sort_by(|a, b| (&a.name, &a.version).cmp(&(&b.name, &b.version)));
+    out
+}
+
+fn cmd_list() {
+    let installed = installed_addons();
+    if installed.is_empty() {
+        println!("No addons installed.");
+        println!();
+        println!("Install one:  lean-ctx addon add <file.ctxpkg>");
+        println!("Build one:    lean-ctx addon release <dir>");
+        return;
+    }
+
+    println!("Installed addons ({}):", installed.len());
+    println!();
+    for a in &installed {
+        let names: Vec<String> = a
+            .modules
+            .iter()
+            .filter_map(|m| m.file_stem().map(|s| s.to_string_lossy().into_owned()))
+            .collect();
+        println!("  {}@{}", a.name, a.version);
+        if names.is_empty() {
+            println!("    (no modules — nothing is loaded from this addon)");
+        } else {
+            println!("    compressors: {}", names.join(", "));
+        }
+    }
+    println!();
+    println!("Modules register as compressors and are visible in `lean-ctx doctor`.");
+}
+
+fn cmd_info(args: &[String]) {
+    let Some(name) = positional(args, "info") else {
+        eprintln!("Usage: lean-ctx addon info <name>");
+        std::process::exit(2);
+    };
+
+    let matches: Vec<Installed> = installed_addons()
+        .into_iter()
+        .filter(|a| a.name == name || a.name.trim_start_matches('@') == name)
+        .collect();
+
+    if matches.is_empty() {
+        eprintln!("No installed addon named `{name}`.");
+        eprintln!("See what is installed with: lean-ctx addon list");
+        std::process::exit(1);
+    }
+
+    for a in matches {
+        println!("{}@{}", a.name, a.version);
+        println!("  stored at   {}", a.dir.display());
+        for module in &a.modules {
+            let bytes = std::fs::read(module).unwrap_or_default();
+            println!(
+                "  module      {}  ({} bytes, sha256 {})",
+                module.file_name().unwrap_or_default().to_string_lossy(),
+                bytes.len(),
+                &sha256_hex(&bytes)[..16],
+            );
+        }
+        let manifest_path = a.dir.join("lean-ctx-addon.toml");
+        match std::fs::read_to_string(&manifest_path) {
+            Ok(text) => {
+                println!();
+                println!("  --- lean-ctx-addon.toml (as published) ---");
+                for line in text.lines() {
+                    println!("  {line}");
+                }
+            }
+            Err(_) => println!("  (no authoring manifest stored)"),
+        }
+    }
+}
+
+fn cmd_add(args: &[String]) {
+    let Some(file) = positional(args, "add").or_else(|| positional(args, "install")) else {
+        eprintln!("Usage: lean-ctx addon add <file.ctxpkg>");
+        std::process::exit(2);
+    };
+    let path = Path::new(&file);
+    let assume_yes = args.iter().any(|a| a == "--yes" || a == "-y");
+
+    let registry = match LocalRegistry::open() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ERROR: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Show what is being installed BEFORE asking. The preview is derived from
+    // the file on disk; the install call re-reads and re-verifies it, so the
+    // prompt can never describe something other than what gets stored.
+    match preview(path) {
+        Ok(p) => {
+            println!("{}@{}", p.name, p.version);
+            println!("  {}", p.description);
+            println!(
+                "  signature   {}",
+                p.signed
+                    .as_deref()
+                    .map_or("UNSIGNED — anyone could have produced this file", |k| k)
+            );
+            for (module, digest, bytes) in &p.modules {
+                println!(
+                    "  module      {module}  ({bytes} bytes, sha256 {})",
+                    &digest[..16]
+                );
+            }
+            println!();
+            println!("Addon modules run inside lean-ctx as WASM: sandboxed, no ambient");
+            println!("environment, output budget enforced by the host.");
+            println!();
+        }
+        Err(e) => {
+            eprintln!("ERROR: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    if !crate::cli::prompt::confirm("Install this addon?", assume_yes) {
+        println!("Aborted. Nothing was installed.");
+        return;
+    }
+
+    match registry.install_addon_from_file(path) {
+        Ok(manifest) => {
+            println!("Installed {}@{}", manifest.name, manifest.version);
+            println!("Its modules load on the next lean-ctx start.");
+        }
+        Err(e) => {
+            eprintln!("ERROR: install failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+struct Preview {
+    name: String,
+    version: String,
+    description: String,
+    signed: Option<String>,
+    modules: Vec<(String, String, usize)>,
+}
+
+/// Read a pack for display only. Verification happens in the install path;
+/// this exists so the consent prompt can name what it is asking about.
+fn preview(path: &Path) -> Result<Preview, String> {
+    let json =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&json).map_err(|e| format!("parse package: {e}"))?;
+    let manifest = value.get("manifest").ok_or("package has no manifest")?;
+
+    let str_at = |k: &str| -> String {
+        manifest
+            .get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let modules = value
+        .get("content")
+        .and_then(|c| c.get("addon"))
+        .and_then(|a| a.get("modules"))
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|m| {
+                    (
+                        m.get("path")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("?")
+                            .to_string(),
+                        m.get("sha256")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&"?".repeat(64))
+                            .to_string(),
+                        m.get("body").and_then(|v| v.as_str()).map_or(0, str::len),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(Preview {
+        name: str_at("name"),
+        version: str_at("version"),
+        description: str_at("description"),
+        signed: manifest
+            .get("signature")
+            .and_then(|s| s.get("public_key"))
+            .and_then(|v| v.as_str())
+            .map(|k| format!("signed by {}…", &k[..k.len().min(16)])),
+        modules,
+    })
+}
+
+fn cmd_remove(args: &[String]) {
+    let Some(name) = positional(args, "remove")
+        .or_else(|| positional(args, "rm"))
+        .or_else(|| positional(args, "uninstall"))
+    else {
+        eprintln!("Usage: lean-ctx addon remove <name>");
+        std::process::exit(2);
+    };
+
+    let matches: Vec<Installed> = installed_addons()
+        .into_iter()
+        .filter(|a| a.name == name || a.name.trim_start_matches('@') == name)
+        .collect();
+
+    if matches.is_empty() {
+        eprintln!("No installed addon named `{name}`.");
+        std::process::exit(1);
+    }
+
+    let mut removed = 0;
+    for a in &matches {
+        match std::fs::remove_dir_all(&a.dir) {
+            Ok(()) => {
+                println!("Removed {}@{}", a.name, a.version);
+                removed += 1;
+            }
+            Err(e) => eprintln!("ERROR: remove {}: {e}", a.dir.display()),
+        }
+    }
+
+    // Also drop the index row so `pack list` does not keep advertising it.
+    if let Ok(registry) = LocalRegistry::open() {
+        let _ = registry.remove(&matches[0].name, None);
+    }
+
+    if removed > 0 {
+        println!("Its modules stop loading on the next lean-ctx start.");
+    }
+}
+
+fn cmd_release(args: &[String]) {
+    let dir = positional(args, "release").unwrap_or_else(|| ".".to_string());
+    let dir = Path::new(&dir);
+    let output = flag_value(args, "--output").or_else(|| flag_value(args, "-o"));
+
+    match build_release(dir, output.as_deref()) {
+        Ok(out) => {
+            println!("Wrote {}", out.display());
+            println!();
+            println!("Install locally:  lean-ctx addon add {}", out.display());
+            println!("Publish:          lean-ctx pack publish {}", out.display());
+        }
+        Err(e) => {
+            eprintln!("ERROR: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Build a signed `.ctxpkg` from an addon directory.
+///
+/// This is the answer to the one complaint the previous addon channel drew:
+/// authors had to run their own CI to produce checksum files for externally
+/// hosted artifacts. Here the modules are read from disk, hashed, compressed
+/// and embedded, and the pack signature covers all of it — one local command,
+/// no artifact host, no CI required.
+fn build_release(dir: &Path, output: Option<&str>) -> Result<PathBuf, String> {
+    let manifest_path = dir.join("lean-ctx-addon.toml");
+    let manifest_toml = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("read {}: {e}", manifest_path.display()))?;
+
+    let parsed: toml::Value =
+        toml::from_str(&manifest_toml).map_err(|e| format!("{}: {e}", manifest_path.display()))?;
+    let table = parsed
+        .get("addon")
+        .ok_or_else(|| format!("{}: missing [addon] table", manifest_path.display()))?;
+    let name = table
+        .get("name")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| format!("{}: [addon] name is required", manifest_path.display()))?;
+    let version = table
+        .get("version")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| format!("{}: [addon] version is required", manifest_path.display()))?;
+    let description = table
+        .get("description")
+        .and_then(toml::Value::as_str)
+        .unwrap_or("");
+
+    let mut wasm_files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|e| format!("read {}: {e}", dir.display()))?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("wasm"))
+        .collect();
+    wasm_files.sort();
+
+    if wasm_files.is_empty() {
+        return Err(format!(
+            "no .wasm module in {} — an addon without a module would install nothing",
+            dir.display()
+        ));
+    }
+
+    let mut modules = Vec::new();
+    for path in &wasm_files {
+        let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| format!("{}: unusable file name", path.display()))?;
+        if !bytes.starts_with(b"\0asm") {
+            return Err(format!(
+                "{file_name} is not a WebAssembly module (bad magic) — was it built with \
+                 `--target wasm32-unknown-unknown`?"
+            ));
+        }
+        modules.push(DocumentBlob::from_plaintext(file_name, &bytes)?);
+    }
+
+    let out_path = output.map_or_else(
+        || {
+            let safe = name.replace('/', "__").replace('@', "");
+            dir.join(format!(
+                "{safe}-{version}.{}",
+                crate::core::contracts::PACKAGE_EXTENSION
+            ))
+        },
+        PathBuf::from,
+    );
+
+    crate::core::context_package::addons_build::write_addon_package(
+        &out_path,
+        name,
+        version,
+        description,
+        &manifest_toml,
+        modules,
+    )?;
+
+    println!(
+        "Packed {} module(s) from {}",
+        wasm_files.len(),
+        dir.display()
+    );
+    Ok(out_path)
+}
+
+fn positional(args: &[String], after: &str) -> Option<String> {
+    args.iter()
+        .skip_while(|a| a.as_str() != after)
+        .skip(1)
+        .find(|a| !a.starts_with('-'))
+        .cloned()
+}
+
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    if let Some(v) = args
+        .iter()
+        .find_map(|a| a.strip_prefix(&format!("{flag}=")))
+    {
+        return Some(v.to_string());
+    }
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(data);
+    crate::core::agent_identity::hex_encode(&h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positional_skips_flags_and_the_verb() {
+        let args: Vec<String> = ["addon", "add", "--yes", "pack.ctxpkg"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(positional(&args, "add"), Some("pack.ctxpkg".into()));
+    }
+
+    #[test]
+    fn flag_value_accepts_both_spellings() {
+        let split: Vec<String> = ["release", ".", "--output", "out.ctxpkg"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(flag_value(&split, "--output"), Some("out.ctxpkg".into()));
+
+        let joined: Vec<String> = ["release", ".", "--output=out.ctxpkg"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(flag_value(&joined, "--output"), Some("out.ctxpkg".into()));
+    }
+
+    /// A directory with a manifest but no module would install an addon that
+    /// does nothing — say so at build time, not after publishing.
+    #[test]
+    fn release_refuses_a_directory_without_a_module() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("lean-ctx-addon.toml"),
+            "[addon]\nname = \"@ns/demo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let err = build_release(dir.path(), None).expect_err("must refuse");
+        assert!(err.contains("no .wasm module"), "{err}");
+    }
+
+    /// A `.wasm` that is not WebAssembly is caught before it is packed, with a
+    /// message that names the likely cause.
+    #[test]
+    fn release_refuses_a_file_that_is_not_webassembly() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("lean-ctx-addon.toml"),
+            "[addon]\nname = \"@ns/demo\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("bogus.wasm"), b"not wasm at all").unwrap();
+        let err = build_release(dir.path(), None).expect_err("must refuse");
+        assert!(err.contains("not a WebAssembly module"), "{err}");
+        assert!(
+            err.contains("wasm32-unknown-unknown"),
+            "must hint the cause: {err}"
+        );
+    }
+
+    #[test]
+    fn release_requires_name_and_version() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("lean-ctx-addon.toml"), "[addon]\n").unwrap();
+        let err = build_release(dir.path(), None).expect_err("must refuse");
+        assert!(err.contains("name is required"), "{err}");
+    }
+}

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -503,6 +503,21 @@ fn cmd_remove(args: &[String]) {
         std::process::exit(1);
     }
 
+    // Read the wired name BEFORE deleting anything. The gateway server name is
+    // the manifest's own `[addon] name`, which is not always the package name —
+    // and the manifest lives inside the directory that is about to go. Reading
+    // it afterwards silently falls back to a guess, the guess misses, and the
+    // gateway keeps an entry for an addon the user believes is gone.
+    let wired_names: Vec<String> = matches
+        .iter()
+        .map(|a| {
+            std::fs::read_to_string(a.dir.join("lean-ctx-addon.toml"))
+                .ok()
+                .and_then(|t| addon_manifest::parse(&t).ok())
+                .map_or_else(|| a.name.clone(), |m| m.addon.name)
+        })
+        .collect();
+
     let mut removed = 0;
     for a in &matches {
         match std::fs::remove_dir_all(&a.dir) {
@@ -519,16 +534,8 @@ fn cmd_remove(args: &[String]) {
         let _ = registry.remove(&matches[0].name, None);
     }
 
-    // And the gateway entry, by the manifest's own addon name — which is the
-    // gateway server name, and is not always the package name.
-    for a in &matches {
-        let manifest_path = a.dir.join("lean-ctx-addon.toml");
-        let wired_name = std::fs::read_to_string(&manifest_path)
-            .ok()
-            .and_then(|t| addon_manifest::parse(&t).ok())
-            .map(|m| m.addon.name)
-            .unwrap_or_else(|| a.name.trim_start_matches('@').to_string());
-        match addon_wiring::unregister(&wired_name) {
+    for wired_name in &wired_names {
+        match addon_wiring::unregister(wired_name) {
             Ok(true) => println!("Unwired `{wired_name}` from the MCP gateway."),
             Ok(false) => {}
             Err(e) => eprintln!("WARNING: could not update the gateway config: {e}"),
@@ -597,11 +604,21 @@ fn build_release(dir: &Path, output: Option<&str>) -> Result<PathBuf, String> {
         .collect();
     wasm_files.sort();
 
+    // An addon must *do* something, but a module is only one of the two ways.
+    // The installer accepts modules or an `[mcp]` server; if the builder
+    // insisted on a module, an MCP-only addon could be installed and never
+    // built — the author would have no way to produce the package at all.
     if wasm_files.is_empty() {
-        return Err(format!(
-            "no .wasm module in {} — an addon without a module would install nothing",
-            dir.display()
-        ));
+        let declares_server = addon_manifest::parse(&manifest_toml)
+            .map(|m| m.mcp.is_some())
+            .unwrap_or(false);
+        if !declares_server {
+            return Err(format!(
+                "{} declares neither a .wasm module nor an [mcp] server — \
+                 installing this addon would have no effect",
+                dir.display()
+            ));
+        }
     }
 
     let mut modules = Vec::new();
@@ -704,8 +721,9 @@ mod tests {
         assert_eq!(flag_value(&joined, "--output"), Some("out.ctxpkg".into()));
     }
 
-    /// A directory with a manifest but no module would install an addon that
-    /// does nothing — say so at build time, not after publishing.
+    /// A directory with a manifest but neither a module nor an `[mcp]` server
+    /// would install an addon that does nothing — say so at build time, not
+    /// after publishing.
     #[test]
     fn release_refuses_a_directory_without_a_module() {
         let dir = tempfile::tempdir().unwrap();
@@ -715,7 +733,28 @@ mod tests {
         )
         .unwrap();
         let err = build_release(dir.path(), None).expect_err("must refuse");
-        assert!(err.contains("no .wasm module"), "{err}");
+        assert!(
+            err.contains("neither a .wasm module nor an [mcp] server"),
+            "{err}"
+        );
+    }
+
+    /// The counterpart: an MCP-only addon is legitimate and must build. The
+    /// installer accepts it, so a builder that demanded a module would leave
+    /// authors unable to produce the very package the installer takes.
+    #[test]
+    fn release_accepts_an_mcp_only_addon() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("lean-ctx-addon.toml"),
+            "[addon]\nname = \"@ns/demo\"\nversion = \"1.0.0\"\n\
+             [mcp]\ncommand = \"demo-server\"\nargs = [\"serve\"]\n",
+        )
+        .unwrap();
+
+        let out = dir.path().join("demo.ctxpkg");
+        build_release(dir.path(), Some(out.to_str().unwrap())).expect("must build");
+        assert!(out.is_file(), "a package was written");
     }
 
     /// A `.wasm` that is not WebAssembly is caught before it is packed, with a
@@ -782,5 +821,33 @@ mod tests {
             assert!(path.is_file(), "available while the guard lives");
         }
         assert!(!path.exists(), "removed when the guard drops");
+    }
+
+    /// `remove` unwires by the manifest's `[addon] name`, and the manifest
+    /// lives in the directory being deleted. Reading it after the delete
+    /// silently falls back to a guess; the guess dropped the leading `@`, so
+    /// `unregister` matched nothing and the gateway kept an entry for an addon
+    /// the user had just removed. Order is the fix, so order is the test.
+    #[test]
+    fn the_wired_name_is_read_before_the_directory_is_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("lean-ctx-addon.toml");
+        std::fs::write(
+            &manifest,
+            "[addon]\nname = \"@ns/demo\"\n[mcp]\ncommand = \"c\"\n",
+        )
+        .unwrap();
+
+        // What cmd_remove does first: resolve the name from the manifest.
+        let wired = std::fs::read_to_string(&manifest)
+            .ok()
+            .and_then(|t| addon_manifest::parse(&t).ok())
+            .map(|m| m.addon.name);
+        assert_eq!(wired.as_deref(), Some("@ns/demo"));
+
+        // Once the directory is gone the name is unrecoverable — which is why
+        // it must not be read at that point.
+        std::fs::remove_dir_all(dir.path()).unwrap();
+        assert!(std::fs::read_to_string(&manifest).is_err());
     }
 }

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -169,9 +169,10 @@ pub fn run() {
                 crate::cli::cmd_addon(&rest);
                 return;
             }
-            // Subprocess plugins are not coming back: an addon is a sandboxed
-            // WASM module (`lean-ctx addon`), which bounds what an extension
-            // can do instead of asking the user to trust that it behaves.
+            // Subprocess plugins are not coming back. An addon is a signed
+            // package: a sandboxed WASM module, or a declared MCP server the
+            // user consents to by reading its argv — either way the trust
+            // decision is bounded and visible (`lean-ctx addon`).
             "plugin" | "plugins" => {
                 eprintln!(
                     "Plugin commands have been removed. Extensions are WASM addons now — \

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -165,8 +165,18 @@ pub fn run() {
                 crate::cli::cmd_policy(&rest);
                 return;
             }
-            "plugin" | "plugins" | "addon" | "addons" => {
-                eprintln!("Addon and plugin commands have been removed.");
+            "addon" | "addons" => {
+                crate::cli::cmd_addon(&rest);
+                return;
+            }
+            // Subprocess plugins are not coming back: an addon is a sandboxed
+            // WASM module (`lean-ctx addon`), which bounds what an extension
+            // can do instead of asking the user to trust that it behaves.
+            "plugin" | "plugins" => {
+                eprintln!(
+                    "Plugin commands have been removed. Extensions are WASM addons now — \
+                     see `lean-ctx addon help`."
+                );
                 std::process::exit(1);
             }
             "embeddings" => {

--- a/rust/src/cli/mod.rs
+++ b/rust/src/cli/mod.rs
@@ -1,3 +1,4 @@
+mod addon_cmd;
 mod addon_deps;
 mod agent_cmd;
 mod agent_tools_cmd;
@@ -112,6 +113,7 @@ pub(crate) use index_cmd::cmd_index;
 pub(crate) use init_cmd::quiet_enabled;
 pub use init_cmd::{cmd_init, cmd_init_quiet};
 pub mod import_cmd;
+pub(crate) use addon_cmd::cmd_addon;
 pub(crate) use instructions_cmd::cmd_instructions;
 pub(crate) use introspect_cmd::cmd_introspect;
 pub(crate) use kit_cmd::cmd_kit;

--- a/rust/src/core/context_package/addon_manifest.rs
+++ b/rust/src/core/context_package/addon_manifest.rs
@@ -42,6 +42,8 @@ pub(crate) struct McpWiring {
     pub url: String,
     pub headers: BTreeMap<String, String>,
     pub sha256: String,
+    /// Typed-integration adapter slug (L4), or empty for a passthrough server.
+    pub integration: String,
 }
 
 impl McpWiring {
@@ -76,6 +78,7 @@ impl McpWiring {
             binary_sha256: self.sha256.clone(),
             url: self.url.clone(),
             headers: self.headers.clone(),
+            integration: self.integration.clone(),
             ..GatewayServer::default()
         }
     }
@@ -118,6 +121,27 @@ fn string_map(table: &toml::Value, key: &str) -> BTreeMap<String, String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Validate the L4 adapter slug, canonicalising it on the way through.
+///
+/// `IntegrationKind::parse` maps anything it does not recognise to `None`, so a
+/// typo (`code_grah`) would install cleanly and route through the generic path
+/// forever — working software that silently does less than the author asked
+/// for. Rejecting it here costs one line and names the manifest.
+fn parse_integration(raw: &str) -> Result<String, String> {
+    let slug = raw.trim();
+    if slug.is_empty() {
+        return Ok(String::new());
+    }
+    let kind = crate::core::mcp_catalog::adapters::IntegrationKind::parse(slug);
+    if kind.is_none() && !slug.eq_ignore_ascii_case("none") {
+        return Err(format!(
+            "lean-ctx-addon.toml: [mcp] unknown integration `{slug}` \
+             (codebase-pack | code-graph | code-symbols | memory | compression | none)"
+        ));
+    }
+    Ok(kind.as_str().to_string())
 }
 
 /// Parse `lean-ctx-addon.toml`.
@@ -186,6 +210,7 @@ pub(crate) fn parse(text: &str) -> Result<AddonManifest, String> {
                 url,
                 headers: string_map(t, "headers"),
                 sha256: string_at(t, "sha256"),
+                integration: parse_integration(&string_at(t, "integration"))?,
             })
         }
     };
@@ -202,29 +227,29 @@ mod tests {
         let m = parse(
             r#"
 [addon]
-name = "lean-md"
+name = "mdcast"
 version = "2.0.0"
 description = "Macro/directive markdown renderer"
 
 [mcp]
 transport = "stdio"
-command = "lean-md"
+command = "mdcast"
 args = ["mcp", "serve"]
 env = { LEAN_MD_MODE = "strict" }
 "#,
         )
         .expect("parse");
 
-        assert_eq!(m.addon.name, "lean-md");
+        assert_eq!(m.addon.name, "mdcast");
         let mcp = m.mcp.expect("wiring");
-        assert_eq!(mcp.describe(), "lean-md mcp serve");
+        assert_eq!(mcp.describe(), "mdcast mcp serve");
         assert_eq!(
             mcp.env.get("LEAN_MD_MODE").map(String::as_str),
             Some("strict")
         );
 
-        let server = mcp.to_gateway_server("lean-md");
-        assert_eq!(server.command, "lean-md");
+        let server = mcp.to_gateway_server("mdcast");
+        assert_eq!(server.command, "mdcast");
         assert_eq!(server.args, vec!["mcp", "serve"]);
         assert!(server.enabled, "a just-consented addon should work");
     }
@@ -253,6 +278,35 @@ headers = { Authorization = "Bearer x" }
     fn a_manifest_without_mcp_is_valid() {
         let m = parse("[addon]\nname = \"squeeze\"\n").expect("parse");
         assert!(m.mcp.is_none());
+    }
+
+    /// A typo in `integration` would otherwise install cleanly and route
+    /// through the generic path forever, which looks like working software.
+    #[test]
+    fn an_unknown_integration_is_refused_and_a_known_one_canonicalises() {
+        let err =
+            parse("[addon]\nname = \"x\"\n[mcp]\ncommand = \"c\"\nintegration = \"code_grah\"\n")
+                .expect_err("must refuse");
+        assert!(err.contains("unknown integration"), "{err}");
+
+        // Aliases are accepted and stored canonically, so the gateway entry
+        // and `addon info` agree on one spelling.
+        for (written, canonical) in [
+            ("repomix", "codebase-pack"),
+            ("callgraph", "code-graph"),
+            ("compressor", "compression"),
+            ("none", "none"),
+        ] {
+            let m = parse(&format!(
+                "[addon]\nname = \"x\"\n[mcp]\ncommand = \"c\"\nintegration = \"{written}\"\n"
+            ))
+            .expect("parse");
+            assert_eq!(m.mcp.expect("wiring").integration, canonical);
+        }
+
+        // Absent stays absent — an empty slug is the documented default.
+        let m = parse("[addon]\nname = \"x\"\n[mcp]\ncommand = \"c\"\n").expect("parse");
+        assert_eq!(m.mcp.expect("wiring").integration, "");
     }
 
     /// Each of these would produce a gateway entry that cannot work. Failing at

--- a/rust/src/core/context_package/addon_manifest.rs
+++ b/rust/src/core/context_package/addon_manifest.rs
@@ -129,7 +129,7 @@ fn string_map(table: &toml::Value, key: &str) -> BTreeMap<String, String> {
 /// typo (`code_grah`) would install cleanly and route through the generic path
 /// forever — working software that silently does less than the author asked
 /// for. Rejecting it here costs one line and names the manifest.
-fn parse_integration(raw: &str) -> Result<String, String> {
+fn parse_integration(raw: &str, table: &str) -> Result<String, String> {
     let slug = raw.trim();
     if slug.is_empty() {
         return Ok(String::new());
@@ -137,11 +137,49 @@ fn parse_integration(raw: &str) -> Result<String, String> {
     let kind = crate::core::mcp_catalog::adapters::IntegrationKind::parse(slug);
     if kind.is_none() && !slug.eq_ignore_ascii_case("none") {
         return Err(format!(
-            "lean-ctx-addon.toml: [mcp] unknown integration `{slug}` \
+            "lean-ctx-addon.toml: [{table}] unknown integration `{slug}` \
              (codebase-pack | code-graph | code-symbols | memory | compression | none)"
         ));
     }
     Ok(kind.as_str().to_string())
+}
+
+/// Resolve the adapter slug from the three places it may come from.
+///
+/// `[addon] integration` is where the field has always been documented and
+/// where every manifest in the wild puts it (see GH #1391). `[mcp] integration`
+/// mirrors the gateway server entry the table translates into, so it is
+/// accepted too and wins when both are present, being the more specific of the
+/// two. Reading only `[mcp]` — as this parser first did — would have silently
+/// ignored the field in every existing manifest, which is the precise failure
+/// the strict validation below exists to prevent.
+///
+/// Falling back to `[addon] categories` restores the documented "empty derives
+/// from categories" behaviour, which used to happen at install time against a
+/// store that no longer exists. Derivation is deliberately **lenient**:
+/// categories are free-form browsing labels (`plans`, `workflow`), so an
+/// unrecognised one means "no adapter", never an error. Only a slug the author
+/// wrote *as* an integration is held to the vocabulary.
+fn resolve_integration(
+    addon_table: &toml::Value,
+    mcp_table: &toml::Value,
+) -> Result<String, String> {
+    let explicit = parse_integration(&string_at(mcp_table, "integration"), "mcp")?;
+    if !explicit.is_empty() {
+        return Ok(explicit);
+    }
+    let from_addon = parse_integration(&string_at(addon_table, "integration"), "addon")?;
+    if !from_addon.is_empty() {
+        return Ok(from_addon);
+    }
+
+    let categories = string_list(addon_table, "categories");
+    let derived = crate::core::mcp_catalog::adapters::IntegrationKind::from_categories(&categories);
+    Ok(if derived.is_none() {
+        String::new()
+    } else {
+        derived.as_str().to_string()
+    })
 }
 
 /// Parse `lean-ctx-addon.toml`.
@@ -210,7 +248,7 @@ pub(crate) fn parse(text: &str) -> Result<AddonManifest, String> {
                 url,
                 headers: string_map(t, "headers"),
                 sha256: string_at(t, "sha256"),
-                integration: parse_integration(&string_at(t, "integration"))?,
+                integration: resolve_integration(addon_table, t)?,
             })
         }
     };
@@ -278,6 +316,59 @@ headers = { Authorization = "Bearer x" }
     fn a_manifest_without_mcp_is_valid() {
         let m = parse("[addon]\nname = \"squeeze\"\n").expect("parse");
         assert!(m.mcp.is_none());
+    }
+
+    /// The manifest from GH #1391, verbatim. `integration` sits under
+    /// `[addon]` there — the documented location, and the one every manifest in
+    /// the wild uses. Reading only `[mcp]` would have ignored it silently.
+    #[test]
+    fn integration_is_read_from_the_addon_table_as_documented() {
+        let m = parse(
+            r#"
+[addon]
+name = "twinmind"
+display_name = "TwinMind MCP"
+version = "0.1.0"
+description = "TwinMind MCP memories, prompts, and tasks over HTTP."
+categories = ["memory"]
+integration = "memory"
+
+[mcp]
+transport = "http"
+url = "https://api.twinmind.com/mcp"
+"#,
+        )
+        .expect("parse");
+        assert_eq!(m.mcp.expect("wiring").integration, "memory");
+    }
+
+    /// `[mcp]` is the more specific of the two and wins when both are set.
+    #[test]
+    fn the_mcp_table_overrides_the_addon_table() {
+        let m = parse(
+            "[addon]\nname = \"x\"\nintegration = \"memory\"\n\
+             [mcp]\ncommand = \"c\"\nintegration = \"compression\"\n",
+        )
+        .expect("parse");
+        assert_eq!(m.mcp.expect("wiring").integration, "compression");
+    }
+
+    /// The documented "empty derives from categories" fallback. Categories are
+    /// free-form browsing labels, so an unrecognised one means "no adapter" —
+    /// erroring there would reject perfectly good manifests.
+    #[test]
+    fn categories_derive_an_adapter_leniently() {
+        let derived = parse(
+            "[addon]\nname = \"x\"\ncategories = [\"workflow\", \"memory\"]\n[mcp]\ncommand = \"c\"\n",
+        )
+        .expect("parse");
+        assert_eq!(derived.mcp.expect("wiring").integration, "memory");
+
+        let none = parse(
+            "[addon]\nname = \"x\"\ncategories = [\"plans\", \"workflow\"]\n[mcp]\ncommand = \"c\"\n",
+        )
+        .expect("unknown categories are not an error");
+        assert_eq!(none.mcp.expect("wiring").integration, "");
     }
 
     /// A typo in `integration` would otherwise install cleanly and route

--- a/rust/src/core/context_package/addon_manifest.rs
+++ b/rust/src/core/context_package/addon_manifest.rs
@@ -1,0 +1,287 @@
+//! `lean-ctx-addon.toml` — the authoring manifest, parsed.
+//!
+//! An addon declares one or both of:
+//!
+//! - **WASM modules**, carried inside the package and loaded into the context
+//!   pipeline (see [`super::addons`]);
+//! - **an MCP server**, declared under `[mcp]` and wired into the gateway.
+//!
+//! The two are not alternatives dressed up as one feature. A compressor has to
+//! run *inside* the pipeline, so it is WASM. A tool that speaks MCP already has
+//! a process model of its own, so wrapping it in WASM would buy nothing — it is
+//! declared and wired instead. Most addons are one or the other; nothing stops
+//! an addon from being both.
+//!
+//! Per `docs/contracts/addon-manifest-v1.md`, `[mcp]` mirrors a
+//! `[[gateway.servers]]` entry, so installation is a translation rather than an
+//! interpretation. What this parser deliberately does **not** carry over from
+//! the pre-3.9.20 manifest is `[install]`: lean-ctx no longer runs
+//! `uv tool install` or `npx` on your behalf. Fetching the server is the user's
+//! step, and the addon only says how to run it once it is there.
+
+use std::collections::BTreeMap;
+
+use crate::core::mcp_catalog::config::{GatewayServer, TransportKind};
+
+/// The `[addon]` table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AddonMeta {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub homepage: String,
+}
+
+/// The `[mcp]` table, when present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct McpWiring {
+    pub transport: TransportKind,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub url: String,
+    pub headers: BTreeMap<String, String>,
+    pub sha256: String,
+}
+
+impl McpWiring {
+    /// One line a human can check before consenting — the whole point of
+    /// showing it is that the reader recognises what will be spawned.
+    pub(crate) fn describe(&self) -> String {
+        match self.transport {
+            TransportKind::Stdio => {
+                if self.args.is_empty() {
+                    self.command.clone()
+                } else {
+                    format!("{} {}", self.command, self.args.join(" "))
+                }
+            }
+            TransportKind::Http => self.url.clone(),
+        }
+    }
+
+    /// Translate into a gateway entry.
+    ///
+    /// `enabled: true` because a user who just consented to installing this
+    /// addon means for it to work; the per-server switch stays available for
+    /// turning it off later without removing the addon.
+    pub(crate) fn to_gateway_server(&self, name: &str) -> GatewayServer {
+        GatewayServer {
+            name: name.to_string(),
+            transport: self.transport,
+            enabled: true,
+            command: self.command.clone(),
+            args: self.args.clone(),
+            env: self.env.clone(),
+            binary_sha256: self.sha256.clone(),
+            url: self.url.clone(),
+            headers: self.headers.clone(),
+            ..GatewayServer::default()
+        }
+    }
+}
+
+/// A parsed authoring manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AddonManifest {
+    pub addon: AddonMeta,
+    pub mcp: Option<McpWiring>,
+}
+
+fn string_at(table: &toml::Value, key: &str) -> String {
+    table
+        .get(key)
+        .and_then(toml::Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn string_list(table: &toml::Value, key: &str) -> Vec<String> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn string_map(table: &toml::Value, key: &str) -> BTreeMap<String, String> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_table)
+        .map(|t| {
+            t.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parse `lean-ctx-addon.toml`.
+///
+/// Fails closed on anything that would produce a half-configured gateway entry:
+/// a stdio server without a command, an http server without a URL, or a URL
+/// that is not `http(s)`. Catching those here means the error names the
+/// manifest line, not a spawn failure hours later.
+pub(crate) fn parse(text: &str) -> Result<AddonManifest, String> {
+    let doc: toml::Value = toml::from_str(text).map_err(|e| format!("lean-ctx-addon.toml: {e}"))?;
+
+    let addon_table = doc
+        .get("addon")
+        .ok_or("lean-ctx-addon.toml: missing [addon] table")?;
+    let name = string_at(addon_table, "name");
+    if name.trim().is_empty() {
+        return Err("lean-ctx-addon.toml: [addon] name is required".into());
+    }
+
+    let addon = AddonMeta {
+        name,
+        version: string_at(addon_table, "version"),
+        description: string_at(addon_table, "description"),
+        homepage: string_at(addon_table, "homepage"),
+    };
+
+    let mcp = match doc.get("mcp") {
+        None => None,
+        Some(t) => {
+            let transport = match string_at(t, "transport").as_str() {
+                "" | "stdio" => TransportKind::Stdio,
+                "http" => TransportKind::Http,
+                other => {
+                    return Err(format!(
+                        "lean-ctx-addon.toml: [mcp] unknown transport `{other}` (stdio | http)"
+                    ));
+                }
+            };
+            let command = string_at(t, "command");
+            let url = string_at(t, "url");
+
+            match transport {
+                TransportKind::Stdio if command.trim().is_empty() => {
+                    return Err(
+                        "lean-ctx-addon.toml: [mcp] transport=stdio requires `command`".into(),
+                    );
+                }
+                TransportKind::Http if url.trim().is_empty() => {
+                    return Err("lean-ctx-addon.toml: [mcp] transport=http requires `url`".into());
+                }
+                TransportKind::Http
+                    if !(url.starts_with("http://") || url.starts_with("https://")) =>
+                {
+                    return Err(format!(
+                        "lean-ctx-addon.toml: [mcp] url must be http(s), got `{url}`"
+                    ));
+                }
+                _ => {}
+            }
+
+            Some(McpWiring {
+                transport,
+                command,
+                args: string_list(t, "args"),
+                env: string_map(t, "env"),
+                url,
+                headers: string_map(t, "headers"),
+                sha256: string_at(t, "sha256"),
+            })
+        }
+    };
+
+    Ok(AddonManifest { addon, mcp })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_stdio_server() {
+        let m = parse(
+            r#"
+[addon]
+name = "lean-md"
+version = "2.0.0"
+description = "Macro/directive markdown renderer"
+
+[mcp]
+transport = "stdio"
+command = "lean-md"
+args = ["mcp", "serve"]
+env = { LEAN_MD_MODE = "strict" }
+"#,
+        )
+        .expect("parse");
+
+        assert_eq!(m.addon.name, "lean-md");
+        let mcp = m.mcp.expect("wiring");
+        assert_eq!(mcp.describe(), "lean-md mcp serve");
+        assert_eq!(
+            mcp.env.get("LEAN_MD_MODE").map(String::as_str),
+            Some("strict")
+        );
+
+        let server = mcp.to_gateway_server("lean-md");
+        assert_eq!(server.command, "lean-md");
+        assert_eq!(server.args, vec!["mcp", "serve"]);
+        assert!(server.enabled, "a just-consented addon should work");
+    }
+
+    #[test]
+    fn parses_an_http_server() {
+        let m = parse(
+            r#"
+[addon]
+name = "remote"
+
+[mcp]
+transport = "http"
+url = "https://example.test/mcp"
+headers = { Authorization = "Bearer x" }
+"#,
+        )
+        .expect("parse");
+        let mcp = m.mcp.expect("wiring");
+        assert_eq!(mcp.transport, TransportKind::Http);
+        assert_eq!(mcp.describe(), "https://example.test/mcp");
+    }
+
+    /// A WASM-only addon has no `[mcp]` table, and that is not an error.
+    #[test]
+    fn a_manifest_without_mcp_is_valid() {
+        let m = parse("[addon]\nname = \"squeeze\"\n").expect("parse");
+        assert!(m.mcp.is_none());
+    }
+
+    /// Each of these would produce a gateway entry that cannot work. Failing at
+    /// parse names the manifest; failing at spawn names a mystery.
+    #[test]
+    fn half_configured_wiring_is_refused() {
+        let cases = [
+            (
+                "[addon]\nname = \"x\"\n[mcp]\ntransport = \"stdio\"\n",
+                "requires `command`",
+            ),
+            (
+                "[addon]\nname = \"x\"\n[mcp]\ntransport = \"http\"\n",
+                "requires `url`",
+            ),
+            (
+                "[addon]\nname = \"x\"\n[mcp]\ntransport = \"http\"\nurl = \"ftp://nope\"\n",
+                "must be http(s)",
+            ),
+            (
+                "[addon]\nname = \"x\"\n[mcp]\ntransport = \"carrier-pigeon\"\n",
+                "unknown transport",
+            ),
+            ("[addon]\nversion = \"1\"\n", "name is required"),
+            ("[mcp]\ncommand = \"x\"\n", "missing [addon]"),
+        ];
+        for (text, expected) in cases {
+            let err = parse(text).expect_err("must refuse");
+            assert!(err.contains(expected), "expected {expected:?} in {err:?}");
+        }
+    }
+}

--- a/rust/src/core/context_package/addon_wiring.rs
+++ b/rust/src/core/context_package/addon_wiring.rs
@@ -15,6 +15,10 @@
 //!    is about to let a process spawn should read its argv.
 //! 3. **`[gateway]` stays global-only and opt-in.** Adding a server does not
 //!    enable the gateway; an addon cannot switch it on for you.
+//!
+//! And one rule that only shows up on the second install: an upgrade replaces
+//! what the *author* declares and keeps what the *user* configured — their
+//! credentials and their per-server off switch. See [`register`].
 
 use crate::core::config::Config;
 use crate::core::mcp_catalog::config::GatewayServer;
@@ -36,20 +40,40 @@ pub(crate) enum Wired {
 }
 
 /// Add (or replace) the addon's gateway entry in the **global** config.
+///
+/// A replace is an upgrade, not a fresh install, so it must not clobber the
+/// parts of the entry the *user* owns rather than the author:
+///
+/// - `secret_env` / `secret_headers` are memento references to credentials. A
+///   manifest cannot carry them by design, so a wholesale replace would silently
+///   drop the token the user configured and the server would simply stop
+///   authenticating, with nothing saying why.
+/// - `enabled = false` is a deliberate decision to keep an addon installed but
+///   idle. Re-enabling it on upgrade would override that silently, which is the
+///   one thing a per-server switch exists to prevent.
+///
+/// Everything else — transport, command, args, url, pin, integration — is the
+/// author's to change between versions, and is taken from the new manifest.
 pub(crate) fn register(manifest: &AddonManifest) -> Result<Wired, String> {
     let Some(wiring) = manifest.mcp.as_ref() else {
         return Ok(Wired::NothingToWire);
     };
     let name = manifest.addon.name.clone();
-    let server: GatewayServer = wiring.to_gateway_server(&name);
+    let mut server: GatewayServer = wiring.to_gateway_server(&name);
 
     let mut cfg = Config::load();
-    let existed = cfg.gateway.servers.iter().any(|s| s.name == name);
+    let previous = cfg.gateway.servers.iter().find(|s| s.name == name).cloned();
+    if let Some(prev) = &previous {
+        server.secret_env = prev.secret_env.clone();
+        server.secret_headers = prev.secret_headers.clone();
+        server.enabled = prev.enabled;
+    }
+
     cfg.gateway.servers.retain(|s| s.name != name);
     cfg.gateway.servers.push(server);
     cfg.save().map_err(|e| format!("save config: {e}"))?;
 
-    Ok(if existed {
+    Ok(if previous.is_some() {
         Wired::Replaced(name)
     } else {
         Wired::Added(name)
@@ -123,6 +147,64 @@ args = ["mcp", "serve"]
                 .filter(|s| s.name == "mdcast")
                 .count(),
             1
+        );
+    }
+
+    /// An upgrade must not silently undo the user's own configuration. The
+    /// credential is the sharp case: a manifest cannot carry `secret_headers`
+    /// by design, so replacing the entry wholesale would drop the token the
+    /// user configured and the server would just stop authenticating, with
+    /// nothing in the output explaining why.
+    #[test]
+    fn an_upgrade_keeps_the_users_secrets_and_their_off_switch() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let m = addon_manifest::parse(STDIO).unwrap();
+        register(&m).unwrap();
+
+        // The user configures a credential and turns the server off.
+        let mut cfg = Config::load();
+        {
+            let entry = cfg
+                .gateway
+                .servers
+                .iter_mut()
+                .find(|s| s.name == "mdcast")
+                .expect("wired");
+            entry.secret_env.insert(
+                "API_TOKEN".to_string(),
+                crate::core::mcp_catalog::config::SecretMementoRef {
+                    id: "memento-1".to_string(),
+                    format: String::new(),
+                },
+            );
+            entry.enabled = false;
+        }
+        cfg.save().unwrap();
+
+        // A newer version of the same addon is installed over it.
+        let upgraded = addon_manifest::parse(
+            "[addon]\nname = \"mdcast\"\n[mcp]\ncommand = \"mdcast\"\nargs = [\"mcp\", \"v2\"]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            register(&upgraded).unwrap(),
+            Wired::Replaced("mdcast".into())
+        );
+
+        let entry = Config::load()
+            .gateway
+            .servers
+            .into_iter()
+            .find(|s| s.name == "mdcast")
+            .expect("still wired");
+        assert_eq!(entry.args, vec!["mcp", "v2"], "the author's change applies");
+        assert!(
+            entry.secret_env.contains_key("API_TOKEN"),
+            "the user's credential survived the upgrade"
+        );
+        assert!(
+            !entry.enabled,
+            "a deliberate off switch is not flipped back on by an upgrade"
         );
     }
 

--- a/rust/src/core/context_package/addon_wiring.rs
+++ b/rust/src/core/context_package/addon_wiring.rs
@@ -1,0 +1,160 @@
+//! Gateway wiring for `kind=addon` packages.
+//!
+//! An addon that declares `[mcp]` is asking lean-ctx to run an external MCP
+//! server on its behalf. That is a bigger ask than storing a sandboxed WASM
+//! module: the server is an ordinary process with the user's own privileges.
+//!
+//! Three deliberate limits, all of them things the pre-3.9.20 channel did and
+//! this one does not:
+//!
+//! 1. **lean-ctx never installs the server.** No `uv tool install`, no `npx`,
+//!    no download. The manifest says how to *run* something; putting it on the
+//!    machine stays the user's step, where their package manager's own trust
+//!    model applies.
+//! 2. **The exact command is shown before consent**, not summarised. A user who
+//!    is about to let a process spawn should read its argv.
+//! 3. **`[gateway]` stays global-only and opt-in.** Adding a server does not
+//!    enable the gateway; an addon cannot switch it on for you.
+
+use crate::core::config::Config;
+use crate::core::mcp_catalog::config::GatewayServer;
+
+use super::addon_manifest::AddonManifest;
+
+/// What `register` did, so the caller can tell the user precisely.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Wired {
+    /// The addon declares no `[mcp]` table.
+    NothingToWire,
+    /// A new gateway entry was added.
+    Added(String),
+    /// An entry with this name already existed and was replaced (re-install or
+    /// upgrade). Replacing rather than duplicating keeps the catalog namespace
+    /// unambiguous — two servers named `lean-md` would make `lean-md::tool`
+    /// mean two things.
+    Replaced(String),
+}
+
+/// Add (or replace) the addon's gateway entry in the **global** config.
+pub(crate) fn register(manifest: &AddonManifest) -> Result<Wired, String> {
+    let Some(wiring) = manifest.mcp.as_ref() else {
+        return Ok(Wired::NothingToWire);
+    };
+    let name = manifest.addon.name.clone();
+    let server: GatewayServer = wiring.to_gateway_server(&name);
+
+    let mut cfg = Config::load();
+    let existed = cfg.gateway.servers.iter().any(|s| s.name == name);
+    cfg.gateway.servers.retain(|s| s.name != name);
+    cfg.gateway.servers.push(server);
+    cfg.save().map_err(|e| format!("save config: {e}"))?;
+
+    Ok(if existed {
+        Wired::Replaced(name)
+    } else {
+        Wired::Added(name)
+    })
+}
+
+/// Drop the addon's gateway entry. Returns whether one was there.
+///
+/// Removal is by name and unconditional: leaving a gateway entry behind after
+/// `addon remove` would keep spawning a process for an addon the user believes
+/// is gone.
+pub(crate) fn unregister(name: &str) -> Result<bool, String> {
+    let mut cfg = Config::load();
+    let before = cfg.gateway.servers.len();
+    cfg.gateway.servers.retain(|s| s.name != name);
+    if cfg.gateway.servers.len() == before {
+        return Ok(false);
+    }
+    cfg.save().map_err(|e| format!("save config: {e}"))?;
+    Ok(true)
+}
+
+/// Whether the gateway itself is on. An addon can be wired while the gateway
+/// is off; the CLI says so rather than letting the user think it is running.
+pub(crate) fn gateway_enabled() -> bool {
+    Config::load().gateway.enabled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::context_package::addon_manifest;
+
+    const STDIO: &str = r#"
+[addon]
+name = "lean-md"
+[mcp]
+command = "lean-md"
+args = ["mcp", "serve"]
+"#;
+
+    #[test]
+    fn a_wasm_only_addon_wires_nothing() {
+        let m = addon_manifest::parse("[addon]\nname = \"squeeze\"\n").unwrap();
+        assert_eq!(register(&m).unwrap(), Wired::NothingToWire);
+    }
+
+    #[test]
+    fn registering_adds_then_replaces_rather_than_duplicating() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let m = addon_manifest::parse(STDIO).unwrap();
+
+        assert_eq!(register(&m).unwrap(), Wired::Added("lean-md".into()));
+        let cfg = Config::load();
+        let entry = cfg
+            .gateway
+            .servers
+            .iter()
+            .find(|s| s.name == "lean-md")
+            .expect("wired");
+        assert_eq!(entry.command, "lean-md");
+        assert_eq!(entry.args, vec!["mcp", "serve"]);
+
+        // Re-install must not leave two servers claiming the same namespace.
+        assert_eq!(register(&m).unwrap(), Wired::Replaced("lean-md".into()));
+        assert_eq!(
+            Config::load()
+                .gateway
+                .servers
+                .iter()
+                .filter(|s| s.name == "lean-md")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn unregister_removes_the_entry_and_reports_whether_it_was_there() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let m = addon_manifest::parse(STDIO).unwrap();
+        register(&m).unwrap();
+
+        assert!(unregister("lean-md").unwrap(), "it was wired");
+        assert!(
+            !Config::load()
+                .gateway
+                .servers
+                .iter()
+                .any(|s| s.name == "lean-md"),
+            "a removed addon must not keep spawning a process"
+        );
+        assert!(!unregister("lean-md").unwrap(), "second call is a no-op");
+    }
+
+    /// Wiring a server must not silently switch the gateway on — that is a
+    /// separate, deliberate decision by the user.
+    #[test]
+    fn registering_does_not_enable_the_gateway() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let before = Config::load().gateway.enabled;
+        register(&addon_manifest::parse(STDIO).unwrap()).unwrap();
+        assert_eq!(
+            Config::load().gateway.enabled,
+            before,
+            "an addon may not turn the gateway on for the user"
+        );
+    }
+}

--- a/rust/src/core/context_package/addon_wiring.rs
+++ b/rust/src/core/context_package/addon_wiring.rs
@@ -30,7 +30,7 @@ pub(crate) enum Wired {
     Added(String),
     /// An entry with this name already existed and was replaced (re-install or
     /// upgrade). Replacing rather than duplicating keeps the catalog namespace
-    /// unambiguous — two servers named `lean-md` would make `lean-md::tool`
+    /// unambiguous — two servers named `mdcast` would make `mdcast::tool`
     /// mean two things.
     Replaced(String),
 }
@@ -85,9 +85,9 @@ mod tests {
 
     const STDIO: &str = r#"
 [addon]
-name = "lean-md"
+name = "mdcast"
 [mcp]
-command = "lean-md"
+command = "mdcast"
 args = ["mcp", "serve"]
 "#;
 
@@ -102,25 +102,25 @@ args = ["mcp", "serve"]
         let _iso = crate::core::data_dir::isolated_data_dir();
         let m = addon_manifest::parse(STDIO).unwrap();
 
-        assert_eq!(register(&m).unwrap(), Wired::Added("lean-md".into()));
+        assert_eq!(register(&m).unwrap(), Wired::Added("mdcast".into()));
         let cfg = Config::load();
         let entry = cfg
             .gateway
             .servers
             .iter()
-            .find(|s| s.name == "lean-md")
+            .find(|s| s.name == "mdcast")
             .expect("wired");
-        assert_eq!(entry.command, "lean-md");
+        assert_eq!(entry.command, "mdcast");
         assert_eq!(entry.args, vec!["mcp", "serve"]);
 
         // Re-install must not leave two servers claiming the same namespace.
-        assert_eq!(register(&m).unwrap(), Wired::Replaced("lean-md".into()));
+        assert_eq!(register(&m).unwrap(), Wired::Replaced("mdcast".into()));
         assert_eq!(
             Config::load()
                 .gateway
                 .servers
                 .iter()
-                .filter(|s| s.name == "lean-md")
+                .filter(|s| s.name == "mdcast")
                 .count(),
             1
         );
@@ -132,16 +132,16 @@ args = ["mcp", "serve"]
         let m = addon_manifest::parse(STDIO).unwrap();
         register(&m).unwrap();
 
-        assert!(unregister("lean-md").unwrap(), "it was wired");
+        assert!(unregister("mdcast").unwrap(), "it was wired");
         assert!(
             !Config::load()
                 .gateway
                 .servers
                 .iter()
-                .any(|s| s.name == "lean-md"),
+                .any(|s| s.name == "mdcast"),
             "a removed addon must not keep spawning a process"
         );
-        assert!(!unregister("lean-md").unwrap(), "second call is a no-op");
+        assert!(!unregister("mdcast").unwrap(), "second call is a no-op");
     }
 
     /// Wiring a server must not silently switch the gateway on — that is a

--- a/rust/src/core/context_package/addons.rs
+++ b/rust/src/core/context_package/addons.rs
@@ -103,9 +103,43 @@ pub(crate) fn materialize_modules(
 /// `addon list` deliberately does not use it — the CLI groups by name and
 /// version, which this flat list cannot express.
 #[cfg(any(feature = "wasm", test))]
+/// Every module the extension registry should load: one version per addon.
+///
+/// The store keeps versions side by side, like every other pack kind, so after
+/// an upgrade `@ns/demo/1.0.0` and `@ns/demo/1.1.0` both exist on disk. Walking
+/// the whole tree would hand the registry two modules with the same file stem
+/// and let load order decide which one wins — and load order was sorted paths,
+/// where `"10.0.0" < "9.0.0"`, so upgrading 9 to 10 would silently keep running
+/// version 9. Old code that keeps running is the failure this whole channel is
+/// careful about elsewhere; it should not arrive through the back door.
+///
+/// One version is chosen per addon by directory mtime — "the one you installed
+/// last". Not by parsing the version: the manifest contract calls `version`
+/// author-declared and free-form, so it is not reliably orderable, whereas the
+/// install that wrote the directory is a fact.
 pub(crate) fn installed_modules(store_root: &Path) -> Vec<PathBuf> {
+    let root = addons_root(store_root);
+    let Ok(addon_dirs) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+
     let mut out = Vec::new();
-    collect_modules(&addons_root(store_root), &mut out, 0);
+    for addon_dir in addon_dirs.flatten().filter(|e| e.path().is_dir()) {
+        let Ok(versions) = std::fs::read_dir(addon_dir.path()) else {
+            continue;
+        };
+        let newest = versions
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .max_by_key(|e| {
+                e.metadata()
+                    .and_then(|m| m.modified())
+                    .unwrap_or(std::time::UNIX_EPOCH)
+            });
+        if let Some(version_dir) = newest {
+            collect_modules(&version_dir.path(), &mut out, 0);
+        }
+    }
     out.sort();
     out
 }
@@ -276,6 +310,41 @@ mod tests {
             names,
             vec!["a.wasm", "z.wasm"],
             "registration order must be deterministic (#498)"
+        );
+    }
+
+    /// After an upgrade both versions sit in the store. Loading both would give
+    /// the registry two modules with the same stem and let load order pick a
+    /// winner — and sorted paths put `"10.0.0"` before `"9.0.0"`, so the *old*
+    /// version would win exactly when the version number crosses ten. Only the
+    /// most recently installed version is loaded.
+    #[test]
+    fn only_the_most_recently_installed_version_is_loaded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let addon = |body: &[u8]| AddonContent {
+            manifest_toml: "[addon]\nname = \"@ns/demo\"\n".into(),
+            modules: vec![DocumentBlob::from_plaintext("demo.wasm", body).unwrap()],
+        };
+
+        // The lexicographic trap: 10.0.0 sorts before 9.0.0.
+        let old = empty_wasm();
+        let mut new = empty_wasm();
+        new.extend_from_slice(&[0x00; 4]);
+        materialize_modules(tmp.path(), &manifest("@ns/demo", "9.0.0"), &addon(&old)).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        materialize_modules(tmp.path(), &manifest("@ns/demo", "10.0.0"), &addon(&new)).unwrap();
+
+        let found = installed_modules(tmp.path());
+        assert_eq!(found.len(), 1, "one version's modules, not both: {found:?}");
+        assert_eq!(
+            std::fs::read(&found[0]).unwrap(),
+            new,
+            "the upgrade must win, not the version that sorts first"
+        );
+        assert!(
+            found[0].to_string_lossy().contains("10.0.0"),
+            "{:?}",
+            found[0]
         );
     }
 

--- a/rust/src/core/context_package/addons.rs
+++ b/rust/src/core/context_package/addons.rs
@@ -1,0 +1,252 @@
+//! `kind=addon` store layout and module materialization.
+//!
+//! Mirrors [`super::skills`] deliberately: an addon pack is the same verified
+//! blob mechanism, pointed at WASM modules instead of documents. Keeping the
+//! two shapes identical means the tamper detection, the path safety and the
+//! idempotent-reinstall behaviour are the ones already proven for skills,
+//! rather than a second implementation that drifts.
+//!
+//! The one difference that matters: these bytes are executable, so
+//! [`super::verify::validate_addon`] additionally pins the `.wasm` extension
+//! and the WebAssembly magic before anything is written.
+
+use std::path::{Path, PathBuf};
+
+use super::content::AddonContent;
+use super::manifest::PackageManifest;
+use super::verify;
+
+/// Store layout for materialized addons:
+/// `<store>/addons/<sanitized-name>/<version>/`.
+///
+/// `@ns/name` → `@ns__name`, mirroring `LocalRegistry::package_dir` and
+/// [`super::skills::skills_dir`].
+pub(crate) fn addons_dir(store_root: &Path, name: &str, version: &str) -> PathBuf {
+    let safe_name = name.replace('/', "__");
+    store_root.join("addons").join(safe_name).join(version)
+}
+
+/// The root installed addons are materialized under.
+///
+/// Install and discovery **must** agree on this path, and the way to guarantee
+/// that is to have one definition rather than two derivations that look alike.
+/// An earlier version of this code had `install` write under the registry root
+/// (`<data_dir>/packages`) while discovery scanned `<data_dir>` — every addon
+/// installed fine and none of them ever loaded.
+pub(crate) fn store_root() -> Result<PathBuf, String> {
+    Ok(crate::core::data_dir::lean_ctx_data_dir()?.join(super::registry::PACKAGES_DIR))
+}
+
+/// The root every installed addon lives under. Discovery walks this.
+pub(crate) fn addons_root(store_root: &Path) -> PathBuf {
+    store_root.join("addons")
+}
+
+/// Write the pack's modules under the store and return the version directory.
+///
+/// Re-install rebuilds the version directory from scratch so a module removed
+/// upstream does not linger and keep getting loaded — the same reasoning as the
+/// skills materializer, with more consequence, because a lingering module here
+/// is code that still runs.
+pub(crate) fn materialize_modules(
+    store_root: &Path,
+    manifest: &PackageManifest,
+    addon: &AddonContent,
+) -> Result<PathBuf, String> {
+    let version_root = addons_dir(store_root, &manifest.name, &manifest.version);
+
+    if version_root.exists() {
+        std::fs::remove_dir_all(&version_root).map_err(|e| e.to_string())?;
+    }
+
+    for blob in &addon.modules {
+        verify::validate_document_path(&blob.path)?;
+        let plain = blob.decode_verified()?;
+        let dest = version_root.join(&blob.path);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        std::fs::write(&dest, &plain).map_err(|e| format!("write {}: {e}", dest.display()))?;
+        // Read-only, and never executable: the module is fed to the wasmi
+        // interpreter, never handed to the OS loader. A `+x` bit here would
+        // only ever help something we do not want to happen.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o444));
+        }
+    }
+
+    // The authoring manifest travels with the modules so `addon info` can show
+    // what the author declared without re-opening the original pack.
+    let manifest_dest = version_root.join("lean-ctx-addon.toml");
+    std::fs::write(&manifest_dest, addon.manifest_toml.as_bytes())
+        .map_err(|e| format!("write {}: {e}", manifest_dest.display()))?;
+
+    Ok(version_root)
+}
+
+/// Every installed `.wasm` module under the store, sorted for determinism.
+///
+/// Sorting is not cosmetic: registration order decides which compressor wins a
+/// name collision, and #498 requires the same corpus to produce the same
+/// answer on every run.
+pub(crate) fn installed_modules(store_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect_modules(&addons_root(store_root), &mut out, 0);
+    out.sort();
+    out
+}
+
+/// Bounded recursive walk. The depth cap is a belt-and-braces stop: paths are
+/// already validated on the way in, so a deep tree here would mean the store
+/// was edited by hand.
+fn collect_modules(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth > 6 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_modules(&path, out, depth + 1);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("wasm") {
+            out.push(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::content::DocumentBlob;
+    use super::*;
+
+    fn manifest(name: &str, version: &str) -> PackageManifest {
+        use super::super::manifest::{
+            CompatibilitySpec, PackageIntegrity, PackageKind, PackageProvenance, PackageStats,
+        };
+        PackageManifest {
+            schema_version: crate::core::contracts::CONTEXT_PACKAGE_V2_SCHEMA_VERSION,
+            conformance_level: None,
+            kind: PackageKind::Addon,
+            name: name.to_string(),
+            version: version.to_string(),
+            description: "test addon".to_string(),
+            author: None,
+            scope: name
+                .starts_with('@')
+                .then(|| name.split('/').next().unwrap_or_default().to_string()),
+            created_at: chrono::Utc::now(),
+            updated_at: None,
+            layers: Vec::new(),
+            dependencies: Vec::new(),
+            tags: Vec::new(),
+            visibility: None,
+            integrity: PackageIntegrity {
+                sha256: "0".repeat(64),
+                content_hash: "0".repeat(64),
+                byte_size: 0,
+            },
+            provenance: PackageProvenance {
+                tool: "lean-ctx".into(),
+                tool_version: env!("CARGO_PKG_VERSION").into(),
+                project_hash: None,
+                source_session_id: None,
+            },
+            compatibility: CompatibilitySpec::default(),
+            stats: PackageStats::default(),
+            signature: None,
+            graph_summary: None,
+            marketplace: None,
+        }
+    }
+
+    /// A minimal valid WebAssembly module: magic + version, nothing else.
+    fn empty_wasm() -> Vec<u8> {
+        vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+    }
+
+    #[test]
+    fn materializes_modules_and_the_authoring_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let addon = AddonContent {
+            manifest_toml: "[addon]\nname = \"demo\"\n".to_string(),
+            modules: vec![DocumentBlob::from_plaintext("demo.wasm", &empty_wasm()).unwrap()],
+        };
+        let root = materialize_modules(tmp.path(), &manifest("@ns/demo", "1.0.0"), &addon).unwrap();
+
+        assert!(root.join("demo.wasm").is_file());
+        assert_eq!(
+            std::fs::read(root.join("demo.wasm")).unwrap(),
+            empty_wasm(),
+            "the stored bytes must be the verified plaintext"
+        );
+        assert!(
+            root.join("lean-ctx-addon.toml").is_file(),
+            "the authoring manifest travels with the modules"
+        );
+        assert!(
+            root.to_string_lossy().contains("@ns__demo"),
+            "scoped names are flattened like every other pack kind: {root:?}"
+        );
+    }
+
+    /// A module dropped upstream must stop being loaded. It is code, so a
+    /// leftover file is not clutter — it is a capability that outlives its pack.
+    #[test]
+    fn reinstall_drops_modules_the_new_version_no_longer_ships() {
+        let tmp = tempfile::tempdir().unwrap();
+        let m = manifest("@ns/demo", "1.0.0");
+
+        let two = AddonContent {
+            manifest_toml: "[addon]\n".into(),
+            modules: vec![
+                DocumentBlob::from_plaintext("a.wasm", &empty_wasm()).unwrap(),
+                DocumentBlob::from_plaintext("b.wasm", &empty_wasm()).unwrap(),
+            ],
+        };
+        materialize_modules(tmp.path(), &m, &two).unwrap();
+        assert_eq!(installed_modules(tmp.path()).len(), 2);
+
+        let one = AddonContent {
+            manifest_toml: "[addon]\n".into(),
+            modules: vec![DocumentBlob::from_plaintext("a.wasm", &empty_wasm()).unwrap()],
+        };
+        let root = materialize_modules(tmp.path(), &m, &one).unwrap();
+        assert!(!root.join("b.wasm").exists(), "b.wasm must be gone");
+        assert_eq!(installed_modules(tmp.path()).len(), 1);
+    }
+
+    #[test]
+    fn discovery_is_sorted_and_ignores_non_modules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let addon = AddonContent {
+            manifest_toml: "[addon]\n".into(),
+            modules: vec![
+                DocumentBlob::from_plaintext("z.wasm", &empty_wasm()).unwrap(),
+                DocumentBlob::from_plaintext("a.wasm", &empty_wasm()).unwrap(),
+            ],
+        };
+        materialize_modules(tmp.path(), &manifest("@ns/demo", "1.0.0"), &addon).unwrap();
+
+        let found = installed_modules(tmp.path());
+        assert_eq!(found.len(), 2, "the .toml must not be picked up: {found:?}");
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["a.wasm", "z.wasm"],
+            "registration order must be deterministic (#498)"
+        );
+    }
+
+    #[test]
+    fn an_empty_store_yields_no_modules() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(installed_modules(tmp.path()).is_empty());
+    }
+}

--- a/rust/src/core/context_package/addons.rs
+++ b/rust/src/core/context_package/addons.rs
@@ -58,6 +58,12 @@ pub(crate) fn materialize_modules(
     if version_root.exists() {
         std::fs::remove_dir_all(&version_root).map_err(|e| e.to_string())?;
     }
+    // Create the version directory up front rather than as a side effect of
+    // writing the first module: an addon may legitimately carry no module at
+    // all (it declares an `[mcp]` server instead), and the manifest below still
+    // has to land somewhere.
+    std::fs::create_dir_all(&version_root)
+        .map_err(|e| format!("create {}: {e}", version_root.display()))?;
 
     for blob in &addon.modules {
         verify::validate_document_path(&blob.path)?;
@@ -197,6 +203,28 @@ mod tests {
         assert!(
             root.to_string_lossy().contains("@ns__demo"),
             "scoped names are flattened like every other pack kind: {root:?}"
+        );
+    }
+
+    /// An MCP-only addon carries no module, and its manifest still has to land
+    /// on disk. Creating the version directory as a side effect of writing the
+    /// first module left this case with nowhere to write — install failed with
+    /// a raw ENOENT after the user had already consented.
+    #[test]
+    fn an_addon_without_modules_still_materializes_its_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let addon = AddonContent {
+            manifest_toml: "[addon]\nname = \"@ns/server-only\"\n[mcp]\ncommand = \"srv\"\n"
+                .to_string(),
+            modules: Vec::new(),
+        };
+
+        let root =
+            materialize_modules(tmp.path(), &manifest("@ns/server-only", "1.0.0"), &addon).unwrap();
+        assert!(root.is_dir(), "the version directory exists");
+        assert!(
+            root.join("lean-ctx-addon.toml").is_file(),
+            "the authoring manifest was written"
         );
     }
 

--- a/rust/src/core/context_package/addons.rs
+++ b/rust/src/core/context_package/addons.rs
@@ -91,6 +91,12 @@ pub(crate) fn materialize_modules(
 /// Sorting is not cosmetic: registration order decides which compressor wins a
 /// name collision, and #498 requires the same corpus to produce the same
 /// answer on every run.
+///
+/// Gated on `wasm`: this exists to feed the module loader, and a build without
+/// that feature (the `lean-ctx-embed` facade, for one) has nothing to feed.
+/// `addon list` deliberately does not use it — the CLI groups by name and
+/// version, which this flat list cannot express.
+#[cfg(any(feature = "wasm", test))]
 pub(crate) fn installed_modules(store_root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     collect_modules(&addons_root(store_root), &mut out, 0);
@@ -101,6 +107,7 @@ pub(crate) fn installed_modules(store_root: &Path) -> Vec<PathBuf> {
 /// Bounded recursive walk. The depth cap is a belt-and-braces stop: paths are
 /// already validated on the way in, so a deep tree here would mean the store
 /// was edited by hand.
+#[cfg(any(feature = "wasm", test))]
 fn collect_modules(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
     if depth > 6 {
         return;

--- a/rust/src/core/context_package/addons_build.rs
+++ b/rust/src/core/context_package/addons_build.rs
@@ -1,0 +1,238 @@
+//! Build a signed `kind=addon` package from an authoring directory.
+//!
+//! The mirror of [`super::skills`]'s builder, and deliberately so: same
+//! integrity chain (compact content JSON is the hashed byte stream, the package
+//! hash chains name+version onto it), same signing key, same self-check on the
+//! exact bytes that will be written.
+//!
+//! What differs is what goes in: WASM modules instead of documents. Embedding
+//! them means the pack signature covers the executable bytes, which is what
+//! lets an author publish without an artifact host, checksum files or CI.
+
+use std::path::Path;
+
+use chrono::Utc;
+
+use super::content::{AddonContent, DocumentBlob, PackageContent};
+use super::manifest::{
+    CompatibilitySpec, PackageIntegrity, PackageKind, PackageManifest, PackageProvenance,
+    PackageStats,
+};
+use super::{keys, signing, verify};
+
+/// Write a signed addon package to `out_path`.
+///
+/// Fails closed: the bytes are verified through the ordinary package verifier
+/// *before* they are written, so a builder bug produces an error here rather
+/// than a package that only fails on someone else's machine.
+pub(crate) fn write_addon_package(
+    out_path: &Path,
+    name: &str,
+    version: &str,
+    description: &str,
+    manifest_toml: &str,
+    modules: Vec<DocumentBlob>,
+) -> Result<(), String> {
+    let content = PackageContent {
+        addon: Some(AddonContent {
+            manifest_toml: manifest_toml.to_string(),
+            modules,
+        }),
+        ..PackageContent::default()
+    };
+
+    let content_json = serde_json::to_string(&content).map_err(|e| e.to_string())?;
+    let content_hash = sha256_hex(content_json.as_bytes());
+    let sha256 = sha256_hex(format!("{name}:{version}:{content_hash}").as_bytes());
+
+    let mut manifest = PackageManifest {
+        schema_version: crate::core::contracts::CONTEXT_PACKAGE_V2_SCHEMA_VERSION,
+        conformance_level: None,
+        kind: PackageKind::Addon,
+        name: name.to_string(),
+        version: version.to_string(),
+        description: description.to_string(),
+        author: None,
+        scope: name
+            .starts_with('@')
+            .then(|| name.split('/').next().unwrap_or_default().to_string()),
+        created_at: Utc::now(),
+        updated_at: None,
+        layers: Vec::new(),
+        dependencies: Vec::new(),
+        tags: Vec::new(),
+        visibility: None,
+        integrity: PackageIntegrity {
+            sha256,
+            content_hash,
+            byte_size: content_json.len() as u64,
+        },
+        provenance: PackageProvenance {
+            tool: "lean-ctx".into(),
+            tool_version: env!("CARGO_PKG_VERSION").into(),
+            project_hash: None,
+            source_session_id: None,
+        },
+        compatibility: CompatibilitySpec::default(),
+        stats: PackageStats::default(),
+        signature: None,
+        graph_summary: None,
+        marketplace: None,
+    };
+
+    manifest.validate().map_err(|errs| errs.join("; "))?;
+    verify::validate_kind_coherence(&manifest, &content).map_err(|errs| errs.join("; "))?;
+
+    let (signing_key, created) = keys::load_or_create()?;
+    if created {
+        println!("Created a new ed25519 signing key for this machine.");
+        println!("It identifies you as the publisher across releases — keep it.");
+    }
+    signing::sign_package(&mut manifest, &content, &signing_key);
+
+    // Typed bundle (not `json!`): serde keeps struct field order, so the
+    // content text stays byte-identical to what was hashed above.
+    #[derive(serde::Serialize)]
+    struct Bundle<'a> {
+        manifest: &'a PackageManifest,
+        content: &'a PackageContent,
+    }
+    let bundle_json = serde_json::to_string_pretty(&Bundle {
+        manifest: &manifest,
+        content: &content,
+    })
+    .map_err(|e| e.to_string())?;
+
+    let self_check = verify::verify_package_text(&bundle_json);
+    if !self_check.valid() {
+        return Err(format!(
+            "internal error — the built pack fails verification: {}",
+            self_check.errors.join("; ")
+        ));
+    }
+
+    if let Some(parent) = out_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(out_path, bundle_json.as_bytes())
+        .map_err(|e| format!("write {}: {e}", out_path.display()))?;
+    Ok(())
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(data);
+    crate::core::agent_identity::hex_encode(&h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_wasm() -> Vec<u8> {
+        vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]
+    }
+
+    /// The full round trip: build a package, then install it through the
+    /// ordinary registry door. If the builder and the verifier ever disagree,
+    /// this fails — which is the only way to be sure an author's `release`
+    /// produces something a user's `add` accepts.
+    #[test]
+    fn a_built_package_installs_through_the_addon_door() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("demo-1.0.0.ctxpkg");
+
+        write_addon_package(
+            &out,
+            "@ns/demo",
+            "1.0.0",
+            "a demo addon",
+            "[addon]\nname = \"@ns/demo\"\nversion = \"1.0.0\"\n",
+            vec![DocumentBlob::from_plaintext("demo.wasm", &empty_wasm()).unwrap()],
+        )
+        .expect("build");
+
+        let registry = super::super::LocalRegistry::open().expect("registry");
+        let manifest = registry
+            .install_addon_from_file(&out)
+            .expect("the package this repo builds must install in this repo");
+        assert_eq!(manifest.name, "@ns/demo");
+
+        let store = super::super::addons::store_root().unwrap();
+        let modules = super::super::addons::installed_modules(&store);
+        assert_eq!(modules.len(), 1, "the module must land in the store");
+        assert_eq!(
+            std::fs::read(&modules[0]).unwrap(),
+            empty_wasm(),
+            "the stored bytes must be the ones that were packed"
+        );
+    }
+
+    /// The inert door must refuse executable content, and say where to go.
+    #[test]
+    fn the_context_import_door_refuses_an_addon() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("demo-1.0.0.ctxpkg");
+        write_addon_package(
+            &out,
+            "@ns/demo",
+            "1.0.0",
+            "",
+            "[addon]\nname = \"@ns/demo\"\n",
+            vec![DocumentBlob::from_plaintext("demo.wasm", &empty_wasm()).unwrap()],
+        )
+        .expect("build");
+
+        let registry = super::super::LocalRegistry::open().expect("registry");
+        let err = registry
+            .import_from_file(&out)
+            .expect_err("import must not store executable content");
+        assert!(
+            err.contains("addon add"),
+            "the error must route the user: {err}"
+        );
+    }
+
+    /// Tampering with a module after signing must be caught at install, not
+    /// discovered when the module runs.
+    #[test]
+    fn a_tampered_module_is_rejected_at_install() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("demo-1.0.0.ctxpkg");
+        write_addon_package(
+            &out,
+            "@ns/demo",
+            "1.0.0",
+            "",
+            "[addon]\nname = \"@ns/demo\"\n",
+            vec![DocumentBlob::from_plaintext("demo.wasm", &empty_wasm()).unwrap()],
+        )
+        .expect("build");
+
+        // Swap the embedded body for a different (still valid base64) payload.
+        let text = std::fs::read_to_string(&out).unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let other =
+            DocumentBlob::from_plaintext("demo.wasm", b"\0asm\x01\x00\x00\x00tampered").unwrap();
+        value["content"]["addon"]["modules"][0]["body"] = serde_json::json!(other.body);
+        std::fs::write(&out, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+
+        let registry = super::super::LocalRegistry::open().expect("registry");
+        let err = registry
+            .install_addon_from_file(&out)
+            .expect_err("a tampered module must not install");
+        assert!(
+            !err.is_empty(),
+            "the failure must be reported, not silently ignored"
+        );
+        let store = super::super::addons::store_root().unwrap();
+        assert!(
+            super::super::addons::installed_modules(&store).is_empty(),
+            "nothing may reach the store when verification fails"
+        );
+    }
+}

--- a/rust/src/core/context_package/content.rs
+++ b/rust/src/core/context_package/content.rs
@@ -65,7 +65,29 @@ pub(crate) struct AddonContent {
     /// Verbatim `lean-ctx-addon.toml` text (authoring contract
     /// `docs/contracts/addon-manifest-v1.md`).
     pub manifest_toml: String,
+    /// WASM modules carried **inside** the pack, hash-pinned exactly like
+    /// `kind=skills` documents.
+    ///
+    /// Embedding rather than referencing external artifacts is the whole point:
+    /// the pack's own signature covers the executable bytes, so an author needs
+    /// no artifact host, no checksum files and no CI to publish one — the
+    /// friction the previous addon channel was reported for. It also removes a
+    /// download step from install, and with it a class of TOCTOU between
+    /// "verified the manifest" and "fetched the binary".
+    ///
+    /// Empty on a pre-extension pack; `validate_kind_coherence` requires at
+    /// least one module for `kind=addon`, so an empty list can only appear on a
+    /// package that predates this field and is rejected there.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modules: Vec<DocumentBlob>,
 }
+
+/// Caps for `kind=addon` module payloads. A WASM module is larger than a
+/// markdown file but still small: `wasmi` instantiates per call, so a
+/// multi-megabyte guest is a design smell, not a use case.
+pub(crate) const MAX_ADDON_MODULES: usize = 8;
+pub(crate) const MAX_ADDON_MODULE_BYTES: usize = 8 * 1024 * 1024;
+pub(crate) const MAX_ADDON_TOTAL_BYTES: usize = 16 * 1024 * 1024;
 
 /// `kind=skills` payload (GH #727): a set of named, verified content blobs
 /// (markdown/scripts). **No execution semantics in lean-ctx** — skills are

--- a/rust/src/core/context_package/mod.rs
+++ b/rust/src/core/context_package/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod addon_manifest;
+pub(crate) mod addon_wiring;
 pub(crate) mod addons;
 pub(crate) mod addons_build;
 pub(crate) mod auto_load;

--- a/rust/src/core/context_package/mod.rs
+++ b/rust/src/core/context_package/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod addons;
+pub(crate) mod addons_build;
 pub(crate) mod auto_load;
 #[allow(dead_code)]
 pub(crate) mod builder;

--- a/rust/src/core/context_package/registry.rs
+++ b/rust/src/core/context_package/registry.rs
@@ -335,11 +335,17 @@ impl LocalRegistry {
         super::verify::validate_kind_coherence(&bundle.manifest, &bundle.content)
             .map_err(|errs| errs.join("; "))?;
         if bundle.manifest.kind == super::manifest::PackageKind::Addon {
+            // Point at the file the caller already has, not at a registry
+            // reference reconstructed from the package name: `addon add` now
+            // resolves a bare `ns/name` over the network, so suggesting that
+            // form would send someone holding a local file to fetch a possibly
+            // different copy of it — or to fail against a registry they never
+            // meant to use.
             return Err(format!(
                 "`{}` is a kind=addon package — install it with `lean-ctx addon add {}` \
                  (addon installs ask for consent before storing executable modules)",
                 bundle.manifest.name,
-                bundle.manifest.name.trim_start_matches('@'),
+                path.display(),
             ));
         }
 

--- a/rust/src/core/context_package/registry.rs
+++ b/rust/src/core/context_package/registry.rs
@@ -7,7 +7,7 @@ use super::content::{CheckpointPackageContentV1, PackageContent};
 use super::manifest::PackageManifest;
 
 const INDEX_FILE: &str = "package-index.json";
-const PACKAGES_DIR: &str = "packages";
+pub(crate) const PACKAGES_DIR: &str = "packages";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PackageIndex {
@@ -85,6 +85,25 @@ impl LocalRegistry {
                 manifest.name,
                 manifest.version,
                 root.display()
+            );
+        }
+
+        // kind=addon: same pattern, executable payload. The modules are
+        // written before the index entry for the same reason — a tampered
+        // module aborts the install instead of leaving a half-registered
+        // package whose code is already on disk.
+        if manifest.kind == super::manifest::PackageKind::Addon {
+            let addon = content
+                .addon
+                .as_ref()
+                .ok_or("kind=addon package has no addon payload")?;
+            let root = super::addons::materialize_modules(&self.root, manifest, addon)?;
+            tracing::info!(
+                "addon pack {}@{} materialized at {} ({} module(s))",
+                manifest.name,
+                manifest.version,
+                root.display(),
+                addon.modules.len()
             );
         }
 
@@ -272,7 +291,11 @@ impl LocalRegistry {
         Ok(bytes.len() as u64)
     }
 
-    pub(crate) fn import_from_file(&self, path: &Path) -> Result<PackageManifest, String> {
+    /// Read a package file into a bundle: extension, size cap, parse.
+    ///
+    /// Shared by both install doors so a `.ctxpkg` is admitted on exactly the
+    /// same terms whether it carries knowledge or code.
+    fn read_bundle(path: &Path) -> Result<(ExportBundle, String), String> {
         if !crate::core::contracts::is_package_file(path) {
             let ext = path
                 .extension()
@@ -297,25 +320,70 @@ impl LocalRegistry {
         let json = std::fs::read_to_string(path).map_err(|e| format!("read package file: {e}"))?;
         let bundle: ExportBundle =
             serde_json::from_str(&json).map_err(|e| format!("parse package: {e}"))?;
+        Ok((bundle, json))
+    }
+
+    pub(crate) fn import_from_file(&self, path: &Path) -> Result<PackageManifest, String> {
+        let (bundle, json) = Self::read_bundle(path)?;
 
         bundle.manifest.validate().map_err(|errs| errs.join("; "))?;
 
         // Kind gate (GH #726): the local context registry stores knowledge,
-        // not capabilities. A kind=addon pack routes through the addon trust
-        // chain (consent, sandbox, binhash) — importing it here would sidestep
-        // every one of those gates.
+        // not capabilities. `import` reads a file the caller already has, so
+        // it is the wrong door for executable content — an addon must arrive
+        // through `addon add`, which is where consent is asked for.
         super::verify::validate_kind_coherence(&bundle.manifest, &bundle.content)
             .map_err(|errs| errs.join("; "))?;
         if bundle.manifest.kind == super::manifest::PackageKind::Addon {
             return Err(format!(
                 "`{}` is a kind=addon package — install it with `lean-ctx addon add {}` \
-                 (addon installs need capability consent + the addon trust chain)",
+                 (addon installs ask for consent before storing executable modules)",
                 bundle.manifest.name,
                 bundle.manifest.name.trim_start_matches('@'),
             ));
         }
 
-        let content_text = extract_top_level_value_text(&json, "content")
+        Self::verify_bundle_integrity(&bundle, &json)?;
+        self.install(&bundle.manifest, &bundle.content)?;
+        Ok(bundle.manifest)
+    }
+
+    /// Install a `kind=addon` package.
+    ///
+    /// Deliberately a separate entry point from [`Self::import_from_file`]
+    /// rather than a flag on it: the two differ only in which kind they accept,
+    /// but they differ completely in consequence. Importing knowledge is
+    /// reversible and inert; installing an addon puts code where the extension
+    /// registry will load it. A caller has to name that intent, and the CLI
+    /// asks the user before calling this.
+    ///
+    /// Every other check is identical, and shared through
+    /// [`Self::verify_bundle_integrity`] — integrity digest, then signature —
+    /// so the executable path can never end up with *weaker* verification than
+    /// the inert one.
+    pub(crate) fn install_addon_from_file(&self, path: &Path) -> Result<PackageManifest, String> {
+        let (bundle, json) = Self::read_bundle(path)?;
+        bundle.manifest.validate().map_err(|errs| errs.join("; "))?;
+        super::verify::validate_kind_coherence(&bundle.manifest, &bundle.content)
+            .map_err(|errs| errs.join("; "))?;
+
+        if bundle.manifest.kind != super::manifest::PackageKind::Addon {
+            return Err(format!(
+                "`{}` is a kind={} package, not an addon — install it with `lean-ctx pack import`",
+                bundle.manifest.name,
+                bundle.manifest.kind.as_str(),
+            ));
+        }
+
+        Self::verify_bundle_integrity(&bundle, &json)?;
+        self.install(&bundle.manifest, &bundle.content)?;
+        Ok(bundle.manifest)
+    }
+
+    /// Content digest, then signature. Shared by both install doors so neither
+    /// can drift into accepting what the other rejects.
+    fn verify_bundle_integrity(bundle: &ExportBundle, json: &str) -> Result<(), String> {
+        let content_text = extract_top_level_value_text(json, "content")
             .ok_or_else(|| "package has no top-level content member".to_string())?;
         verify_integrity(&bundle.manifest, content_text)?;
 
@@ -329,9 +397,7 @@ impl LocalRegistry {
                 "signature verification failed — the package was modified after signing".into(),
             );
         }
-
-        self.install(&bundle.manifest, &bundle.content)?;
-        Ok(bundle.manifest)
+        Ok(())
     }
 
     fn package_dir(&self, name: &str, version: &str) -> PathBuf {

--- a/rust/src/core/context_package/verify.rs
+++ b/rust/src/core/context_package/verify.rs
@@ -15,6 +15,7 @@ use super::content::{
 };
 use super::manifest::{PackageKind, PackageLayer, PackageManifest};
 
+mod addon;
 mod text;
 pub(crate) use text::compact_json_text;
 
@@ -123,9 +124,14 @@ pub(crate) fn validate_kind_coherence(
     let mut errors = Vec::new();
     match manifest.kind {
         PackageKind::Addon => {
-            errors.push("kind=addon packages are no longer supported".into());
+            match &content.addon {
+                None => errors.push("kind=addon requires a content.addon payload".into()),
+                Some(addon) => addon::validate_addon(addon, &mut errors),
+            }
+            if content.documents.is_some() {
+                errors.push("content.documents payload requires kind=skills".into());
+            }
         }
-
         PackageKind::Skills => {
             if content.addon.is_some() {
                 errors.push("content.addon payload requires kind=addon".into());

--- a/rust/src/core/context_package/verify/addon.rs
+++ b/rust/src/core/context_package/verify/addon.rs
@@ -1,0 +1,98 @@
+//! `kind=addon` payload validation.
+//!
+//! Split out of `verify.rs` because that file is at the 1500-line gate, and a
+//! payload whose bytes get executed deserves to be read on its own anyway.
+
+/// Validate a `kind=addon` payload: a verbatim authoring manifest plus at
+/// least one embedded WASM module.
+///
+/// The modules are hash-pinned `DocumentBlob`s, so the same tamper detection
+/// that protects skills content protects executable bytes here — decode is
+/// verified against the pinned digest before anything reaches disk. Paths must
+/// end in `.wasm`: the store is scanned for modules to load, and a payload that
+/// can drop arbitrary filenames there would widen that scan into "execute
+/// whatever the pack shipped".
+pub(super) fn validate_addon(
+    addon: &crate::core::context_package::content::AddonContent,
+    errors: &mut Vec<String>,
+) {
+    use crate::core::context_package::content::{
+        MAX_ADDON_MODULE_BYTES, MAX_ADDON_MODULES, MAX_ADDON_TOTAL_BYTES,
+    };
+
+    if addon.manifest_toml.trim().is_empty() {
+        errors.push("kind=addon payload has an empty manifest_toml".into());
+    }
+    if addon.modules.is_empty() {
+        errors.push(
+            "kind=addon payload carries no modules — a pack that predates embedded \
+             modules cannot be installed by this version"
+                .into(),
+        );
+        return;
+    }
+    if addon.modules.len() > MAX_ADDON_MODULES {
+        errors.push(format!(
+            "addon payload has {} modules (cap: {MAX_ADDON_MODULES})",
+            addon.modules.len()
+        ));
+        return;
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut total: usize = 0;
+    for blob in &addon.modules {
+        if let Err(e) = super::validate_document_path(&blob.path) {
+            errors.push(e);
+            continue;
+        }
+        if !std::path::Path::new(&blob.path)
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case("wasm"))
+        {
+            errors.push(format!(
+                "addon module `{}` must be a `.wasm` file",
+                blob.path
+            ));
+            continue;
+        }
+        if !seen.insert(blob.path.as_str()) {
+            errors.push(format!("duplicate addon module `{}`", blob.path));
+            continue;
+        }
+        if blob.sha256.len() != 64 || !blob.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+            errors.push(format!(
+                "`{}`: sha256 must be a 64-char hex string",
+                blob.path
+            ));
+            continue;
+        }
+        match blob.decode_verified() {
+            Ok(plain) => {
+                if plain.len() > MAX_ADDON_MODULE_BYTES {
+                    errors.push(format!(
+                        "addon module `{}` is {} bytes (cap: {MAX_ADDON_MODULE_BYTES})",
+                        blob.path,
+                        plain.len()
+                    ));
+                }
+                // Reject anything that is not a WebAssembly module before it is
+                // ever stored: `\0asm` + version 1. Cheap, and it keeps a
+                // mislabelled or corrupt payload from reaching the loader.
+                if !plain.starts_with(b"\0asm") {
+                    errors.push(format!(
+                        "addon module `{}` is not a WebAssembly module (bad magic)",
+                        blob.path
+                    ));
+                }
+                total += plain.len();
+            }
+            Err(e) => errors.push(e),
+        }
+    }
+    if total > MAX_ADDON_TOTAL_BYTES {
+        errors.push(format!(
+            "addon payload decodes to {total} bytes (cap: {MAX_ADDON_TOTAL_BYTES})"
+        ));
+    }
+}

--- a/rust/src/core/context_package/verify/addon.rs
+++ b/rust/src/core/context_package/verify/addon.rs
@@ -22,11 +22,27 @@ pub(super) fn validate_addon(
 
     if addon.manifest_toml.trim().is_empty() {
         errors.push("kind=addon payload has an empty manifest_toml".into());
+        return;
     }
-    if addon.modules.is_empty() {
+
+    // The manifest is the contract between author and host, so it is parsed
+    // here rather than at install: a package that cannot be understood must not
+    // be storable, let alone installable.
+    let manifest = match crate::core::context_package::addon_manifest::parse(&addon.manifest_toml) {
+        Ok(m) => m,
+        Err(e) => {
+            errors.push(e);
+            return;
+        }
+    };
+
+    // An addon declares WASM modules, an MCP server, or both. Neither means
+    // installing it would have no effect — a defect in the package, not a state
+    // worth storing.
+    if addon.modules.is_empty() && manifest.mcp.is_none() {
         errors.push(
-            "kind=addon payload carries no modules — a pack that predates embedded \
-             modules cannot be installed by this version"
+            "kind=addon payload declares neither a WASM module nor an [mcp] server — \
+             installing it would have no effect"
                 .into(),
         );
         return;

--- a/rust/src/core/context_package/verify/tests.rs
+++ b/rust/src/core/context_package/verify/tests.rs
@@ -541,6 +541,13 @@ fn addon_content(toml: &str) -> PackageContent {
     PackageContent {
         addon: Some(crate::core::context_package::content::AddonContent {
             manifest_toml: toml.to_string(),
+            modules: vec![
+                crate::core::context_package::content::DocumentBlob::from_plaintext(
+                    "demo.wasm",
+                    &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+                )
+                .expect("blob"),
+            ],
         }),
         ..PackageContent::default()
     }

--- a/rust/src/core/extension_registry.rs
+++ b/rust/src/core/extension_registry.rs
@@ -82,12 +82,27 @@ impl ExtensionRegistry {
         // Format-aware chunkers (csv/json/eml/html) register through the same
         // public path so they are first-class + conformance-checked (EPIC 12.13).
         crate::core::extractors::register_into(&mut reg);
-        // Opt-in WASM compressors discovered from `LEAN_CTX_WASM_DIR` (EPIC 12.8).
+        // Extensions from installed `kind=addon` packs — signed, hash-pinned
+        // and locally re-verified on install. This is the supported channel;
+        // `LEAN_CTX_WASM_DIR` below stays as an unsigned developer override for
+        // authoring a module before it is packaged.
+        //
         // First-class once registered: discoverable via `/v1/capabilities` and
         // checked by the conformance scorecard like any other compressor.
         #[cfg(feature = "wasm")]
-        if let Ok(dir) = std::env::var("LEAN_CTX_WASM_DIR") {
-            crate::core::wasm_ext::register_compressors_from_dir(&mut reg, dir);
+        {
+            if let Ok(store) = crate::core::context_package::addons::store_root() {
+                for module in crate::core::context_package::addons::installed_modules(&store) {
+                    if let Some(stem) = module.file_stem().and_then(|s| s.to_str())
+                        && let Ok(c) = crate::core::wasm_ext::WasmCompressor::load(&module, stem)
+                    {
+                        reg.register_compressor(std::sync::Arc::new(c));
+                    }
+                }
+            }
+            if let Ok(dir) = std::env::var("LEAN_CTX_WASM_DIR") {
+                crate::core::wasm_ext::register_compressors_from_dir(&mut reg, dir);
+            }
         }
         reg
     }

--- a/rust/src/core/mcp_catalog/binary_pin.rs
+++ b/rust/src/core/mcp_catalog/binary_pin.rs
@@ -1,0 +1,190 @@
+//! Fail-closed SHA-256 pinning for gateway `stdio` servers.
+//!
+//! `[[gateway.servers]] binary_sha256` — and the `sha256` field of an addon's
+//! `[mcp]` table, which translates into it — is a promise that the executable
+//! about to be spawned is the one the user vouched for. Until 3.10.1 the value
+//! was parsed, stored, shown, and then dropped at the spawn point, so a pin
+//! bought nothing but the appearance of one. `docs/contracts/addon-manifest-v1.md`
+//! described the enforcement that this module now actually performs.
+//!
+//! Two details that matter more than the hashing itself:
+//!
+//! - **Resolve against the PATH the child will see.** The server's own `env`
+//!   may override `PATH`; hashing whatever our process would find while the
+//!   child runs something else would verify the wrong file.
+//! - **Spawn the resolved path, not the bare name.** Once a pin is set the
+//!   caller launches the exact file that was hashed, so name resolution cannot
+//!   land on a different binary between the check and the spawn. This does not
+//!   make the pair atomic — nothing short of holding the file open would — but
+//!   it removes the ambiguity a pin exists to remove.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::core::pathjail;
+
+/// Resolve `command` the way the spawned child would, honouring a `PATH`
+/// override in the server's own environment.
+fn resolve(command: &str, env: &BTreeMap<String, String>) -> Result<PathBuf, String> {
+    let as_path = Path::new(command);
+    if as_path.is_absolute() || as_path.components().count() > 1 {
+        return as_path
+            .is_file()
+            .then(|| pathjail::canonicalize_or_self(as_path))
+            .ok_or_else(|| format!("pinned binary does not exist: {command}"));
+    }
+
+    let path_var = match env.get("PATH") {
+        Some(overridden) => std::ffi::OsString::from(overridden),
+        None => std::env::var_os("PATH").unwrap_or_default(),
+    };
+    for directory in std::env::split_paths(&path_var) {
+        let candidate = directory.join(command);
+        if candidate.is_file() {
+            return Ok(pathjail::canonicalize_or_self(&candidate));
+        }
+    }
+    Err(format!("pinned binary `{command}` was not found on PATH"))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+/// Verify the pin, returning the path to spawn.
+///
+/// `Ok(None)` means "unpinned, spawn the command as written" — an empty pin is
+/// the documented default and must stay a no-op, or every existing gateway
+/// entry would break. Any other outcome, including a binary that cannot be
+/// found or read, is an error: a pin that cannot be checked has failed.
+pub(crate) async fn verify(
+    command: &str,
+    env: &BTreeMap<String, String>,
+    pin: &str,
+) -> Result<Option<PathBuf>, String> {
+    let expected = pin.trim().trim_start_matches("0x");
+    if expected.is_empty() {
+        return Ok(None);
+    }
+
+    let path = resolve(command, env)?;
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("cannot read pinned binary {}: {e}", path.display()))?;
+    let actual = hex(&Sha256::digest(&bytes));
+
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(Some(path))
+    } else {
+        Err(format!(
+            "binary_sha256 mismatch for `{command}` — refusing to spawn.\n  \
+             expected {expected}\n  actual   {actual}\n  \
+             path     {}\n\
+             The pinned executable is not the one on disk. Re-pin deliberately \
+             (shasum -a 256) only if you know why it changed.",
+            path.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_exe(dir: &Path, name: &str, body: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn an_empty_pin_is_a_no_op() {
+        let env = BTreeMap::new();
+        assert_eq!(verify("anything", &env, "").await.unwrap(), None);
+        assert_eq!(verify("anything", &env, "   ").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_matching_pin_returns_the_resolved_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = write_exe(tmp.path(), "srv", b"payload");
+        let digest = hex(&Sha256::digest(b"payload"));
+
+        let got = verify(exe.to_str().unwrap(), &BTreeMap::new(), &digest)
+            .await
+            .expect("pin matches")
+            .expect("pinned");
+        assert_eq!(got, pathjail::canonicalize_or_self(&exe));
+
+        // The value `shasum -a 256` prints, and an 0x-prefixed upper-case
+        // variant, are the same pin.
+        let loud = format!("0x{}", digest.to_uppercase());
+        assert!(
+            verify(exe.to_str().unwrap(), &BTreeMap::new(), &loud)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn a_mismatch_refuses_and_names_both_digests() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = write_exe(tmp.path(), "srv", b"actual bytes");
+        let wrong = "0".repeat(64);
+
+        let err = verify(exe.to_str().unwrap(), &BTreeMap::new(), &wrong)
+            .await
+            .expect_err("must refuse");
+        assert!(err.contains("mismatch"), "{err}");
+        assert!(err.contains(&wrong), "the expected digest: {err}");
+        assert!(
+            err.contains(&hex(&Sha256::digest(b"actual bytes"))),
+            "the actual digest: {err}"
+        );
+    }
+
+    /// A pin that cannot be checked has failed — silently spawning would be the
+    /// one outcome a pin exists to prevent.
+    #[tokio::test]
+    async fn a_missing_binary_is_an_error_not_a_skip() {
+        let err = verify(
+            "/nonexistent/lean-ctx-test-binary",
+            &BTreeMap::new(),
+            &"a".repeat(64),
+        )
+        .await
+        .expect_err("must refuse");
+        assert!(err.contains("does not exist"), "{err}");
+    }
+
+    /// The child resolves `PATH` from its own environment, so the check must
+    /// too — otherwise we hash one file and spawn another.
+    #[tokio::test]
+    async fn resolution_honours_a_path_override_in_the_server_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = write_exe(tmp.path(), "pinned-srv", b"in the override dir");
+        let digest = hex(&Sha256::digest(b"in the override dir"));
+
+        let mut env = BTreeMap::new();
+        env.insert("PATH".to_string(), tmp.path().display().to_string());
+
+        let got = verify("pinned-srv", &env, &digest)
+            .await
+            .expect("found via the overridden PATH")
+            .expect("pinned");
+        assert_eq!(got, pathjail::canonicalize_or_self(&exe));
+
+        // Without the override the bare name is not on the real PATH.
+        assert!(
+            verify("pinned-srv", &BTreeMap::new(), &digest)
+                .await
+                .is_err()
+        );
+    }
+}

--- a/rust/src/core/mcp_catalog/client.rs
+++ b/rust/src/core/mcp_catalog/client.rs
@@ -41,8 +41,14 @@ pub async fn open(
                 env,
                 binary_sha256,
             } => {
-                let _ = binary_sha256;
-                let mut cmd = tokio::process::Command::new(command);
+                // A pin that is parsed, stored and shown but never checked is
+                // worse than no pin: it reads as a guarantee. Verified here,
+                // and the resolved path is what gets spawned.
+                let resolved = super::binary_pin::verify(command, env, binary_sha256).await?;
+                let mut cmd = match resolved {
+                    Some(path) => tokio::process::Command::new(path),
+                    None => tokio::process::Command::new(command),
+                };
                 cmd.args(args);
                 if !env.is_empty() {
                     cmd.envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())));

--- a/rust/src/core/mcp_catalog/mod.rs
+++ b/rust/src/core/mcp_catalog/mod.rs
@@ -12,6 +12,7 @@
 //! Fully no-op until `[mcp_catalog] enabled = true` in config.
 
 pub mod adapters;
+mod binary_pin;
 pub mod catalog;
 pub mod client;
 pub mod config;

--- a/rust/src/doctor/checks/addons.rs
+++ b/rust/src/doctor/checks/addons.rs
@@ -1,0 +1,172 @@
+//! Installed addons: what actually loaded, and what did not.
+//!
+//! `addon list` reads the store — the files on disk. This check reads the
+//! **extension registry**, which is what the running engine uses. Between the
+//! two sits the thing worth verifying: `addon add` checks a module's four magic
+//! bytes, which is a prefix and not a parse, so a truncated or corrupt module
+//! installs cleanly, sits in the right directory with the right digest, and is
+//! then refused by the loader. Only a check on this side can tell a healthy
+//! install from that one, which is why `addon list` points here.
+
+use crate::doctor::{BOLD, DIM, GREEN, Outcome, RED, RST, YELLOW};
+
+/// Compare the modules present in the addon store against the compressors the
+/// registry actually holds.
+///
+/// Returns `None` when nothing is installed: a user with no addons should not
+/// get a line about addons.
+pub(crate) fn addons_loaded_outcome() -> Option<Outcome> {
+    let store = crate::core::context_package::addons::store_root().ok()?;
+
+    // Names the store expects to provide, derived exactly the way the loader
+    // derives them — one version per addon, registered by file stem.
+    let expected: Vec<String> = {
+        #[cfg(feature = "wasm")]
+        {
+            crate::core::context_package::addons::installed_modules(&store)
+                .iter()
+                .filter_map(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()))
+                .collect()
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            let _ = &store;
+            Vec::new()
+        }
+    };
+
+    // A declared MCP server is not a compressor and never appears in the
+    // registry, so it must not be counted as a module that failed to load.
+    let wired = wired_addon_count();
+
+    if expected.is_empty() && wired == 0 {
+        return None;
+    }
+
+    let registered: Vec<String> = crate::core::extension_registry::global()
+        .read()
+        .map(|r| r.compressor_names())
+        .unwrap_or_default();
+
+    let missing: Vec<&String> = expected
+        .iter()
+        .filter(|name| !registered.contains(name))
+        .collect();
+
+    let gateway_note = if wired > 0 && !crate::core::config::Config::load().gateway.enabled {
+        format!(", {wired} MCP server(s) wired but {YELLOW}gateway off{RST}")
+    } else if wired > 0 {
+        format!(", {wired} MCP server(s) wired")
+    } else {
+        String::new()
+    };
+
+    if missing.is_empty() {
+        let modules = if expected.is_empty() {
+            format!("{DIM}no WASM modules{RST}")
+        } else {
+            format!("{GREEN}{} module(s) loaded{RST}", expected.len())
+        };
+        return Some(Outcome {
+            ok: true,
+            line: format!("{BOLD}Addons{RST}  {modules}{gateway_note}"),
+        });
+    }
+
+    // Installed but not registered: the module is on disk and the engine
+    // declined it. Say which, because the name is what the author debugs with.
+    //
+    // The hint names the parse, not the ABI: missing entrypoints do *not*
+    // prevent registration — they surface when the compressor is called — so a
+    // module that fails here failed to be read as WebAssembly at all.
+    Some(Outcome {
+        ok: false,
+        line: format!(
+            "{BOLD}Addons{RST}  {RED}{} of {} module(s) failed to load{RST}: {}  \
+             {DIM}(present on disk but not readable as WebAssembly — likely truncated, \
+             corrupt, or not built for wasm32-unknown-unknown){RST}{gateway_note}",
+            missing.len(),
+            expected.len(),
+            missing
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        ),
+    })
+}
+
+/// How many installed addons declare an `[mcp]` server.
+fn wired_addon_count() -> usize {
+    let Ok(store) = crate::core::context_package::addons::store_root() else {
+        return 0;
+    };
+    let root = crate::core::context_package::addons::addons_root(&store);
+    let Ok(names) = std::fs::read_dir(root) else {
+        return 0;
+    };
+    let mut count = 0;
+    for name_entry in names.flatten().filter(|e| e.path().is_dir()) {
+        let Ok(versions) = std::fs::read_dir(name_entry.path()) else {
+            continue;
+        };
+        let declares = versions
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .any(|version| {
+                std::fs::read_to_string(version.path().join("lean-ctx-addon.toml"))
+                    .ok()
+                    .and_then(|t| crate::core::context_package::addon_manifest::parse(&t).ok())
+                    .is_some_and(|m| m.mcp.is_some())
+            });
+        if declares {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A user with no addons should not be told about addons.
+    #[test]
+    fn no_addons_means_no_line() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        assert!(addons_loaded_outcome().is_none());
+    }
+
+    /// The point of the check: a module present on disk but absent from the
+    /// registry is a failure the user can act on, and `addon list` alone could
+    /// never report it, because the store looks perfectly healthy.
+    ///
+    /// The payload here has valid WebAssembly magic and a corrupt body. That is
+    /// precisely the gap install cannot close: `addon add` checks the magic
+    /// bytes, which is a four-byte prefix, not a parse — so a truncated or
+    /// corrupted module installs cleanly and only fails when the engine tries
+    /// to load it. (An *empty but valid* module, by contrast, loads fine; the
+    /// ABI entrypoints are resolved when a compressor is called, not when the
+    /// module is read.)
+    #[cfg(feature = "wasm")]
+    #[test]
+    fn a_module_that_does_not_load_is_reported_as_a_failure() {
+        let _iso = crate::core::data_dir::isolated_data_dir();
+        let store = crate::core::context_package::addons::store_root().unwrap();
+        let dir = crate::core::context_package::addons::addons_root(&store)
+            .join("@ns__broken")
+            .join("1.0.0");
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut corrupt = vec![0x00, 0x61, 0x73, 0x6d, 1, 0, 0, 0];
+        corrupt.extend_from_slice(b"not a section");
+        std::fs::write(dir.join("brk.wasm"), &corrupt).unwrap();
+
+        let outcome = addons_loaded_outcome().expect("a line, since a module is installed");
+        assert!(!outcome.ok, "{}", outcome.line);
+        assert!(
+            outcome.line.contains("brk"),
+            "names the module: {}",
+            outcome.line
+        );
+    }
+}

--- a/rust/src/doctor/checks/mod.rs
+++ b/rust/src/doctor/checks/mod.rs
@@ -4,6 +4,7 @@
 //! re-exported flat so `doctor/mod.rs` and `doctor/report.rs` keep addressing
 //! `checks::foo()` — the split is purely structural.
 
+mod addons;
 mod clients;
 mod environment;
 mod providers;
@@ -11,6 +12,7 @@ mod proxy;
 mod security;
 mod storage;
 
+pub(crate) use addons::*;
 pub(crate) use clients::*;
 pub(crate) use environment::*;
 pub(crate) use providers::*;

--- a/rust/src/doctor/mod.rs
+++ b/rust/src/doctor/mod.rs
@@ -599,6 +599,13 @@ fn run_inner(json: bool) -> u32 {
         board.check(cbt);
     }
 
+    // 14b) Installed addons: what the registry actually holds, which is not
+    // the same question as what the store contains — `addon list` reads disk,
+    // this reads the running engine.
+    if let Some(ref addons) = addons_loaded_outcome() {
+        board.check(addons);
+    }
+
     // 15) BM25 cache health
     let bm25_health = bm25_cache_health_outcome();
     board.check(&bm25_health);


### PR DESCRIPTION
The addon path was never deleted in the 3.9.20 cleanup — it was **walled off**. The pack format kept `PackageKind::Addon` and an `AddonContent` payload, the WASM ABI, sandbox and loader all survived, and `wasm-abi-v1` still documented the ABI. Two lines held the wall up:

```rust
// verify.rs:149
PackageKind::Addon => errors.push("kind=addon packages are no longer supported".into());

// registry.rs:309 — pointed at a command that exited 1
"install it with `lean-ctx addon add {}`"
```

This connects what was already there. The ~12k lines the cleanup removed — `commerce.rs` (payments), `bootstrap.rs`, `ort_provision.rs`, a parallel registry/trust/sandbox stack — stay gone.

## The design decision: the module ships inside the package

`AddonContent` gains `modules: Vec<DocumentBlob>` — the same hash-pinned blob type `kind=skills` already uses.

The reported friction of the old channel was that an author needed **their own CI** to produce SHA files for externally hosted artifacts. Embedding removes the artifact host, the checksum files and the CI in one move: the package signature covers the executable bytes. It also removes a download from install, and with it the window between *"verified the manifest"* and *"fetched the binary"*.

```bash
lean-ctx addon release ./my-addon    # hashes, embeds, signs — one local command
lean-ctx addon add ./my-addon-1.0.0.ctxpkg
```

## What lands

| File | |
|---|---|
| `core/context_package/addons.rs` | store layout + materialization |
| `core/context_package/addons_build.rs` | signed package builder |
| `core/context_package/verify/addon.rs` | payload validation |
| `cli/addon_cmd.rs` | `list · info · add · remove · release` |

**`wasm` moves into default features.** Without it the shipped binary cannot load an extension at all — the channel would exist only for people who build their own. Measured on aarch64-apple-darwin, release profile: **83,065,536 → 83,815,584 bytes, +750 KB, +0.90%**.

**No `search` subcommand.** Search implies a curated index, which is a marketplace, which is out of scope. A package is a file you install, or one you fetch from a registry you name.

## Verification, not trust

`addon add` re-verifies the signature **locally** rather than trusting its source ("registry compromise ≠ client compromise"), checks every module against its pinned SHA-256 *and* the WebAssembly magic bytes, prints the publisher key and digests, then asks — and refuses non-interactively without `--yes`. `pack import` still declines executable content and routes to the right door.

Both doors share `verify_bundle_integrity`, so the executable path can never end up with weaker checks than the inert one. Modules are stored read-only and never marked executable: they go to the wasmi interpreter, never the OS loader.

## Two bugs the tests caught

1. **Install wrote to `<data_dir>/packages/addons/`, discovery scanned `<data_dir>/addons/`.** Every addon would have installed cleanly and never loaded — the worst kind of failure, because nothing errors. Both now derive from one `addons::store_root()`.
2. **A module insertion stole an attribute.** Adding the new modules to `context_package/mod.rs` placed them between an `#[allow(dead_code)]` and the module it belonged to, moving it from `skills` to `addons`. Clippy then reported dead code in a file this branch never touched — checking against `main` is what separated my mistake from a pre-existing one.

## Scope, stated rather than implied

The ABI reaches **compressors and context providers**. Chunkers, read modes and render transforms exist as Rust traits and are **not** exposed over it — the guide and contract say so rather than leaving authors to find out.

`wasm-abi-v1` and `addon-manifest-v1` move Research → **Preview**: the local channel is supported, the ABI is versioned but **not frozen**, and a breaking change would ship as `wasm-abi-v2` with an overlap window rather than a silent edit to v1. There is still no marketplace, and the docs keep saying so.

`verify.rs` hit 1583 lines with the new validator; it moved to `verify/addon.rs` rather than onto the LOC-gate allowlist.

## Verification

- `cargo test --lib` → **10601 passed, 0 failed** (15 new)
- `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines` → clean
- `cargo fmt --check`, `loc-gate.sh`, `check-narrative-governance.py`, `check-sdk-surface.py`, `check-package-versions.py`, `verify-delivery-evidence.py` → all pass

A round-trip test builds a package and installs it through the real registry door; a tamper test flips an embedded module and asserts nothing reaches the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)