### PR TITLE
fix(autonomy): avoid blocking first tool call on graph build

### DIFF
--- a/rust/src/tools/autonomy.rs
+++ b/rust/src/tools/autonomy.rs
@@ -120,6 +120,15 @@ pub fn session_lifecycle_pre_hook(
         return None;
     }
 
+    // Automatic context is opportunistic: a cold graph must never put the
+    // triggering interactive tool call on the synchronous graph-build path.
+    // `open_best_effort` starts the lazy build and returns None until ready;
+    // keep the one-shot latch open so a later tool call can retry.
+    if crate::core::graph_provider::open_best_effort(&root).is_none() {
+        state.session_initialized.store(false, Ordering::SeqCst);
+        return None;
+    }
+
     let (result, usable) = if let Some(task_desc) = task {
         crate::tools::ctx_preload::handle(cache, task_desc, Some(&root), crp_mode)
     } else {

--- a/rust/tests/autonomy_tests.rs
+++ b/rust/tests/autonomy_tests.rs
@@ -33,35 +33,115 @@ fn make_disabled_state() -> AutonomyState {
 }
 
 #[test]
+#[serial_test::serial]
 fn session_lifecycle_fires_once() {
     let state = make_state();
     let mut cache = SessionCache::new();
 
-    let _first = session_lifecycle_pre_hook(
+    let project = tempfile::tempdir().expect("project tempdir");
+    let src = project.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("lib.rs"), "pub fn answer() -> usize { 42 }\n")
+        .expect("write project fixture");
+
+    let root = project.path().to_string_lossy().to_string();
+
+    let graph = lean_ctx::core::graph_provider::open_or_build(&root);
+    assert!(graph.is_some(), "test setup must prewarm the graph");
+    drop(graph);
+
+    let first = session_lifecycle_pre_hook(
         &state,
         "ctx_read",
         &mut cache,
-        Some("fix auth bug"),
-        Some("/tmp/test-project"),
+        None,
+        Some(&root),
         CrpMode::Tdd,
+    );
+
+    assert!(
+        first
+            .as_deref()
+            .is_some_and(|out| out.contains("--- AUTO CONTEXT ---")),
+        "warm graph must inject overview auto context on the first eligible call"
+    );
+    assert!(
+        state.session_initialized.load(Ordering::SeqCst),
+        "flag must be set after successful warm-graph initialization"
     );
 
     let second = session_lifecycle_pre_hook(
         &state,
         "ctx_read",
         &mut cache,
-        Some("fix auth bug"),
-        Some("/tmp/test-project"),
+        None,
+        Some(&root),
         CrpMode::Tdd,
     );
 
     assert!(
-        state.session_initialized.load(Ordering::SeqCst),
-        "flag must be set after first call"
+        second.is_none(),
+        "second call must not inject auto context again"
     );
-    assert!(second.is_none(), "second call must return None");
 }
 
+#[test]
+#[serial_test::serial]
+fn session_lifecycle_warm_graph_with_task_fires_once() {
+    let state = make_state();
+    let mut cache = SessionCache::new();
+
+    let project = tempfile::tempdir().expect("project tempdir");
+    let src = project.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("auth.rs"),
+        "pub fn authenticate_user() -> bool { true }\n",
+    )
+    .expect("write project fixture");
+
+    let root = project.path().to_string_lossy().to_string();
+
+    let graph = lean_ctx::core::graph_provider::open_or_build(&root);
+    assert!(graph.is_some(), "test setup must prewarm the graph");
+    drop(graph);
+
+    let task = "fix authentication in src/auth.rs authenticate_user";
+
+    let first = session_lifecycle_pre_hook(
+        &state,
+        "ctx_search",
+        &mut cache,
+        Some(task),
+        Some(&root),
+        CrpMode::Tdd,
+    );
+
+    assert!(
+        first
+            .as_deref()
+            .is_some_and(|out| out.contains("--- AUTO CONTEXT ---")),
+        "warm graph with a relevant task must inject preload auto context"
+    );
+    assert!(
+        state.session_initialized.load(Ordering::SeqCst),
+        "successful task preload must claim the one-shot latch"
+    );
+
+    let second = session_lifecycle_pre_hook(
+        &state,
+        "ctx_search",
+        &mut cache,
+        Some(task),
+        Some(&root),
+        CrpMode::Tdd,
+    );
+
+    assert!(
+        second.is_none(),
+        "task preload must run at most once per session"
+    );
+}
 #[test]
 fn session_lifecycle_skips_without_project_root() {
     let state = make_state();
@@ -278,5 +358,63 @@ fn enrich_after_read_no_index() {
     assert!(
         result.related_hint.is_none(),
         "must return None when no project index exists"
+    );
+}
+
+#[test]
+fn session_lifecycle_cold_graph_without_task_keeps_retry_eligible() {
+    let mut state = make_state();
+    state.config.enabled = true;
+    state.config.auto_preload = true;
+
+    let project = tempfile::tempdir().expect("project tempdir");
+    let root = project.path().to_string_lossy().to_string();
+    let mut cache = SessionCache::new();
+
+    let result = session_lifecycle_pre_hook(
+        &state,
+        "ctx_search",
+        &mut cache,
+        None,
+        Some(&root),
+        CrpMode::Tdd,
+    );
+
+    assert!(
+        result.is_none(),
+        "cold graph must not synchronously inject auto context"
+    );
+    assert!(
+        !state.session_initialized.load(Ordering::SeqCst),
+        "cold graph must keep the session eligible for a later auto-context retry"
+    );
+}
+
+#[test]
+fn session_lifecycle_cold_graph_with_task_keeps_retry_eligible() {
+    let mut state = make_state();
+    state.config.enabled = true;
+    state.config.auto_preload = true;
+
+    let project = tempfile::tempdir().expect("project tempdir");
+    let root = project.path().to_string_lossy().to_string();
+    let mut cache = SessionCache::new();
+
+    let result = session_lifecycle_pre_hook(
+        &state,
+        "ctx_search",
+        &mut cache,
+        Some("fix authentication bug"),
+        Some(&root),
+        CrpMode::Tdd,
+    );
+
+    assert!(
+        result.is_none(),
+        "cold graph must not synchronously inject task preload"
+    );
+    assert!(
+        !state.session_initialized.load(Ordering::SeqCst),
+        "cold graph must keep the session eligible for a later task-preload retry"
     );
 }

--- a/rust/tests/autonomy_tests.rs
+++ b/rust/tests/autonomy_tests.rs
@@ -341,6 +341,7 @@ fn enrich_after_read_disabled() {
 }
 
 #[test]
+#[serial_test::serial]
 fn enrich_after_read_no_index() {
     let state = make_state();
     let mut cache = SessionCache::new();

--- a/rust/tests/power_user_worksession.rs
+++ b/rust/tests/power_user_worksession.rs
@@ -132,9 +132,10 @@ async fn phase1_session_task_and_overview() {
 async fn phase1_tree_depth() {
     let _lock = lean_ctx::core::data_dir::test_env_lock();
     let (_dir, engine) = setup_project();
+    let project = _dir.path().join("project");
 
     let tree = engine
-        .call_tool_text("ctx_tree", Some(json!({"depth": 3})))
+        .call_tool_text("ctx_tree", Some(json!({"path": project, "depth": 3})))
         .await
         .expect("tree");
     assert!(tree.contains("src"), "tree should show src: {tree}");


### PR DESCRIPTION
## Summary

Make autonomous session initialization non-blocking when the project graph is still cold

Fixes #1687 

## Problem

The first eligible MCP tool call could synchronously enter the graph-build path through the autonomy lifecycle hook

On Windows this reproduced as:

```text
BEFORE
ctx_search, cold graph, default autonomy: ~30078 ms
```

Disabling only `auto_preload` removed the delay, isolating the stall to autonomous session initialization

## Fix

Use the graph provider's best-effort path before automatic overview/preload execution.

When the graph is cold:

- `open_best_effort()` kicks off the lazy graph build
- the interactive MCP call returns without waiting for that build
- the session initialization latch is reopened so a later eligible call can retry

When the graph is already available, the existing overview/preload behavior continues normally.

Explicit `ctx_overview` and `ctx_preload` calls are unchanged

## Runtime result

Same Windows release-build harness:

```text
BEFORE
ctx_search, cold graph, default autonomy: 30078 ms

AFTER
ctx_search, cold graph, default autonomy:    47 ms
ctx_search, cold graph, auto_preload=false: 47 ms
```

The approximately 30-second first-call stall is removed without disabling autonomous preload

## Regression tests

Coverage includes:

- cold graph without task remains retry-eligible
- cold graph with task remains retry-eligible
- warm overview auto-context injects once
- warm task preload injects once

Validation:

```text
autonomy_tests:    19/19 passed
anti-flake:        10/10 complete suite runs passed
cargo fmt:         passed
git diff --check:  passed
release build:     passed
```

## Windows baseline limitations

The repository currently has unrelated Windows failures in broader quality gates.

On a clean worktree at upstream commit:

```text
8317dcb1d3db60c2063fd1e1c188e527004edea7
```

`cargo clippy --lib -- -D warnings` fails with 57 pre-existing Windows lint diagnostics. The patched branch encounters the same baseline diagnostics and none originate from the files changed by this PR.

The broader Windows test suite also contains unrelated pre-existing platform/environment failures, so those are reported separately rather than attributed to this patch
