### PR TITLE
fix(ctx_shell): two refusals that described the wrong rule (#1671, #1674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-01
 
+### Fixed — the tee refusal contradicted itself (#1671)
+
+- `echo hi | tee <project>/dist/index.html` was refused with "tee without pipe",
+  in a message whose next sentence stated that `cmd | tee file` is allowed. The
+  command *is* piped, so the stated reason was wrong and the message described
+  the very form it had just rejected as permitted.
+- The rule was always the destination: a `tee` target outside the permitted
+  write paths is refused whether it is piped, mid-pipeline, or bare. Naming the
+  pipe also sent callers off to restructure their pipeline, which cannot help —
+  `… | tee FILE | wc -l` is judged identically.
+- The refusal now names the destination and the rule, and says plainly that
+  piping makes no difference. The verdict itself is unchanged.
+- Reported by a reviewer who read the message, concluded the block was correct
+  because an alternative was offered, and closed a session review with no
+  findings. The self-contradiction is what made the verdict look settled.
+
+### Fixed — a cancelled background job still reported "running" (#1674)
+
+- `background_action: "cancel"` killed the job but replied `state: "running"` —
+  byte-indistinguishable from a status poll, while the very next `status` call
+  on the same job returned `cancelled` with exit 130.
+- The header already said "cancel requested"; the structured `state` field,
+  which is what the caller actually reads, did not. `cancel` returns the job's
+  state as it was *before* the worker noticed the flag.
+- A cancel accepted on a running job now reports `cancelled`, and its summary
+  acknowledges the cancel instead of saying `no output` — previously the cancel
+  reply was strictly less informative than the poll it was mistaken for.
+- Cancelling a job that had already finished still reports what actually
+  happened; `cancel` only sets its flag on a running job.
+- This is problem 1 of #1246, which was closed with only problem 2 fixed.
+
 ### Fixed — the redirect verdict depended on where the redirect sat (#1659)
 
 - `echo hi 1>/dev/null` was allowed; `echo hi 1>/dev/null; echo ok` was blocked

--- a/rust/src/tools/ctx_shell.rs
+++ b/rust/src/tools/ctx_shell.rs
@@ -41,17 +41,22 @@ pub(crate) fn validate_command_with_write_allow_paths(
 
     // #989: tee detection must run on heredoc-stripped text to avoid false
     // positives when the word "tee" appears in heredoc/quoted payloads.
-    // `cmd | tee file` (piped) is output capture, not file authoring — the
-    // primary output still goes to stdout for the agent. Only bare `tee file`
-    // (not piped) is blocked as it is equivalent to `cat > file`.
-    if has_disallowed_tee_target(&cmd_no_heredoc, write_allow_paths, project_root) {
-        return Some(
-            "ERROR: ctx_shell detected a file-write command (tee without pipe). \
-             Use the native Write tool to create/modify files. \
-             ctx_shell is ONLY for reading command output. \
-             Piped tee (cmd | tee file) is allowed for output capture."
-                .to_string(),
-        );
+    //
+    // #1671: the rule is the destination, not the pipe. The message used to say
+    // "tee without pipe" and then state that piped tee is allowed — so it
+    // rejected a command and, in the next sentence, described that exact
+    // command as permitted. A reviewer read it, concluded the block was correct
+    // because an alternative was offered, and closed a review with no findings.
+    // Naming the pipe also sent callers off to restructure their pipeline,
+    // which cannot help: `… | tee FILE | wc -l` is judged identically.
+    if let Some(target) = disallowed_tee_target(&cmd_no_heredoc, write_allow_paths, project_root) {
+        return Some(format!(
+            "ERROR: ctx_shell refuses `tee {target}` — the destination is inside the \
+             project, and ctx_shell is ONLY for reading command output. \
+             Piping makes no difference: the destination decides. \
+             Use the native Write tool to create/modify project files, or tee to a \
+             scratch path (/tmp, /var/tmp, $TMPDIR), which is allowed."
+        ));
     }
 
     if is_heredoc_file_write(command, write_allow_paths, project_root) {
@@ -352,14 +357,20 @@ fn tee_targets(command: &str) -> Vec<String> {
         .collect()
 }
 
-fn has_disallowed_tee_target(
+/// The first `tee` destination that is not a permitted write target.
+///
+/// Returns the path so the refusal can name it (#1671). The rule is entirely
+/// about the destination — whether the `tee` is piped makes no difference — and
+/// a message that cannot name the destination ends up describing some other
+/// rule instead.
+fn disallowed_tee_target(
     command: &str,
     write_allow_paths: &[String],
     project_root: Option<&str>,
-) -> bool {
-    tee_targets(command).into_iter().any(|target| {
+) -> Option<String> {
+    tee_targets(command).into_iter().find(|target| {
         !target.is_empty()
-            && !is_write_allowed_redirect_target(&target, write_allow_paths, project_root)
+            && !is_write_allowed_redirect_target(target, write_allow_paths, project_root)
     })
 }
 
@@ -1186,6 +1197,60 @@ COMMIT_MSG"
             validate_command("echo secret > /tmpfoo/leak.txt").is_some(),
             "/tmpfoo is not /tmp — must be blocked"
         );
+    }
+
+    // --- GH #1671: the tee refusal names the rule that produced it ---
+
+    /// The message said "tee without pipe" and then, one sentence later, that
+    /// piped tee is allowed — rejecting a command while describing it as
+    /// permitted. The rule is the destination.
+    #[test]
+    fn the_tee_refusal_does_not_contradict_itself() {
+        let msg = validate_command_with_write_allow_paths(
+            "echo hi | tee /Users/me/proj/dist/index.html",
+            &[],
+            Some("/Users/me/proj"),
+        )
+        .expect("a project destination is refused");
+
+        assert!(
+            !msg.contains("without pipe"),
+            "the command is piped; naming the pipe is the wrong reason: {msg}"
+        );
+        assert!(
+            !msg.contains("Piped tee (cmd | tee file) is allowed"),
+            "must not call the rejected form permitted: {msg}"
+        );
+        assert!(
+            msg.contains("/Users/me/proj/dist/index.html"),
+            "name the destination that caused it: {msg}"
+        );
+        assert!(
+            msg.contains("destination"),
+            "state the rule that produced the verdict: {msg}"
+        );
+    }
+
+    /// Every form the reporter tried is judged the same way, so the message
+    /// must not send the caller off to restructure the pipeline.
+    #[test]
+    fn the_pipe_position_never_changes_the_tee_verdict() {
+        for cmd in [
+            "tee /Users/me/proj/out.txt",
+            "echo hi | tee /Users/me/proj/out.txt",
+            "echo hi | tee /Users/me/proj/out.txt | wc -l",
+        ] {
+            let msg = validate_command_with_write_allow_paths(cmd, &[], Some("/Users/me/proj"))
+                .unwrap_or_else(|| panic!("must be refused: {cmd}"));
+            assert!(msg.contains("Piping makes no difference"), "{cmd}: {msg}");
+        }
+        // A scratch destination stays allowed, piped or not.
+        for cmd in ["tee /tmp/probe.txt", "echo hi | tee /tmp/probe.txt"] {
+            assert!(
+                validate_command_with_write_allow_paths(cmd, &[], Some("/Users/me/proj")).is_none(),
+                "{cmd}"
+            );
+        }
     }
 
     // --- GH #1672: a heredoc body is data, not a command ---

--- a/rust/src/tools/registered/ctx_shell.rs
+++ b/rust/src/tools/registered/ctx_shell.rs
@@ -1204,6 +1204,12 @@ mod tests {
 
     /// #1246: a cancel must never come back as a tool error, and must not read
     /// like a status poll that did nothing.
+    ///
+    /// #1674: the second half of that only became true here. This asserted
+    /// `Running` — the very value that made a cancel indistinguishable from a
+    /// poll, against the intent stated one line above. #1246 fixed the
+    /// error-reporting half and left the state; the state is the half the
+    /// caller reads.
     #[test]
     fn cancel_is_acknowledged_and_never_reports_a_failure() {
         let running = JobState::Running {
@@ -1212,7 +1218,7 @@ mod tests {
         let (text, outcome) = format_background_state("shell_x", true, Some(running.clone()));
         let outcome = background(outcome);
         assert!(!outcome.is_error);
-        assert_eq!(outcome.state, BackgroundJobState::Running);
+        assert_eq!(outcome.state, BackgroundJobState::Cancelled);
         assert_eq!(outcome.exit_code, None);
         assert!(text.is_empty());
         assert!(

--- a/rust/src/tools/registered/ctx_shell_background.rs
+++ b/rust/src/tools/registered/ctx_shell_background.rs
@@ -41,24 +41,41 @@ pub(super) fn format_background_state(
             // long-running job reflects progress instead of a bare
             // "running" with no signal of whether it is advancing.
             let output = redact_shell_output_secrets(&output);
-            let head = if is_cancel {
-                format!(
-                    "[background:{id} cancel requested — job is stopping; poll status for the final output]"
+            let captured = summarize_background_output(&output);
+            // #1674: the structured verdict has to differ too. The header
+            // already said "cancel requested", but `state` stayed `running` —
+            // and `state` is what the caller reads. A cancel reply that is
+            // byte-indistinguishable from a status poll reads as a no-op, so
+            // the caller works around a job that is already gone. `cancel` only
+            // sets the flag on a job that is Running, so this arm is exactly
+            // the accepted-cancel case; every later observation of this job
+            // reports `cancelled`, and so does this one.
+            let (head, job_state, summary) = if is_cancel {
+                (
+                    format!(
+                        "[background:{id} cancel requested — job is stopping; poll status for the final output]"
+                    ),
+                    BackgroundJobState::Cancelled,
+                    format!("cancel accepted — job is stopping ({captured})"),
                 )
             } else {
-                format!("[background:{id} running]")
+                (
+                    format!("[background:{id} running]"),
+                    BackgroundJobState::Running,
+                    captured,
+                )
             };
             (
                 output.clone(),
                 ShellOutcome::Background(BackgroundShellOutcome {
-                    state: BackgroundJobState::Running,
+                    state: job_state,
                     exit_code: None,
                     job_id: id.to_string(),
                     archive_id: None,
                     archive_truncated: None,
                     captured_chars: None,
                     archived_chars: None,
-                    summary: summarize_background_output(&output),
+                    summary,
                     is_error: false,
                     display: Some(BackgroundDisplay {
                         header: head,
@@ -149,4 +166,82 @@ pub(super) fn redact_shell_output_secrets(output: &str) -> String {
         );
     }
     redacted
+}
+
+#[cfg(test)]
+mod gh1674 {
+    use super::*;
+
+    fn running(output: &str) -> Option<JobState> {
+        Some(JobState::Running {
+            output: output.to_string(),
+        })
+    }
+
+    fn background(outcome: &ShellOutcome) -> &BackgroundShellOutcome {
+        match outcome {
+            ShellOutcome::Background(b) => b,
+            other => panic!("expected a background outcome, got {other:?}"),
+        }
+    }
+
+    /// The reported failure: cancelling a running job replied `state: running`,
+    /// byte-identical to a status poll, so the cancel read as a no-op and the
+    /// caller worked around a job that was already gone.
+    #[test]
+    fn cancelling_a_running_job_reports_a_terminal_state() {
+        let (_, outcome) = format_background_state("shell_abc", true, running(""));
+        let b = background(&outcome);
+
+        assert_eq!(b.state, BackgroundJobState::Cancelled);
+        assert_ne!(
+            b.state,
+            BackgroundJobState::Running,
+            "a cancel reply must not be indistinguishable from a poll"
+        );
+        assert!(!b.is_error, "a caller-requested cancel is not a failure");
+        assert_eq!(b.exit_code, None);
+    }
+
+    /// It must also say more than a poll, not less: `no output` was strictly
+    /// less informative than the status call it was mistaken for.
+    #[test]
+    fn the_cancel_summary_acknowledges_the_cancel() {
+        let (_, outcome) = format_background_state("shell_abc", true, running(""));
+        assert!(
+            background(&outcome).summary.contains("cancel accepted"),
+            "{}",
+            background(&outcome).summary
+        );
+
+        let (_, with_output) =
+            format_background_state("shell_abc", true, running("tick 1\ntick 2"));
+        let summary = &background(&with_output).summary;
+        assert!(summary.contains("cancel accepted"), "{summary}");
+        assert!(
+            summary.contains("tick 2"),
+            "captured output is still reported: {summary}"
+        );
+    }
+
+    /// A plain poll is untouched.
+    #[test]
+    fn a_status_poll_still_reports_running() {
+        let (_, outcome) = format_background_state("shell_abc", false, running("tick 1"));
+        let b = background(&outcome);
+        assert_eq!(b.state, BackgroundJobState::Running);
+        assert_eq!(b.summary, "tick 1");
+    }
+
+    /// Cancelling a job that already finished reports what actually happened,
+    /// not a cancellation. `cancel` sets its flag only on a running job.
+    #[test]
+    fn cancelling_an_already_finished_job_reports_its_real_verdict() {
+        let finished = Some(JobState::Completed {
+            output: "done".to_string(),
+            exit_code: 0,
+        });
+        let (_, outcome) = format_background_state("shell_abc", true, finished);
+        assert_eq!(background(&outcome).state, BackgroundJobState::Completed);
+    }
 }


### PR DESCRIPTION
Two reports where the tool's own diagnostics were wrong — not the verdicts, the
messages describing them. Both fixes are pinned by tests confirmed red against
the unpatched code.

## #1671 — the tee refusal contradicted itself

`echo hi | tee <project>/dist/index.html` was refused with **"tee without
pipe"**, in a message whose next sentence reads *"Piped tee (cmd | tee file) is
allowed for output capture."* The command is piped. The message rejected a
command and then described that exact form as permitted.

The rule was always the **destination**: a tee target outside the permitted
write paths is refused whether it is bare, piped, or mid-pipeline. Naming the
pipe sent callers off to restructure their pipeline, which cannot help —
`… | tee FILE | wc -l` is judged identically.

The refusal now names the destination and the rule. **The verdict is
unchanged**: a project path is still refused, a scratch path still allowed,
piped or not. Changing the policy would be a separate decision; this PR only
makes the diagnostic match the rule that produced it.

Worth noting how it was found: a reviewer read the message, concluded the block
was correct because an alternative was offered, and closed a session review with
no findings. The self-contradiction is what made the wrong verdict look settled.

## #1674 — a cancelled job still reported "running"

`background_action: "cancel"` killed the job and replied `state: "running"` —
byte-indistinguishable from a status poll, while the very next `status` call on
the same job returned `cancelled` with exit 130.

The header already said "cancel requested"; the structured `state` field, which
is what the caller actually reads, did not. `cancel` returns the job's state as
it was *before* the worker noticed the flag.

A cancel accepted on a running job now reports `cancelled`, and its summary
acknowledges the cancel instead of `no output` — the cancel reply had been
strictly *less* informative than the poll it was mistaken for. Cancelling a job
that had already finished still reports what actually happened, since `cancel`
sets its flag only on a running job; that case has its own test.

This is problem 1 of #1246, which was closed with only problem 2 fixed. I hit it
myself while fixing the previous batch: I read `running` after a cancel,
concluded it was a no-op, and worked around a job that was already gone.

## Verification

- `cargo test --lib`: full suite green.
- `PREFLIGHT_BASE=github/main scripts/preflight.sh`: **PASSED**, 7/7 gates.
- Both new behaviours were run against the unpatched code first and observed to
  fail.

Fixes #1671
Fixes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
