### PR TITLE
feat(shell): a timed-out recursive walk says what probably ate it (#1655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Added — a timed-out recursive walk says what probably ate it (#1655)
+
+- **The `.gitignore` asymmetry is now visible.** `ctx_glob` and `ctx_tree`
+  honour `.gitignore`; `ctx_shell` runs the user's own `grep`/`find`, which does
+  not. A repo with nested checkouts under `.claude/worktrees/` therefore
+  searches a multiple of the intended tree, and nothing said so — the reporter
+  hit this twice and diagnosed it both times from memory of his own earlier
+  issue (#1089) rather than from the tool.
+- On a timed-out recursive walk, the notice now names the bulk directories that
+  actually exist under the search root, with real file counts, and points at
+  `ctx_search`:
+
+  ```
+  [hint: rust/target/ (5000+ files), cookbook/node_modules/ (5000+ files) under
+   this path — walked by grep/find, but ignored by ctx_search and ctx_glob,
+   which honour .gitignore. Scope the path, add --exclude-dir, or use ctx_search.]
+  ```
+
+- **Nothing about the command's traversal changes.** Silently rewriting a user's
+  `grep` would be worse than the timeout; the report says so and is right. This
+  is an explanation after the fact.
+- Three honesty constraints, because a hint that guesses is worse than none:
+  only directories that exist are named; counts come from a bounded walk and a
+  capped count renders as `N+` rather than being passed off as a total; and no
+  percentage of the walk is claimed, because we know what is on disk, not what
+  the command traversed.
+- `rg` is deliberately excluded — it already honours `.gitignore`, so an ignored
+  directory does not explain a slow `rg`, and saying otherwise would send the
+  reader after the wrong cause. A command that already excludes the directory
+  gets no hint either.
+
 ### Fixed — `ctx_grep` turned context lines into files and inflated the count (#1648)
 
 - **A context line is no longer parsed as a file header.** GNU grep separates a

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -262,6 +262,13 @@ pub(crate) fn execute_command_with_env_cancellable(
                 still_running.join(" | ")
             ));
         }
+        // #1655: a recursive walk does not read `.gitignore`, so a nested
+        // checkout the other ctx_* tools never see can dominate it. Say so
+        // after the fact — the command's own traversal is left alone.
+        if let Some(hint) = super::walk_hint::walk_hint(command, cwd) {
+            text.push('\n');
+            text.push_str(&hint);
+        }
     }
     if cancelled {
         if !text.ends_with('\n') && !text.is_empty() {

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -26,6 +26,7 @@ use roots::has_project_marker;
 pub mod tool_trait;
 pub mod tool_visibility;
 pub mod tools_config_watch;
+pub(crate) mod walk_hint;
 
 use futures::FutureExt;
 use rmcp::ErrorData;

--- a/rust/src/server/walk_hint.rs
+++ b/rust/src/server/walk_hint.rs
@@ -1,0 +1,250 @@
+//! Why a recursive walk timed out (GH #1655, follow-up to #1089).
+//!
+//! `ctx_glob` and `ctx_tree` honour `.gitignore`; `ctx_shell` runs the user's
+//! own `grep`/`find`, which does not. So a directory invisible to one tool is
+//! walked by the other, and a repo with nested checkouts under
+//! `.claude/worktrees/` searches a multiple of the intended tree. The reporter
+//! hit this twice and diagnosed it both times from memory of his own earlier
+//! issue rather than from anything the tool said.
+//!
+//! This does **not** change what the command traverses. Silently rewriting a
+//! user's `grep` would be worse than the timeout — the reporter says so himself
+//! and he is right. It only explains, after the fact, what was probably eaten.
+//!
+//! Honesty constraints, because a hint that guesses is worse than none:
+//!
+//! - Only directories that **actually exist** under the search root are named.
+//! - Counts are real, from a bounded walk; a count that hit the cap is rendered
+//!   `N+`, never rounded up into a total.
+//! - No percentage of the walk is claimed. We do not know what the command
+//!   traversed, only what is there.
+
+use std::path::Path;
+
+/// Commands whose cost scales with the tree, and which do not read `.gitignore`.
+const RECURSIVE_TOOLS: &[&str] = &["grep", "egrep", "fgrep", "find", "ack", "ag"];
+
+/// Directories that dominate a walk when present: nested checkouts and
+/// dependency trees.
+///
+/// Deliberately narrower than [`crate::core::auto_findings::NOISE_PATH_SEGMENTS`],
+/// which also lists small directories (`.cursor`, `terminals`) whose presence
+/// says nothing about why a walk was slow. Naming those would dilute the hint.
+const BULK_DIRS: &[&str] = &[
+    ".worktrees",
+    "worktrees",
+    ".codex-worktrees",
+    "node_modules",
+    "target",
+    "vendor",
+    ".venv",
+    "venv",
+    "site-packages",
+    ".next",
+    ".cache",
+];
+
+/// How deep to look for a bulk directory. `.claude/worktrees/` is two levels
+/// down, which is the reported case; three leaves room without turning the
+/// search itself into a walk.
+const SCAN_DEPTH: usize = 3;
+
+/// Stop counting a directory here. The number only has to be big enough to
+/// justify the hint, and this runs on an already-slow error path.
+const COUNT_CAP: usize = 5_000;
+
+/// A hint for a timed-out command, or `None` when there is nothing honest to say.
+pub(crate) fn walk_hint(command: &str, cwd: &str) -> Option<String> {
+    if !is_recursive_walk(command) {
+        return None;
+    }
+
+    let root = Path::new(cwd);
+    let mut found: Vec<(String, usize, bool)> = Vec::new();
+    collect_bulk_dirs(root, root, 0, &mut found);
+
+    // A directory the command already excludes is not the explanation.
+    found.retain(|(rel, _, _)| !command.contains(rel.as_str()));
+    if found.is_empty() {
+        return None;
+    }
+
+    // Biggest first: the directory most likely to explain the timeout leads.
+    found.sort_by_key(|f| std::cmp::Reverse(f.1));
+    found.truncate(3);
+
+    let named: Vec<String> = found
+        .iter()
+        .map(|(rel, n, capped)| format!("{rel}/ ({n}{} files)", if *capped { "+" } else { "" }))
+        .collect();
+
+    Some(format!(
+        "[hint: {} under this path — walked by grep/find, but ignored by \
+         ctx_search and ctx_glob, which honour .gitignore. Scope the path, add \
+         --exclude-dir, or use ctx_search.]",
+        named.join(", ")
+    ))
+}
+
+/// Does this command walk a tree without reading `.gitignore`?
+///
+/// `rg` is deliberately absent: it honours `.gitignore` already, so a slow `rg`
+/// is not explained by an ignored directory and the hint would mislead.
+fn is_recursive_walk(command: &str) -> bool {
+    for segment in command.split(|c| matches!(c, '|' | ';' | '&')) {
+        let mut words = segment.split_whitespace().skip_while(|w| w.contains('='));
+        let Some(base) = words.next() else { continue };
+        let base = base.rsplit('/').next().unwrap_or(base);
+        if !RECURSIVE_TOOLS.contains(&base) {
+            continue;
+        }
+        // `find` is always recursive; grep-likes need -r/-R.
+        if base == "find" {
+            return true;
+        }
+        if segment
+            .split_whitespace()
+            .any(|w| w.starts_with('-') && !w.starts_with("--") && w.contains(['r', 'R']))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Shallow search for bulk directories, recording each one's bounded file count.
+/// Does not descend *into* a match — its own contents are what we are counting.
+fn collect_bulk_dirs(root: &Path, dir: &Path, depth: usize, out: &mut Vec<(String, usize, bool)>) {
+    if depth > SCAN_DEPTH || out.len() >= 16 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if BULK_DIRS.contains(&name.as_str()) {
+            let (count, capped) = count_files(&path);
+            if let Ok(rel) = path.strip_prefix(root) {
+                out.push((rel.to_string_lossy().into_owned(), count, capped));
+            }
+            continue; // its contents are the count, not more candidates
+        }
+        collect_bulk_dirs(root, &path, depth + 1, out);
+    }
+}
+
+/// Files under `dir`, stopping at [`COUNT_CAP`]. Returns `(count, hit_cap)`.
+fn count_files(dir: &Path) -> (usize, bool) {
+    let mut stack = vec![dir.to_path_buf()];
+    let mut count = 0usize;
+    while let Some(next) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&next) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            match entry.file_type() {
+                Ok(t) if t.is_dir() => stack.push(entry.path()),
+                Ok(_) => {
+                    count += 1;
+                    if count >= COUNT_CAP {
+                        return (COUNT_CAP, true);
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+    }
+    (count, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn make_tree(root: &Path, rel: &str, files: usize) {
+        let dir = root.join(rel);
+        std::fs::create_dir_all(&dir).unwrap();
+        for i in 0..files {
+            std::fs::write(dir.join(format!("f{i}.go")), b"x").unwrap();
+        }
+    }
+
+    #[test]
+    fn recognises_recursive_grep_but_not_rg() {
+        assert!(is_recursive_walk("grep -rn needle ."));
+        assert!(is_recursive_walk("grep -Rn needle ."));
+        assert!(is_recursive_walk("find . -name '*.go'"));
+        assert!(is_recursive_walk("cd /x && grep -rn a ."));
+        // Non-recursive grep walks nothing.
+        assert!(!is_recursive_walk("grep needle file.txt"));
+        // rg honours .gitignore, so an ignored directory does not explain it —
+        // claiming otherwise would send the reader after the wrong cause.
+        assert!(!is_recursive_walk("rg needle"));
+    }
+
+    /// The reporter's shape: full checkouts two levels down under `.claude/`.
+    #[test]
+    fn names_nested_checkouts_with_real_counts() {
+        let t = tmp();
+        make_tree(t.path(), ".claude/worktrees/a", 12);
+        make_tree(t.path(), ".claude/worktrees/b", 8);
+        make_tree(t.path(), "src", 3);
+
+        let hint = walk_hint("grep -rn needle .", t.path().to_str().unwrap())
+            .expect("a hint for a recursive grep over a tree with nested checkouts");
+        assert!(hint.contains("worktrees"), "{hint}");
+        assert!(
+            hint.contains("20 files"),
+            "real count, not an estimate: {hint}"
+        );
+        assert!(hint.contains("ctx_search"), "{hint}");
+        assert!(!hint.contains('%'), "no invented percentage: {hint}");
+    }
+
+    /// A command that already excludes the directory has been diagnosed
+    /// already; repeating it is noise.
+    #[test]
+    fn stays_quiet_when_the_command_already_excludes_it() {
+        let t = tmp();
+        make_tree(t.path(), ".worktrees/a", 5);
+        assert!(
+            walk_hint(
+                "grep -rn needle . | grep -v '.worktrees'",
+                t.path().to_str().unwrap()
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn stays_quiet_without_bulk_directories() {
+        let t = tmp();
+        make_tree(t.path(), "src", 4);
+        assert!(walk_hint("grep -rn needle .", t.path().to_str().unwrap()).is_none());
+    }
+
+    #[test]
+    fn stays_quiet_for_a_non_walking_command() {
+        let t = tmp();
+        make_tree(t.path(), "node_modules/x", 5);
+        assert!(walk_hint("cargo test", t.path().to_str().unwrap()).is_none());
+    }
+
+    /// A huge tree must not be counted exhaustively on an error path; the cap
+    /// is reported as `N+` rather than passed off as a total.
+    #[test]
+    fn a_capped_count_is_marked_as_a_floor() {
+        let (n, capped) = (COUNT_CAP, true);
+        let rendered = format!("{n}{} files", if capped { "+" } else { "" });
+        assert!(rendered.starts_with("5000+"), "{rendered}");
+    }
+}


### PR DESCRIPTION
Fixes #1655 (follow-up to #1089, whose first ask never landed).

`ctx_glob` and `ctx_tree` honour `.gitignore`. `ctx_shell` runs the user's own `grep`/`find`, which does not. A directory invisible to one tool is walked by the other, so a repo with nested checkouts under `.claude/worktrees/` searches a multiple of the intended tree — and **nothing said so**. The reporter hit this twice and diagnosed it both times from memory of his own earlier issue.

On a timed-out recursive walk, the notice now names the bulk directories that exist under the search root, with real counts:

```
[hint: rust/target/ (5000+ files), cookbook/node_modules/ (5000+ files) under
 this path — walked by grep/find, but ignored by ctx_search and ctx_glob,
 which honour .gitignore. Scope the path, add --exclude-dir, or use ctx_search.]
```

That output is from **this repository**, which has exactly the reported shape.

## What it deliberately does not do

Change what the command traverses. Silently rewriting a user's `grep` would be worse than the timeout — the report says so and is right. This explains after the fact; it does not intervene.

## Three honesty constraints

A hint that guesses is worse than none:

- Only directories that **actually exist** are named.
- Counts come from a **bounded** walk (cap 5000, on an already-slow error path); a capped count renders `N+` rather than being passed off as a total.
- **No percentage is claimed.** The issue suggests "82% of the walk was under …", which would read better and would be invented — we know what is on disk, not what the command traversed.

## Two exclusions, both to avoid pointing at the wrong cause

- **`rg` does not trigger it.** It already honours `.gitignore`, so an ignored directory does not explain a slow `rg`. Naming one would send the reader after the wrong thing — the same defect as #1654.
- **`BULK_DIRS` is narrower than `NOISE_PATH_SEGMENTS`**, which the issue suggested as the seed. That list also carries small directories (`.cursor`, `terminals`) whose presence says nothing about why a walk was slow.

A command that already excludes the directory gets no hint either.

## Verification

`cargo test --lib` 10649 passed, 0 failed; clippy `--all-features` and the embed facade clean; fmt, `gen_docs --check`, loc-gate, narrative governance pass. Six new tests including the nested-checkout shape, plus output checked against this repo rather than only through assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)