### PR TITLE
feat(skills): add lean-ctx-review, a session friction review skill

### DIFF
--- a/.claude-plugin/manifest.json
+++ b/.claude-plugin/manifest.json
@@ -18,7 +18,7 @@
     "args": ["--mcp"],
     "env": {}
   },
-  "skills": ["skills/lean-ctx"],
+  "skills": ["skills/lean-ctx", "skills/lean-ctx-review"],
   "capabilities": [
     "file-read",
     "file-edit",

--- a/skills/lean-ctx-review/SKILL.md
+++ b/skills/lean-ctx-review/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: lean-ctx-review
+description: Review how the lean-ctx ctx_* MCP tools performed in the current session and file upstream issues for confirmed problems. Use when the user asks to review/audit lean-ctx tool performance, says "lean-ctx review", asks why ctx_* tools failed or fell back to native tools, or wants to report a lean-ctx bug.
+---
+
+# lean-ctx session review
+
+Upstream repo: `yvgude/lean-ctx` (https://github.com/yvgude/lean-ctx).
+
+Reads a Claude Code session transcript, so it applies to agents that write
+`~/.claude/projects/*/*.jsonl`. Other harnesses need their own extractor; the
+triage rules below are harness-independent.
+
+## 1. Extract
+
+Run from this skill's directory (needs `python3`):
+
+```bash
+python3 scripts/scan_session.py
+```
+
+Defaults to the newest transcript under `~/.claude/projects/*/` — the live
+Claude Code session. Pass a path to review a different one. `-d N` dumps call
+`#N` in full.
+
+The script reports **facts, not verdicts**: every `ctx_*` call in order, which
+results the harness flagged `is_error`, which calls repeated identical
+arguments, which asked for `raw`/`fresh` output, and how many native
+`Read`/`Grep`/`Bash` calls happened. It deliberately does not guess which of
+those is a problem — that judgment is yours, below.
+
+Transcripts run to megabytes, so read the table, not the raw JSONL.
+
+## 2. Triage
+
+**Start from `is_error`.** In practice every genuine tool failure carries it.
+Then read the call list for the softer signals: identical retries, `raw`/`fresh`
+re-reads, native calls clustered right after a `ctx_*` call, or a sequence that
+only completed once `ctx_*` was abandoned.
+
+### Before absolving anything, do these two things
+
+Skipping them is how this review returns a false "nothing to report". Both cost
+one command each.
+
+**Search the tracker for the guard or tool you are about to excuse.** Do this
+during triage, not at step 4. A closed issue defines intended behaviour: if a
+shipped fix says a form is supported and you just watched it fail, that is a
+regression and one of the most valuable things this review finds. It also stops
+you re-filing a settled design decision.
+
+```bash
+gh issue list --repo yvgude/lean-ctx --search "<guard or tool keyword>" --state all
+```
+
+**Probe the stated rationale — never accept a message's self-description.**
+An error explains itself, and that explanation can be wrong. Three checks, each
+one command:
+
+- *Does the sanctioned alternative achieve the same thing?* If the block is
+  bypassable through a route the message itself recommends, it constrains syntax,
+  not capability. Sometimes that is deliberate (structured input parses reliably
+  where a shell string does not) — decide which, do not assume.
+- *Does the stated reason match the observed rule?* Vary one axis at a time. A
+  guard blaming payload size that actually keys on path, or blaming a pipe on a
+  command that is piped, is misdiagnosing itself.
+- *Does the message contradict itself?* A rejection that also states the rejected
+  form is allowed is a finding on its own, whichever way the policy should go.
+
+A wrong diagnostic is a real bug even when the block is correct: it sends the
+next caller down a route that cannot work.
+
+### Not a finding
+
+- **Words inside returned content.** A file containing `http.StatusConflict`, a
+  `git rebase` printing `CONFLICT (content):`, `gh` returning
+  `"mergeable":"CONFLICTING"`, a test run printing `not found`. The tool
+  returned exactly what was asked for. Judge the tool's own behaviour, never the
+  payload's vocabulary.
+- **Self-reference.** Any result that quotes a previous scan, this skill, or a
+  transcript will echo every error word in it.
+- **Guard blocks — only after they survive the probe above.** Inline env
+  overrides (`GIT_EDITOR=`), shell redirects (`>`/`>>`), non-allowlisted
+  commands, paths outside the project root. "It offered an alternative and the
+  alternative worked" is *not* enough to clear one: that is true of a guard whose
+  reason is wrong, whose rule is different from its description, or that
+  contradicts itself. Clear it only once the stated rationale holds up.
+- **Malformed tool input.** `InputValidationError` on `__unparsedToolInput` is
+  the caller's own JSON serialization — commonly a raw tab or newline inside a
+  string — rejected before lean-ctx ever ran.
+- **My own wrong arguments**, a genuinely missing file, a failing build.
+
+### Confirmable
+
+The tool did something wrong or unhelpful *given correct input*:
+
+- wrong, lossy, or truncated output where the mode promises otherwise
+- content injected into output documented as verbatim, or anything that breaks a
+  documented output format (e.g. corrupting batch-read separators)
+- a crash, hang, or schema mismatch against the documented parameters
+- a documented mode behaving differently than described
+- a retry that only succeeded after dropping to native tools
+- **a wrong or self-contradicting diagnostic**, even where the block itself is
+  right — naming the wrong cause sends the next caller down a route that cannot
+  work, and costs more than the block did
+- **a regression against a closed issue**: a shipped fix says the form is
+  supported, and it is not
+
+## 3. Reproduce
+
+**No minimal repro, no issue.** Re-run the exact tool and arguments. If it
+passes, try to isolate the trigger; if you cannot, do not file — report the
+observation to the user instead, saying plainly that it did not reproduce and
+what you tried. Guessing at internals is worse than silence.
+
+`lean-ctx --version` for the version line.
+
+Zero confirmed findings is a valid and common result. Say so and file nothing.
+
+## 4. File
+
+Only for confirmed findings, one issue per distinct problem. You searched the
+tracker during triage; widen it here if the finding shifted:
+
+```bash
+gh issue list --repo yvgude/lean-ctx --search "<keywords>" --state all
+```
+
+Skip if already reported — and read the close text before re-filing, since a
+closed issue may have already conceded the point you are about to raise. When a
+finding contradicts a closed fix, cite it and frame the issue as the gap in that
+fix. Otherwise:
+
+```bash
+gh issue create --repo yvgude/lean-ctx --title "..." --body-file <file>
+```
+
+Body: what happened, expected, minimal repro (exact tool + args), version, OS.
+No speculation about internals. End every issue body with the Claude Code
+attribution footer. Report the issue `html_url` back to the user.

--- a/skills/lean-ctx-review/scripts/scan_session.py
+++ b/skills/lean-ctx-review/scripts/scan_session.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Extract lean-ctx (ctx_*) tool calls from a Claude Code session transcript.
+
+Usage:
+  scan_session.py [transcript.jsonl]         summary table
+  scan_session.py [transcript.jsonl] -d N    full args + output for call #N
+  scan_session.py --selftest
+
+Reports facts only: what was called, what the harness marked as an error, what
+repeated, what asked for uncompressed output. Deciding which of those is a
+lean-ctx problem is the reviewer's job - see SKILL.md. Earlier versions guessed
+by grepping results for words like CONFLICT, which flagged any file whose body
+happened to contain them.
+
+Default transcript: newest *.jsonl under ~/.claude/projects (= the live session).
+"""
+import glob
+import json
+import os
+import sys
+
+PREFIX = "mcp__lean-ctx__"
+NATIVE = {"Read", "Grep", "Glob", "Bash", "Edit", "Write"}
+
+
+def latest():
+    files = glob.glob(os.path.expanduser("~/.claude/projects/*/*.jsonl"))
+    if not files:
+        sys.exit("no transcripts found")
+    return max(files, key=os.path.getmtime)
+
+
+def text_of(content):
+    if isinstance(content, str):
+        return content
+    out = []
+    for b in content or []:
+        if isinstance(b, dict):
+            out.append(b.get("text") or b.get("content") or "")
+        else:
+            out.append(str(b))
+    return "\n".join(x if isinstance(x, str) else json.dumps(x) for x in out)
+
+
+def parse(records):
+    """Pair tool_use with tool_result by id. -> (rows, native tool names)."""
+    calls, results, order, native = {}, {}, [], []
+
+    for rec in records:
+        content = (rec.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "tool_use":
+                name = b.get("name", "")
+                if name.startswith(PREFIX):
+                    calls[b["id"]] = (name[len(PREFIX):], b.get("input", {}))
+                    order.append(b["id"])
+                elif name in NATIVE:
+                    native.append(name)
+            elif b.get("type") == "tool_result":
+                results[b.get("tool_use_id")] = (
+                    bool(b.get("is_error")), text_of(b.get("content")))
+
+    rows, seen = [], {}
+    for i, cid in enumerate(order, 1):
+        if cid not in results:
+            continue  # in-flight, e.g. this scan itself
+        tool, args = calls[cid]
+        err, out = results[cid]
+        key = (tool, json.dumps(args, sort_keys=True))
+        rows.append({
+            "n": i,
+            "tool": tool,
+            "args": args,
+            "err": err,
+            "out": out,
+            "retry_of": seen.get(key),
+            "uncompressed": bool(args.get("raw") or args.get("fresh")
+                                 or args.get("mode") == "raw"),
+        })
+        seen.setdefault(key, i)
+    return rows, native
+
+
+def one_line(row, width=110):
+    args = json.dumps(row["args"])
+    tags = ""
+    if row["retry_of"]:
+        tags += f" [identical retry of #{row['retry_of']}]"
+    if row["uncompressed"]:
+        tags += " [raw/fresh]"
+    if row["err"]:
+        tags += " [is_error]"
+    return f"  #{row['n']:<4} {row['tool']:<12} {args[:width]}{tags}"
+
+
+def show(row, limit=800):
+    print(f"\n#{row['n']} {row['tool']}" + ("  [is_error]" if row["err"] else ""))
+    print(f"  args: {json.dumps(row['args'])[:600]}")
+    print(f"  out : {row['out'][:limit]}")
+
+
+def selftest():
+    def rec(*blocks):
+        return {"message": {"content": list(blocks)}}
+
+    use = lambda i, n, inp: {"type": "tool_use", "id": i, "name": n, "input": inp}
+    res = lambda i, t, e=False: {"type": "tool_result", "tool_use_id": i,
+                                 "content": t, "is_error": e}
+
+    rows, native = parse([
+        rec(use("a", PREFIX + "ctx_read", {"path": "x.go"})),
+        rec(res("a", "package main // CONFLICT not found panic:")),
+        rec(use("b", "Bash", {}), use("c", PREFIX + "ctx_read", {"path": "x.go"})),
+        rec(res("c", "package main")),
+        rec(use("d", PREFIX + "ctx_shell", {"command": "ls", "fresh": True})),
+        rec(res("d", "boom", True)),
+        rec(use("e", PREFIX + "ctx_shell", {"command": "pending"})),
+    ])
+
+    # native Bash is counted, not numbered; call #4 is still in flight
+    assert [r["n"] for r in rows] == [1, 2, 3], [r["n"] for r in rows]
+    assert native == ["Bash"], native
+    # a body full of scary words is not a signal; only the harness flag is
+    assert not rows[0]["err"], "content must not manufacture an error"
+    assert rows[1]["retry_of"] == 1, "identical args = retry of the first call"
+    assert rows[0]["retry_of"] is None
+    assert rows[2]["err"] and rows[2]["uncompressed"]
+    assert "identical retry of #1" in one_line(rows[1])
+    print("selftest ok")
+
+
+def main():
+    argv = sys.argv[1:]
+    if "--selftest" in argv:
+        return selftest()
+
+    detail = None
+    if "-d" in argv:
+        k = argv.index("-d")
+        detail = int(argv[k + 1])
+        del argv[k:k + 2]
+
+    path = argv[0] if argv else latest()
+    with open(path) as fh:
+        records = []
+        for line in fh:
+            try:
+                records.append(json.loads(line))
+            except ValueError:
+                continue
+
+    rows, native = parse(records)
+    errors = [r for r in rows if r["err"]]
+
+    if detail is not None:
+        for r in rows:
+            if r["n"] == detail:
+                return show(r, limit=100_000)
+        sys.exit(f"no call #{detail}")
+
+    print(f"transcript: {path}")
+    print(f"lean-ctx calls: {len(rows)} ({len(errors)} flagged is_error)   "
+          f"native calls: {len(native)} ({', '.join(sorted(set(native))) or '-'})")
+
+    if errors:
+        print(f"\nis_error results ({len(errors)}):")
+        for r in errors:
+            show(r)
+
+    print(f"\nall calls (-d N for full output):")
+    for r in rows:
+        print(one_line(r))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a second skill, `skills/lean-ctx-review`, that reviews how the `ctx_*`
tools actually behaved in a session and turns confirmed problems into issues
worth reading.

It came out of using lean-ctx daily and repeatedly reaching the end of a session
thinking "something there was friction, but I no longer remember what". This
makes that pass repeatable, and — more importantly — makes it *accurate*.

## What it does

`scripts/scan_session.py` parses a Claude Code transcript and reports facts
only: every `ctx_*` call in order, which results the harness flagged
`is_error`, which calls repeated identical arguments, which asked for
`raw`/`fresh`, and how many native `Read`/`Grep`/`Bash` calls happened. No
verdicts. `-d N` dumps one call in full.

`SKILL.md` holds the judgment: what is and is not a lean-ctx defect.

## Why the split matters

The first version of this scanned results for words like `CONFLICT`,
`not found`, `panic:`. On a real session that produced 9 signals of which 6
were noise — it flagged a `ctx_read` of a Go file containing
`http.StatusConflict`, a `ctx_shell` running `git rebase` that legitimately
printed `CONFLICT (content):`, and `gh` returning `"mergeable":"CONFLICTING"`.
In every case the tool had done its job perfectly and the *payload* tripped the
filter. Same session after the split: 4 error rows, no noise.

A word list cannot tell a tool's behaviour from the content it correctly
returned. Prose can.

The triage rules also encode the harder failure — being too charitable. An
error message explains itself, and that explanation can be wrong, so the skill
requires probing a guard's stated rationale and searching this tracker before
excusing anything. That rule is not hypothetical: applying it turned a block I
had already dismissed as working-as-designed into #1671.

## Scope, and what this does not do

`rust/src/rules_inject/skills.rs` installs a single `SKILL_TEMPLATE` into a
hardcoded `skills/lean-ctx` per agent, so **`lean-ctx setup` will not install
this skill**. It reaches users through the plugin's `skills` array only. Making
`setup` skill-aware means generalising `build_skill_targets`, the template
constant, `uninstall/mod.rs` and `doctor/checks/environment.rs` — a change to
the CLI surface that belongs in its own spec-anchored PR, not smuggled into an
additive one. Happy to write it if you want the capability.

Two things worth your explicit call:

- **Python in a Rust repo.** The existing skill ships `install.sh`; this ships a
  180-line Python extractor, and there is no Python tooling here today. The
  pre-commit hooks are `types: [rust]` so nothing lints it. If you would rather
  this were a `lean-ctx` subcommand, that is a better home — transcript parsing
  suits the binary more than a script beside a skill — and it makes the work
  spec-shaped instead.
- **A bug-filing skill inside its own project.** Its whole discipline is "no
  minimal repro, no issue", so it should cut filing noise rather than add it.
  Still your tradeoff to accept.

No spec dir: additive skill + one manifest line, no `rust/src/**` touched.
`scan_session.py --selftest` covers the extractor, including the regression
where a result body full of scary words must produce no signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
