### PR TITLE
docs(release): finalize 3.10.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [3.10.1] — 2026-09-04
+
 ### Fixed — phone DLP confused repository numbers with phone numbers (#1682)
 
 - The phone detector no longer treats ordinary bare numbers such as issue and
@@ -111,8 +113,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - A sibling test pins both directions, so the relaxation cannot quietly mute the
   invariant. Whether an unrelated writer touches the data directory without
   `test_env_lock()` remains open and is unaffected by this.
-
-## [3.10.1] — 2026-09-01
 
 ### Fixed — the tee refusal contradicted itself (#1671)
 


### PR DESCRIPTION
## Summary

- move every change merged since the planned 3.10.1 cut from `Unreleased` into the 3.10.1 section
- set the release-candidate date to 2026-09-04
- leave `Unreleased` empty for subsequent development

## Verification

- release tag/version coupling accepts `v3.10.1`
- external SDK surface guard passes
- engine-coupled npm package versions match 3.10.1
- diff is changelog-only and whitespace-clean

This prepares the repository for the founder-controlled release. It does not create a tag or publish artifacts.
