### PR TITLE
fix(codex): keep browser auth off API-key proxy rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [3.10.1] — 2026-09-04
 
+### Fixed — Codex browser login was sent to the API-key endpoint (#1685)
+
+- `lean-ctx wrap codex` now selects the `/v1` proxy rail only when Codex has
+  positive API-key evidence. Browser-login credentials in an older `auth.json`,
+  the OS credential store, or another unreadable/unknown auth state stay on
+  Codex's native ChatGPT rail.
+- This prevents the misleading `401 Unauthorized: Missing scopes:
+  api.responses.write` failure seen after a successful browser login. Explicit
+  API-key users continue to use the compressed `/v1` route unchanged.
+
 ### Fixed — phone DLP confused repository numbers with phone numbers (#1682)
 
 - The phone detector no longer treats ordinary bare numbers such as issue and

--- a/rust/src/cli/addon_cmd.rs
+++ b/rust/src/cli/addon_cmd.rs
@@ -837,7 +837,7 @@ mod tests {
     fn positional_skips_flags_and_the_verb() {
         let args: Vec<String> = ["addon", "add", "--yes", "pack.ctxpkg"]
             .iter()
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect();
         assert_eq!(positional(&args, "add"), Some("pack.ctxpkg".into()));
     }
@@ -846,13 +846,13 @@ mod tests {
     fn flag_value_accepts_both_spellings() {
         let split: Vec<String> = ["release", ".", "--output", "out.ctxpkg"]
             .iter()
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect();
         assert_eq!(flag_value(&split, "--output"), Some("out.ctxpkg".into()));
 
         let joined: Vec<String> = ["release", ".", "--output=out.ctxpkg"]
             .iter()
-            .map(|s| s.to_string())
+            .map(ToString::to_string)
             .collect();
         assert_eq!(flag_value(&joined, "--output"), Some("out.ctxpkg".into()));
     }

--- a/rust/src/proxy_setup/codex.rs
+++ b/rust/src/proxy_setup/codex.rs
@@ -405,25 +405,36 @@ pub(crate) fn codex_uses_chatgpt_login(home: &Path) -> bool {
     auth_is_chatgpt(&codex_dir)
 }
 
-/// True when `<codex_dir>/auth.json` records a ChatGPT/backend auth mode.
-/// False when the file is missing, unreadable, or in API-key mode.
+/// True when Codex should remain on its native/Codex-backend auth rail.
+///
+/// Codex treats a legacy file without `auth_mode` as ChatGPT auth unless it
+/// contains `OPENAI_API_KEY`. Mirror that fallback: otherwise browser OAuth
+/// tokens get sent to the API-key `/v1` rail and OpenAI rejects them with a
+/// misleading `api.responses.write` scope error (#1685). Missing, unreadable,
+/// malformed, or unknown auth state also stays native; only positive API-key
+/// evidence may select the `/v1` rail.
 pub(crate) fn auth_is_chatgpt(codex_dir: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(codex_dir.join("auth.json")) else {
-        return false;
+        return true;
     };
     let Ok(doc) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return false;
+        return true;
     };
-    let Some(mode) = doc.get("auth_mode").and_then(|v| v.as_str()) else {
-        return false;
-    };
-    let normalized = mode
-        .chars()
-        .filter(char::is_ascii_alphanumeric)
-        .collect::<String>()
-        .to_ascii_lowercase();
-    matches!(
-        normalized.as_str(),
-        "chatgpt" | "chatgptauthtokens" | "personalaccesstoken" | "agentidentity"
-    )
+    match doc.get("auth_mode").and_then(|v| v.as_str()) {
+        Some(mode) => {
+            let normalized = mode
+                .chars()
+                .filter(char::is_ascii_alphanumeric)
+                .collect::<String>()
+                .to_ascii_lowercase();
+            !matches!(
+                normalized.as_str(),
+                "apikey" | "bedrockapikey" | "bedrockaccesskeys"
+            )
+        }
+        None => doc
+            .get("OPENAI_API_KEY")
+            .and_then(|v| v.as_str())
+            .is_none_or(|v| v.trim().is_empty()),
+    }
 }

--- a/rust/src/proxy_setup/tests.rs
+++ b/rust/src/proxy_setup/tests.rs
@@ -637,7 +637,16 @@ fn auth_is_chatgpt_detects_login_mode() {
     let codex_dir = dir.path().join(".codex");
     std::fs::create_dir_all(&codex_dir).unwrap();
 
-    assert!(!auth_is_chatgpt(&codex_dir), "no auth.json => not chatgpt");
+    assert!(
+        auth_is_chatgpt(&codex_dir),
+        "unknown auth must stay off the API-key rail"
+    );
+
+    std::fs::write(codex_dir.join("auth.json"), "not json").unwrap();
+    assert!(
+        auth_is_chatgpt(&codex_dir),
+        "malformed auth must stay off the API-key rail"
+    );
 
     std::fs::write(
         codex_dir.join("auth.json"),
@@ -653,7 +662,32 @@ fn auth_is_chatgpt_detects_login_mode() {
     .unwrap();
     assert!(auth_is_chatgpt(&codex_dir), "chatgpt mode => true");
 
-    for mode in ["chatgptAuthTokens", "personalAccessToken", "agentIdentity"] {
+    std::fs::write(
+        codex_dir.join("auth.json"),
+        r#"{"tokens":{"access_token":"x"}}"#,
+    )
+    .unwrap();
+    assert!(
+        auth_is_chatgpt(&codex_dir),
+        "legacy browser login without auth_mode => chatgpt"
+    );
+
+    std::fs::write(
+        codex_dir.join("auth.json"),
+        r#"{"OPENAI_API_KEY":"sk-test"}"#,
+    )
+    .unwrap();
+    assert!(
+        !auth_is_chatgpt(&codex_dir),
+        "legacy API key without auth_mode => not chatgpt"
+    );
+
+    for mode in [
+        "chatgptAuthTokens",
+        "headers",
+        "personalAccessToken",
+        "agentIdentity",
+    ] {
         std::fs::write(
             codex_dir.join("auth.json"),
             format!(r#"{{"auth_mode":"{mode}","tokens":{{"access_token":"x"}}}}"#),

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -699,7 +699,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn the_timeout_line_does_not_imply_a_pipeline() {
-        let joined = vec!["a".to_string(), "b".to_string()].join("; ");
+        let joined = ["a".to_string(), "b".to_string()].join("; ");
         assert!(!joined.contains('|'), "no pipe may be invented: {joined}");
     }
 

--- a/rust/tests/codex_proxy_554.rs
+++ b/rust/tests/codex_proxy_554.rs
@@ -147,6 +147,41 @@ fn proxy_enable_respects_codex_auth_mode_554() {
 
     const CHATGPT_AUTH: &str = r#"{"auth_mode":"chatgpt","tokens":{"access_token":"x"}}"#;
 
+    // Browser credentials may live outside auth.json (for example in the OS
+    // credential store). Ambiguous auth must remain native instead of sending
+    // a browser token to the API-key endpoint (#1685).
+    {
+        let _no_optin = EnvVar::cleared("LEAN_CTX_CODEX_CHATGPT_PROXY");
+        let (home, codex) = codex_home_with_auth(CHATGPT_AUTH);
+        std::fs::remove_file(codex.join("auth.json")).unwrap();
+        let _codex_home = CodexHome::set(&codex);
+        let (_listener, port) = dummy_proxy_port();
+        lean_ctx::proxy_setup::install_proxy_env_unchecked(home.path(), port, true, false);
+
+        let cfg = std::fs::read_to_string(codex.join("config.toml")).unwrap();
+        assert!(
+            !cfg.contains("openai_base_url"),
+            "unknown/keyring auth must never use the API-key /v1 rail, got:\n{cfg}"
+        );
+    }
+
+    // Codex 0.133 still accepts legacy browser-login files without an explicit
+    // auth_mode and resolves them as ChatGPT auth. Never route their OAuth token
+    // onto the API-key `/v1` rail (#1685).
+    {
+        let _no_optin = EnvVar::cleared("LEAN_CTX_CODEX_CHATGPT_PROXY");
+        let (home, codex) = codex_home_with_auth(r#"{"tokens":{"access_token":"x"}}"#);
+        let _codex_home = CodexHome::set(&codex);
+        let (_listener, port) = dummy_proxy_port();
+        lean_ctx::proxy_setup::install_proxy_env_unchecked(home.path(), port, true, false);
+
+        let cfg = std::fs::read_to_string(codex.join("config.toml")).unwrap();
+        assert!(
+            !cfg.contains("openai_base_url"),
+            "legacy browser login must never use the API-key /v1 rail, got:\n{cfg}"
+        );
+    }
+
     // --- ChatGPT login, default (opt-out): stay native, write no proxy entries (#597).
     {
         let _no_optin = EnvVar::cleared("LEAN_CTX_CODEX_CHATGPT_PROXY");


### PR DESCRIPTION
Fixes #1685.

## What changed

- Route Codex through the API-key `/v1` proxy only when API-key authentication
  is positively identified.
- Keep browser OAuth, legacy auth files without `auth_mode`, keychain-backed or
  otherwise unknown auth states on Codex's native ChatGPT rail.
- Recognize current Codex backend auth modes, including header-managed auth.
- Document the fix in the 3.10.1 changelog.
- Apply four test-only Rust 1.97 Clippy rewrites required by the repository's
  pre-commit hook; runtime behavior is unchanged.

## Why

Codex 0.133 accepts browser-login credentials without a readable explicit
`auth_mode` (including external credential-store cases). LeanCTX interpreted
that ambiguity as API-key mode, wrote a local `/v1` endpoint, and forwarded the
browser token to `api.openai.com`; upstream then returned a misleading 401 for
missing `api.responses.write` scope.

## Verification

- Regression: legacy browser auth without `auth_mode` stays native.
- Regression: absent/keychain auth stays native.
- Compatibility: explicit current and legacy API-key auth still selects `/v1`.
- Focused unit and integration tests pass.
- Full quality-gate evidence will be attached before merge.
