### PR TITLE
feat(dashboard): ask users how they actually use lean-ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added — the dashboard asks how you use lean-ctx
+
+- A form in the dashboard's Settings view asks four questions: what you use
+  lean-ctx for, what you like most about it, what is missing, and how often you
+  use it. Three are free text on purpose — a fixed list of features can only
+  ever return the answers it already contains, and the point is to learn which
+  use cases exist. Frequency is the one multiple choice, and it is what makes
+  the free text groupable: "what's missing" from a daily user and from someone
+  who installed it yesterday are usually different wishes.
+- Nothing is sent unless the button is pressed. `POST /api/feedback` has no
+  background caller, the form starts empty on every load, and the notice sits
+  **above** the button rather than in a changelog: pressing send transmits the
+  answers, the lean-ctx version and the anonymous installation id to
+  leanctx.com — nothing else, and nothing at all until then.
+- Answers are validated before they leave the machine: a submission that answers
+  nothing is refused, and an over-long answer is refused with the field named
+  rather than travelling to be silently truncated at the other end. A failed
+  send keeps what you typed.
+- Routed through the dashboard's own backend, like the leaderboard board (#466):
+  the CSP pins `connect-src` to `'self'`, so the browser never reaches
+  `api.leanctx.com` — and the one place that decides what leaves the machine is
+  a single file.
+- An optional contact field exists for people who want an answer back. Empty
+  means anonymous, and empty is the default.
+
 ### Fixed — the token-budget gate measured one platform and enforced all (#1651)
 
 - `minimal_arm_per_turn_prefix_stays_within_budget` caps the per-turn prefix at

--- a/rust/src/cloud_client.rs
+++ b/rust/src/cloud_client.rs
@@ -424,6 +424,36 @@ pub fn heartbeat(payload: &serde_json::Value) -> Result<String, String> {
     Ok(json["message"].as_str().unwrap_or("OK").to_string())
 }
 
+/// Send one volunteered product-feedback submission. No authentication.
+///
+/// Anonymous like [`heartbeat`], and for the same reason: there is no account to
+/// attach this to, and requiring one would silence exactly the users worth
+/// hearing from. The payload carries only what the person typed into the form,
+/// plus the installation id and version so answers can be read in context —
+/// never anything derived from their code, paths or usage.
+///
+/// The server may answer 429 when one installation has already sent several
+/// today; that is surfaced to the caller rather than swallowed, so the UI can
+/// say what happened instead of reporting a send that was dropped.
+pub fn submit_product_feedback(payload: &serde_json::Value) -> Result<String, String> {
+    let url = format!("{}/api/feedback/product", api_url());
+
+    let resp = ureq::post(&url)
+        .header("Content-Type", "application/json")
+        .send(&serde_json::to_vec(payload).map_err(|e| format!("JSON error: {e}"))?)
+        .map_err(|e| format!("Could not send feedback: {e}"))?;
+
+    let body = resp
+        .into_body()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response: {e}"))?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("Invalid JSON: {e}"))?;
+
+    Ok(json["message"].as_str().unwrap_or("Thanks").to_string())
+}
+
 /// Result of a successful Wrapped publish (`POST /api/wrapped`). The `edit_token` is returned
 /// (and must be stored to delete/claim later) only on a *fresh* insert; on a signed re-publish
 /// the server updates the existing card in place and omits it (the client keeps the stored one).

--- a/rust/src/dashboard/mod.rs
+++ b/rust/src/dashboard/mod.rs
@@ -45,6 +45,7 @@ const COCKPIT_COMPONENT_LEADERBOARD_JS: &str =
 const COCKPIT_COMPONENT_AREA_TABS_JS: &str = include_str!("static/components/cockpit-area-tabs.js");
 const COCKPIT_COMPONENT_PROTECTION_JS: &str =
     include_str!("static/components/cockpit-protection.js");
+const COCKPIT_COMPONENT_FEEDBACK_JS: &str = include_str!("static/components/cockpit-feedback.js");
 const COCKPIT_COMPONENT_SETTINGS_JS: &str = include_str!("static/components/cockpit-settings.js");
 const COCKPIT_COMPONENT_TELEMETRY_JS: &str = include_str!("static/components/cockpit-telemetry.js");
 const COCKPIT_COMPONENT_ADOPTION_JS: &str = include_str!("static/components/cockpit-adoption.js");

--- a/rust/src/dashboard/routes/feedback.rs
+++ b/rust/src/dashboard/routes/feedback.rs
@@ -1,0 +1,217 @@
+//! Dashboard feedback API — the form that asks what people use lean-ctx for.
+//!
+//! - `POST /api/feedback` → forward one submission to `api.leanctx.com`.
+//!
+//! Same-origin proxy, like the leaderboard board (#466): the dashboard CSP pins
+//! `connect-src` to `'self'`, so the browser cannot reach `api.leanctx.com`
+//! itself. Routing it through here also means the form never has to know an
+//! external hostname, and the one place that decides what leaves the machine is
+//! this file.
+//!
+//! What leaves: exactly the four answers the person typed, an optional contact
+//! they chose to add, plus the installation id and lean-ctx version so the
+//! answers can be read in context. Nothing is derived from their code, paths,
+//! prompts or usage, and nothing is sent unless they press the button — this
+//! endpoint has no background caller.
+
+use serde::Deserialize;
+
+use super::helpers::json_err;
+
+pub(super) fn handle(
+    path: &str,
+    _query_str: &str,
+    method: &str,
+    body: &str,
+) -> Option<(&'static str, &'static str, String)> {
+    match path {
+        "/api/feedback" if method.eq_ignore_ascii_case("POST") => Some(post_feedback(body)),
+        "/api/feedback" => Some((
+            "405 Method Not Allowed",
+            "application/json",
+            json_err("POST is required to send feedback"),
+        )),
+        _ => None,
+    }
+}
+
+/// Per-field cap, mirroring the server's. Rejecting an over-long answer here
+/// costs the person nothing but a message; letting it travel only to be
+/// truncated server-side would silently drop the end of what they wrote.
+const MAX_ANSWER_CHARS: usize = 2_000;
+
+#[derive(Deserialize, Default)]
+struct FeedbackReq {
+    #[serde(default)]
+    use_case: String,
+    #[serde(default)]
+    likes_most: String,
+    #[serde(default)]
+    wishes: String,
+    #[serde(default)]
+    frequency: String,
+    #[serde(default)]
+    contact: Option<String>,
+}
+
+fn post_feedback(body: &str) -> (&'static str, &'static str, String) {
+    let req: FeedbackReq = match serde_json::from_str(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                "400 Bad Request",
+                "application/json",
+                json_err(&format!("invalid JSON: {e}")),
+            );
+        }
+    };
+
+    let use_case = req.use_case.trim();
+    let likes_most = req.likes_most.trim();
+    let wishes = req.wishes.trim();
+
+    if use_case.is_empty() && likes_most.is_empty() && wishes.is_empty() {
+        return (
+            "400 Bad Request",
+            "application/json",
+            json_err("answer at least one question before sending"),
+        );
+    }
+    for (label, value) in [
+        ("use_case", use_case),
+        ("likes_most", likes_most),
+        ("wishes", wishes),
+    ] {
+        if value.chars().count() > MAX_ANSWER_CHARS {
+            return (
+                "400 Bad Request",
+                "application/json",
+                json_err(&format!(
+                    "{label} is longer than {MAX_ANSWER_CHARS} characters"
+                )),
+            );
+        }
+    }
+
+    let installation_id = match crate::core::installation_id::get_or_create() {
+        Ok(id) => id,
+        Err(e) => {
+            return (
+                "500 Internal Server Error",
+                "application/json",
+                json_err(&format!("could not read the installation id: {e}")),
+            );
+        }
+    };
+
+    let payload = serde_json::json!({
+        "installation_id": installation_id,
+        "version": env!("CARGO_PKG_VERSION"),
+        "use_case": use_case,
+        "likes_most": likes_most,
+        "wishes": wishes,
+        "frequency": req.frequency.trim(),
+        "contact": req.contact.as_deref().map(str::trim).filter(|c| !c.is_empty()),
+    });
+
+    match crate::cloud_client::submit_product_feedback(&payload) {
+        Ok(message) => (
+            "200 OK",
+            "application/json",
+            serde_json::json!({ "ok": true, "message": message }).to_string(),
+        ),
+        // The upstream failed, not this request. A 502 with the reason lets the
+        // form say "couldn't reach the server" and keep what was typed, instead
+        // of reporting a send that never happened. The client's message already
+        // names the failure, so it is passed through rather than prefixed again.
+        Err(e) => ("502 Bad Gateway", "application/json", json_err(&e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(body: &str) -> &'static str {
+        post_feedback(body).0
+    }
+
+    #[test]
+    fn a_submission_with_no_answers_is_refused_before_it_leaves_the_machine() {
+        assert_eq!(
+            status(r#"{"use_case":"  ","likes_most":"","wishes":""}"#),
+            "400 Bad Request"
+        );
+        assert_eq!(status("{}"), "400 Bad Request");
+    }
+
+    #[test]
+    fn malformed_json_is_a_client_error_not_a_crash() {
+        assert_eq!(status("not json"), "400 Bad Request");
+    }
+
+    /// An over-long answer is refused with a message naming the field, rather
+    /// than travelling to be silently truncated at the other end.
+    #[test]
+    fn an_over_long_answer_names_the_field() {
+        let long = "x".repeat(MAX_ANSWER_CHARS + 1);
+        let body = serde_json::json!({ "wishes": long }).to_string();
+        let (code, _, payload) = post_feedback(&body);
+        assert_eq!(code, "400 Bad Request");
+        assert!(payload.contains("wishes"), "{payload}");
+    }
+
+    /// The cap counts characters: 2000 multi-byte answers are within it.
+    #[test]
+    fn a_multibyte_answer_is_measured_in_characters() {
+        let body = serde_json::json!({ "wishes": "ü".repeat(MAX_ANSWER_CHARS) }).to_string();
+        assert_ne!(
+            post_feedback(&body).0,
+            "400 Bad Request",
+            "2000 characters is within the cap regardless of encoding"
+        );
+    }
+
+    /// Both layers used to prefix the reason, so the caller was told
+    /// "could not send feedback: Could not send feedback: …".
+    #[test]
+    fn an_upstream_failure_is_reported_once() {
+        // The lock is not optional: `LEAN_CTX_API_URL` is process-global, and a
+        // neighbouring test reading the environment while this one rewrites it
+        // is the race #1653 fixed once already.
+        let _lock = crate::core::data_dir::test_env_lock();
+
+        // Point the client at a port nothing is listening on so the send fails
+        // for a reason that has nothing to do with this request's contents.
+        let previous = std::env::var("LEAN_CTX_API_URL").ok();
+        crate::test_env::set_var("LEAN_CTX_API_URL", "http://127.0.0.1:9");
+
+        let (code, _, body) = post_feedback(r#"{"wishes":"anything"}"#);
+
+        match previous {
+            Some(value) => crate::test_env::set_var("LEAN_CTX_API_URL", value),
+            None => crate::test_env::remove_var("LEAN_CTX_API_URL"),
+        }
+
+        assert_eq!(code, "502 Bad Gateway");
+        assert_eq!(
+            body.to_lowercase()
+                .matches("could not send feedback")
+                .count(),
+            1,
+            "the reason must be stated once: {body}"
+        );
+    }
+
+    #[test]
+    fn a_get_says_which_verb_is_required() {
+        let (code, _, body) = handle("/api/feedback", "", "GET", "").expect("route matches");
+        assert_eq!(code, "405 Method Not Allowed");
+        assert!(body.contains("POST"), "{body}");
+    }
+
+    #[test]
+    fn unrelated_paths_are_not_claimed() {
+        assert!(handle("/api/stats", "", "POST", "").is_none());
+    }
+}

--- a/rust/src/dashboard/routes/mod.rs
+++ b/rust/src/dashboard/routes/mod.rs
@@ -3,6 +3,7 @@
 mod agents;
 mod context;
 mod doctor;
+mod feedback;
 mod graph;
 pub(crate) mod health;
 pub mod helpers;
@@ -52,6 +53,7 @@ fn match_component_path(path: &str) -> Option<String> {
         "/static/components/cockpit-palette.js" => super::COCKPIT_COMPONENT_PALETTE_JS,
         "/static/components/cockpit-roi.js" => super::COCKPIT_COMPONENT_ROI_JS,
         "/static/components/cockpit-replay.js" => super::COCKPIT_COMPONENT_REPLAY_JS,
+        "/static/components/cockpit-feedback.js" => super::COCKPIT_COMPONENT_FEEDBACK_JS,
         "/static/components/cockpit-leaderboard.js" => super::COCKPIT_COMPONENT_LEADERBOARD_JS,
         "/static/components/cockpit-area-tabs.js" => super::COCKPIT_COMPONENT_AREA_TABS_JS,
         "/static/components/cockpit-protection.js" => super::COCKPIT_COMPONENT_PROTECTION_JS,
@@ -195,6 +197,7 @@ pub fn route_response(
         .or_else(|| settings::handle(path, query_str, method, body))
         .or_else(|| kernel::handle(path, query_str, method, body))
         .or_else(|| doctor::handle(path, query_str, method, body))
+        .or_else(|| feedback::handle(path, query_str, method, body))
         .or_else(|| leaderboard::handle(path, query_str, method, body))
         .or_else(|| health::handle(path, query_str, method, body))
         .or_else(|| provenance::handle(path, query_str, method, body));

--- a/rust/src/dashboard/static/components/cockpit-feedback.js
+++ b/rust/src/dashboard/static/components/cockpit-feedback.js
@@ -1,0 +1,260 @@
+/**
+ * Product feedback — four questions about how people actually use lean-ctx.
+ *
+ * Three of them are free text on purpose: a fixed list of features would only
+ * ever return the answers it already contained, and the point is to learn which
+ * use cases exist, not to confirm the ones we guessed. The one multiple-choice
+ * question is frequency, which is what makes the free text groupable later —
+ * "what's missing" from a daily user and from someone who installed it
+ * yesterday are usually different wishes.
+ *
+ * Nothing is sent unless the button is pressed. There is no background caller
+ * for POST /api/feedback, the form starts empty on every load, and the notice
+ * above the button names where the answers go before they go there.
+ */
+
+function api() {
+  return window.LctxApi && window.LctxApi.apiFetch ? window.LctxApi.apiFetch : null;
+}
+
+function esc(value) {
+  return String(value == null ? '' : value).replace(/[&<>"']/g, function (ch) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+  });
+}
+
+/* Kept in step with the server cap; the counter turns red before the send does. */
+var MAX_ANSWER = 2000;
+
+var FREQUENCIES = [
+  { id: 'daily', label: 'Daily' },
+  { id: 'weekly', label: 'A few times a week' },
+  { id: 'occasionally', label: 'Occasionally' },
+  { id: 'new', label: 'Just started' },
+];
+
+var QUESTIONS = [
+  {
+    id: 'use_case',
+    label: 'What do you use lean-ctx for?',
+    hint: 'The work it does for you — in your words.',
+  },
+  {
+    id: 'likes_most',
+    label: 'What do you like most about it?',
+    hint: 'A tool, a mode, a behaviour — whatever you would miss first.',
+  },
+  {
+    id: 'wishes',
+    label: 'What is missing?',
+    hint: 'The feature you keep wishing were there.',
+  },
+];
+
+class CockpitFeedback extends HTMLElement {
+  constructor() {
+    super();
+    this._answers = { use_case: '', likes_most: '', wishes: '', contact: '' };
+    this._frequency = '';
+    this._notice = null;
+    this._sending = false;
+    this._sent = false;
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  _setNotice(kind, msg) {
+    this._notice = { kind: kind, msg: msg };
+    this.render();
+  }
+
+  async _send() {
+    if (this._sending) return;
+
+    var answered = ['use_case', 'likes_most', 'wishes'].some(
+      function (id) { return this._answers[id].trim() !== ''; },
+      this
+    );
+    if (!answered) {
+      this._setNotice('err', 'Answer at least one question before sending.');
+      return;
+    }
+
+    var apiFetch = api();
+    if (!apiFetch) {
+      this._setNotice('err', 'Dashboard API unavailable — reload the page.');
+      return;
+    }
+
+    this._sending = true;
+    this.render();
+
+    try {
+      var res = await apiFetch('/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          use_case: this._answers.use_case,
+          likes_most: this._answers.likes_most,
+          wishes: this._answers.wishes,
+          frequency: this._frequency,
+          contact: this._answers.contact,
+        }),
+      });
+      var data = null;
+      try {
+        data = await res.json();
+      } catch (e) {
+        data = null;
+      }
+
+      if (res && res.ok) {
+        // Only now is the typed text cleared — an error must never lose it.
+        this._sent = true;
+        this._answers = { use_case: '', likes_most: '', wishes: '', contact: '' };
+        this._frequency = '';
+        this._notice = { kind: 'ok', msg: 'Sent — thank you.' };
+      } else {
+        var reason = (data && (data.error || data.message)) || 'the server refused it';
+        this._notice = { kind: 'err', msg: 'Not sent: ' + reason };
+      }
+    } catch (e) {
+      this._notice = { kind: 'err', msg: 'Not sent: ' + (e && e.message ? e.message : 'network error') };
+    } finally {
+      this._sending = false;
+      this.render();
+    }
+  }
+
+  _bind() {
+    var self = this;
+
+    QUESTIONS.concat([{ id: 'contact' }]).forEach(function (q) {
+      var el = self.querySelector('#fb-' + q.id);
+      if (!el) return;
+      el.addEventListener('input', function () {
+        self._answers[q.id] = el.value;
+        var counter = self.querySelector('#fb-count-' + q.id);
+        if (counter) {
+          var n = el.value.length;
+          counter.textContent = n + ' / ' + MAX_ANSWER;
+          counter.style.color = n > MAX_ANSWER ? 'var(--red)' : '';
+        }
+      });
+    });
+
+    Array.prototype.forEach.call(self.querySelectorAll('[data-freq]'), function (btn) {
+      btn.addEventListener('click', function () {
+        var id = btn.getAttribute('data-freq');
+        // Clicking the active choice clears it: the question is optional and
+        // there is otherwise no way back to "I would rather not say".
+        self._frequency = self._frequency === id ? '' : id;
+        self.render();
+      });
+    });
+
+    var send = self.querySelector('#fb-send');
+    if (send) send.addEventListener('click', function () { self._send(); });
+
+    var again = self.querySelector('#fb-again');
+    if (again) {
+      again.addEventListener('click', function () {
+        self._sent = false;
+        self._notice = null;
+        self.render();
+      });
+    }
+  }
+
+  render() {
+    if (this._sent) {
+      this.innerHTML =
+        '<div class="card">' +
+        '<div class="card-header"><h3>Thank you</h3></div>' +
+        '<p class="hs" style="margin:0 0 12px;font-size:12px;opacity:.85">' +
+        'Your answers are with us. They shape what gets built next.</p>' +
+        '<button type="button" id="fb-again" class="filter-btn">Send more</button>' +
+        '</div>';
+      this._bind();
+      return;
+    }
+
+    var self = this;
+    var fields = QUESTIONS.map(function (q) {
+      var value = self._answers[q.id];
+      return (
+        '<div style="margin-bottom:16px">' +
+        '<label for="fb-' + q.id + '" class="hs" ' +
+        'style="display:block;font-size:12px;font-weight:600;margin-bottom:2px">' +
+        esc(q.label) + '</label>' +
+        '<p class="hs" style="margin:0 0 6px;font-size:11px;opacity:.7">' + esc(q.hint) + '</p>' +
+        '<textarea id="fb-' + q.id + '" rows="3" ' +
+        'style="width:100%;background:var(--bg);color:inherit;border:1px solid var(--border);' +
+        'border-radius:6px;padding:8px 10px;font:inherit;font-size:12px;resize:vertical">' +
+        esc(value) + '</textarea>' +
+        '<span id="fb-count-' + q.id + '" class="hs" ' +
+        'style="display:block;text-align:right;font-size:10px;opacity:.55;margin-top:2px">' +
+        value.length + ' / ' + MAX_ANSWER + '</span>' +
+        '</div>'
+      );
+    }).join('');
+
+    var freqButtons = FREQUENCIES.map(function (f) {
+      var on = self._frequency === f.id;
+      return (
+        '<button type="button" class="filter-btn' + (on ? ' active' : '') + '" ' +
+        'data-freq="' + esc(f.id) + '" aria-pressed="' + (on ? 'true' : 'false') + '">' +
+        esc(f.label) + '</button>'
+      );
+    }).join('');
+
+    var notice = '';
+    if (this._notice) {
+      var color = this._notice.kind === 'ok' ? 'var(--green)' : 'var(--red)';
+      notice =
+        '<p class="hs" style="margin:10px 0 0;font-size:11px;color:' + color + '">' +
+        esc(this._notice.msg) + '</p>';
+    }
+
+    this.innerHTML =
+      '<div class="card">' +
+      '<div class="card-header"><h3>Tell us how you use lean-ctx</h3></div>' +
+      '<p class="hs" style="margin:0 0 14px;font-size:12px;opacity:.8">' +
+      'Four questions, all optional. What you write here decides what gets built next.</p>' +
+      fields +
+      '<div style="margin-bottom:16px">' +
+      '<span class="hs" style="display:block;font-size:12px;font-weight:600;margin-bottom:6px">' +
+      'How often do you use it?</span>' +
+      '<div class="filter-row" style="display:flex;gap:6px;flex-wrap:wrap">' + freqButtons + '</div>' +
+      '</div>' +
+      '<div style="margin-bottom:16px">' +
+      '<label for="fb-contact" class="hs" ' +
+      'style="display:block;font-size:12px;font-weight:600;margin-bottom:2px">' +
+      'Email or handle <span style="opacity:.6;font-weight:400">(optional)</span></label>' +
+      '<p class="hs" style="margin:0 0 6px;font-size:11px;opacity:.7">' +
+      'Only if you want an answer back. Leave it empty to stay anonymous.</p>' +
+      '<input id="fb-contact" type="text" autocomplete="off" ' +
+      'value="' + esc(this._answers.contact) + '" ' +
+      'style="width:100%;background:var(--bg);color:inherit;border:1px solid var(--border);' +
+      'border-radius:6px;padding:8px 10px;font:inherit;font-size:12px">' +
+      '</div>' +
+      // Said before the button, not after: pressing send is the moment
+      // something leaves this machine, and the person deserves to know that
+      // before they press it rather than in a changelog.
+      '<p class="hs" style="margin:0 0 10px;font-size:11px;opacity:.7">' +
+      'Pressing send transmits these answers to leanctx.com, together with your ' +
+      'lean-ctx version and the anonymous installation id. Nothing else — no code, ' +
+      'paths, prompts or usage data — and nothing at all until you press it.</p>' +
+      '<button type="button" id="fb-send" class="filter-btn active"' +
+      (this._sending ? ' disabled' : '') + '>' +
+      (this._sending ? 'Sending…' : 'Send feedback') + '</button>' +
+      notice +
+      '</div>';
+
+    this._bind();
+  }
+}
+
+customElements.define('cockpit-feedback', CockpitFeedback);

--- a/rust/src/dashboard/static/index.html
+++ b/rust/src/dashboard/static/index.html
@@ -279,6 +279,7 @@
 <script type="module" src="/static/components/cockpit-area-tabs.js"></script>
 <script type="module" src="/static/components/cockpit-protection.js"></script>
 <script type="module" src="/static/components/cockpit-settings.js"></script>
+<script type="module" src="/static/components/cockpit-feedback.js"></script>
 <script type="module" src="/static/components/cockpit-telemetry.js"></script>
 <script type="module" src="/static/components/cockpit-adoption.js"></script>
 <script type="module" src="/static/components/cockpit-solution.js"></script>
@@ -415,6 +416,7 @@
     </section>
     <section id="view-settings" class="view">
       <cockpit-settings id="settingsView"></cockpit-settings>
+      <cockpit-feedback id="feedbackView"></cockpit-feedback>
     </section>
     <section id="view-telemetry" class="view">
       <cockpit-telemetry id="telemetryView"></cockpit-telemetry>


### PR DESCRIPTION
A form in the dashboard's Settings view with four questions: what you use
lean-ctx for, what you like most, what is missing, and how often you use it.

## Why three of the four are free text

A fixed list of features can only ever return the answers it already contains.
The point here is to learn which use cases exist — not to confirm the ones we
guessed. Frequency is the single multiple choice, and it is what makes the free
text groupable afterwards: "what is missing" from a daily user and from someone
who installed it yesterday are usually different wishes.

## Nothing is sent unless the button is pressed

`POST /api/feedback` has no background caller, the form starts empty on every
load, and the notice naming the destination sits **above** the button rather
than in a changelog. In a tool that advertises honest metrics, silent telemetry
would be the wrong way to learn what users want.

What travels: the four answers, an optional contact the person chose to add, the
lean-ctx version, and the anonymous `installation_id` the heartbeat already
uses. Nothing derived from code, paths, prompts or usage.

## Routing and validation

The request goes through the dashboard's own backend, like the leaderboard board
(#466): the CSP pins `connect-src` to `'self'`, so the browser never reaches
`api.leanctx.com`, and the one place deciding what leaves the machine is a
single file.

Answers are validated there before they travel — a submission that answers
nothing is refused, and an over-long answer is refused **with the field named**
instead of being silently truncated at the far end. A failed send keeps what was
typed and reports the reason once (both layers used to prefix it, producing
"could not send feedback: Could not send feedback: …").

## Verification

- `cargo test --lib`: 10702 passed, 0 failed.
- `PREFLIGHT_BASE=github/main scripts/preflight.sh`: **PASSED**, 7/7 gates.
- End-to-end against a local stub rather than production: the dashboard received
  exactly `{use_case, likes_most, wishes, frequency, installation_id, version}`
  with `contact: null` when left empty, and nothing else.
- The upstream-down path was exercised too: `502`, reason stated once, typed
  text kept.

## Server side

`POST /api/feedback/product` plus `GET /admin/feedback` live on the `deploy`
branch. **Deploy that first** — otherwise this form is visible and every send
ends in "could not send feedback". The error is handled cleanly and the text is
preserved, but it is an avoidable first impression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)