### PR TITLE
fix(test): serialise session_accumulator_tracks — it races the accumulator

### DIFF
--- a/rust/src/core/savings_footer.rs
+++ b/rust/src/core/savings_footer.rs
@@ -356,6 +356,17 @@ pub mod tests {
 
     #[test]
     fn session_accumulator_tracks() {
+        // The accumulator is process-global, and `session_counter_removed_from_footer`
+        // records `record_savings(100, 50)` twenty times under this lock. Without
+        // taking it here, one of those lands between this test's `reset_session()`
+        // and its `session_totals()`, and the assertion reads 400 instead of 300 —
+        // which is exactly how it failed on Windows in CI on main (02e49e7c), where
+        // thread scheduling differs enough to make the race visible.
+        //
+        // Same class as the GL #556 leak noted above: shared state, some tests
+        // serialised and some not.
+        let _lock = crate::core::data_dir::test_env_lock();
+
         reset_session();
         record_savings(100, 50);
         record_savings(200, 80);


### PR DESCRIPTION
**main is currently red.** `Test (windows-latest)` on `02e49e7c`:

```
core::savings_footer::tests::session_accumulator_tracks
left: 400, right: 300
```

## Cause

The session accumulator is process-global. `session_counter_removed_from_footer` calls `record_savings(100, 50)` twenty times, and **400 = 100 + 200 + exactly one of those** landing between this test's `reset_session()` and its `session_totals()`.

Six tests in the file take `test_env_lock()`. This one did not.

## Not caused by the merge that surfaced it

`590b7268..02e49e7c` is 59 markdown files and one Python script — **zero Rust files**. Checked before looking further. Windows thread scheduling is simply where the race became visible; the four preceding main runs passed by luck.

The file already carries a note about GL #556, where leaked state made footers appear in unrelated tests. Same class: shared state, some tests serialised and some not. The new comment names the CI run so the next person does not have to re-derive why the lock is there.

## Verification

- 5 consecutive `cargo test --lib savings_footer` runs — 21 passed each.
- Full `cargo test --lib` — 10643 passed, 0 failed.
- `clippy --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)