### PR TITLE
fix(shell): quoting restarts inside $( … ), as POSIX says (#1646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Fixed — `ctx_shell` split inline scripts at a quoted `;` (#1646)
+
+- **Quoting now restarts inside `$( … )`, as POSIX specifies.** The command
+  scanner tracked quotes as two flat booleans and never noticed `$(` while
+  inside double quotes, so in
+  `echo "$(python3 -c "import sys;print(1)")"` the *inner* opening quote closed
+  the *outer* one. `import sys;print(1)` then looked unquoted, the `;` split a
+  second "command" out of a line of Python, and the allowlist rejected
+  `print(1))`. Any inline `python3 -c` / `perl -e` / `node -e` with more than one
+  statement was unusable, and `shell_allow_inline_scripts` could not help
+  because the damage happened during splitting, before that policy is consulted.
+  The scanner now keeps a stack of lexical contexts; `$( … )` and backticks push
+  a fresh one.
+- **No enforcement was traded away for it.** Commands a substitution genuinely
+  runs are found by the substitution scanner, which re-splits the inner text —
+  that path is unchanged, and a test now pins it in both its modes (warn by
+  default, block under `shell_strict_mode`) so a future change to the splitter
+  cannot quietly move it.
+- **An implausible base is reported as a mis-split, not an allowlist gap.** The
+  reporter was told to run
+  `lean-ctx allow print(urllib.parse.quote(sys.argv[1],safe=)) $RU)&code_challenge=…`
+  — a suggestion that cannot work and hides the real fault. A token that could
+  not be an executable name now says so and asks for a bug report instead.
+- **`ctx_shell`'s own description no longer contradicts its block message.** It
+  said a `[BLOCKED]` command should be escalated to `ctx_execute(language="shell")`;
+  the block message said not to, because both enforce the same allowlist. The
+  block message was right. The description now points at what actually resolves
+  a block, and marks `ctx_execute` as subject to the active tool profile — the
+  reporter's session did not advertise it at all.
+
 This release includes the defect fixes merged after the `v3.10.0` tag
 (`5b69202`), the addon channel, and the additive SDK Agent Tools interface
 below. None of it is present in the 3.10.0 artifacts.

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -613,7 +613,7 @@ WORKFLOW: preferred — auto-compresses output (build/test/log).
 raw=true for verbatim output; inline=true for moderately-sized verbatim output.
 [exit:N] on errors (lossless).
 POLICY: allowlisted read-only path.
-A [BLOCKED] command is permanent; ctx_execute shares this allowlist, not a way around it — fix with `lean-ctx allow <cmd>` or shell_allowlist/shell_security.
+A [BLOCKED] command is permanent; ctx_execute shares the same allowlist — fix with `lean-ctx allow <cmd>`.
 ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute (when exposed).
 
 Parameters: `background_action`, `command`, `cwd`, `env`, `inline`, `job_id`, `raw`, `run_in_background`, `timeout_ms`

--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -612,9 +612,9 @@ Parameters: `action`*, `session_id`, `value`
 WORKFLOW: preferred — auto-compresses output (build/test/log).
 raw=true for verbatim output; inline=true for moderately-sized verbatim output.
 [exit:N] on errors (lossless).
-POLICY (by design): allowlisted read-only path; ctx_execute is the trusted script path.
-A [BLOCKED] command is permanent — escalate to ctx_execute(language="shell"), do not retry here.
-ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute.
+POLICY: allowlisted read-only path.
+A [BLOCKED] command is permanent; ctx_execute shares this allowlist, not a way around it — fix with `lean-ctx allow <cmd>` or shell_allowlist/shell_security.
+ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute (when exposed).
 
 Parameters: `background_action`, `command`, `cwd`, `env`, `inline`, `job_id`, `raw`, `run_in_background`, `timeout_ms`
 

--- a/rust/src/core/shell_allowlist/config.rs
+++ b/rust/src/core/shell_allowlist/config.rs
@@ -33,6 +33,21 @@ pub(super) fn effective_allowlist() -> Vec<String> {
     list
 }
 
+/// Could this token plausibly be an executable name?
+///
+/// Deliberately permissive — the point is to catch obvious scanner debris
+/// (unbalanced parens, quotes, `$`, `&`, embedded spaces), not to validate
+/// against the filesystem. A name that would need quoting to type is not a name
+/// the user should be told to allowlist.
+pub(super) fn is_plausible_command_name(base: &str) -> bool {
+    if base.is_empty() {
+        return false;
+    }
+    !base.chars().any(|c| {
+        c.is_whitespace() || matches!(c, '(' | ')' | '"' | '\'' | '$' | '&' | '|' | ';' | '`')
+    })
+}
+
 /// Builds the actionable, self-diagnosing message shown when a command's base binary
 /// is not in the allowlist. Unlike a bare "not allowed" string, it tells the user
 /// (1) the exact additive fix, (2) the real config path the MCP server reads, and
@@ -44,6 +59,23 @@ pub(super) fn allowlist_block_message(base: &str) -> String {
         || "~/.lean-ctx/config.toml".to_string(),
         |p| p.display().to_string(),
     );
+
+    // A base that cannot be a command name means the scanner mis-split the line,
+    // not that the user needs to allow something. Printing
+    // `lean-ctx allow print(urllib.parse.quote(sys.argv[1],safe=))` — a real
+    // example from GH #1646 — invites the reader to copy a command that cannot
+    // work and hides the actual fault. Say which it is.
+    if !is_plausible_command_name(base) {
+        return format!(
+            "[BLOCKED] '{base}' is not in the shell allowlist — but it does not look like a \
+             command name, which means lean-ctx split your command line wrongly rather than \
+             finding a command to gate.\n\
+             Do NOT run `lean-ctx allow` on it; that would allowlist a fragment.\n\
+             Quote the fragment differently if you can, and please report the original command \
+             at https://github.com/yvgude/lean-ctx/issues — a mis-split is a bug in lean-ctx.\n\
+             Config in effect: {cfg_path}"
+        );
+    }
 
     let mut msg = format!(
         "[BLOCKED — DO NOT RETRY] '{base}' is not in the shell allowlist. \

--- a/rust/src/core/shell_allowlist/inline_script_tests.rs
+++ b/rust/src/core/shell_allowlist/inline_script_tests.rs
@@ -1,0 +1,121 @@
+//! Tests for GH #1646: inline scripts inside `$( … )`.
+//!
+//! Extracted from `tests.rs` to keep it under the repo's LOC gate
+//! (`scripts/loc-gate.sh`), the same reason `substitution_tests.rs` exists.
+
+use super::*;
+
+// --- GH #1646: an implausible base means a mis-split, not a missing allowlist entry ---
+
+/// The reporter was told to run
+/// `lean-ctx allow print(urllib.parse.quote(sys.argv[1],safe=)) $RU)&code_challenge=…`.
+/// That is not a command, it is scanner debris, and the suggestion could only
+/// waste the reader's time. Name the real fault instead.
+#[test]
+fn a_mangled_base_is_reported_as_a_split_bug_not_an_allowlist_gap() {
+    let msg = allowlist_block_message("print(urllib.parse.quote(sys.argv[1],safe=))");
+    assert!(
+        msg.contains("split your command line wrongly"),
+        "should name the mis-split: {msg}"
+    );
+    assert!(
+        !msg.contains("run  lean-ctx allow"),
+        "must not suggest allowlisting a fragment: {msg}"
+    );
+    assert!(
+        msg.contains("issues"),
+        "should point at reporting it: {msg}"
+    );
+}
+
+/// A real command name keeps the actionable message — the guard must not
+/// swallow the common case.
+#[test]
+fn a_real_command_name_still_gets_the_allow_suggestion() {
+    let msg = allowlist_block_message("terraform");
+    assert!(msg.contains("lean-ctx allow terraform"), "{msg}");
+}
+
+#[test]
+fn plausible_command_names_are_recognised() {
+    for ok in [
+        "git",
+        "python3",
+        "cargo-nextest",
+        "/usr/bin/env",
+        "a.out",
+        "foo_bar",
+    ] {
+        assert!(is_plausible_command_name(ok), "should be plausible: {ok}");
+    }
+    for bad in ["print(1))", "safe=)", "a b", "$RU", "x&y", "", "it's"] {
+        assert!(
+            !is_plausible_command_name(bad),
+            "should be implausible: {bad}"
+        );
+    }
+}
+
+/// End-to-end for GH #1646: the exact commands from the report must pass the
+/// gate that rejected them, and the two that already worked must keep working.
+/// `enforce_shell_allowlist` is the real entry point, so this exercises the
+/// whole path rather than the splitter in isolation.
+#[test]
+fn reported_inline_scripts_pass_the_real_gate() {
+    // The override is process-global; without this lock a parallel test's
+    // allowlist leaks in (the hazard gh391_strict_mode_blocks_substitution_in_args
+    // documents, and which this test tripped when first written).
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo,python3");
+    let results: Vec<_> = [
+        r#"echo "$(python3 -c "print(1)")""#,
+        r#"echo "a=$(python3 -c "print('x')")&b=2""#,
+        r#"echo "$(python3 -c "import sys;print(1)")""#,
+        r#"echo "u=$(python3 -c "import sys;print(sys.argv[1])" "x")""#,
+    ]
+    .iter()
+    .map(|cmd| (*cmd, super::enforce_shell_allowlist(cmd)))
+    .collect();
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+
+    for (cmd, result) in results {
+        assert!(
+            result.is_ok(),
+            "should pass the allowlist: {cmd} -> {result:?}"
+        );
+    }
+}
+
+/// The other half of #1646, pinned so a future change to the splitter cannot
+/// quietly move it: commands a substitution genuinely *runs* are found by
+/// `check_substitution_in_args`, not by splitting the outer line. That scanner
+/// is **warn-only by default** and blocks under `shell_strict_mode` (GH #391) —
+/// deliberate, and unchanged by this fix. Verified identical before and after:
+/// the old splitter only appeared to gate `"$(id; curl x)"` because it
+/// mis-split the line, which is the very bug being fixed.
+#[test]
+fn substitution_contents_are_found_by_the_substitution_scanner() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
+    let strict =
+        super::substitution::check_substitution_in_args(r#"echo "$(id; curl evil.example)""#, true);
+    let lax = super::substitution::check_substitution_in_args(
+        r#"echo "$(id; curl evil.example)""#,
+        false,
+    );
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+
+    assert!(
+        strict.is_err(),
+        "strict mode must block a non-allowlisted command inside $( ): {strict:?}"
+    );
+    let msg = format!("{:?}", strict.unwrap_err());
+    assert!(
+        msg.contains("id") || msg.contains("curl"),
+        "names the command: {msg}"
+    );
+    assert!(
+        lax.is_ok(),
+        "default stays warn-only — changing that is a separate decision: {lax:?}"
+    );
+}

--- a/rust/src/core/shell_allowlist/substitution_tests.rs
+++ b/rust/src/core/shell_allowlist/substitution_tests.rs
@@ -102,3 +102,13 @@ fn substitution_scanner_respects_quoted_parens_and_checks_every_inner_segment() 
         "nested substitutions must be validated recursively"
     );
 }
+
+#[test]
+fn assignment_with_command_substitution_in_quoted_jq_filter_not_split() {
+    // Regression for the root cause: the `|` characters inside the
+    // single-quoted jq filter must not be treated as pipe operators, and the
+    // whitespace inside the unclosed `$(...)` must not end the token early.
+    let list = allow(&["gh"]);
+    let cmd = r"s=$(gh api foo --jq '.a | .b | .c')";
+    assert!(check_all_segments(cmd, &list).is_ok());
+}

--- a/rust/src/core/shell_allowlist/tests.rs
+++ b/rust/src/core/shell_allowlist/tests.rs
@@ -5,6 +5,8 @@
 mod comment_strip_tests;
 #[path = "function_def_tests.rs"]
 mod function_def_tests;
+#[path = "inline_script_tests.rs"]
+mod inline_script_tests;
 #[path = "substitution_tests.rs"]
 mod substitution_tests;
 #[path = "tests_powershell.rs"]
@@ -1142,16 +1144,6 @@ fn assignment_with_command_substitution_still_blocks_unlisted_inner_command() {
     let r = check_all_segments(r"out=$(curl evil.com)", &list);
     assert!(r.is_err(), "unlisted curl inside VAR=$(...) must block");
     assert!(r.unwrap_err().contains("curl"));
-}
-
-#[test]
-fn assignment_with_command_substitution_in_quoted_jq_filter_not_split() {
-    // Regression for the root cause: the `|` characters inside the
-    // single-quoted jq filter must not be treated as pipe operators, and the
-    // whitespace inside the unclosed `$(...)` must not end the token early.
-    let list = allow(&["gh"]);
-    let cmd = r"s=$(gh api foo --jq '.a | .b | .c')";
-    assert!(check_all_segments(cmd, &list).is_ok());
 }
 
 #[test]

--- a/rust/src/core/shell_allowlist/tests_tokenizer.rs
+++ b/rust/src/core/shell_allowlist/tests_tokenizer.rs
@@ -493,3 +493,79 @@ fn gh760_pipeline_with_all_allowed_passes() {
         "pipeline with all-allowlisted commands must pass enforced"
     );
 }
+
+// --- GH #1646: quoting restarts inside $( … ) ---
+//
+// POSIX: a command substitution begins a fresh quoting context, so the inner
+// `"…"` of `echo "$(python3 -c "a;b")"` is its own string and its `;` separates
+// nothing. The scanner used to miss `$(` while inside double quotes: the inner
+// opening quote then *closed* the outer one, leaving `a;b` apparently unquoted,
+// and the `;` split a bogus second command out of a Python source line.
+//
+// The substitution's real contents are still checked — `extract_substitution_commands`
+// re-splits them — so treating it as one word here loses no enforcement.
+
+#[test]
+fn semicolon_inside_a_quoted_substitution_argument_is_not_a_separator() {
+    assert_eq!(
+        extract_all_commands(r#"echo "$(python3 -c "import sys;print(1)")""#),
+        vec![r#"echo "$(python3 -c "import sys;print(1)")""#],
+        "the ; belongs to the Python source, not the shell"
+    );
+}
+
+/// Every row of the reporter's narrowing table, including the two that worked
+/// before — a fix that broke those would be a different bug.
+#[test]
+fn reported_substitution_cases_are_each_one_command() {
+    for cmd in [
+        r#"echo "$(python3 -c "print(1)")""#,
+        r#"echo "a=$(python3 -c "print('x')")&b=2""#,
+        r#"echo "$(python3 -c "import sys;print(1)")""#,
+        r#"echo "u=$(python3 -c "import sys;print(sys.argv[1])" "x")""#,
+    ] {
+        assert_eq!(
+            extract_all_commands(cmd).len(),
+            1,
+            "should be one command: {cmd}"
+        );
+    }
+}
+
+/// The security-relevant half: a substitution really does run the commands
+/// inside it, so they must still be found — just by the substitution scanner
+/// rather than by splitting the outer line at a quote-protected `;`.
+#[test]
+fn commands_inside_a_substitution_are_still_extracted() {
+    let inner = extract_all_commands("id; whoami");
+    assert_eq!(inner, vec!["id", "whoami"], "inner text splits normally");
+}
+
+#[test]
+fn nested_and_arithmetic_substitutions_stay_balanced() {
+    assert_eq!(
+        extract_all_commands(r#"echo "$(echo "$(date)")""#).len(),
+        1,
+        "nested $( ) must not leak a separator"
+    );
+    assert_eq!(
+        extract_all_commands(r#"echo "$((1+2))""#).len(),
+        1,
+        "arithmetic expansion is balanced too"
+    );
+    // A real top-level separator after a substitution must still split.
+    assert_eq!(
+        extract_all_commands(r#"echo "$(date)"; id"#),
+        vec![r#"echo "$(date)""#, "id"],
+        "a ; outside the substitution still separates"
+    );
+}
+
+#[test]
+fn backtick_substitution_restarts_quoting_too() {
+    assert_eq!(
+        extract_all_commands("echo \"`python3 -c \"import sys;print(1)\"`\"").len(),
+        1,
+        "the older backtick form has the same restart rule"
+    );
+}

--- a/rust/src/core/shell_allowlist/tokenizer.rs
+++ b/rust/src/core/shell_allowlist/tokenizer.rs
@@ -110,6 +110,60 @@ pub(super) fn extract_all_commands(command: &str) -> Vec<String> {
         .collect()
 }
 
+/// One lexical context.
+///
+/// A command substitution starts a **fresh** one. POSIX says quoting restarts
+/// inside `$( … )`, so in `echo "$(python3 -c "a;b")"` the inner `"…"` is its
+/// own string and its `;` separates nothing (GH #1646). Tracking quotes as two
+/// flat booleans could not express that: the scanner never noticed `$(` while
+/// inside double quotes, so the inner opening quote *closed* the outer one,
+/// `a;b` looked unquoted, and the `;` split a bogus command out of a Python
+/// source line — which the allowlist then rejected with an unusable suggestion.
+///
+/// Treating the substitution as one word here loses no enforcement: its real
+/// contents are re-split and checked by `substitution::extract_substitution_commands`,
+/// which is where commands that a substitution genuinely *runs* are caught.
+#[derive(Clone, Copy)]
+struct Frame {
+    in_single_quote: bool,
+    in_double_quote: bool,
+    paren_depth: u32,
+    /// #939: brace groups (`{ cmd; }`) need the same operator-shielding as
+    /// `( cmd )` subshells — otherwise a `}` that closes a `{` opened on an
+    /// earlier physical line (e.g. after heredoc-body stripping collapses the
+    /// body between them) is misread as its own bare command segment.
+    brace_depth: u32,
+    kind: FrameKind,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FrameKind {
+    /// The command line itself. Separators split only at this level.
+    Base,
+    /// Opened by `$(`, closed by the matching `)`.
+    DollarParen,
+    /// Opened and closed by a backtick — the older substitution form, same
+    /// quoting-restart rule.
+    Backtick,
+}
+
+impl Frame {
+    const fn new(kind: FrameKind) -> Self {
+        Self {
+            in_single_quote: false,
+            in_double_quote: false,
+            paren_depth: 0,
+            brace_depth: 0,
+            kind,
+        }
+    }
+
+    /// Inside quotes, or inside a group whose closing delimiter is still open.
+    const fn shields_operators(&self) -> bool {
+        self.in_single_quote || self.in_double_quote || self.paren_depth > 0 || self.brace_depth > 0
+    }
+}
+
 /// Split command string on shell operators: ;, &&, ||, |
 /// Respects single/double quotes, parentheses nesting, and backslash escapes
 /// outside single quotes (GL #1160): `rg split\.label\|quantityLabel` is ONE
@@ -122,38 +176,67 @@ pub(super) fn split_on_operators(command: &str) -> Vec<&str> {
     let bytes = command.as_bytes();
     let len = bytes.len();
     let mut i = 0;
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
-    let mut paren_depth: u32 = 0;
-    // #939: brace groups (`{ cmd; }`) need the same operator-shielding as
-    // `( cmd )` subshells — otherwise a `}` that closes a `{` opened on an
-    // earlier physical line (e.g. after heredoc-body stripping collapses the
-    // body between them) is misread as its own bare command segment.
-    let mut brace_depth: u32 = 0;
+    // Stack, not booleans: see [`Frame`]. Index 0 is always the command line.
+    let mut stack: Vec<Frame> = vec![Frame::new(FrameKind::Base)];
 
     while i < len {
         let ch = bytes[i];
+        // `$(` and a backtick open a substitution wherever the shell would
+        // expand one: unquoted, or inside double quotes. Single quotes inhibit
+        // it entirely, which the single-quote arm below handles by consuming
+        // everything to the closing quote.
+        let opens_substitution = |i: usize| -> Option<(FrameKind, usize)> {
+            match bytes[i] {
+                b'$' if i + 1 < len && bytes[i + 1] == b'(' => Some((FrameKind::DollarParen, 2)),
+                b'`' => Some((FrameKind::Backtick, 1)),
+                _ => None,
+            }
+        };
 
-        if in_single_quote {
+        let frame = *stack.last().expect("base frame is never popped");
+
+        if frame.in_single_quote {
             if ch == b'\'' {
-                in_single_quote = false;
+                stack.last_mut().expect("frame").in_single_quote = false;
             }
             i += 1;
             continue;
         }
 
-        if in_double_quote {
+        if frame.in_double_quote {
             match ch {
                 // \" stays inside the string; \\ consumes both so `"x\\"` closes.
                 b'\\' => i = (i + 2).min(len),
                 b'"' => {
-                    in_double_quote = false;
+                    stack.last_mut().expect("frame").in_double_quote = false;
                     i += 1;
                 }
-                _ => i += 1,
+                _ => {
+                    if let Some((kind, width)) = opens_substitution(i) {
+                        stack.push(Frame::new(kind));
+                        i += width;
+                    } else {
+                        i += 1;
+                    }
+                }
             }
             continue;
         }
+
+        // Unquoted within the current frame.
+        if let Some((kind, width)) = opens_substitution(i) {
+            if kind == FrameKind::Backtick && frame.kind == FrameKind::Backtick {
+                // The same character closes a backtick substitution.
+                stack.pop();
+            } else {
+                stack.push(Frame::new(kind));
+            }
+            i += width;
+            continue;
+        }
+
+        let at_top = stack.len() == 1;
+        let unshielded = at_top && !frame.shields_operators();
 
         match ch {
             b'\\' => {
@@ -162,35 +245,43 @@ pub(super) fn split_on_operators(command: &str) -> Vec<&str> {
                 i = (i + 2).min(len);
             }
             b'\'' => {
-                in_single_quote = true;
+                stack.last_mut().expect("frame").in_single_quote = true;
                 i += 1;
             }
             b'"' => {
-                in_double_quote = true;
+                stack.last_mut().expect("frame").in_double_quote = true;
                 i += 1;
             }
             b'(' => {
-                paren_depth += 1;
+                stack.last_mut().expect("frame").paren_depth += 1;
                 i += 1;
             }
             b')' => {
-                paren_depth = paren_depth.saturating_sub(1);
+                let top = stack.last_mut().expect("frame");
+                if top.kind == FrameKind::DollarParen && top.paren_depth == 0 {
+                    // Matching close of `$(` — back to the enclosing context,
+                    // whose quoting resumes exactly where it left off.
+                    stack.pop();
+                } else {
+                    top.paren_depth = top.paren_depth.saturating_sub(1);
+                }
                 i += 1;
             }
             b'{' => {
-                brace_depth += 1;
+                stack.last_mut().expect("frame").brace_depth += 1;
                 i += 1;
             }
             b'}' => {
-                brace_depth = brace_depth.saturating_sub(1);
+                let top = stack.last_mut().expect("frame");
+                top.brace_depth = top.brace_depth.saturating_sub(1);
                 i += 1;
             }
-            b'\n' | b'\r' | b';' if paren_depth == 0 && brace_depth == 0 => {
+            b'\n' | b'\r' | b';' if unshielded => {
                 segments.push(&command[start..i]);
                 i += 1;
                 start = i;
             }
-            b'&' if paren_depth == 0 && brace_depth == 0 => {
+            b'&' if unshielded => {
                 if i + 1 < len && bytes[i + 1] == b'&' {
                     // &&
                     segments.push(&command[start..i]);
@@ -209,7 +300,7 @@ pub(super) fn split_on_operators(command: &str) -> Vec<&str> {
                     start = i;
                 }
             }
-            b'|' if paren_depth == 0 && brace_depth == 0 => {
+            b'|' if unshielded => {
                 if i + 1 < len && bytes[i + 1] == b'|' {
                     // ||
                     segments.push(&command[start..i]);

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -30,9 +30,11 @@ impl McpTool for CtxShellTool {
             "WORKFLOW: preferred — auto-compresses output (build/test/log).\n\
               raw=true for verbatim output; inline=true for moderately-sized verbatim output.\n\
              [exit:N] on errors (lossless).\n\
-             POLICY (by design): allowlisted read-only path; ctx_execute is the trusted script path.\n\
-             A [BLOCKED] command is permanent — escalate to ctx_execute(language=\"shell\"), do not retry here.\n\
-             ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute.",
+             POLICY: allowlisted read-only path.\n\
+             A [BLOCKED] command is permanent; ctx_execute shares this allowlist, not a way \
+             around it — fix with `lean-ctx allow <cmd>` or shell_allowlist/shell_security.\n\
+             ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute \
+             (when exposed).",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -31,8 +31,8 @@ impl McpTool for CtxShellTool {
               raw=true for verbatim output; inline=true for moderately-sized verbatim output.\n\
              [exit:N] on errors (lossless).\n\
              POLICY: allowlisted read-only path.\n\
-             A [BLOCKED] command is permanent; ctx_execute shares this allowlist, not a way \
-             around it — fix with `lean-ctx allow <cmd>` or shell_allowlist/shell_security.\n\
+             A [BLOCKED] command is permanent; ctx_execute shares the same allowlist — fix with \
+             `lean-ctx allow <cmd>`.\n\
              ANTIPATTERN: multi-line scripts, sh/bash script.sh, $var-as-command → ctx_execute \
              (when exposed).",
             json!({


### PR DESCRIPTION
Fixes #1646.

```
ctx_shell(command: 'echo "$(python3 -c "import sys;print(1)")"')
[BLOCKED] 'print(1))' is not in the shell allowlist
```

The splitter tracked quotes as two flat booleans and never noticed `$(` while inside double quotes. The **inner** opening quote therefore closed the **outer** one, `import sys;print(1)` looked unquoted, and the `;` split a second "command" out of a line of Python. POSIX restarts quoting inside a command substitution — that inner `"…"` is its own string.

Any inline `python3 -c` / `perl -e` / `node -e` with more than one statement was unusable. `shell_allow_inline_scripts` could not help: the damage happens during splitting, before that policy is consulted.

The scanner now keeps a stack of lexical contexts; `$(` and backticks push a fresh one.

## No enforcement was traded away

A substitution really does run the commands inside it, so "stop splitting there" would be wrong if it hid them. It does not — `check_substitution_in_args` re-splits the inner text, and that path is untouched.

I wrote a test asserting `echo "$(id; curl evil.example)"` is blocked. **It failed.** Before assuming I had caused it, I ran it against the unpatched tokenizer, where it fails identically: that scanner is warn-only by default and blocks under `shell_strict_mode` (#391, deliberate). The old splitter only *appeared* to gate that line because it mis-split it. The test now pins both modes.

## Two secondary defects from the same report

The suggested remedy was uncopyable:

```
lean-ctx allow print(urllib.parse.quote(sys.argv[1],safe=)) $RU)&code_challenge=…
```

A token that cannot be an executable name means a mis-split, not a missing allowlist entry. That case now says so and asks for a bug report.

And `ctx_shell`'s description contradicted its own block message — it said to escalate a `[BLOCKED]` command to `ctx_execute`, the message said not to because both enforce the same allowlist. The message was right. The reporter's session advertised 13 tools and `ctx_execute` was not among them, so an agent following the old text had nowhere to go.

## Token budget

Tool descriptions ride in every request's prefix. First draft: 1984 against a 1965 cap. A second trim left 9 tokens of headroom — a trap for the next editor. Final **1953**, +11 over main's 1942, measured by setting the cap to 1 and reading the assert, then restoring the constant.

## Verification

- Three tests in `tests_tokenizer.rs` **fail against the unpatched tokenizer** and pass after — checked, because tests written alongside a fix prove nothing until seen red.
- `cargo test --lib` 10639 passed, 0 failed; clippy `--all-features` clean; fmt, loc-gate, narrative governance pass.
- New tests in `inline_script_tests.rs`: `tests.rs` sat at exactly 1499 lines, so the module declaration alone would have breached the LOC gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)