### PR TITLE
fix: an elided block says so, and the walk hint stops blaming the cwd (#1679, #1680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed — lines vanished mid-result behind a content-shaped marker (#1679)
+
+- `gh issue view … --comments` came back with 34 lines removed from the middle,
+  marked only by `... (34 more lines)` — a string shaped like output, which the
+  caller could not tell from a line the command printed.
+- It was the *only* trace. The `[lean-ctx: …→… tok]` footer that announces a
+  compression is hidden on the MCP path by default (`SavingsFooter::Auto` is
+  invisible in an MCP context), and that is the primary path. So a lossy result
+  was indistinguishable from a complete one, with nothing to recover from.
+- Elisions now announce themselves:
+  `[lean-ctx: 34 lines elided — re-run with raw=true for the full output]`. It
+  is unmistakably ours and names a route that always works — unlike an archive
+  handle, `raw=true` does not depend on the response having been archived or on
+  a hint tier being enabled.
+- Applied at all 41 elision sites across 34 compressors through one shared
+  helper, and a test walks the source tree so a new compressor cannot hand-roll
+  the old marker back in.
+- The reporter suspected a dedup/repeat-collapse path because the elided block
+  was a near-duplicate of the preceding comment. It was not: `gh issue view`
+  runs `compact_head_tail(output, 40, 40)`, so with 114 non-blank lines exactly
+  34 fall in the middle. The duplicate comment was a coincidence of where the
+  cut landed.
+
+### Fixed — the walk hint blamed directories that were never walked (#1680)
+
+- `grep -rn PATTERN /absolute/path/outside/the/root/file.go`, run from a project
+  root, produced a hint naming `.claude/worktrees/`, `node_modules/` and
+  `.venv/` "walked by grep/find". grep read exactly one file, and none of those
+  directories are under it — the list tracked the shell's cwd, not the path the
+  command was given.
+- Already fixed on main by the #1662 follow-up, which scans the command's own
+  path operands instead of its starting directory; this adds the reporter's
+  exact scenario as a regression test, including that a single file operand
+  never produces a hint at all.
+
+
 ### Added — the dashboard asks how you use lean-ctx
 
 - A form in the dashboard's Settings view asks four questions: what you use

--- a/rust/src/core/patterns/ansible.rs
+++ b/rust/src/core/patterns/ansible.rs
@@ -78,8 +78,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/artisan.rs
+++ b/rust/src/core/patterns/artisan.rs
@@ -243,9 +243,9 @@ fn compress_tinker(output: &str) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..8].join("\n"),
-        lines.len() - 8
+        super::elision_marker(lines.len() - 8)
     )
 }
 
@@ -255,9 +255,9 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }
 

--- a/rust/src/core/patterns/aws.rs
+++ b/rust/src/core/patterns/aws.rs
@@ -234,8 +234,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/bazel.rs
+++ b/rust/src/core/patterns/bazel.rs
@@ -110,8 +110,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/bun.rs
+++ b/rust/src/core/patterns/bun.rs
@@ -142,8 +142,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/cargo.rs
+++ b/rust/src/core/patterns/cargo.rs
@@ -456,9 +456,9 @@ fn compress_tree(output: &str) -> String {
     if direct.is_empty() {
         let shown = &lines[..20.min(lines.len())];
         return format!(
-            "{}\n... ({} more lines)",
+            "{}\n{}",
             shown.join("\n"),
-            lines.len() - 20
+            super::elision_marker(lines.len() - 20)
         );
     }
 
@@ -490,9 +490,9 @@ fn compress_fmt(output: &str) -> String {
         lines.join("\n")
     } else {
         format!(
-            "{}\n... ({} more lines)",
+            "{}\n{}",
             lines[..5].join("\n"),
-            lines.len() - 5
+            super::elision_marker(lines.len() - 5)
         )
     }
 }
@@ -519,9 +519,9 @@ fn compress_update(output: &str) -> String {
             return lines.join("\n");
         }
         return format!(
-            "{}\n... ({} more lines)",
+            "{}\n{}",
             lines[..5].join("\n"),
-            lines.len() - 5
+            super::elision_marker(lines.len() - 5)
         );
     }
 

--- a/rust/src/core/patterns/cmake.rs
+++ b/rust/src/core/patterns/cmake.rs
@@ -159,8 +159,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/composer.rs
+++ b/rust/src/core/patterns/composer.rs
@@ -94,8 +94,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/deno.rs
+++ b/rust/src/core/patterns/deno.rs
@@ -138,8 +138,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/docker.rs
+++ b/rust/src/core/patterns/docker.rs
@@ -378,9 +378,9 @@ fn compress_inspect(output: &str) -> String {
     if trimmed.lines().count() > 20 {
         let lines: Vec<&str> = trimmed.lines().collect();
         return format!(
-            "{}\n... ({} more lines)",
+            "{}\n{}",
             lines[..10].join("\n"),
-            lines.len() - 10
+            super::elision_marker(lines.len() - 10)
         );
     }
     trimmed.to_string()
@@ -510,9 +510,9 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }
 

--- a/rust/src/core/patterns/dotnet.rs
+++ b/rust/src/core/patterns/dotnet.rs
@@ -295,8 +295,8 @@ fn compact_or_ok(output: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/eslint.rs
+++ b/rust/src/core/patterns/eslint.rs
@@ -138,8 +138,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/gh.rs
+++ b/rust/src/core/patterns/gh.rs
@@ -261,9 +261,9 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }
 
@@ -278,8 +278,9 @@ fn compact_head_tail(text: &str, head: usize, tail: usize) -> String {
     }
     let omitted = lines.len() - head - tail;
     format!(
-        "{}\n... ({omitted} more lines)\n{}",
+        "{}\n{}\n{}",
         lines[..head].join("\n"),
+        super::elision_marker(omitted),
         lines[lines.len() - tail..].join("\n"),
     )
 }
@@ -337,7 +338,15 @@ mod tests {
         let out = compact_head_tail(&lines, 5, 5);
         assert!(out.contains("L0") && out.contains("L4"));
         assert!(out.contains("L195") && out.contains("L199"));
-        assert!(out.contains("... (190 more lines)"));
+        // #1679: the marker is unmistakably lean-ctx's, not content-shaped,
+        // and names the way back — it is the only trace of the cut once the
+        // savings footer is hidden, which is the default on the MCP path.
+        assert!(out.contains("[lean-ctx: 190 lines elided"), "{out}");
+        assert!(out.contains("raw=true"), "{out}");
+        assert!(
+            !out.contains("... (190 more lines)"),
+            "the content-shaped marker must be gone: {out}"
+        );
         assert!(!out.contains("L100"));
     }
 }

--- a/rust/src/core/patterns/golang.rs
+++ b/rust/src/core/patterns/golang.rs
@@ -209,8 +209,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/helm.rs
+++ b/rust/src/core/patterns/helm.rs
@@ -148,8 +148,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/just.rs
+++ b/rust/src/core/patterns/just.rs
@@ -54,9 +54,9 @@ fn compress_evaluate(output: &str) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..10].join("\n"),
-        lines.len() - 10
+        super::elision_marker(lines.len() - 10)
     )
 }
 
@@ -109,7 +109,7 @@ fn compress_run(output: &str) -> String {
             .collect::<Vec<_>>()
             .join("\n");
         if total_lines > 15 {
-            return format!("{shown}\n... ({} more lines)", total_lines - 15);
+            return format!("{shown}\n{}", super::elision_marker(total_lines - 15));
         }
         return shown;
     }

--- a/rust/src/core/patterns/kubectl.rs
+++ b/rust/src/core/patterns/kubectl.rs
@@ -312,9 +312,9 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }
 

--- a/rust/src/core/patterns/mix.rs
+++ b/rust/src/core/patterns/mix.rs
@@ -140,8 +140,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/mod.rs
+++ b/rust/src/core/patterns/mod.rs
@@ -198,6 +198,24 @@ fn shorter_only(compressed: String, original: &str) -> Option<String> {
     }
 }
 
+/// How an elided block announces itself (GH #1679).
+///
+/// The old marker was `... (N more lines)`, which reads as content: a caller
+/// could not tell it from a line the command actually printed. Worse, it was the
+/// *only* trace of the cut — the savings footer that would have announced it is
+/// hidden on the MCP path by default (`SavingsFooter::Auto` → invisible in an
+/// MCP context), which is the primary path. So a lossy result was
+/// indistinguishable from a complete one, with nothing to recover from.
+///
+/// This marker is unmistakably ours, and names the way back. `raw=true` is what
+/// the server instructions and every other compression annotation already point
+/// at, and unlike an archive handle it is always available — it does not depend
+/// on the response having been archived or on a hint tier being enabled.
+pub(crate) fn elision_marker(omitted: usize) -> String {
+    let plural = if omitted == 1 { "line" } else { "lines" };
+    format!("[lean-ctx: {omitted} {plural} elided — re-run with raw=true for the full output]")
+}
+
 type PatternMatcher = fn(&str) -> bool;
 type PatternHandler = fn(&str, &str) -> Option<String>;
 
@@ -944,5 +962,90 @@ mod tests {
         let output = "On branch main\nnothing to commit";
         assert!(try_specific_pattern("gh pr list", output).is_some());
         assert!(try_specific_pattern("gh run list", output).is_some());
+    }
+}
+
+#[cfg(test)]
+mod gh1679 {
+    use super::*;
+
+    /// The reported failure: a `gh issue view --comments` result had 34 lines
+    /// removed from the middle, marked only by `... (34 more lines)`. That
+    /// string is shaped like content — the caller could not tell it from a line
+    /// the command printed — and it was the only trace, because the savings
+    /// footer that would have announced the cut is hidden on the MCP path by
+    /// default. A lossy result was indistinguishable from a complete one.
+    #[test]
+    fn an_elision_announces_itself_as_ours() {
+        let marker = elision_marker(34);
+
+        assert!(
+            marker.starts_with("[lean-ctx:"),
+            "must be unmistakably ours, not content-shaped: {marker}"
+        );
+        assert!(
+            !marker.contains("more lines)"),
+            "the old content-shaped wording must be gone: {marker}"
+        );
+        assert!(marker.contains("34"), "{marker}");
+    }
+
+    /// The marker is the only thing guaranteed to survive, so the way back has
+    /// to be in it. `raw=true` always works — unlike an archive handle, it does
+    /// not depend on the response having been archived or on a hint tier.
+    #[test]
+    fn the_marker_names_a_recovery_that_always_exists() {
+        assert!(
+            elision_marker(1).contains("raw=true"),
+            "{}",
+            elision_marker(1)
+        );
+    }
+
+    #[test]
+    fn one_line_is_not_called_lines() {
+        assert!(
+            elision_marker(1).contains("1 line elided"),
+            "{}",
+            elision_marker(1)
+        );
+        assert!(
+            elision_marker(2).contains("2 lines elided"),
+            "{}",
+            elision_marker(2)
+        );
+    }
+
+    /// Every compressor that elides must use the shared marker. A new one that
+    /// hand-rolls `... (N more lines)` would reintroduce exactly this bug, so
+    /// the source tree is the assertion.
+    #[test]
+    fn no_compressor_hand_rolls_the_old_marker() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/core/patterns");
+        let mut offenders = Vec::new();
+
+        for entry in std::fs::read_dir(&dir).expect("patterns dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&path).expect("read pattern source");
+            // Only the production half: tests legitimately name the old string
+            // to assert it is gone, and this module documents it.
+            let production = source
+                .split_once("#[cfg(test)]")
+                .map_or(source.as_str(), |(head, _)| head);
+            if production.contains("more lines)")
+                && path.file_name().and_then(|n| n.to_str()) != Some("mod.rs")
+            {
+                offenders.push(path.display().to_string());
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these compressors elide with the old content-shaped marker; \
+             use super::elision_marker() instead: {offenders:?}"
+        );
     }
 }

--- a/rust/src/core/patterns/mypy.rs
+++ b/rust/src/core/patterns/mypy.rs
@@ -101,9 +101,9 @@ pub fn compress(_command: &str, output: &str) -> Option<String> {
         Some(trimmed.to_string())
     } else {
         Some(format!(
-            "{}\n... ({} more lines)",
+            "{}\n{}",
             lines[..8].join("\n"),
-            lines.len() - 8
+            super::elision_marker(lines.len() - 8)
         ))
     }
 }

--- a/rust/src/core/patterns/mysql.rs
+++ b/rust/src/core/patterns/mysql.rs
@@ -85,8 +85,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/next_build.rs
+++ b/rust/src/core/patterns/next_build.rs
@@ -152,8 +152,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/npm.rs
+++ b/rust/src/core/patterns/npm.rs
@@ -310,8 +310,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/pip.rs
+++ b/rust/src/core/patterns/pip.rs
@@ -171,8 +171,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/playwright.rs
+++ b/rust/src/core/patterns/playwright.rs
@@ -134,8 +134,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/pnpm.rs
+++ b/rust/src/core/patterns/pnpm.rs
@@ -162,8 +162,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/poetry.rs
+++ b/rust/src/core/patterns/poetry.rs
@@ -346,8 +346,8 @@ fn fallback_compact(output: &str) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/prettier.rs
+++ b/rust/src/core/patterns/prettier.rs
@@ -42,8 +42,8 @@ pub fn compress(output: &str) -> Option<String> {
 
     let lines: Vec<&str> = trimmed.lines().collect();
     Some(format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..5].join("\n"),
-        lines.len() - 5
+        super::elision_marker(lines.len() - 5)
     ))
 }

--- a/rust/src/core/patterns/prisma.rs
+++ b/rust/src/core/patterns/prisma.rs
@@ -117,8 +117,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/psql.rs
+++ b/rust/src/core/patterns/psql.rs
@@ -75,9 +75,9 @@ fn compress_describe(output: &str) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..20].join("\n"),
-        lines.len() - 20
+        super::elision_marker(lines.len() - 20)
     )
 }
 
@@ -87,8 +87,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/ruff.rs
+++ b/rust/src/core/patterns/ruff.rs
@@ -109,8 +109,8 @@ fn compact_output(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/swift.rs
+++ b/rust/src/core/patterns/swift.rs
@@ -126,8 +126,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/systemd.rs
+++ b/rust/src/core/patterns/systemd.rs
@@ -125,8 +125,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/core/patterns/wget.rs
+++ b/rust/src/core/patterns/wget.rs
@@ -50,8 +50,8 @@ pub fn compress(output: &str) -> Option<String> {
         return Some(useful.join("\n"));
     }
     Some(format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         useful[..3].join("\n"),
-        useful.len() - 3
+        super::elision_marker(useful.len() - 3)
     ))
 }

--- a/rust/src/core/patterns/zig.rs
+++ b/rust/src/core/patterns/zig.rs
@@ -84,8 +84,8 @@ fn compact_lines(text: &str, max: usize) -> String {
         return lines.join("\n");
     }
     format!(
-        "{}\n... ({} more lines)",
+        "{}\n{}",
         lines[..max].join("\n"),
-        lines.len() - max
+        super::elision_marker(lines.len() - max)
     )
 }

--- a/rust/src/server/walk_hint.rs
+++ b/rust/src/server/walk_hint.rs
@@ -454,3 +454,76 @@ mod gh1662_scope {
         assert!(walk_hint("grep -rn pattern \"$DIR\"", &cwd).is_some());
     }
 }
+
+#[cfg(test)]
+mod gh1680 {
+    use super::*;
+
+    /// The reporter's case: `grep -rn PATTERN /abs/path/outside/file.go` run
+    /// from a project root that contains `node_modules/`. The hint named three
+    /// directories under the cwd and asserted they were "walked by grep/find" —
+    /// grep read exactly one file, and none of them are under it.
+    #[test]
+    fn an_explicit_path_outside_the_root_is_not_blamed_on_the_cwd() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let bulk = repo.path().join("node_modules");
+        std::fs::create_dir_all(&bulk).expect("mkdir");
+        for i in 0..40 {
+            std::fs::write(bulk.join(format!("f{i}.js")), "x").expect("write");
+        }
+
+        let elsewhere = tempfile::tempdir().expect("tempdir");
+        let target = elsewhere.path().join("types.go");
+        std::fs::write(&target, "package main").expect("write");
+
+        let command = format!("grep -rn \"EvConnected\" {}", target.display());
+        let hint = walk_hint(&command, &repo.path().to_string_lossy());
+
+        assert!(
+            hint.is_none(),
+            "grep read one file outside the root; nothing under the cwd was walked: {hint:?}"
+        );
+    }
+
+    /// The same command rooted at the cwd still gets the hint — the fix must
+    /// not silence the case the hint exists for.
+    #[test]
+    fn the_intended_case_still_fires() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let bulk = repo.path().join("node_modules");
+        std::fs::create_dir_all(&bulk).expect("mkdir");
+        for i in 0..40 {
+            std::fs::write(bulk.join(format!("f{i}.js")), "x").expect("write");
+        }
+        std::fs::write(repo.path().join("main.go"), "package main").expect("write");
+
+        let hint = walk_hint(
+            "grep -rn \"EvConnected\" --include=*.go .",
+            &repo.path().to_string_lossy(),
+        );
+        assert!(
+            hint.is_some_and(|h| h.contains("node_modules/")),
+            "a walk rooted at the repo does traverse node_modules"
+        );
+    }
+
+    /// A single explicit file is not a tree, so even under the cwd the advice
+    /// ("scope the path", "add --exclude-dir") would have nothing to act on.
+    #[test]
+    fn a_single_file_operand_never_produces_a_hint() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let bulk = repo.path().join("node_modules");
+        std::fs::create_dir_all(&bulk).expect("mkdir");
+        for i in 0..40 {
+            std::fs::write(bulk.join(format!("f{i}.js")), "x").expect("write");
+        }
+        let file = repo.path().join("main.go");
+        std::fs::write(&file, "package main").expect("write");
+
+        let hint = walk_hint(
+            &format!("grep -rn x {}", file.display()),
+            &repo.path().to_string_lossy(),
+        );
+        assert!(hint.is_none(), "{hint:?}");
+    }
+}


### PR DESCRIPTION
## #1679 — lines vanished mid-result behind a content-shaped marker

`gh issue view … --comments` came back with 34 lines removed from the middle,
marked only by `... (34 more lines)` — a string shaped like output, which the
caller could not tell from a line the command actually printed.

That marker was the **only** trace. The `[lean-ctx: …→… tok]` footer that
announces a compression is hidden on the MCP path by default
(`SavingsFooter::Auto` → invisible in an MCP context), and the MCP path is the
primary one. So a lossy result was indistinguishable from a complete one, and
carried nothing to recover from. As the reporter put it: a silent gap marked
only by a content-shaped string is the worst case.

Elisions now render:

```
[lean-ctx: 34 lines elided — re-run with raw=true for the full output]
```

`raw=true` rather than an archive handle is deliberate: the marker is the one
thing guaranteed to survive, and `raw=true` always works — an archive handle
depends on the response having been archived and on a hint tier being enabled.

One shared `elision_marker()` backs **all 41 elision sites across 34
compressors**, and a test walks the source tree so a new compressor cannot
hand-roll the old marker back in.

**A correction to the report, recorded for the next reader.** The reporter
reasoned toward a dedup/repeat-collapse path, because the elided block was a
near-duplicate of the comment before it. It is the size-based compressor:
`compress_issue_view` → `compact_head_tail(output, 40, 40)`, so with 114
non-blank lines exactly 34 land in the middle. The duplicate comment was a
coincidence of where the cut fell.

## #1680 — the walk hint blamed directories that were never walked

`grep -rn PATTERN /absolute/path/outside/the/root/file.go`, run from a project
root, produced a hint naming `.claude/worktrees/`, `node_modules/` and `.venv/`
"walked by grep/find". grep read exactly one file, and none of those directories
are under it — the list tracked the shell's cwd, not the path the command was
given.

**Already fixed on main** by the #1662 follow-up, which scans the command's own
path operands instead of its starting directory. The report is against released
3.10.1, which predates that. So this adds the reporter's exact scenario as a
regression test rather than a second fix: an explicit path outside the root
produces no hint, a single file operand produces none either (the advice would
have nothing to act on), and the case the hint exists for still fires.

### Not done, deliberately

The report's *Secondary* point — the hint riding along on a call passing
`inline: true`, which the schema describes as verbatim — is left alone. The same
responses already carry `[exit:N]`, `[truncated: cap=…]`, `[still running at
timeout: …]` and `[cancelled: …]`; making only the walk hint verbatim-aware
would add an inconsistency rather than remove one, and leave a parser no better
off. The clean fix is moving every framework annotation out of the execution
layer into the tool layer, across the foreground, background and detach paths —
worth doing, too large to smuggle into this PR.

## Verification

- `cargo test --lib`: 10710 passed, 0 failed.
- `PREFLIGHT_BASE=github/main scripts/preflight.sh`: **PASSED**, 7/7 gates.
- The one existing test that asserted the old marker now asserts it is gone.

Fixes #1679
Fixes #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)