### PR TITLE
fix(grep): context lines are context, not files (#1648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Fixed — `ctx_grep` turned context lines into files and inflated the count (#1648)
+
+- **A context line is no longer parsed as a file header.** GNU grep separates a
+  match with `path:line:content` and context with `path-line-content`; the
+  compressor split at the *first colon anywhere on the line*. So
+  `…/mod_1.py-2-    try:` split at the colon inside the Python source, becoming
+  a file named after the whole fragment with empty content — counted as both a
+  file and a match. The reporter's 40 matches in 40 files rendered as
+  `160 matches in 160F`, with every context line gone.
+- The delimiter is now the first colon *followed by a line number and another
+  colon*, and context is resolved against paths a match line already proved
+  exist. Anchoring on known paths is what makes it unambiguous: in
+  `src/v-1-x/mod.py-10-ctx` there are three candidate `-` delimiters and one
+  correct answer, and grep only emits context for a file it also matched in.
+- Context now renders under its real file, in grep's own convention (`3:` for a
+  match, `2-` for context), and the per-file cap counts **matches** — capping
+  raw lines would have silently dropped matches as soon as context was asked
+  for. Line content is trimmed, as it already was for matches.
+- Unparseable lines, including grep's `--` group separators, are dropped instead
+  of becoming synthetic files.
+- The failure was silent and read as absence: a caller could not tell the
+  context had been dropped rather than being absent from the file. It only
+  triggered when a context line contained a colon — common in Python, YAML, Go
+  struct tags and prose — which is why the single-file, uncompressed path looked
+  correct.
+
 ### Fixed — `ctx_shell` split inline scripts at a quoted `;` (#1646)
 
 - **Quoting now restarts inside `$( … )`, as POSIX specifies.** The command

--- a/rust/src/core/patterns/grep.rs
+++ b/rust/src/core/patterns/grep.rs
@@ -6,21 +6,32 @@ fn normalize_shell_tokens(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// One rendered line: a match, or a context line around one.
+#[derive(Clone, Copy)]
+struct Entry<'a> {
+    line_num: usize,
+    content: &'a str,
+    is_match: bool,
+}
+
 pub fn compress(output: &str) -> Option<String> {
     let lines: Vec<&str> = output.lines().collect();
     if lines.len() < 3 {
         return None;
     }
 
-    let mut by_file: HashMap<&str, Vec<(usize, &str)>> = HashMap::new();
+    let mut by_file: HashMap<&str, Vec<Entry<'_>>> = HashMap::new();
     let mut total_matches = 0usize;
 
+    // Pass 1 — matches only (`path:line:content`).
     for line in &lines {
-        if let Some((file, rest)) = parse_grep_line(line) {
+        if let Some((file, line_num, content)) = parse_match_line(line) {
             total_matches += 1;
-            let line_num = extract_line_num(rest);
-            let content = strip_line_num(rest);
-            by_file.entry(file).or_default().push((line_num, content));
+            by_file.entry(file).or_default().push(Entry {
+                line_num,
+                content,
+                is_match: true,
+            });
         }
     }
 
@@ -28,35 +39,74 @@ pub fn compress(output: &str) -> Option<String> {
         return None;
     }
 
+    // Pass 2 — context (`path-line-content`), resolved against the paths pass 1
+    // already proved exist (GH #1648).
+    //
+    // Doing it this way, rather than scanning for a `-digits-` delimiter, is
+    // what makes it unambiguous: both a path and the context text may contain
+    // hyphens and digits, but grep only emits context for a file it also
+    // matched in, so the path is always one we have already seen.
+    let known: Vec<&str> = by_file.keys().copied().collect();
+    for line in &lines {
+        if parse_match_line(line).is_some() {
+            continue;
+        }
+        if let Some((file, line_num, content)) = parse_context_line(line, &known) {
+            by_file.entry(file).or_default().push(Entry {
+                line_num,
+                content,
+                is_match: false,
+            });
+        }
+        // Anything else — grep's `--` group separators, stray text — is
+        // dropped. It used to become a synthetic file with empty content,
+        // inflating both the file and the match count.
+    }
+
     let max_matches_per_file = if total_matches > 200 { 5 } else { 10 };
 
     let mut result = format!("{total_matches} matches in {}F:\n", by_file.len());
-    let mut sorted_files: Vec<_> = by_file.iter().collect();
-    sorted_files.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then_with(|| a.0.cmp(b.0)));
+    let mut sorted_files: Vec<_> = by_file.iter_mut().collect();
+    sorted_files.sort_by(|a, b| {
+        let am = a.1.iter().filter(|e| e.is_match).count();
+        let bm = b.1.iter().filter(|e| e.is_match).count();
+        bm.cmp(&am).then_with(|| a.0.cmp(b.0))
+    });
 
-    for (file, matches) in &sorted_files {
+    for (file, entries) in &mut sorted_files {
+        entries.sort_by_key(|e| (e.line_num, !e.is_match));
+        let match_count = entries.iter().filter(|e| e.is_match).count();
         let short = shorten_path(file);
-        result.push_str(&format!("\n{short} ({}):", matches.len()));
-        let show = matches.iter().take(max_matches_per_file);
-        for (ln, content) in show {
-            let trimmed = content.trim();
+        result.push_str(&format!("\n{short} ({match_count}):"));
+
+        // The cap counts *matches*, and any context around a shown match comes
+        // with it — capping raw lines would silently drop matches once context
+        // was requested.
+        let mut shown_matches = 0usize;
+        for entry in entries.iter() {
+            if entry.is_match {
+                if shown_matches == max_matches_per_file {
+                    break;
+                }
+                shown_matches += 1;
+            }
+            let trimmed = entry.content.trim();
             let short_content = if trimmed.len() > 120 {
                 let truncated: String = trimmed.chars().take(119).collect();
                 format!("{truncated}…")
             } else {
                 trimmed.to_string()
             };
-            if *ln > 0 {
-                result.push_str(&format!("\n  {ln}: {short_content}"));
+            // grep's own convention: `:` marks a match, `-` marks context.
+            let sep = if entry.is_match { ':' } else { '-' };
+            if entry.line_num > 0 {
+                result.push_str(&format!("\n  {}{sep} {short_content}", entry.line_num));
             } else {
                 result.push_str(&format!("\n  {short_content}"));
             }
         }
-        if matches.len() > max_matches_per_file {
-            result.push_str(&format!(
-                "\n  ... +{} more",
-                matches.len() - max_matches_per_file
-            ));
+        if match_count > shown_matches {
+            result.push_str(&format!("\n  ... +{} more", match_count - shown_matches));
         }
     }
 
@@ -71,8 +121,14 @@ pub fn compress(output: &str) -> Option<String> {
     Some(result)
 }
 
-fn parse_grep_line(line: &str) -> Option<(&str, &str)> {
-    // Skip Windows drive letter (e.g. "C:" at position 1)
+/// Parse a match line: `path:line:content`.
+///
+/// The delimiter is the first colon *followed by digits and another colon* —
+/// not simply the first colon on the line (GH #1648). The old rule split
+/// `…/mod_1.py-2-    try:` at the colon inside the Python source, inventing a
+/// file named after the whole fragment.
+fn parse_match_line(line: &str) -> Option<(&str, usize, &str)> {
+    // Skip a Windows drive letter (e.g. "C:" at position 1).
     let start = if line.len() >= 2
         && line.as_bytes()[0].is_ascii_alphabetic()
         && line.as_bytes()[1] == b':'
@@ -81,32 +137,58 @@ fn parse_grep_line(line: &str) -> Option<(&str, &str)> {
     } else {
         0
     };
-    if let Some(rel_pos) = line[start..].find(':') {
-        let pos = start + rel_pos;
-        let file = &line[..pos];
-        if file.contains('/') || file.contains('\\') || file.contains('.') {
-            let rest = &line[pos + 1..];
-            return Some((file, rest));
+
+    let (file, line_num, content) = split_numbered(line, ':', start)?;
+    if file.contains('/') || file.contains('\\') || file.contains('.') {
+        Some((file, line_num, content))
+    } else {
+        None
+    }
+}
+
+/// Split `prefix<D><digits><D>rest` at the first delimiter that is actually
+/// followed by a line number.
+fn split_numbered(line: &str, delim: char, start: usize) -> Option<(&str, usize, &str)> {
+    let bytes = line.as_bytes();
+    let mut from = start;
+    while let Some(rel) = line[from..].find(delim) {
+        let at = from + rel;
+        let after = at + delim.len_utf8();
+        let digits = bytes[after..]
+            .iter()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        if digits > 0 && bytes.get(after + digits).copied() == Some(delim as u8) {
+            let num = line[after..after + digits].parse().ok()?;
+            return Some((&line[..at], num, &line[after + digits + 1..]));
         }
+        from = at + delim.len_utf8();
     }
     None
 }
 
-fn extract_line_num(rest: &str) -> usize {
-    if let Some(pos) = rest.find(':') {
-        rest[..pos].parse().unwrap_or(0)
-    } else {
-        0
+/// Parse a context line: `path-line-content`, where `path` is one grep already
+/// reported a match in.
+///
+/// Anchoring on a known path rather than scanning for `-digits-` is what keeps
+/// this unambiguous: `src/v-1-x/mod.py-10-ctx` has three candidate delimiters
+/// and only one correct answer.
+fn parse_context_line<'a>(line: &'a str, known: &[&'a str]) -> Option<(&'a str, usize, &'a str)> {
+    for file in known {
+        let Some(rest) = line.strip_prefix(*file).and_then(|r| r.strip_prefix('-')) else {
+            continue;
+        };
+        let digits = rest
+            .as_bytes()
+            .iter()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        if digits > 0 && rest.as_bytes().get(digits).copied() == Some(b'-') {
+            let num = rest[..digits].parse().ok()?;
+            return Some((file, num, &rest[digits + 1..]));
+        }
     }
-}
-
-fn strip_line_num(rest: &str) -> &str {
-    if let Some(pos) = rest.find(':')
-        && rest[..pos].chars().all(|c| c.is_ascii_digit())
-    {
-        return &rest[pos + 1..];
-    }
-    rest
+    None
 }
 
 fn shorten_path(path: &str) -> &str {
@@ -236,5 +318,82 @@ mod tests {
                 );
             }
         }
+    }
+
+    // --- GH #1648: context lines (`path-line-text`) are not matches ---
+
+    /// The reporter's repro, reduced: 40 files, one match each, `-C 2`.
+    /// GNU grep separates a match with `:` and context with `-`; the parser
+    /// took the FIRST colon anywhere on the line, so `…/mod_1.py-2-    try:`
+    /// became a *file* named `…/mod_1.py-2-    try` with empty content —
+    /// counted as both a file and a match.
+    fn repro_with_context(files: usize) -> String {
+        let mut out = Vec::new();
+        for i in 1..=files {
+            let f = format!("/tmp/leanctx-grep-repro/mod_{i}.py");
+            out.push(format!("{f}-1-def handler_{i}():"));
+            out.push(format!("{f}-2-    try:"));
+            out.push(format!("{f}:3:        target_pattern_here()"));
+            out.push(format!("{f}-4-    except Exception:"));
+            out.push(format!("{f}-5-        pass"));
+            out.push("--".to_string());
+        }
+        out.join("\n")
+    }
+
+    #[test]
+    fn context_lines_do_not_become_files_or_matches() {
+        let result = compress(&repro_with_context(40)).expect("should compress");
+        assert!(
+            result.starts_with("40 matches in 40F:"),
+            "40 real matches in 40 files, not one per context line: {}",
+            result.lines().next().unwrap_or("")
+        );
+        assert!(
+            !result.contains("-2-"),
+            "a context line must not appear as a file header: {result}"
+        );
+        assert!(
+            !result.contains("try (1)"),
+            "text must not be truncated at a colon into a path: {result}"
+        );
+    }
+
+    /// The content the reporter lost. A context line whose text contains a
+    /// colon (Python, YAML, Go tags, prose) is exactly the case that broke.
+    #[test]
+    fn context_text_survives_intact() {
+        let result = compress(&repro_with_context(40)).expect("should compress");
+        assert!(
+            result.contains("try:"),
+            "the context line's own text, colon included, must survive: {result}"
+        );
+    }
+
+    /// `--` group separators are grep's, not data.
+    #[test]
+    fn group_separators_are_ignored() {
+        let out = (1..=20)
+            .map(|i| format!("a/b.rs-{}-ctx\na/b.rs:{i}:hit\n--", i * 10))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = compress(&out).expect("should compress");
+        assert!(result.starts_with("20 matches in 1F:"), "{result}");
+    }
+
+    /// A path containing `-<digits>-` must not be mistaken for a context
+    /// delimiter. Context is resolved against paths already seen in match
+    /// lines, so the ambiguity never arises.
+    #[test]
+    fn a_hyphenated_path_is_not_split_as_context() {
+        let out = (1..=20)
+            .map(|i| format!("src/v-1-x/mod.py-{}-ctx\nsrc/v-1-x/mod.py:{i}:hit", i * 10))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = compress(&out).expect("should compress");
+        assert!(
+            result.starts_with("20 matches in 1F:"),
+            "one file, not one per hyphen: {result}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #1648.

```
160 matches in 160F:            ← for 40 matches in 40 files
/tmp/…/mod_1.py-2-    try (1):  ← a "file" named after a line of Python
```

GNU grep separates a match with `path:line:content` and context with `path-line-content`. The compressor split at the **first colon anywhere on the line**, so a context line split at the colon inside the source it was quoting — becoming a file named after the whole fragment, with empty content, counted as both a file and a match.

It only misfired when a context line contained a colon (Python, YAML, Go struct tags, prose), which is why the uncompressed single-file path looked correct. **Two of the four tests I wrote from the repro passed before the fix** for exactly that reason; they are kept, because they cover cases the new parser could plausibly break.

## What changed

The match delimiter is now the first colon *followed by a line number and another colon*. Context is parsed in a second pass and resolved against paths a match line already proved exist.

Anchoring on known paths rather than scanning for `-digits-` is what makes it unambiguous: `src/v-1-x/mod.py-10-ctx` offers three candidate delimiters and one correct answer — and grep only emits context for a file it also matched in.

Context renders under its real file in grep's own convention (`3:` match, `2-` context). The per-file cap now counts **matches**: capping raw lines would have silently dropped matches as soon as context was requested, trading one quiet data loss for another.

## Before / after, on the reporter's repro

```
40 matches in 40F:

/tmp/leanctx-grep-repro/mod_1.py (1):
  1- def handler_1():
  2- try:
  3: target_pattern_here()
  4- except Exception:
  5- pass
```

## Verification

- `cargo test --lib` 10643 passed, 0 failed; clippy `--all-features` clean; fmt, `gen_docs --check`, loc-gate, narrative governance pass.
- Output inspected directly against the repro, not only through assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)