### PR TITLE
fix: two guards that reported the wrong thing (#1651, #1658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to lean-ctx are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed — the token-budget gate measured one platform and enforced all (#1651)
+
+- `minimal_arm_per_turn_prefix_stays_within_budget` caps the per-turn prefix at
+  1965 tokens, but the prefix is not the same size everywhere: the Windows shell
+  hint is empty on POSIX. A developer measured 1941 on macOS, read 24 tokens of
+  headroom, and CI enforced a number ~15 higher. #1646 spent three CI
+  round-trips on it; the CHANGELOG records the same trap in #1625.
+- The guard now prices the Windows-only hint on every platform and asserts the
+  worst case, so a local run reports the number CI will enforce — 1958 instead
+  of 1941, and 7 tokens of real headroom instead of an imagined 24.
+- The hint's formatting moved into one function the runtime and the guard share,
+  so the two cannot drift apart.
+- The failure message now also names the second invisible consequence of editing
+  a `tool_def`: `docs/reference/generated/mcp-tools.md` embeds the description
+  verbatim, so `gen_docs --check` fails too. Neither is visible from the diff.
+
+### Fixed — a relocation guard failed on writers it was not about (#1658)
+
+- `descriptor_bound_root_relocation_never_retargets_a_replacement_root` failed
+  intermittently on Linux with `left: 1, right: 0`, which named nothing — a real
+  boundary breach and an unrelated writer were indistinguishable.
+- The assertion was stricter than the invariant its own message stated: it
+  required the replacement root to be *entirely empty* while claiming to check
+  "no artifact or temporary leaf".
+- Directories are bound *before* the root is renamed away, so anything reaching
+  the replacement can only have got there by re-resolving the path — which
+  recreates the artifact tree, the published name, or its temporary. Those three
+  still fail, and the message now lists what was found. Anything else came from
+  a different writer and is not this guard's subject.
+- A sibling test pins both directions, so the relaxation cannot quietly mute the
+  invariant. Whether an unrelated writer touches the data directory without
+  `test_env_lock()` remains open and is unaffected by this.
+
 ## [3.10.1] — 2026-09-01
 
 ### Fixed — the tee refusal contradicted itself (#1671)

--- a/rust/src/core/context_overhead.rs
+++ b/rust/src/core/context_overhead.rs
@@ -264,9 +264,28 @@ pub mod tests {
             o.tool_count,
             crate::core::tool_profiles::ToolProfile::Minimal.tool_count() + 1,
         );
+        // #1651: enforce the largest platform, not the running one. The shell
+        // hint is empty on POSIX and not on Windows, so measuring only where
+        // you happen to sit answers a different question than CI asks. #1646
+        // spent three CI round-trips on an edit that measured 1953 on macOS and
+        // failed at 1968 on Windows; the CHANGELOG records the same trap in
+        // #1625. A local run now reports the number CI will enforce.
+        let windows_only = if cfg!(windows) {
+            0
+        } else {
+            crate::instructions::max_shell_hint_tokens()
+        };
+        let worst_case = o.total_tokens() + windows_only;
+
         assert!(
-            o.total_tokens() <= MINIMAL_ARM_PREFIX_BUDGET_TOKENS,
-            "minimal-arm per-turn prefix = {} tok (schemas {} + instr {} + rules {}), budget {}",
+            worst_case <= MINIMAL_ARM_PREFIX_BUDGET_TOKENS,
+            "minimal-arm per-turn prefix = {worst_case} tok on the largest platform \
+             (here {} = schemas {} + instr {} + rules {}, plus {windows_only} for the \
+             Windows-only shell hint), budget {}.\n\
+             Editing a `tool_def` description also changes \
+             docs/reference/generated/mcp-tools.md — re-run \
+             `cargo run --example gen_docs --features dev-tools` or the Documentation \
+             job fails too. Neither consequence is visible from the diff.",
             o.total_tokens(),
             o.tool_schema_tokens,
             o.instruction_tokens,

--- a/rust/src/core/engine_interface/tests.rs
+++ b/rust/src/core/engine_interface/tests.rs
@@ -607,6 +607,58 @@ fn descriptor_relative_parent_swap_never_writes_replacement_or_outside() {
     }
 }
 
+/// Entries in a replacement data root that mean the bound write was re-resolved
+/// by path — the breach the relocation guard exists to catch (#1658).
+///
+/// Directories are bound before the root is renamed away, so nothing can reach
+/// the replacement except through a fresh path resolution, which would recreate
+/// the artifact tree, publish the final name, or leave its temporary. Anything
+/// else in there came from a different writer and is not this guard's subject;
+/// failing on it is what made the guard flaky without ever naming a cause.
+fn boundary_breach<'a>(entries: &'a [String], final_name: &str) -> Vec<&'a String> {
+    let artifact_tree = OUTPUT_DIRECTORY
+        .split('/')
+        .next()
+        .expect("output directory has a first component");
+    entries
+        .iter()
+        .filter(|name| {
+            name.as_str() == artifact_tree || name.as_str() == final_name || name.contains(".tmp")
+        })
+        .collect()
+}
+
+/// The relaxed guard must still catch what it was written for. Both directions
+/// are pinned here so a later relaxation cannot quietly mute the invariant.
+#[test]
+fn the_relocation_guard_catches_a_breach_and_ignores_a_foreign_writer() {
+    let final_name = "f00d.txt".to_string();
+
+    for breach in [
+        "engine-interface".to_string(),
+        final_name.clone(),
+        "f00d.txt.tmp91237".to_string(),
+    ] {
+        let entries = vec![breach.clone()];
+        assert_eq!(
+            boundary_breach(&entries, &final_name).len(),
+            1,
+            "must still be caught: {breach}"
+        );
+    }
+
+    let foreign = vec![
+        "archives".to_string(),
+        "sessions".to_string(),
+        "cloud".to_string(),
+        "knowledge.db".to_string(),
+    ];
+    assert!(
+        boundary_breach(&foreign, &final_name).is_empty(),
+        "an unrelated writer is not a descriptor-binding breach"
+    );
+}
+
 #[cfg(any(unix, windows))]
 #[test]
 fn descriptor_bound_root_relocation_never_retargets_a_replacement_root() {
@@ -650,12 +702,30 @@ fn descriptor_bound_root_relocation_never_retargets_a_replacement_root() {
 
     let did_relocate = relocated.load(std::sync::atomic::Ordering::SeqCst);
     let bound_root = if did_relocate {
-        assert_eq!(
-            std::fs::read_dir(&data_root)
-                .expect("replacement data root")
-                .count(),
-            0,
-            "replacement root received no artifact or temporary leaf"
+        // #1658: assert the invariant, not emptiness. This used to require the
+        // replacement root to have *no entries at all*, while its own message
+        // claimed the narrower "no artifact or temporary leaf" — so any
+        // unrelated writer touching the data directory failed a test about
+        // descriptor binding, intermittently and only on Linux. `left: 1,
+        // right: 0` named nothing, which is why the first failure could not be
+        // told apart from a real boundary breach.
+        //
+        // What a real breach looks like is specific: the directories are bound
+        // *before* the barrier renames the root, so anything landing in the
+        // replacement can only have got there by re-resolving the path
+        // afterwards — which would recreate the artifact tree
+        // (`engine-interface/…`), the published name, or its temporary leaf.
+        // Those still fail, and now they say what was found.
+        let entries: Vec<String> = std::fs::read_dir(&data_root)
+            .expect("replacement data root")
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        let breach = boundary_breach(&entries, &final_name);
+        assert!(
+            breach.is_empty(),
+            "replacement root received an artifact or temporary leaf: {breach:?} \
+             (all entries: {entries:?})"
         );
         &opened_root
     } else {

--- a/rust/src/instructions.rs
+++ b/rust/src/instructions.rs
@@ -595,8 +595,19 @@ fn build_shell_hint() -> String {
     if !cfg!(windows) {
         return String::new();
     }
-    let name = crate::shell::shell_name();
-    let is_posix = matches!(name.as_str(), "bash" | "sh" | "zsh" | "fish");
+    shell_hint_text(&crate::shell::shell_name())
+}
+
+/// The Windows shell hint for `name`, independent of the running platform.
+///
+/// Split out for the per-turn token budget (#1651). The hint is empty on POSIX
+/// and not on Windows, so the prefix is not the same size everywhere — and a
+/// budget measured where the developer happens to sit answers a different
+/// question than the one CI enforces. The guard prices this branch on every
+/// platform, and calls the same function the runtime does so the two cannot
+/// drift apart.
+pub(crate) fn shell_hint_text(name: &str) -> String {
+    let is_posix = matches!(name, "bash" | "sh" | "zsh" | "fish");
     if is_posix {
         format!("\nSHELL: {name} (POSIX) — no PowerShell cmdlets.\n")
     } else if name.contains("powershell") || name.contains("pwsh") {
@@ -604,6 +615,31 @@ fn build_shell_hint() -> String {
     } else {
         format!("\nSHELL: {name}.\n")
     }
+}
+
+/// The largest number of tokens [`build_shell_hint`] can add on Windows (#1651).
+///
+/// The candidate list is not closed — `shell_name()` returns whatever basename
+/// it finds — but it covers every branch of [`shell_hint_text`] with the longest
+/// realistic name, which is what the budget needs. An exotic long shell name
+/// would cost a token or two more; the budget carries margin for exactly that.
+#[cfg(test)]
+pub(crate) fn max_shell_hint_tokens() -> usize {
+    const BUDGETED_SHELL_NAMES: &[&str] = &[
+        "powershell",
+        "pwsh",
+        "cmd",
+        "bash",
+        "sh",
+        "zsh",
+        "fish",
+        "git-bash",
+    ];
+    BUDGETED_SHELL_NAMES
+        .iter()
+        .map(|name| crate::core::tokens::count_tokens(&shell_hint_text(name)))
+        .max()
+        .unwrap_or(0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Two test guards whose numbers did not mean what they appeared to mean. Neither
changes product behaviour; both change what a failure tells you.

## #1651 — the token-budget gate measured one platform and enforced all

The per-turn prefix is capped at 1965 tokens, but it is **not the same size on
every platform**: the Windows shell hint is empty on POSIX. A developer measured
1941 on macOS, read 24 tokens of headroom, and CI enforced a number ~15 higher.
#1646 spent three CI round-trips on exactly that, and the CHANGELOG records the
same trap in #1625.

The guard now prices the Windows-only hint on every platform and asserts the
worst case. A local run reports **1958** — what CI will enforce — and **7 tokens
of real headroom** instead of an imagined 24.

The hint's formatting moved into one function the runtime and the guard share,
so the measured cost cannot drift from the emitted text. The failure message
also names the second invisible consequence of editing a `tool_def`:
`mcp-tools.md` embeds the description verbatim, so `gen_docs --check` fails too.

Note the headroom is genuinely tight. That is now *visible* rather than
imagined, which was the point; buying more room by trimming descriptions is a
separate call and would only reset the clock.

## #1658 — a relocation guard failed on writers it was not about

`descriptor_bound_root_relocation_never_retargets_a_replacement_root` failed
intermittently on Linux with `left: 1, right: 0` — a number naming nothing, so a
real boundary breach and an unrelated writer were indistinguishable. It was
filed rather than patched for that reason.

The assertion was **stricter than the invariant its own message stated**: it
required the replacement root to be entirely empty while claiming to check "no
artifact or temporary leaf".

Directories are bound *before* the barrier renames the root away, so nothing can
reach the replacement except by re-resolving the path afterwards — which
recreates the artifact tree (`engine-interface/…`), publishes the final name, or
leaves its temporary. **Those three still fail**, and the message now lists what
it found. Anything else came from a different writer and is not this guard's
subject.

A sibling test pins both directions, so the relaxation cannot quietly mute the
invariant. Whether some test writes into the data directory without
`test_env_lock()` remains open; this does not answer that, and does not need to.

## Verification

- `cargo test --lib`: 10696 passed, 0 failed.
- The budget figure was read directly, by setting the cap to 1 and reading the
  assertion, then restoring it — the same method the issue describes.
- Clippy `-D warnings` and loc-gate green.

Fixes #1651
Fixes #1658

🤖 Generated with [Claude Code](https://claude.com/claude-code)