### PR TITLE
fix(ctx_shell): seven field reports on guards and output honesty (#1659–#1663, #1666, #1672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   which is indistinguishable from "this walk is fine". A `cd` that cannot be
   resolved statically stays silent rather than naming directories from
   somewhere else.
+- Because it now runs on the fast path, it scans what the command was actually
+  pointed at: `grep -r pattern src/` is no longer blamed on a `node_modules/`
+  it never enters.
 
 ### Fixed — grep output was sampled head+tail, dropping the line that mattered (#1663)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   tested decision this fix leaves alone.
 - The refusal now names a route that works for the payload at hand.
 
+### Fixed — a heredoc body mentioning a download was refused (#1672)
+
+- `git commit -F - <<'MSG' … curl -sL -o shot.png … MSG` was blocked as a file
+  download. Nothing runs inside a heredoc body — the text was a commit message.
+- The redirect guard (#931) and the `tee` guard (#989) already run on
+  heredoc-stripped text; the download guard was simply never switched over and
+  still read the raw command. It now uses the same stripped form.
+- Found while writing the commit message for #1661, which quoted the guard's own
+  advice back at it. Any heredoc payload naming `curl -o`, `wget` or `dd of=`
+  was affected: commit messages, PR bodies, docs, fixtures.
+
 ### Fixed — a piped recursive grep ran for two minutes with no warning (#1662)
 
 - `grep -rn … --include=*.go . | head` produced its ten lines almost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,105 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Fixed — the redirect verdict depended on where the redirect sat (#1659)
+
+- `echo hi 1>/dev/null` was allowed; `echo hi 1>/dev/null; echo ok` was blocked
+  as a file write. Same redirect, same shell semantics, opposite verdicts — the
+  only difference was a following `;`.
+- The scanner read the redirect target up to the next **whitespace**, so a
+  trailing `;` became part of it. The target was `/dev/null;`, which is not
+  `/dev/null`, so the exemption never applied. `&&` happened to work only
+  because a space precedes it.
+- The target now ends at a shell metacharacter as well. The same bug silently
+  hit file-descriptor duplication: `cmd >&2; echo ok` was blocked too.
+- `>|` (noclobber override) and `>&` (fd duplication) are parsed as part of the
+  operator rather than as the first character of the target, and `(` is
+  deliberately **not** a terminator — it would reduce the process-substitution
+  target `>(tee out.txt)` to an empty word, which falls through unblocked. Both
+  are pinned by tests.
+
+### Fixed — a truncated response cut off the line naming the way back (#1660)
+
+- When a `ctx_shell` result exceeded the turn budget, it reported
+  `[… truncated at ~4062 of 4432 tokens — use ctx_read with lines= …]`. There
+  is no file: the bytes came from a subprocess. `ctx_read` needs a `path`, so
+  the suggested recovery could not be carried out at all.
+- The cause is mechanical. The archive reference — the one line that names the
+  stored copy and how to read it — is appended to the **end** of the response,
+  and truncation keeps a **prefix**. The recovery line was therefore always the
+  first thing discarded, and the response advertised a route it had just
+  removed.
+- The budget now reserves room for that line and re-attaches it after the cut,
+  and the notice points at it instead of naming a file tool that cannot accept
+  stream output. If the budget is too small for both, the recovery line wins:
+  it is what makes everything else retrievable.
+
+### Fixed — no in-tool way to download a binary (#1661)
+
+- `cd <scratchpad> && curl -sL -o shot.png <url>` was blocked, and both
+  suggested fallbacks were text-only: piping a PNG to stdout floods the context
+  with bytes, and `Write` takes a string. Fetching an attachment for triage had
+  no sanctioned route, which trained agents to fall back to native shell.
+- Downloads into a scratch directory were already permitted (#1021) — but only
+  when written as an absolute path. Judged as the bare string `shot.png`, a
+  target that lands squarely inside the sanctioned directory read as a project
+  write. Command segments are now paired with the directory they actually run
+  in, so a relative target is judged where it lands.
+- The #391 boundary is unchanged: a relative target outside a scratch directory,
+  or one behind a `cd "$VAR"` that cannot be resolved, is still a file write.
+  `wget` and `dd` keep no scratch carve-out at all — a separate, separately
+  tested decision this fix leaves alone.
+- The refusal now names a route that works for the payload at hand.
+
+### Fixed — a piped recursive grep ran for two minutes with no warning (#1662)
+
+- `grep -rn … --include=*.go . | head` produced its ten lines almost
+  immediately, then kept walking `node_modules` and `.git` for another two
+  minutes and auto-detached past the foreground cap. No redirect, no hint.
+- The hint added in #1655 was only ever emitted on **timeout** — the one thing a
+  command that already looked finished never reaches. It now runs for any
+  recursive walk, which is where it was needed: `head` closes early, the output
+  arrives at once, and nothing signals the walk is still going.
+- It also follows a leading `cd`: `cd repo && grep -r … .` walks a tree the
+  call's own `cwd` never named, and scanning the wrong directory found nothing,
+  which is indistinguishable from "this walk is fine". A `cd` that cannot be
+  resolved statically stays silent rather than naming directories from
+  somewhere else.
+
+### Fixed — grep output was sampled head+tail, dropping the line that mattered (#1663)
+
+- A recursive grep returned 236 matches; the compressor showed 14 and omitted
+  222. The single line proving a struct field was read sat at position 205,
+  inside the dropped middle. The reporter concluded the field was dead code and
+  only found out otherwise when the build failed.
+- Head+tail sampling assumes the interesting content is at the edges. For a
+  search result every line is a discrete answer and the decisive one is at an
+  arbitrary position — usually the *unusual* one. Sampling is biased against
+  exactly the line that matters, and `[222 lines omitted]` reads as "more of the
+  same" rather than "the answer may be in here".
+- Output with the `path:line:` shape is now never sampled. It is delivered as a
+  contiguous, ordered prefix with an unmissable notice naming the true match
+  count, so absence in the output can never be mistaken for absence in the
+  results. A `12:34:56` log timestamp is not a path and keeps the old sampler,
+  pinned by a test.
+
+### Fixed — a rerouted heredoc ignored the call's cwd (#1666)
+
+- `ctx_shell(cwd=<worktree>, command="python3 - <<EOF … EOF\necho $(pwd)")` ran
+  its two halves in two different directories: the shell remainder honoured
+  `cwd`, the interpreter rerouted to `ctx_execute` (#1403) inherited the server
+  process's directory. Both reported success.
+- A script doing `open("api/api.go")` then resolved against the project root
+  instead of the worktree, found no match, rewrote that file byte-identically,
+  and returned no error. With a replacement that *does* match, this is a silent
+  write to the wrong file.
+- The working directory is now resolved once, before the interpreter runs, and
+  both halves use it. A directory that cannot be entered is reported as itself:
+  falling back to the inherited one is the bug this exists to fix. Under
+  `sandbox_level >= 1` the directory is also granted read access in the seatbelt
+  and Landlock profiles, which otherwise deny by default; write permission is
+  deliberately not granted, since that boundary belongs to the sandbox level.
+
 ### Fixed — a single-line payload over budget delivered nothing (#1665)
 
 - `ctx_read` on a one-line file above the turn budget returned

--- a/rust/src/core/budget.rs
+++ b/rust/src/core/budget.rs
@@ -24,6 +24,44 @@ pub(crate) enum BudgetAction {
 /// an expand hint so the agent can retrieve the remainder.
 ///
 /// Returns `(possibly_truncated_text, action)`.
+/// Cap a finished response body at the configured per-turn fresh-token limit.
+///
+/// Applies uniformly to every tool, including raw shell output and explicit
+/// full reads; oversized archivable responses keep the `ctx_expand` handle
+/// their archive stage produced.
+///
+/// `verbatim` selects the larger budget (#1582): `raw=true` is what every
+/// compression annotation and the server instructions name as the way back to
+/// the original bytes, and holding it to the same 4096-token backstop as an
+/// unrequested response made that documented recovery path silently
+/// unreachable above ~16 KB.
+///
+/// `recovery` is the line naming where the full output is retrievable. It is
+/// already part of `text`; passing it separately is what lets the cut re-attach
+/// it instead of discarding it with the rest of the tail (#1660).
+pub(crate) fn enforce_turn_budget(text: &str, verbatim: bool, recovery: Option<&str>) -> String {
+    let cfg = crate::core::config::Config::load();
+    let limit = if verbatim {
+        cfg.turn_fresh_limit_verbatim_effective()
+    } else {
+        cfg.turn_fresh_limit_effective()
+    };
+    if limit == 0 {
+        return text.to_string();
+    }
+    let (budgeted, action) = apply_turn_budget(text, limit, recovery);
+    if let BudgetAction::Truncated {
+        original_tokens,
+        delivered_tokens,
+    } = action
+    {
+        tracing::debug!(
+            "budget: truncated {original_tokens} → {delivered_tokens} tokens (limit {limit})"
+        );
+    }
+    budgeted
+}
+
 /// `recovery`, when given, is a line that must survive the cut (GH #1660).
 ///
 /// Truncation keeps a prefix, and the line naming the way back to the full

--- a/rust/src/core/budget.rs
+++ b/rust/src/core/budget.rs
@@ -24,7 +24,20 @@ pub(crate) enum BudgetAction {
 /// an expand hint so the agent can retrieve the remainder.
 ///
 /// Returns `(possibly_truncated_text, action)`.
-pub(crate) fn apply_turn_budget(text: &str, fresh_limit: usize) -> (String, BudgetAction) {
+/// `recovery`, when given, is a line that must survive the cut (GH #1660).
+///
+/// Truncation keeps a prefix, and the line naming the way back to the full
+/// output — the archive handle — is appended at the very end of the response.
+/// So the one line the caller needed was always the first thing discarded, and
+/// a truncated shell result advertised a recovery route it had just removed.
+/// Passing that line here reserves room for it and re-attaches it after the
+/// cut, which is also what lets the notice name a route that exists: command
+/// output has no path, so `ctx_read(lines=)` was never reachable for it.
+pub(crate) fn apply_turn_budget(
+    text: &str,
+    fresh_limit: usize,
+    recovery: Option<&str>,
+) -> (String, BudgetAction) {
     if fresh_limit == 0 {
         return (text.to_string(), BudgetAction::PassThrough);
     }
@@ -34,25 +47,48 @@ pub(crate) fn apply_turn_budget(text: &str, fresh_limit: usize) -> (String, Budg
         return (text.to_string(), BudgetAction::PassThrough);
     }
 
+    let recovery = recovery.filter(|r| !r.trim().is_empty());
+    let footer = recovery
+        .map(|r| format!("\n{}", r.trim_end()))
+        .unwrap_or_default();
+    let footer_tokens = count_tokens(&footer);
+
     // Reserve the recovery hint before selecting content. A turn budget is a
     // hard delivery limit, so the hint itself must not push the response over
     // the configured cap.
-    let provisional_hint = truncation_hint(fresh_limit, token_count, text);
-    let first_content_limit = fresh_limit.saturating_sub(count_tokens(&provisional_hint));
+    let budget_for_body = fresh_limit.saturating_sub(footer_tokens);
+    let provisional_hint = truncation_hint(budget_for_body, token_count, text, recovery.is_some());
+    let first_content_limit = budget_for_body.saturating_sub(count_tokens(&provisional_hint));
     let first_truncated = truncate_to_token_budget(text, first_content_limit);
     let first_delivered_tokens = count_tokens(&first_truncated);
-    let hint = truncation_hint(first_delivered_tokens, token_count, text);
+    let hint = truncation_hint(
+        first_delivered_tokens,
+        token_count,
+        text,
+        recovery.is_some(),
+    );
 
-    let content_limit = fresh_limit.saturating_sub(count_tokens(&hint));
+    let content_limit = budget_for_body.saturating_sub(count_tokens(&hint));
     let truncated = truncate_to_token_budget(text, content_limit);
     let delivered_tokens = count_tokens(&truncated);
-    let hint = truncation_hint(delivered_tokens, token_count, text);
+    let hint = truncation_hint(delivered_tokens, token_count, text, recovery.is_some());
 
-    let result = format!("{truncated}{hint}");
+    let result = format!("{truncated}{hint}{footer}");
     let result = if count_tokens(&result) <= fresh_limit {
         result
     } else {
-        truncate_to_token_budget(&hint, fresh_limit)
+        // Body plus notice already exceed the cap on their own. The recovery
+        // line is what makes the rest retrievable, so it is the last thing to
+        // go, not the first — ahead of the notice that merely describes the
+        // cut, and ahead of the body it points back to.
+        let notice_and_footer = format!("{hint}{footer}");
+        if count_tokens(&notice_and_footer) <= fresh_limit {
+            notice_and_footer
+        } else if !footer.is_empty() && count_tokens(&footer) <= fresh_limit {
+            footer.clone()
+        } else {
+            truncate_to_token_budget(&notice_and_footer, fresh_limit)
+        }
     };
 
     (
@@ -69,8 +105,18 @@ pub(crate) fn apply_turn_budget(text: &str, fresh_limit: usize) -> (String, Budg
 /// `lines=` can only narrow something that has lines. On a single-line payload
 /// it is a dead end (GH #1665), so that case names `mode="raw"`, which the
 /// reporter confirmed returns the full content.
-fn truncation_hint(delivered_tokens: usize, token_count: usize, source: &str) -> String {
-    let recovery = if source.lines().nth(1).is_some() {
+fn truncation_hint(
+    delivered_tokens: usize,
+    token_count: usize,
+    source: &str,
+    has_recovery_line: bool,
+) -> String {
+    let recovery = if has_recovery_line {
+        // The line that follows names the archived copy and how to read it.
+        // Naming a file-oriented tool here instead would be wrong twice over:
+        // command output has no path, and the real route is right below.
+        "the full output is archived — see the next line"
+    } else if source.lines().nth(1).is_some() {
         "use ctx_read with lines= parameter to see specific sections"
     } else {
         "single line — lines= cannot narrow it; use ctx_read(mode=\"raw\") for the full content"
@@ -139,7 +185,7 @@ mod tests {
     #[test]
     fn passthrough_when_within_budget() {
         let text = "small content";
-        let (result, action) = apply_turn_budget(text, 1000);
+        let (result, action) = apply_turn_budget(text, 1000, None);
         assert_eq!(result, text);
         assert_eq!(action, BudgetAction::PassThrough);
     }
@@ -147,7 +193,7 @@ mod tests {
     #[test]
     fn passthrough_when_budget_is_zero() {
         let text = "any content at all";
-        let (result, action) = apply_turn_budget(text, 0);
+        let (result, action) = apply_turn_budget(text, 0, None);
         assert_eq!(result, text);
         assert_eq!(action, BudgetAction::PassThrough);
     }
@@ -160,7 +206,7 @@ mod tests {
             .join("\n");
         let limit = 256;
 
-        let (result, action) = apply_turn_budget(&text, limit);
+        let (result, action) = apply_turn_budget(&text, limit, None);
 
         assert!(matches!(action, BudgetAction::Truncated { .. }));
         assert!(count_tokens(&result) <= limit);
@@ -173,7 +219,7 @@ mod tests {
             .map(|i| format!("fn function_{i}() {{ let x = {i}; }}"))
             .collect();
         let text = lines.join("\n");
-        let (result, action) = apply_turn_budget(&text, 100);
+        let (result, action) = apply_turn_budget(&text, 100, None);
 
         assert!(result.contains("[… truncated"));
         assert!(result.contains("use ctx_read with lines="));
@@ -195,7 +241,7 @@ mod tests {
     #[test]
     fn truncation_preserves_complete_lines() {
         let text = "line one\nline two\nline three\nline four\nline five";
-        let (result, _) = apply_turn_budget(text, 5);
+        let (result, _) = apply_turn_budget(text, 5, None);
         let body = result.split("\n[… truncated").next().unwrap();
         assert!(
             !body.ends_with(char::is_whitespace),
@@ -225,7 +271,7 @@ mod gh1665 {
         let text = one_line(20_000);
         assert_eq!(text.lines().count(), 1, "precondition: one line");
 
-        let (out, action) = apply_turn_budget(&text, 500);
+        let (out, action) = apply_turn_budget(&text, 500, None);
         assert!(
             matches!(action, BudgetAction::Truncated { .. }),
             "precondition: over budget"
@@ -257,14 +303,14 @@ mod gh1665 {
     /// caller there.
     #[test]
     fn the_hint_names_a_recovery_that_exists() {
-        let (single, _) = apply_turn_budget(&one_line(20_000), 500);
+        let (single, _) = apply_turn_budget(&one_line(20_000), 500, None);
         assert!(single.contains("mode=\"raw\""), "{single:?}");
 
         let multi = (0..4000)
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
             .join("\n");
-        let (multi_out, _) = apply_turn_budget(&multi, 500);
+        let (multi_out, _) = apply_turn_budget(&multi, 500, None);
         assert!(multi_out.contains("lines="), "multi-line keeps lines=");
     }
 
@@ -276,8 +322,94 @@ mod gh1665 {
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
             .join("\n");
-        let (out, _) = apply_turn_budget(&text, 500);
+        let (out, _) = apply_turn_budget(&text, 500, None);
         let body = out.split("\n[…").next().unwrap();
         assert!(body.ends_with(|c: char| c.is_ascii_digit()), "{body:?}");
+    }
+}
+
+#[cfg(test)]
+mod gh1660 {
+    use super::*;
+
+    fn long_body() -> String {
+        (0..4_000)
+            .map(|i| format!("line {i} of shell output"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    const RECOVERY: &str =
+        "[Archived: 51200 chars (12800 tok). ctx_expand(\"c3ef0ac76145035d\") or read /tmp/a.txt]";
+
+    /// The reported failure: the archive handle is appended to the end of the
+    /// body, truncation keeps a prefix, so the response announced a recovery it
+    /// had just cut off.
+    #[test]
+    fn the_recovery_line_survives_the_cut() {
+        let text = format!("{}\n{RECOVERY}", long_body());
+        let (out, action) = apply_turn_budget(&text, 500, Some(RECOVERY));
+
+        assert!(
+            matches!(action, BudgetAction::Truncated { .. }),
+            "precondition: over budget"
+        );
+
+        // The bug, still reachable: with the handle merely appended to the body
+        // and nothing told to preserve it, the prefix-keeping cut removes it.
+        let (unaware, _) = apply_turn_budget(&text, 500, None);
+        assert!(
+            !unaware.contains("c3ef0ac76145035d"),
+            "precondition: this is what the reporter saw"
+        );
+
+        assert!(
+            out.contains("c3ef0ac76145035d"),
+            "the archive handle must survive truncation: {out}"
+        );
+        assert!(
+            out.trim_end().ends_with(RECOVERY.trim_end()),
+            "and stay the last line: {out}"
+        );
+        assert!(
+            count_tokens(&out) <= 500,
+            "the budget is still a hard cap: {} tokens",
+            count_tokens(&out)
+        );
+    }
+
+    /// Command output has no path, so naming `ctx_read(lines=)` sent the caller
+    /// to a tool call that cannot accept the content.
+    #[test]
+    fn the_notice_does_not_name_a_route_that_cannot_work() {
+        let text = format!("{}\n{RECOVERY}", long_body());
+        let (out, _) = apply_turn_budget(&text, 500, Some(RECOVERY));
+
+        assert!(
+            !out.contains("ctx_read with lines="),
+            "must not point at a file tool for stream output: {out}"
+        );
+        assert!(out.contains("archived"), "{out}");
+    }
+
+    /// When there is nothing to preserve, behaviour is unchanged — the file
+    /// tools stay the right answer for a truncated file read.
+    #[test]
+    fn without_a_recovery_line_the_file_hint_stays() {
+        let (out, _) = apply_turn_budget(&long_body(), 500, None);
+        assert!(out.contains("ctx_read with lines="), "{out}");
+    }
+
+    /// Even when body plus notice alone blow the cap, the recovery line is the
+    /// last thing dropped — it is what makes everything else retrievable.
+    #[test]
+    fn a_tiny_budget_spends_itself_on_the_way_back() {
+        let text = format!("{}\n{RECOVERY}", long_body());
+        let (out, _) = apply_turn_budget(&text, 40, Some(RECOVERY));
+        assert!(
+            out.contains("c3ef0ac76145035d"),
+            "handle must outlive the body: {out}"
+        );
+        assert!(count_tokens(&out) <= 40, "{} tokens", count_tokens(&out));
     }
 }

--- a/rust/src/core/command_cwd.rs
+++ b/rust/src/core/command_cwd.rs
@@ -1,0 +1,165 @@
+//! Which directory a command's segments actually run in (GH #1661, #1662).
+//!
+//! A tool call carries one `cwd`, but the command it runs may move: `cd repo &&
+//! grep -rn … .` walks a tree the call never named, and `cd "$SCRATCH" && curl
+//! -o shot.png …` writes to a directory that is sanctioned for exactly that.
+//! Judging either against the call's `cwd` alone gets the answer wrong — too
+//! lenient in the first case, too strict in the second.
+//!
+//! Only a plain leading `cd <literal>` is followed. Anything the shell would
+//! have to evaluate — a variable, a substitution, `pushd`, a subshell — leaves
+//! the directory unknown, and an unknown directory is reported as such rather
+//! than guessed at.
+
+use std::path::{Path, PathBuf};
+
+/// One command segment together with the directory it runs in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentCwd {
+    pub segment: String,
+    /// `None` once a `cd` has moved somewhere this cannot resolve statically.
+    pub cwd: Option<PathBuf>,
+}
+
+/// Split `command` into segments, tracking `cd` as it goes.
+///
+/// Segmentation is delegated to the shell tokenizer so this never disagrees
+/// with the allowlist about where one command ends and the next begins.
+pub fn segments_with_cwd(command: &str, base: Option<&Path>) -> Vec<SegmentCwd> {
+    let mut cwd: Option<PathBuf> = base.map(Path::to_path_buf);
+    let mut out = Vec::new();
+
+    for segment in super::shell_allowlist::extract_all_commands_pub(command) {
+        if let Some(target) = cd_target(&segment) {
+            cwd = resolve_cd(cwd.as_deref(), target);
+            // The `cd` itself runs in the directory it is leaving; recording it
+            // with the new one would misattribute a `cd` that fails.
+            out.push(SegmentCwd {
+                segment,
+                cwd: cwd.clone(),
+            });
+            continue;
+        }
+        out.push(SegmentCwd {
+            segment,
+            cwd: cwd.clone(),
+        });
+    }
+    out
+}
+
+/// The directory in effect once every segment has run.
+pub fn final_cwd(command: &str, base: Option<&Path>) -> Option<PathBuf> {
+    segments_with_cwd(command, base)
+        .last()
+        .and_then(|s| s.cwd.clone())
+}
+
+/// The literal argument of a segment that is exactly `cd <path>`.
+fn cd_target(segment: &str) -> Option<&str> {
+    let mut words = segment.split_whitespace();
+    if words.next()? != "cd" {
+        return None;
+    }
+    let target = words.next()?;
+    if words.next().is_some() {
+        // `cd a b` is not something to reason about.
+        return None;
+    }
+    Some(target)
+}
+
+/// Apply one `cd`, or give up on knowing the directory.
+///
+/// `cd` with no resolvable target is not "stay here": it moves somewhere this
+/// cannot see. Returning `None` keeps callers from judging a later segment
+/// against a directory it does not run in.
+fn resolve_cd(from: Option<&Path>, target: &str) -> Option<PathBuf> {
+    let unquoted = target.trim_matches(['"', '\'']);
+    if unquoted.is_empty() || unquoted.contains('$') || unquoted.contains('`') || unquoted == "-" {
+        return None;
+    }
+    let path = Path::new(unquoted);
+    if path.is_absolute() {
+        return Some(normalize(path));
+    }
+    // `cd ~` and `cd ~/x` are the shell's expansion, not a relative path.
+    if let Some(rest) = unquoted.strip_prefix('~') {
+        let home = std::env::var_os("HOME").map(PathBuf::from)?;
+        let rest = rest.trim_start_matches('/');
+        return Some(normalize(&home.join(rest)));
+    }
+    Some(normalize(&from?.join(path)))
+}
+
+/// Resolve `.` and `..` textually. The directory may not exist yet, so this
+/// deliberately does not touch the filesystem.
+fn normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_leading_cd_moves_the_following_segments() {
+        let segs = segments_with_cwd(
+            "cd /tmp/work && curl -o x.png http://e/x",
+            Some(Path::new("/proj")),
+        );
+        assert_eq!(
+            segs.last().unwrap().cwd.as_deref(),
+            Some(Path::new("/tmp/work"))
+        );
+    }
+
+    #[test]
+    fn without_a_cd_every_segment_keeps_the_call_directory() {
+        let segs = segments_with_cwd("echo a && echo b", Some(Path::new("/proj")));
+        assert!(
+            segs.iter()
+                .all(|s| s.cwd.as_deref() == Some(Path::new("/proj")))
+        );
+    }
+
+    #[test]
+    fn a_relative_cd_is_joined_onto_the_call_directory() {
+        assert_eq!(
+            final_cwd("cd sub/dir && ls", Some(Path::new("/proj"))),
+            Some(PathBuf::from("/proj/sub/dir"))
+        );
+        assert_eq!(
+            final_cwd("cd ../side && ls", Some(Path::new("/proj/here"))),
+            Some(PathBuf::from("/proj/side"))
+        );
+    }
+
+    /// A directory the shell would have to compute is unknown, not the old one
+    /// — judging a later segment against a stale directory is how a guard ends
+    /// up permitting or blocking the wrong thing.
+    #[test]
+    fn an_unresolvable_cd_makes_the_directory_unknown() {
+        assert_eq!(
+            final_cwd("cd \"$TMPDIR\" && ls", Some(Path::new("/proj"))),
+            None
+        );
+        assert_eq!(final_cwd("cd - && ls", Some(Path::new("/proj"))), None);
+    }
+
+    #[test]
+    fn no_base_and_no_cd_is_unknown() {
+        assert_eq!(final_cwd("ls -la", None), None);
+    }
+}

--- a/rust/src/core/command_cwd.rs
+++ b/rust/src/core/command_cwd.rs
@@ -79,17 +79,55 @@ fn resolve_cd(from: Option<&Path>, target: &str) -> Option<PathBuf> {
     if unquoted.is_empty() || unquoted.contains('$') || unquoted.contains('`') || unquoted == "-" {
         return None;
     }
+    // `cd ~` and `cd ~/x` are the shell's expansion, not a relative path.
+    if let Some(rest) = unquoted.strip_prefix('~') {
+        let home = std::env::var_os("HOME").map(PathBuf::from)?;
+        return Some(join_in(&home, rest.trim_start_matches('/')));
+    }
+    // This is shell text, so `/tmp` is an absolute POSIX path even on Windows,
+    // where `Path::is_absolute` says otherwise. Agents write Unix paths there
+    // routinely (Git Bash, WSL, generated commands) — the same reason
+    // `is_unix_scratch_prefix` exists (#1467). Treating them as relative made a
+    // `cd /tmp` resolve to nothing on Windows, and the guard then judged the
+    // download target against no directory at all.
+    if unquoted.starts_with('/') {
+        return Some(PathBuf::from(normalize_posix(unquoted)));
+    }
     let path = Path::new(unquoted);
     if path.is_absolute() {
         return Some(normalize(path));
     }
-    // `cd ~` and `cd ~/x` are the shell's expansion, not a relative path.
-    if let Some(rest) = unquoted.strip_prefix('~') {
-        let home = std::env::var_os("HOME").map(PathBuf::from)?;
-        let rest = rest.trim_start_matches('/');
-        return Some(normalize(&home.join(rest)));
+    Some(join_in(from?, unquoted))
+}
+
+/// Join `rel` under `base`, keeping a POSIX-rooted base POSIX.
+///
+/// `Path::join` would splice a backslash into `/tmp` on Windows, and the
+/// scratch-prefix checks match on `/tmp/`.
+pub fn join_in(base: &Path, rel: &str) -> PathBuf {
+    let base_str = base.to_string_lossy();
+    if base_str.starts_with('/') {
+        return PathBuf::from(normalize_posix(&format!(
+            "{}/{rel}",
+            base_str.trim_end_matches('/')
+        )));
     }
-    Some(normalize(&from?.join(path)))
+    normalize(&base.join(rel))
+}
+
+/// Resolve `.` and `..` in a POSIX path textually, on any platform.
+fn normalize_posix(path: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    format!("/{}", out.join("/"))
 }
 
 /// Resolve `.` and `..` textually. The directory may not exist yet, so this
@@ -156,6 +194,26 @@ mod tests {
             None
         );
         assert_eq!(final_cwd("cd - && ls", Some(Path::new("/proj"))), None);
+    }
+
+    /// A Unix path in shell text stays a Unix path on Windows too (#1467).
+    /// This is the case that broke CI: `cd /tmp` resolved to nothing there, so
+    /// the download guard judged `shot.png` against no directory at all.
+    #[test]
+    fn a_unix_path_in_shell_text_is_absolute_on_every_platform() {
+        assert_eq!(
+            final_cwd("cd /tmp && curl -o shot.png https://e/x", None),
+            Some(PathBuf::from("/tmp"))
+        );
+        assert_eq!(
+            final_cwd("cd /private/tmp/session/../session && ls", None),
+            Some(PathBuf::from("/private/tmp/session"))
+        );
+        assert_eq!(
+            join_in(Path::new("/tmp/work"), "sub/shot.png"),
+            PathBuf::from("/tmp/work/sub/shot.png"),
+            "and joins with a forward slash, which the scratch prefixes match on"
+        );
     }
 
     #[test]

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -12,6 +12,7 @@ pub mod codebook;
 #[cfg(target_os = "macos")]
 pub(crate) mod codesign;
 pub mod cognitive;
+pub mod command_cwd;
 pub(crate) mod compress_preview;
 pub(crate) mod compression_safety;
 pub mod compressor;

--- a/rust/src/core/sandbox.rs
+++ b/rust/src/core/sandbox.rs
@@ -19,6 +19,22 @@ const MAX_OUTPUT_BYTES: usize = 32_768;
 const MAX_CODE_BYTES: usize = 256 * 1024;
 
 pub fn execute(language: &str, code: &str, timeout_secs: Option<u64>) -> SandboxResult {
+    execute_in(language, code, timeout_secs, None)
+}
+
+/// Same as [`execute`], but runs the snippet in `cwd` (GH #1666).
+///
+/// A caller that already resolved a working directory — `ctx_shell` rerouting
+/// an interpreter heredoc, for one — must be able to hand it over. Without
+/// this, the snippet inherited the server process's directory while the rest
+/// of the same tool call ran in `cwd`, so relative paths in the snippet
+/// resolved against a different tree and quietly hit the wrong files.
+pub fn execute_in(
+    language: &str,
+    code: &str,
+    timeout_secs: Option<u64>,
+    cwd: Option<&std::path::Path>,
+) -> SandboxResult {
     if code.len() > MAX_CODE_BYTES {
         return SandboxResult {
             stdout: String::new(),
@@ -53,7 +69,7 @@ pub fn execute(language: &str, code: &str, timeout_secs: Option<u64>) -> Sandbox
         .unwrap_or_else(|| crate::core::config::Config::load().sandbox_level);
 
     if sandbox_level >= 1 && cfg!(target_os = "macos") {
-        let result = seatbelt_execute(&runtime, code, timeout);
+        let result = seatbelt_execute(&runtime, code, timeout, cwd);
         let duration_ms = start.elapsed().as_millis() as u64;
         return match result {
             Ok((stdout, stderr, exit_code)) => SandboxResult {
@@ -74,7 +90,7 @@ pub fn execute(language: &str, code: &str, timeout_secs: Option<u64>) -> Sandbox
     } else if sandbox_level >= 1 {
         #[cfg(target_os = "linux")]
         {
-            let result = landlock_execute(&runtime, code, timeout);
+            let result = landlock_execute(&runtime, code, timeout, cwd);
             let duration_ms = start.elapsed().as_millis() as u64;
             return match result {
                 Ok((stdout, stderr, exit_code)) => SandboxResult {
@@ -101,9 +117,9 @@ pub fn execute(language: &str, code: &str, timeout_secs: Option<u64>) -> Sandbox
     }
 
     let result = if runtime.needs_temp_file {
-        execute_with_file(&runtime, code, timeout)
+        execute_with_file(&runtime, code, timeout, cwd)
     } else {
-        execute_with_stdin(&runtime, code, timeout)
+        execute_with_stdin(&runtime, code, timeout, cwd)
     };
 
     let duration_ms = start.elapsed().as_millis() as u64;
@@ -250,6 +266,7 @@ fn seatbelt_execute(
     runtime: &RuntimeConfig,
     code: &str,
     timeout: u64,
+    cwd: Option<&std::path::Path>,
 ) -> Result<(String, String, i32), String> {
     let tmp_dir = std::env::temp_dir().join("lean-ctx-sandbox");
     let _ = std::fs::create_dir_all(&tmp_dir);
@@ -270,7 +287,14 @@ fn seatbelt_execute(
         let file_path = tmp.into_temp_path();
         std::fs::write(&file_path, code).map_err(|e| format!("Failed to write temp file: {e}"))?;
 
-        let allowed = [file_path.to_path_buf()];
+        let mut allowed = vec![file_path.to_path_buf()];
+        // The profile denies by default, so a working directory the caller
+        // chose has to be granted explicitly — otherwise the snippet starts
+        // there and cannot read a thing (#1666). Write permission is
+        // deliberately not granted: that boundary belongs to sandbox_level.
+        if let Some(dir) = cwd {
+            allowed.push(dir.to_path_buf());
+        }
         let allowed_refs: Vec<&std::path::Path> =
             allowed.iter().map(std::path::PathBuf::as_path).collect();
         let file_str = file_path.to_string_lossy().to_string();
@@ -288,6 +312,7 @@ fn seatbelt_execute(
             &allowed_refs,
             &env_pairs,
             timeout,
+            cwd,
         );
         let _ = std::fs::remove_file(&file_path);
         result
@@ -298,12 +323,17 @@ fn seatbelt_execute(
             .map(std::string::String::as_str)
             .collect();
         args.push(code);
+        let allowed: Vec<std::path::PathBuf> =
+            cwd.map(|d| vec![d.to_path_buf()]).unwrap_or_default();
+        let allowed_refs: Vec<&std::path::Path> =
+            allowed.iter().map(std::path::PathBuf::as_path).collect();
         super::sandbox_seatbelt::execute_sandboxed(
             &runtime.command,
             &args,
-            &[],
+            &allowed_refs,
             &env_pairs,
             timeout,
+            cwd,
         )
     }
 }
@@ -313,6 +343,7 @@ fn landlock_execute(
     runtime: &RuntimeConfig,
     code: &str,
     timeout: u64,
+    cwd: Option<&std::path::Path>,
 ) -> Result<(String, String, i32), String> {
     let tmp_dir = std::env::temp_dir().join("lean-ctx-sandbox");
     let _ = std::fs::create_dir_all(&tmp_dir);
@@ -333,7 +364,10 @@ fn landlock_execute(
         let file_path = tmp.into_temp_path();
         std::fs::write(&file_path, code).map_err(|e| format!("Failed to write temp file: {e}"))?;
 
-        let allowed = [file_path.to_path_buf()];
+        let mut allowed = vec![file_path.to_path_buf()];
+        if let Some(dir) = cwd {
+            allowed.push(dir.to_path_buf());
+        }
         let allowed_refs: Vec<&std::path::Path> =
             allowed.iter().map(std::path::PathBuf::as_path).collect();
         let file_str = file_path.to_string_lossy().to_string();
@@ -351,6 +385,7 @@ fn landlock_execute(
             &allowed_refs,
             &env_pairs,
             timeout,
+            cwd,
         );
         let _ = std::fs::remove_file(&file_path);
         result
@@ -361,12 +396,17 @@ fn landlock_execute(
             .map(std::string::String::as_str)
             .collect();
         args.push(code);
+        let allowed: Vec<std::path::PathBuf> =
+            cwd.map(|d| vec![d.to_path_buf()]).unwrap_or_default();
+        let allowed_refs: Vec<&std::path::Path> =
+            allowed.iter().map(std::path::PathBuf::as_path).collect();
         super::sandbox_landlock::execute_sandboxed(
             &runtime.command,
             &args,
-            &[],
+            &allowed_refs,
             &env_pairs,
             timeout,
+            cwd,
         )
     }
 }
@@ -398,12 +438,33 @@ fn apply_sandbox_env(cmd: &mut Command, runtime: &RuntimeConfig) {
     cmd.env("LEAN_CTX_SANDBOX", "1");
 }
 
+/// Run the child in `cwd` when the caller resolved one (GH #1666).
+///
+/// A directory that no longer exists would make `spawn` fail with a message
+/// about the *command*, which reads as a missing interpreter. Falling back to
+/// the inherited directory is not an option either — running somewhere other
+/// than the caller asked, without saying so, is the bug this exists to fix —
+/// so an unusable directory is reported as itself.
+fn apply_cwd(cmd: &mut Command, cwd: Option<&std::path::Path>) -> Result<(), String> {
+    let Some(dir) = cwd else { return Ok(()) };
+    if !dir.is_dir() {
+        return Err(format!(
+            "working directory does not exist: {}",
+            dir.display()
+        ));
+    }
+    cmd.current_dir(dir);
+    Ok(())
+}
+
 fn execute_with_stdin(
     runtime: &RuntimeConfig,
     code: &str,
     timeout: u64,
+    cwd: Option<&std::path::Path>,
 ) -> Result<(String, String, i32), String> {
     let mut cmd = Command::new(&runtime.command);
+    apply_cwd(&mut cmd, cwd)?;
     for arg in &runtime.args {
         cmd.arg(arg);
     }
@@ -434,6 +495,7 @@ fn execute_with_file(
     runtime: &RuntimeConfig,
     code: &str,
     timeout: u64,
+    cwd: Option<&std::path::Path>,
 ) -> Result<(String, String, i32), String> {
     let tmp_dir = std::env::temp_dir().join("lean-ctx-sandbox");
     let _ = std::fs::create_dir_all(&tmp_dir);
@@ -449,9 +511,10 @@ fn execute_with_file(
     std::fs::write(&file_path, code).map_err(|e| format!("Failed to write temp file: {e}"))?;
 
     let result = if runtime.command == "rustc_script" {
-        execute_rust(&file_path, timeout)
+        execute_rust(&file_path, timeout, cwd)
     } else {
         let mut cmd = Command::new(&runtime.command);
+        apply_cwd(&mut cmd, cwd)?;
         for arg in &runtime.args {
             cmd.arg(arg);
         }
@@ -481,6 +544,7 @@ fn execute_with_file(
 fn execute_rust(
     source_path: &std::path::Path,
     timeout: u64,
+    cwd: Option<&std::path::Path>,
 ) -> Result<(String, String, i32), String> {
     let binary_path = source_path.with_extension("");
 
@@ -505,6 +569,7 @@ fn execute_rust(
     }
 
     let mut run_cmd = Command::new(&binary_path);
+    apply_cwd(&mut run_cmd, cwd)?;
     run_cmd.env_clear();
     for key in SANDBOX_ENV_ALLOWLIST {
         if let Ok(val) = std::env::var(key) {
@@ -683,6 +748,45 @@ pub mod tests {
         let result = execute("python", "print('hello sandbox')", None);
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.contains("hello sandbox"));
+    }
+
+    /// GH #1666: a snippet must run where the caller said, because relative
+    /// paths inside it are resolved there. The `cwd: None` half of this test is
+    /// the pre-fix behaviour — it is what made a script edit the project root
+    /// while the caller was working in a worktree, and report success.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn execute_in_resolves_relative_paths_against_the_given_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("only-here.txt"), "x").expect("write marker");
+
+        let scoped = execute_in("shell", "cat only-here.txt", None, Some(dir.path()));
+        assert_eq!(scoped.exit_code, 0, "stderr: {}", scoped.stderr);
+        assert!(scoped.stdout.contains('x'), "{scoped:?}");
+
+        // Without a cwd the same relative path resolves somewhere else, which
+        // is exactly what the reported bug did silently.
+        let unscoped = execute_in("shell", "cat only-here.txt", None, None);
+        assert_ne!(
+            unscoped.exit_code, 0,
+            "precondition: the marker is only reachable from the given directory"
+        );
+    }
+
+    /// A directory that cannot be entered is reported as itself. Falling back
+    /// to the inherited directory would reinstate the silent wrong-tree run.
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn execute_in_reports_a_missing_directory_instead_of_falling_back() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+
+        let result = execute_in("shell", "pwd", None, Some(&missing));
+        assert_ne!(result.exit_code, 0, "{result:?}");
+        assert!(
+            result.stderr.contains("working directory does not exist"),
+            "{result:?}"
+        );
     }
 
     #[test]

--- a/rust/src/core/sandbox_landlock.rs
+++ b/rust/src/core/sandbox_landlock.rs
@@ -251,9 +251,10 @@ pub(crate) fn execute_sandboxed(
     allowed_read_paths: &[&Path],
     env: &[(String, String)],
     timeout_secs: u64,
+    cwd: Option<&Path>,
 ) -> Result<(String, String, i32), String> {
     let ruleset = LandlockRuleset::new(allowed_read_paths, interpreter);
-    execute_with_landlock(&ruleset, interpreter, args, env, timeout_secs)
+    execute_with_landlock(&ruleset, interpreter, args, env, timeout_secs, cwd)
 }
 
 #[cfg(target_os = "linux")]
@@ -263,11 +264,22 @@ fn execute_with_landlock(
     args: &[&str],
     env: &[(String, String)],
     timeout_secs: u64,
+    cwd: Option<&Path>,
 ) -> Result<(String, String, i32), String> {
     use std::os::unix::process::CommandExt;
 
     let mut cmd = Command::new(interpreter);
     cmd.args(args);
+    // #1666: run where the caller asked, not where the server happens to sit.
+    if let Some(dir) = cwd {
+        if !dir.is_dir() {
+            return Err(format!(
+                "working directory does not exist: {}",
+                dir.display()
+            ));
+        }
+        cmd.current_dir(dir);
+    }
 
     cmd.env_clear();
     cmd.env("PATH", "/usr/bin:/bin:/usr/local/bin");
@@ -327,6 +339,7 @@ fn execute_with_landlock(
     _args: &[&str],
     _env: &[(String, String)],
     _timeout_secs: u64,
+    _cwd: Option<&Path>,
 ) -> Result<(String, String, i32), String> {
     unreachable!("sandbox_landlock module should only be called on Linux")
 }
@@ -412,7 +425,7 @@ mod tests {
     #[test]
     #[ignore = "requires Linux 5.13+ with Landlock; run manually"]
     fn landlock_exec_echo() {
-        let result = execute_sandboxed("/bin/echo", &["hello"], &[], &[], 5);
+        let result = execute_sandboxed("/bin/echo", &["hello"], &[], &[], 5, None);
         assert!(result.is_ok());
         let (stdout, _, code) = result.unwrap();
         assert_eq!(code, 0);
@@ -423,7 +436,7 @@ mod tests {
     #[test]
     #[ignore = "requires Linux 5.13+ with Landlock; run manually"]
     fn landlock_denies_read_outside_allowed() {
-        let result = execute_sandboxed("/bin/cat", &["/root/.bashrc"], &[], &[], 5);
+        let result = execute_sandboxed("/bin/cat", &["/root/.bashrc"], &[], &[], 5, None);
         if let Ok((_, _, code)) = result {
             assert_ne!(code, 0, "cat should fail reading outside allowed paths");
         }

--- a/rust/src/core/sandbox_seatbelt.rs
+++ b/rust/src/core/sandbox_seatbelt.rs
@@ -56,11 +56,23 @@ pub(crate) fn execute_sandboxed(
     allowed_read_paths: &[&Path],
     env: &[(String, String)],
     timeout_secs: u64,
+    cwd: Option<&Path>,
 ) -> Result<(String, String, i32), String> {
     let profile = seatbelt_profile(allowed_read_paths, interpreter);
     let profile_path = wrap_with_seatbelt(&profile)?;
 
     let mut cmd = Command::new("sandbox-exec");
+    // #1666: the caller's working directory, when it named one. The profile
+    // above already grants read access to it.
+    if let Some(dir) = cwd {
+        if !dir.is_dir() {
+            return Err(format!(
+                "working directory does not exist: {}",
+                dir.display()
+            ));
+        }
+        cmd.current_dir(dir);
+    }
     cmd.args(["-f", &profile_path.to_string_lossy()]);
     cmd.arg(interpreter);
     cmd.args(args);
@@ -169,7 +181,7 @@ mod tests {
     #[test]
     #[ignore = "sandbox-exec behavior varies by macOS version; run manually"]
     fn seatbelt_exec_echo() {
-        let result = execute_sandboxed("/bin/echo", &["hello"], &[], &[], 5);
+        let result = execute_sandboxed("/bin/echo", &["hello"], &[], &[], 5, None);
         assert!(result.is_ok());
         let (stdout, _, code) = result.unwrap();
         assert_eq!(code, 0);
@@ -185,6 +197,7 @@ mod tests {
             &[],
             &[],
             5,
+            None,
         );
         if let Ok((_, stderr, code)) = result {
             assert_ne!(code, 0, "curl should fail under sandbox: {stderr}");

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -1121,42 +1121,14 @@ pub(in crate::server) async fn dispatch_and_post_process(
         result_text = pre_compression;
     }
 
-    // Turn-level budget enforcement (#1306): cap fresh tokens per response.
-    // This applies uniformly to every tool, including raw shell output and
-    // explicit full reads. Oversized archivable responses retain their
-    // ctx_expand handle from the archive stage above.
-    //
-    // #1582: a read the caller explicitly asked to be verbatim gets the larger
-    // verbatim budget. `raw=true` is what every compression annotation and the
-    // server instructions name as the way back to the original bytes; holding
-    // it to the same 4096-token backstop as an unrequested response made that
-    // documented recovery path silently unreachable above ~16 KB.
-    let cfg = crate::core::config::Config::load();
-    let budget_limit = if verbatim_requested(name, args) {
-        cfg.turn_fresh_limit_verbatim_effective()
-    } else {
-        cfg.turn_fresh_limit_effective()
-    };
-    if budget_limit > 0 {
-        // The recovery line is already part of `result_text`; handing it over
-        // separately lets the budget re-attach it after the cut instead of
-        // discarding it with the rest of the tail.
-        let (budgeted, action) = crate::core::budget::apply_turn_budget(
-            &result_text,
-            budget_limit,
-            recovery_line.as_deref(),
-        );
-        if let crate::core::budget::BudgetAction::Truncated {
-            original_tokens,
-            delivered_tokens,
-        } = action
-        {
-            tracing::debug!(
-                "budget: truncated {original_tokens} → {delivered_tokens} tokens (limit {budget_limit})"
-            );
-        }
-        result_text = budgeted;
-    }
+    // Turn-level budget enforcement (#1306), including the limit choice and the
+    // recovery line that has to survive the cut. It lives in `core::budget`
+    // because it is budget policy, not pipeline sequencing.
+    result_text = crate::core::budget::enforce_turn_budget(
+        &result_text,
+        verbatim_requested(name, args),
+        recovery_line.as_deref(),
+    );
 
     let compressed_input_tokens = crate::core::tokens::count_tokens(&result_text) as u64;
     let raw_input_tokens = compressed_input_tokens

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -534,12 +534,18 @@ pub(in crate::server) async fn dispatch_and_post_process(
 
     // Raw output stays byte-pure: the body is archived (ctx_expand works),
     // but the hint decoration is only appended to non-raw deliveries.
+    // #1660: remembered, not just appended. Truncation below keeps a prefix,
+    // so a hint pinned to the end of the body was the first thing cut — the
+    // response then said it was truncated while the line naming the archived
+    // copy had already been removed.
+    let mut recovery_line: Option<String> = None;
     if !is_raw_shell
         && !firewalled
         && profile_hints.archive_hint()
         && let Some(hint) = archive_hint
     {
         result_text = format!("{result_text}\n{hint}");
+        recovery_line = Some(hint);
     }
 
     let had_auto_context = auto_context.is_some();
@@ -1132,7 +1138,14 @@ pub(in crate::server) async fn dispatch_and_post_process(
         cfg.turn_fresh_limit_effective()
     };
     if budget_limit > 0 {
-        let (budgeted, action) = crate::core::budget::apply_turn_budget(&result_text, budget_limit);
+        // The recovery line is already part of `result_text`; handing it over
+        // separately lets the budget re-attach it after the cut instead of
+        // discarding it with the rest of the tail.
+        let (budgeted, action) = crate::core::budget::apply_turn_budget(
+            &result_text,
+            budget_limit,
+            recovery_line.as_deref(),
+        );
         if let crate::core::budget::BudgetAction::Truncated {
             original_tokens,
             delivered_tokens,

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -267,13 +267,23 @@ pub(crate) fn execute_command_with_env_cancellable(
                 still_running.join("; ")
             ));
         }
-        // #1655: a recursive walk does not read `.gitignore`, so a nested
-        // checkout the other ctx_* tools never see can dominate it. Say so
-        // after the fact — the command's own traversal is left alone.
-        if let Some(hint) = super::walk_hint::walk_hint(command, cwd) {
+    }
+    // #1655/#1662: a recursive walk does not read `.gitignore`, so a nested
+    // checkout the other ctx_* tools never see can dominate it. Say so after
+    // the fact — the command's own traversal is left alone.
+    //
+    // Not only on timeout (#1662): `grep -r … | head` is the shape agents
+    // actually type, and it is the shape where the cost hides best. `head`
+    // closes early, the ten visible lines arrive at once, and the walk keeps
+    // running for two more minutes behind a result that already looked
+    // finished. Reported as "no redirect, no hint" — because the only place
+    // this was emitted was a timeout that a fast-looking command never
+    // reached.
+    if let Some(hint) = super::walk_hint::walk_hint(command, cwd) {
+        if !text.is_empty() && !text.ends_with('\n') {
             text.push('\n');
-            text.push_str(&hint);
         }
+        text.push_str(&hint);
     }
     if cancelled {
         if !text.ends_with('\n') && !text.is_empty() {

--- a/rust/src/server/walk_hint.rs
+++ b/rust/src/server/walk_hint.rs
@@ -145,10 +145,10 @@ fn walk_roots(command: &str, base: &Path) -> Vec<std::path::PathBuf> {
                 continue;
             }
             let candidate = Path::new(trimmed);
-            roots.push(if candidate.is_absolute() {
+            roots.push(if candidate.is_absolute() || trimmed.starts_with('/') {
                 candidate.to_path_buf()
             } else {
-                base.join(candidate)
+                crate::core::command_cwd::join_in(base, trimmed)
             });
         }
         if paths.is_empty() {

--- a/rust/src/server/walk_hint.rs
+++ b/rust/src/server/walk_hint.rs
@@ -63,15 +63,25 @@ pub(crate) fn walk_hint(command: &str, cwd: &str) -> Option<String> {
     // named. Scanning the call directory would then look at the wrong place and
     // report nothing, which is indistinguishable from "this walk is fine".
     let moved = crate::core::command_cwd::final_cwd(command, Some(Path::new(cwd)));
-    let root: &Path = match moved.as_deref() {
+    let base: &Path = match moved.as_deref() {
         Some(dir) => dir,
         // A `cd` this cannot resolve means the directory walked is unknown;
         // naming directories from somewhere else would be a guess.
         None if command.split_whitespace().any(|w| w == "cd") => return None,
         None => Path::new(cwd),
     };
+
+    // Scan what the command actually walks. Now that this runs for every
+    // recursive walk rather than only on timeout (#1662), scanning the starting
+    // directory regardless of scope would announce `node_modules/` for a
+    // `grep -r pattern src/` that never goes near it — a confident hint about a
+    // directory the command never entered.
     let mut found: Vec<(String, usize, bool)> = Vec::new();
-    collect_bulk_dirs(root, root, 0, &mut found);
+    for root in walk_roots(command, base) {
+        collect_bulk_dirs(&root, &root, 0, &mut found);
+    }
+    found.sort_by(|a, b| a.0.cmp(&b.0));
+    found.dedup_by(|a, b| a.0 == b.0);
 
     // A directory the command already excludes is not the explanation.
     found.retain(|(rel, _, _)| !command.contains(rel.as_str()));
@@ -94,6 +104,61 @@ pub(crate) fn walk_hint(command: &str, cwd: &str) -> Option<String> {
          --exclude-dir, or use ctx_search.]",
         named.join(", ")
     ))
+}
+
+/// The directories a recursive command was pointed at.
+///
+/// For a grep-like the first non-flag word is the pattern and the rest are
+/// paths; `find` takes its paths first, before any predicate. When no path is
+/// given, the walk starts where the command runs.
+fn walk_roots(command: &str, base: &Path) -> Vec<std::path::PathBuf> {
+    let mut roots = Vec::new();
+    for segment in command.split(|c| matches!(c, '|' | ';' | '&')) {
+        let mut words = segment.split_whitespace().skip_while(|w| w.contains('='));
+        let Some(tool) = words.next() else { continue };
+        let tool = tool.rsplit('/').next().unwrap_or(tool);
+        if !RECURSIVE_TOOLS.contains(&tool) {
+            continue;
+        }
+        let is_find = tool == "find";
+        let mut operands: Vec<&str> = Vec::new();
+        for word in words {
+            if word.starts_with('-') {
+                // A `find` predicate takes arguments (`-name '*.go'`), and its
+                // paths are already behind us, so stop at the first one.
+                if is_find {
+                    break;
+                }
+                continue;
+            }
+            operands.push(word);
+        }
+        let paths = if is_find || operands.is_empty() {
+            operands.as_slice()
+        } else {
+            &operands[1..]
+        };
+        for path in paths {
+            let trimmed = path.trim_matches(['"', '\'']);
+            // A path the shell would have to expand is not one to scan.
+            if trimmed.is_empty() || trimmed.contains('$') {
+                continue;
+            }
+            let candidate = Path::new(trimmed);
+            roots.push(if candidate.is_absolute() {
+                candidate.to_path_buf()
+            } else {
+                base.join(candidate)
+            });
+        }
+        if paths.is_empty() {
+            roots.push(base.to_path_buf());
+        }
+    }
+    if roots.is_empty() {
+        roots.push(base.to_path_buf());
+    }
+    roots
 }
 
 /// Does this command walk a tree without reading `.gitignore`?
@@ -325,5 +390,67 @@ mod gh1662 {
             &repo.path().to_string_lossy(),
         );
         assert!(hint.is_none(), "must not guess: {hint:?}");
+    }
+}
+
+#[cfg(test)]
+mod gh1662_scope {
+    use super::*;
+
+    fn repo_with_bulk() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nm = dir.path().join("node_modules");
+        std::fs::create_dir_all(&nm).expect("mkdir");
+        for i in 0..40 {
+            std::fs::write(nm.join(format!("f{i}.js")), "x").expect("write");
+        }
+        std::fs::create_dir_all(dir.path().join("src")).expect("mkdir");
+        std::fs::write(dir.path().join("src/main.go"), "package main").expect("write");
+        dir
+    }
+
+    /// Now that the hint fires for every recursive walk and not only on
+    /// timeout, it must not announce a directory the command never enters.
+    #[test]
+    fn a_scoped_walk_is_not_blamed_on_a_directory_outside_its_scope() {
+        let repo = repo_with_bulk();
+        let cwd = repo.path().to_string_lossy();
+
+        assert!(
+            walk_hint("grep -rn pattern src/", &cwd).is_none(),
+            "src/ holds no bulk directory"
+        );
+        assert!(
+            walk_hint("grep -rn pattern .", &cwd).is_some(),
+            "a walk rooted at the repo does hit node_modules"
+        );
+    }
+
+    #[test]
+    fn find_takes_its_paths_before_the_predicates() {
+        let repo = repo_with_bulk();
+        let cwd = repo.path().to_string_lossy();
+
+        assert!(walk_hint("find src -name '*.go'", &cwd).is_none());
+        assert!(walk_hint("find . -name '*.go'", &cwd).is_some());
+    }
+
+    /// An absolute path argument is scanned as given, not joined onto the cwd.
+    #[test]
+    fn an_absolute_path_argument_is_used_as_is() {
+        let repo = repo_with_bulk();
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let command = format!("grep -rn pattern {}", repo.path().display());
+
+        assert!(walk_hint(&command, &elsewhere.path().to_string_lossy()).is_some());
+    }
+
+    /// A path the shell would expand is not something to scan; the command's
+    /// own directory remains the honest fallback.
+    #[test]
+    fn an_unexpandable_path_falls_back_to_the_command_directory() {
+        let repo = repo_with_bulk();
+        let cwd = repo.path().to_string_lossy();
+        assert!(walk_hint("grep -rn pattern \"$DIR\"", &cwd).is_some());
     }
 }

--- a/rust/src/server/walk_hint.rs
+++ b/rust/src/server/walk_hint.rs
@@ -59,7 +59,17 @@ pub(crate) fn walk_hint(command: &str, cwd: &str) -> Option<String> {
         return None;
     }
 
-    let root = Path::new(cwd);
+    // #1662: `cd repo && grep -rn … .` walks a tree the call's own cwd never
+    // named. Scanning the call directory would then look at the wrong place and
+    // report nothing, which is indistinguishable from "this walk is fine".
+    let moved = crate::core::command_cwd::final_cwd(command, Some(Path::new(cwd)));
+    let root: &Path = match moved.as_deref() {
+        Some(dir) => dir,
+        // A `cd` this cannot resolve means the directory walked is unknown;
+        // naming directories from somewhere else would be a guess.
+        None if command.split_whitespace().any(|w| w == "cd") => return None,
+        None => Path::new(cwd),
+    };
     let mut found: Vec<(String, usize, bool)> = Vec::new();
     collect_bulk_dirs(root, root, 0, &mut found);
 
@@ -246,5 +256,74 @@ mod tests {
         let (n, capped) = (COUNT_CAP, true);
         let rendered = format!("{n}{} files", if capped { "+" } else { "" });
         assert!(rendered.starts_with("5000+"), "{rendered}");
+    }
+}
+
+#[cfg(test)]
+mod gh1662 {
+    use super::*;
+
+    /// A repo with the two directories that dominate a `grep -r`.
+    fn repo_with_bulk() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for bulk in ["node_modules", ".git"] {
+            let sub = dir.path().join(bulk);
+            std::fs::create_dir_all(&sub).expect("mkdir");
+            for i in 0..40 {
+                std::fs::write(sub.join(format!("f{i}.js")), "x").expect("write");
+            }
+        }
+        std::fs::write(dir.path().join("main.go"), "package main").expect("write");
+        dir
+    }
+
+    /// The reported shape: a recursive grep piped into `head`. `head` closes
+    /// early, so the visible output arrives fast while the walk runs on.
+    #[test]
+    fn a_piped_recursive_grep_is_still_a_recursive_walk() {
+        assert!(is_recursive_walk(
+            "grep -rn \"spine-go/mocks\" --include=*.go . | head"
+        ));
+    }
+
+    #[test]
+    fn a_piped_recursive_grep_gets_the_hint() {
+        let repo = repo_with_bulk();
+        let hint = walk_hint(
+            "grep -rn \"mocks\" --include=*.go . | head",
+            &repo.path().to_string_lossy(),
+        );
+        let hint = hint.expect("bulk directories under the walked path must be named");
+        assert!(hint.contains("node_modules/"), "{hint}");
+        assert!(hint.contains("ctx_search"), "{hint}");
+    }
+
+    /// The walked tree is the one the command `cd`s into, not the call's own.
+    #[test]
+    fn the_hint_follows_a_leading_cd() {
+        let repo = repo_with_bulk();
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+
+        let command = format!(
+            "cd {} && grep -rn \"mocks\" --include=*.go . | head",
+            repo.path().display()
+        );
+        let hint = walk_hint(&command, &elsewhere.path().to_string_lossy());
+        assert!(
+            hint.is_some_and(|h| h.contains("node_modules/")),
+            "the scan must follow the cd, not the call directory"
+        );
+    }
+
+    /// A `cd` into a directory this cannot resolve leaves the walked tree
+    /// unknown — better silent than naming directories from somewhere else.
+    #[test]
+    fn an_unresolvable_cd_stays_silent() {
+        let repo = repo_with_bulk();
+        let hint = walk_hint(
+            "cd \"$REPO\" && grep -rn x . | head",
+            &repo.path().to_string_lossy(),
+        );
+        assert!(hint.is_none(), "must not guess: {hint:?}");
     }
 }

--- a/rust/src/shell/compress/engine.rs
+++ b/rust/src/shell/compress/engine.rs
@@ -953,12 +953,92 @@ fn truncate_verbatim(output: &str, original_tokens: usize, family: TokenizerFami
     result
 }
 
+/// Does this line have the `path:line:` shape every `grep -n` / `rg` match has?
+///
+/// The prefix must not be all digits, which is what separates a path from a
+/// `12:34:56` timestamp in a log — the one common shape that would otherwise
+/// read as a match.
+fn looks_like_match_line(line: &str) -> bool {
+    let Some(first) = line.find(':') else {
+        return false;
+    };
+    let path = &line[..first];
+    if path.is_empty()
+        || path.bytes().all(|b| b.is_ascii_digit())
+        || path.chars().any(char::is_whitespace)
+    {
+        return false;
+    }
+    let rest = &line[first + 1..];
+    let Some(second) = rest.find(':') else {
+        return false;
+    };
+    second > 0 && rest[..second].bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Is this output a search result rather than a log?
+fn is_match_shaped(lines: &[&str]) -> bool {
+    let considered: Vec<&&str> = lines.iter().filter(|l| !l.trim().is_empty()).collect();
+    if considered.len() < 20 {
+        return false;
+    }
+    let matched = considered
+        .iter()
+        .filter(|l| looks_like_match_line(l))
+        .count();
+    matched * 10 >= considered.len() * 9
+}
+
+/// GH #1663: search results are not logs, and must never be sampled.
+///
+/// Head+tail sampling assumes the interesting content sits at the edges. For a
+/// search result every line is a discrete answer and the decisive one is at an
+/// arbitrary position — usually the *unusual* one, the single reader among two
+/// hundred writers. Sampling is biased against exactly the line that matters,
+/// and `[222 lines omitted]` reads as "more of the same" rather than "the
+/// answer may be in here". A reporter concluded a struct field was dead code on
+/// a sampled result whose dropped middle held the line proving it was read.
+///
+/// So: keep a contiguous prefix, in order, and say plainly that this is a
+/// sample and how many matches were not shown. The full set stays reachable
+/// through the archive reference the caller already gets.
+fn truncate_match_lines(
+    lines: &[&str],
+    original_tokens: usize,
+    family: TokenizerFamily,
+) -> Option<String> {
+    const SHOWN: usize = 40;
+    if lines.len() <= SHOWN {
+        return None;
+    }
+    let total = lines.len();
+    let hidden = total - SHOWN;
+
+    let mut compressed = lines[..SHOWN].join("\n");
+    compressed.push_str(&format!(
+        "\n[⚠ SAMPLE — showing the first {SHOWN} of {total} matching lines, in order; \
+         {hidden} not shown. This is NOT a complete result set: nothing here rules \
+         out a match further down. Narrow the pattern or use ctx_search before \
+         concluding anything from absence.]"
+    ));
+
+    let ct = count_tokens_for(&compressed, family);
+    if ct >= original_tokens {
+        return None;
+    }
+    Some(shell_savings_footer(&compressed, original_tokens, ct))
+}
+
 fn truncate_with_safety_scan(
     lines: &[&str],
     original_tokens: usize,
     family: TokenizerFamily,
 ) -> Option<String> {
     use crate::core::safety_needles;
+
+    if is_match_shaped(lines) {
+        return truncate_match_lines(lines, original_tokens, family);
+    }
 
     let first = &lines[..5];
     let last = &lines[lines.len() - 5..];
@@ -1200,5 +1280,80 @@ mod tests {
             classify_build_output("RUST_LOG=debug cargo build", "warning: unused variable", 0),
             BuildOutputKind::WarningsOnly
         );
+    }
+}
+
+#[cfg(test)]
+mod gh1663 {
+    use super::*;
+
+    /// 236 grep matches, the decisive one at 205 — the reporter's real case.
+    fn grep_output() -> Vec<String> {
+        let mut v: Vec<String> = (0..236)
+            .map(|i| format!("./interp/typecheck.go:{}:\t\t\tc0 = c0.child[0]", 90 + i))
+            .collect();
+        v[204] = "./interp/debugger.go:720:\tfor _, ch := range sc.child {".to_string();
+        v
+    }
+
+    #[test]
+    fn grep_shaped_output_is_never_sampled_head_and_tail() {
+        let owned = grep_output();
+        let lines: Vec<&str> = owned.iter().map(String::as_str).collect();
+        assert!(is_match_shaped(&lines), "precondition: reads as matches");
+
+        let out = truncate_with_safety_scan(&lines, 10_000, TokenizerFamily::Cl100k)
+            .expect("output is long enough to compress");
+
+        assert!(
+            !out.contains("safety-relevant lines preserved"),
+            "the head+tail sampler must not run on search results: {out}"
+        );
+        assert!(
+            out.contains("SAMPLE"),
+            "the sample must announce itself: {out}"
+        );
+        assert!(
+            out.contains("of 236 matching lines"),
+            "and name the true match count: {out}"
+        );
+    }
+
+    /// What is shown is a contiguous, ordered prefix — so "not in the output"
+    /// can never be mistaken for "not in the results".
+    #[test]
+    fn the_shown_matches_are_a_contiguous_prefix() {
+        let owned = grep_output();
+        let lines: Vec<&str> = owned.iter().map(String::as_str).collect();
+        let out = truncate_with_safety_scan(&lines, 10_000, TokenizerFamily::Cl100k).unwrap();
+
+        let body: Vec<&str> = out
+            .lines()
+            .take_while(|l| !l.starts_with("[⚠ SAMPLE"))
+            .collect();
+        for (i, line) in body.iter().enumerate() {
+            assert_eq!(*line, lines[i], "line {i} is out of order or substituted");
+        }
+    }
+
+    /// A log with timestamps must keep the sampler: `12:34:56` is not a path.
+    #[test]
+    fn timestamped_logs_are_not_mistaken_for_matches() {
+        let owned: Vec<String> = (0..120)
+            .map(|i| format!("12:34:{:02} INFO worker {i} still running", i % 60))
+            .collect();
+        let lines: Vec<&str> = owned.iter().map(String::as_str).collect();
+        assert!(!is_match_shaped(&lines), "a timestamp is not a path");
+    }
+
+    /// A short result set is delivered whole — no notice, no sampling.
+    #[test]
+    fn a_small_match_set_is_not_truncated_at_all() {
+        let owned: Vec<String> = (0..25)
+            .map(|i| format!("src/main.rs:{i}:    let x = {i};"))
+            .collect();
+        let lines: Vec<&str> = owned.iter().map(String::as_str).collect();
+        assert!(is_match_shaped(&lines));
+        assert!(truncate_match_lines(&lines, 10_000, TokenizerFamily::Cl100k).is_none());
     }
 }

--- a/rust/src/tools/ctx_execute.rs
+++ b/rust/src/tools/ctx_execute.rs
@@ -11,12 +11,27 @@ pub fn handle(
     intent: Option<&str>,
     timeout: Option<u64>,
 ) -> (String, ShellOutcome) {
+    handle_in(language, code, intent, timeout, None)
+}
+
+/// Same as [`handle`], but runs the snippet in `cwd` (GH #1666).
+///
+/// `ctx_shell` reroutes an interpreter heredoc here and has already resolved a
+/// working directory for the rest of the same call; passing it on is what keeps
+/// both halves of that call in one directory.
+pub fn handle_in(
+    language: &str,
+    code: &str,
+    intent: Option<&str>,
+    timeout: Option<u64>,
+    cwd: Option<&std::path::Path>,
+) -> (String, ShellOutcome) {
     if language.eq_ignore_ascii_case("shell")
         && let Err(message) = crate::core::shell_allowlist::check_shell_allowlist(code)
     {
         return (message.to_string(), ShellOutcome::Blocked);
     }
-    let result = sandbox::execute(language, code, timeout);
+    let result = sandbox::execute_in(language, code, timeout, cwd);
     (
         format_result(&result, intent),
         ShellOutcome::Exit(result.exit_code),

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -69,8 +69,10 @@ pub(crate) fn validate_command_with_write_allow_paths(
             "ERROR: ctx_shell detected a file download/write ({reason}). \
              ctx_shell is ONLY for reading command output — redirect-free flags bypass \
              this doctrine, so they are blocked too (GH #391). \
-             Fetch to stdout instead (curl <url>, wget -qO- <url>) or use the editor's \
-             native tools to create files."
+             For text, fetch to stdout: curl <url> / wget -qO- <url>. \
+             For a binary (image, PDF, archive) neither stdout nor the editor's Write \
+             tool can carry the bytes — download to an absolute scratch path instead, \
+             e.g. curl -sL -o /tmp/shot.png <url>, which is permitted (GH #1661)."
         ));
     }
 
@@ -113,7 +115,28 @@ fn is_scratch_path(path: &str) -> bool {
 /// (`curl -o`, `wget` default mode, `dd of=`) — the redirect-free equivalent of
 /// `> file`, reported as a `validate_command` bypass in GH #391.
 fn download_to_file_reason(command: &str) -> Option<String> {
-    for seg in crate::core::shell_allowlist::extract_all_commands_pub(command) {
+    // #1661: the scratch carve-out is written in absolute paths, but agents
+    // reach a scratch directory the way a person would — `cd <scratchpad> &&
+    // curl -o shot.png …`. Judged as the bare string `shot.png`, a target that
+    // lands squarely inside the sanctioned directory looked like a project
+    // write and was blocked, leaving no in-tool way to fetch a binary at all.
+    // Segments are paired with the directory they actually run in so a relative
+    // target is judged where it lands.
+    for seg_cwd in crate::core::command_cwd::segments_with_cwd(command, None) {
+        let seg = seg_cwd.segment;
+        let here = seg_cwd.cwd;
+        let resolve = |path: &str| -> String {
+            let p = std::path::Path::new(path);
+            if p.is_absolute() || is_unix_scratch_prefix(path) {
+                return path.to_string();
+            }
+            // Without a known directory the target stays unresolved, which the
+            // scratch check then rejects — the guard errs closed.
+            match here.as_deref() {
+                Some(dir) => dir.join(p).to_string_lossy().into_owned(),
+                None => path.to_string(),
+            }
+        };
         let tokens = crate::core::shell_allowlist::shell_tokenize(seg.trim());
         let Some(first) = tokens.first() else {
             continue;
@@ -148,7 +171,7 @@ fn download_to_file_reason(command: &str) -> Option<String> {
                         None
                     };
                     if let Some(path) = target {
-                        if is_scratch_path(path) {
+                        if is_scratch_path(&resolve(path)) {
                             continue;
                         }
                         return Some(format!("curl {tok}"));
@@ -367,11 +390,35 @@ fn has_file_write_redirect(
             } else {
                 i + 1
             };
-            let target: String = command[target_start..]
-                .trim_start()
+            // The redirect *operator* can carry one more character: `>|`
+            // overrides noclobber and `>&` duplicates a descriptor. Neither
+            // belongs to the target word, so strip it before reading the word
+            // and re-attach `&` for the fd check below.
+            let rest = command[target_start..].trim_start();
+            let (rest, fd_dup) = match rest.strip_prefix('|') {
+                Some(r) => (r, false),
+                None => match rest.strip_prefix('&') {
+                    Some(r) => (r, true),
+                    None => (rest, false),
+                },
+            };
+            // The word ends at whitespace *or* at a shell metacharacter
+            // (#1659). Stopping only at whitespace made the verdict depend on
+            // where the redirect sat: `echo a 1>/dev/null` read the target as
+            // `/dev/null` and was allowed, while `echo a 1>/dev/null; echo b`
+            // read `/dev/null;` — semicolon included, since it is not
+            // whitespace — missed the /dev/null exemption, and was blocked as a
+            // file write. `&&` happened to work only because a space precedes
+            // it. Same redirect, same shell semantics, opposite verdicts.
+            //
+            // `(` is deliberately not a terminator: it would reduce the
+            // process-substitution target `>(cmd)` to an empty word, and an
+            // empty word falls through unblocked.
+            let word: String = rest
                 .chars()
-                .take_while(|c| !c.is_whitespace())
+                .take_while(|c| !c.is_whitespace() && !matches!(c, ';' | '&' | '|' | ')' | '<'))
                 .collect();
+            let target = if fd_dup { format!("&{word}") } else { word };
             if target == "/dev/null" || target == "/dev/stdout" || target == "/dev/stderr" {
                 i += 1;
                 continue;
@@ -1130,5 +1177,132 @@ COMMIT_MSG"
             validate_command("echo secret > /tmpfoo/leak.txt").is_some(),
             "/tmpfoo is not /tmp — must be blocked"
         );
+    }
+
+    // --- GH #1661: a relative download target is judged where it lands ---
+
+    /// The reported case: `cd <scratchpad> && curl -o shot.png <url>`. The
+    /// destination is inside the sanctioned scratch directory, but as the bare
+    /// string `shot.png` it read as a project write — so fetching a binary had
+    /// no in-tool route at all and pushed the agent to native shell.
+    #[test]
+    fn a_relative_download_into_a_scratch_directory_is_allowed() {
+        for cmd in [
+            "cd /tmp && curl -sL -o shot.png https://example.com/a.png",
+            "cd /private/tmp/claude-501/session && curl -sL -o shot.png https://e/x",
+            "cd /tmp/work && curl -sL -o sub/shot.png https://e/x",
+        ] {
+            assert!(
+                download_to_file_reason(cmd).is_none(),
+                "scratch destination must stay reachable: {cmd}"
+            );
+        }
+    }
+
+    /// The #391 boundary is untouched: a relative target outside a scratch
+    /// directory — or one this cannot resolve — is still a file write.
+    #[test]
+    fn a_download_into_the_project_is_still_blocked() {
+        for cmd in [
+            "curl -sL -o shot.png https://example.com/a.png",
+            "cd /Users/me/project && curl -sL -o shot.png https://e/x",
+            "cd \"$SCRATCH\" && curl -sL -o shot.png https://e/x",
+            "cd /tmp && curl -sL -o /Users/me/project/shot.png https://e/x",
+            "wget https://example.com/a.tar.gz",
+            "dd if=/dev/zero of=/Users/me/project/block.bin",
+            // wget/dd keep no scratch carve-out at all — a documented,
+            // separately tested decision this fix deliberately leaves alone.
+            "cd /tmp && wget -O page.html https://e/x",
+            "cd /tmp && dd if=/dev/zero of=block.bin bs=1 count=1",
+        ] {
+            assert!(
+                download_to_file_reason(cmd).is_some(),
+                "must stay blocked: {cmd}"
+            );
+        }
+    }
+
+    /// The refusal has to name a route that works for the payload at hand.
+    /// Both suggested fallbacks were text-only, so for an image the message
+    /// left native Bash as the only way forward.
+    #[test]
+    fn the_refusal_names_a_route_that_works_for_binaries() {
+        let msg =
+            validate_command("curl -sL -o shot.png https://example.com/a.png").expect("blocked");
+        assert!(msg.contains("scratch"), "{msg}");
+        assert!(msg.contains("/tmp/"), "{msg}");
+    }
+
+    // --- GH #1659: the redirect verdict must not depend on position ---
+
+    /// The reporter's table, verbatim. The target was read up to whitespace, so
+    /// a trailing `;` became part of it (`/dev/null;`), the exemption missed,
+    /// and the identical redirect was blocked in a non-final segment.
+    #[test]
+    fn dev_null_is_exempt_in_every_position() {
+        for cmd in [
+            "echo hi 1>/dev/null",
+            "echo a; echo b 1>/dev/null",
+            "echo hi 1>/dev/null; echo ok",
+            "echo a 1>/dev/null; echo b; echo c",
+            "diff -q /etc/hosts /etc/hosts 1>/dev/null && echo SAME",
+            "echo hi 1>/dev/null && echo ok",
+            "echo hi >/dev/null; echo ok",
+            "echo hi >/dev/null | cat",
+            "(echo hi >/dev/null); echo ok",
+        ] {
+            assert!(
+                !has_file_write_redirect(cmd, &[], None),
+                "/dev/null is never a file write: {cmd}"
+            );
+        }
+    }
+
+    /// A redirect operator can carry one more character (`>|` noclobber
+    /// override, `>&` fd duplication). Terminating the word at metacharacters
+    /// must not swallow those — nor may it empty out a process-substitution
+    /// target, since an empty target falls through unblocked.
+    #[test]
+    fn redirect_operator_suffixes_keep_their_meaning() {
+        for allowed in [
+            "echo x >&1",
+            "echo x >&2; echo ok",
+            "echo x >&-",
+            "echo x 1>&2 | cat",
+        ] {
+            assert!(
+                !has_file_write_redirect(allowed, &[], None),
+                "fd duplication is not a file write: {allowed}"
+            );
+        }
+        for blocked in [
+            "echo x >|out.txt",
+            "echo x >|out.txt; echo ok",
+            "echo x > >(tee out.txt)",
+            "echo x > >(tee out.txt); echo ok",
+        ] {
+            assert!(
+                has_file_write_redirect(blocked, &[], None),
+                "still a file write: {blocked}"
+            );
+        }
+    }
+
+    /// The guard itself must not weaken: a real file target is still a write,
+    /// including in a non-final segment, which is the position the bug made
+    /// *over*-strict rather than under.
+    #[test]
+    fn a_real_file_target_is_still_a_write_in_any_position() {
+        for cmd in [
+            "echo hi > out.txt",
+            "echo hi > out.txt; echo ok",
+            "echo a; echo hi >> out.txt; echo b",
+            "echo hi > out.txt && echo ok",
+        ] {
+            assert!(
+                has_file_write_redirect(cmd, &[], None),
+                "a file write must still be caught: {cmd}"
+            );
+        }
     }
 }

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -127,13 +127,17 @@ fn download_to_file_reason(command: &str) -> Option<String> {
         let here = seg_cwd.cwd;
         let resolve = |path: &str| -> String {
             let p = std::path::Path::new(path);
-            if p.is_absolute() || is_unix_scratch_prefix(path) {
+            // `starts_with('/')`: shell text, so a Unix-absolute target is
+            // absolute on Windows too, where `is_absolute` disagrees (#1467).
+            if p.is_absolute() || path.starts_with('/') {
                 return path.to_string();
             }
             // Without a known directory the target stays unresolved, which the
             // scratch check then rejects — the guard errs closed.
             match here.as_deref() {
-                Some(dir) => dir.join(p).to_string_lossy().into_owned(),
+                Some(dir) => crate::core::command_cwd::join_in(dir, path)
+                    .to_string_lossy()
+                    .into_owned(),
                 None => path.to_string(),
             }
         };

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -64,7 +64,12 @@ pub(crate) fn validate_command_with_write_allow_paths(
         );
     }
 
-    if let Some(reason) = download_to_file_reason(command) {
+    // #1672: on the heredoc-stripped text, for the same reason as #931 and
+    // #989 above. A download flag inside a heredoc *body* is opaque data — a
+    // commit message, a doc, a fixture — and refusing the call for it blocks
+    // writing about the guard at all. This detector was simply never switched
+    // over when the other two were.
+    if let Some(reason) = download_to_file_reason(&cmd_no_heredoc) {
         return Some(format!(
             "ERROR: ctx_shell detected a file download/write ({reason}). \
              ctx_shell is ONLY for reading command output — redirect-free flags bypass \
@@ -1180,6 +1185,45 @@ COMMIT_MSG"
         assert!(
             validate_command("echo secret > /tmpfoo/leak.txt").is_some(),
             "/tmpfoo is not /tmp — must be blocked"
+        );
+    }
+
+    // --- GH #1672: a heredoc body is data, not a command ---
+
+    /// Found live: a commit message quoting the guard's own advice was refused
+    /// as if it were a download. Nothing runs inside a heredoc body.
+    #[test]
+    fn a_download_flag_inside_a_heredoc_body_is_not_a_download() {
+        let commit = "git commit -F - <<'MSG'\n\
+             fix(x): something\n\
+             \n\
+             The reported case: cd /scratch && curl -sL -o shot.png https://e/x\n\
+             MSG";
+        assert!(
+            validate_command(commit).is_none(),
+            "a heredoc body is opaque data: {:?}",
+            validate_command(commit)
+        );
+
+        for body in [
+            "cat <<'EOF'\nwget https://example.com/a.tar.gz\nEOF",
+            "cat <<'EOF'\ndd if=/dev/zero of=/etc/passwd\nEOF",
+        ] {
+            assert!(validate_command(body).is_none(), "{body}");
+        }
+    }
+
+    /// The guard itself is untouched: a real download outside a heredoc, and
+    /// one on the same line as a heredoc redirection, are still refused.
+    #[test]
+    fn a_real_download_beside_a_heredoc_is_still_blocked() {
+        assert!(
+            validate_command("curl -sL -o shot.png https://e/x && cat <<'EOF'\nharmless\nEOF")
+                .is_some()
+        );
+        assert!(
+            validate_command("cat <<'EOF'\nharmless\nEOF\ncurl -sL -o shot.png https://e/x")
+                .is_some()
         );
     }
 

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -1018,6 +1018,35 @@ fn parse_interpreter_heredoc_prelude(prelude: &str) -> Option<&'static str> {
     }
 }
 
+/// The one working directory both halves of a rerouted heredoc call run in.
+///
+/// Resolution goes through the session so an explicit `cwd` is validated
+/// against the configured roots, exactly as the non-rerouted path does. A `cwd`
+/// the caller named that cannot be validated is an error, never a silent
+/// substitution (#1666).
+///
+/// `Ok(None)` means only that no directory could be established without a
+/// session. The heredoc-only path never needed one and must keep working; the
+/// shell remainder always required a session and keeps requiring it.
+fn resolve_reroute_cwd(
+    ctx: &ToolContext,
+    explicit_cwd: Option<&str>,
+) -> Result<Option<String>, ErrorData> {
+    let Some(session_lock) = ctx.session.as_ref() else {
+        if explicit_cwd.is_some() {
+            return Err(ErrorData::internal_error(
+                "session not available — cannot validate the requested working directory",
+                None,
+            ));
+        }
+        return Ok(None);
+    };
+    let guard =
+        crate::server::bounded_lock::read_for(session_lock, "ctx_shell_cwd", SESSION_LOCK_BUDGET);
+    let (cwd, _) = resolve_effective_cwd(guard, explicit_cwd)?;
+    Ok(Some(cwd))
+}
+
 fn handle_interpreter_heredoc_reroute(
     args: &Map<String, Value>,
     ctx: &ToolContext,
@@ -1028,8 +1057,21 @@ fn handle_interpreter_heredoc_reroute(
     let timeout_ms = get_int(args, "timeout_ms").and_then(|n| u64::try_from(n).ok());
     let timeout_secs = timeout_ms.map(|ms| ms.div_ceil(1000).max(1));
 
-    let (exec_text, exec_outcome) =
-        crate::tools::ctx_execute::handle(language, code, None, timeout_secs);
+    // #1666: resolve the working directory *before* the interpreter runs. The
+    // shell remainder below always ran in the call's `cwd`; the rerouted
+    // interpreter ran wherever the server process happened to sit. One tool
+    // call, two directories — and a script using relative paths silently read
+    // and wrote the wrong tree while reporting success.
+    let explicit_cwd = get_str(args, "cwd");
+    let exec_cwd = resolve_reroute_cwd(ctx, explicit_cwd.as_deref())?;
+
+    let (exec_text, exec_outcome) = crate::tools::ctx_execute::handle_in(
+        language,
+        code,
+        None,
+        timeout_secs,
+        exec_cwd.as_deref().map(std::path::Path::new),
+    );
     let reroute_note = format!(
         "\n[ctx_shell: interpreter heredoc auto-rerouted to ctx_execute(language=\"{language}\")]"
     );
@@ -1058,14 +1100,10 @@ fn handle_interpreter_heredoc_reroute(
         });
     }
 
-    let session_lock = ctx
-        .session
-        .as_ref()
-        .ok_or_else(|| ErrorData::internal_error("session not available", None))?;
-    let explicit_cwd = get_str(args, "cwd");
-    let guard =
-        crate::server::bounded_lock::read_for(session_lock, "ctx_shell_cwd", SESSION_LOCK_BUDGET);
-    let (effective_cwd, _) = resolve_effective_cwd(guard, explicit_cwd.as_deref())?;
+    // Unchanged from before #1666: running the shell remainder requires a
+    // validated working directory.
+    let effective_cwd =
+        exec_cwd.ok_or_else(|| ErrorData::internal_error("session not available", None))?;
 
     let extra_env: std::collections::HashMap<String, String> = args
         .get("env")


### PR DESCRIPTION
Seven reports from the 3.10.1 field batch, all in `ctx_shell`'s guards and output
handling. Each fix is pinned by tests that were **confirmed red against the
unpatched code** before being committed.

## What was wrong

**#1659 — the redirect verdict depended on where the redirect sat.**
`echo hi 1>/dev/null` was allowed; `echo hi 1>/dev/null; echo ok` was blocked as
a file write. The scanner read the target up to the next *whitespace*, so a
trailing `;` became part of it: `/dev/null;` is not `/dev/null`, and the
exemption never applied. `&&` worked only because a space precedes it. The same
bug silently hit descriptor duplication — `cmd >&2; echo ok` was blocked too.

**#1660 — a truncated response cut off the line naming the way back.**
Mechanical: the archive reference is appended to the **end** of the response and
truncation keeps a **prefix**, so the one line naming the stored copy was always
the first thing discarded. The response then advertised a recovery route it had
just removed — and pointed at `ctx_read(lines=)` for content that has no path.

**#1661 — no in-tool way to download a binary.**
Scratch downloads were already permitted (#1021), but only when written as an
absolute path. `cd <scratchpad> && curl -o shot.png <url>` was judged as the
bare string `shot.png` and read as a project write, leaving stdout (floods the
context with PNG bytes) and `Write` (takes a string) as the only suggestions.

**#1662 — a piped recursive grep ran for two minutes with no warning.**
The #1655 hint was only ever emitted on *timeout* — the one thing a command that
already looked finished never reaches. `head` closes early, ten lines arrive at
once, and the walk keeps going behind a result that looks complete.

**#1663 — grep output was sampled head+tail, dropping the line that mattered.**
236 matches, 14 shown, 222 omitted; the line proving a struct field was read sat
at position 205. The reporter concluded the field was dead code and found out
otherwise when the build failed. Sampling assumes the interesting content is at
the edges — for a search result it is at an arbitrary position, and usually it
is the *unusual* line.

**#1666 — a rerouted heredoc ignored the call's cwd.**
One tool call ran its two halves in two directories: the shell remainder
honoured `cwd`, the interpreter rerouted to `ctx_execute` inherited the server
process's directory. A script doing `open("api/api.go")` resolved against the
project root instead of the worktree, found no match, rewrote that file
byte-identically, and reported success.

**#1672 — a heredoc body mentioning a download was refused.**
Found while committing the #1661 fix: the message quoted the advice the refusal
itself prints. The redirect guard (#931) and the `tee` guard (#989) already run
on heredoc-stripped text; the download guard was never switched over.

## What changed

- Redirect targets end at a shell metacharacter. `>|` and `>&` are parsed as
  part of the operator; `(` is deliberately **not** a terminator, since it would
  reduce `>(tee out.txt)` to an empty word that falls through unblocked.
- The turn budget takes the recovery line as a separate argument, reserves room
  for it, and re-attaches it after the cut. If the budget fits only one of the
  two, the recovery line wins over the notice describing the cut.
- A new `core::command_cwd` pairs each command segment with the directory it
  actually runs in, following a plain literal `cd`. A `cd "$VAR"` leaves the
  directory *unknown* rather than stale — callers then err closed.
- The walk hint runs for any recursive walk, and scans the command's own path
  operands rather than its starting directory, so `grep -r pattern src/` is no
  longer blamed on a `node_modules/` it never enters.
- Output with the `path:line:` shape is delivered as a contiguous, ordered
  prefix with a notice naming the true match count. A `12:34:56` log timestamp
  is not a path and keeps the old sampler.
- The heredoc reroute resolves its working directory once, before the
  interpreter runs, and both halves use it. Under `sandbox_level >= 1` the
  directory is granted **read** access in the seatbelt and Landlock profiles,
  which otherwise deny by default; write permission is deliberately not granted,
  since that boundary belongs to the sandbox level.
- The download guard reads the same heredoc-stripped command the redirect and
  `tee` guards already read.
- A Unix path in shell text is absolute on Windows too, where `is_absolute`
  disagrees — the case `Test (windows-latest)` caught on the first push.
- Turn-budget enforcement moved out of `call_tool/pipeline.rs` into
  `core::budget`, which is where budget policy belongs and keeps the file under
  the 1500-line gate.

## Boundaries deliberately left alone

- The #391 download boundary is unchanged: a relative target outside a scratch
  directory, or behind an unresolvable `cd`, is still a file write. `wget` and
  `dd` keep **no** scratch carve-out — a separate, separately tested decision.
- The heredoc-only path still needs no session; the shell remainder still
  requires one.
- No command is ever rewritten. #1662 asked for injected `--exclude-dir`; that
  would silently change which matches exist, which is the same class of harm as
  #1663.

## Verification

- `cargo test --lib`: 10 687 passed, 0 failed.
- `cargo test --test main`: 873 passed / 5 failed — **identical to the
  `github/main` baseline on the same machine**, so this branch adds no new
  integration failure.
- `scripts/preflight.sh`: all gates green (fmt, clippy `-D warnings`, whitespace,
  Windows cross-check, doc generation, loc-gate, narrative governance).
- Every new test was run against the unpatched code first and observed to fail.

Fixes #1659
Fixes #1660
Fixes #1661
Fixes #1662
Fixes #1663
Fixes #1666
Fixes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
