### PR TITLE
fix(graph): validate project before claiming lazy build trigger

### DIFF
--- a/rust/src/core/graph_provider.rs
+++ b/rust/src/core/graph_provider.rs
@@ -613,7 +613,9 @@ fn trigger_lazy_graph_build(project_root: &str) {
     if cfg!(test) {
         return;
     }
-    if GRAPH_BUILD_TRIGGERED.swap(true, Ordering::SeqCst) {
+    // Preserve the cheap post-trigger fast path, but do not claim the latch
+    // until the root has been validated as an actual project.
+    if GRAPH_BUILD_TRIGGERED.load(Ordering::SeqCst) {
         return;
     }
     let root = Path::new(project_root);
@@ -622,6 +624,9 @@ fn trigger_lazy_graph_build(project_root: &str) {
     let is_project = crate::core::pathutil::has_project_marker(root)
         || crate::core::pathutil::has_multi_repo_children(root);
     if !is_project {
+        return;
+    }
+    if GRAPH_BUILD_TRIGGERED.swap(true, Ordering::SeqCst) {
         return;
     }
     // #682.2: build via the same reliable worker that builds the JSON index

--- a/rust/tests/lazy_graph_build_latch_tests.rs
+++ b/rust/tests/lazy_graph_build_latch_tests.rs
@@ -1,0 +1,78 @@
+use std::time::{Duration, Instant};
+
+use lean_ctx::core::graph_provider;
+
+#[test]
+fn non_project_root_does_not_consume_lazy_build_trigger() {
+    // This is a standalone integration-test binary, so the process-global
+    // GRAPH_BUILD_TRIGGERED latch starts fresh for this test.
+    let isolated = tempfile::tempdir().expect("isolated state tempdir");
+    let data = isolated.path().join("data");
+    let config = isolated.path().join("config");
+    let state = isolated.path().join("state");
+    let cache = isolated.path().join("cache");
+
+    for dir in [&data, &config, &state, &cache] {
+        std::fs::create_dir_all(dir).expect("create isolated state dir");
+    }
+
+    let _env_lock = lean_ctx::core::data_dir::test_env_lock();
+
+    // SAFETY: this integration-test binary contains only this test, and the
+    // shared test_env_lock serializes LeanCTX tests that mutate these variables.
+    unsafe {
+        std::env::set_var("LEAN_CTX_DATA_DIR", &data);
+        std::env::set_var("LEAN_CTX_CONFIG_DIR", &config);
+        std::env::set_var("LEAN_CTX_STATE_DIR", &state);
+        std::env::set_var("LEAN_CTX_CACHE_DIR", &cache);
+    }
+
+    // First call: definitely not a project. It must not consume the process-wide
+    // opportunity to start a later legitimate lazy graph build.
+    let non_project = tempfile::tempdir().expect("non-project tempdir");
+    let non_project_root = non_project.path().to_string_lossy().to_string();
+
+    assert!(
+        graph_provider::open_best_effort(&non_project_root).is_none(),
+        "empty non-project fixture must not already have a graph"
+    );
+
+    // Second call: a real, cold project in the SAME LeanCTX process.
+    let project = tempfile::tempdir().expect("project tempdir");
+    std::fs::create_dir_all(project.path().join(".git")).expect("create .git marker");
+    std::fs::create_dir_all(project.path().join("src")).expect("create src dir");
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"lazy_build_latch_repro\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write Cargo.toml");
+    std::fs::write(
+        project.path().join("src").join("lib.rs"),
+        "pub fn answer() -> usize { 42 }\n",
+    )
+    .expect("write source fixture");
+
+    let project_root = project.path().to_string_lossy().to_string();
+
+    assert!(
+        graph_provider::open_best_effort(&project_root).is_none(),
+        "fresh project fixture must start with a cold graph"
+    );
+
+    // Behavior assertion, not a latency benchmark:
+    // a valid project must eventually become available after best-effort access.
+    // The deadline only prevents a broken implementation from hanging the test.
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        if graph_provider::open_best_effort(&project_root).is_some() {
+            break;
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "lazy graph build never started/completed for the valid project after a prior non-project root"
+        );
+
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}


### PR DESCRIPTION
## Summary

Prevent a non-project root from consuming the process-wide lazy graph build trigger.

Fixes #1689

`trigger_lazy_graph_build()` now keeps the existing cheap post-trigger fast path, validates that `project_root` is an actual project, and only then claims `GRAPH_BUILD_TRIGGERED`.

This preserves the existing once-per-process behavior for valid projects while allowing a later valid cold project to start its lazy graph build after an earlier non-project access.

## Test plan

- [x] Regression test: clean upstream baseline fails when a non-project root is followed by a valid cold project in the same process
- [x] Same regression test passes after the fix
- [x] Regression test repeated 10/10 successfully
- [x] `cargo test --lib graph_provider::tests -- --test-threads=1`
- [x] `cargo test --test issue_249_index_observability -- --test-threads=1`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [ ] `cargo test -- --test-threads=1` — not claimed here; the clean Windows baseline at this upstream commit has unrelated pre-existing suite failures
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean Windows baseline at this upstream commit already fails on pre-existing lint diagnostics

## Notes for reviewers

- Risk areas / edge cases: the process-wide trigger remains process-wide; this PR only prevents non-project roots from claiming it
- Backwards compatibility: no API changes; valid-project once-per-process behavior is unchanged
- Performance: an early non-mutating latch read preserves the existing cheap path after a build has already been triggered
- Docs updated: not needed; internal lazy-build ordering only

## Baseline / regression evidence

Clean upstream:

```text
8317dcb1d3db60c2063fd1e1c188e527004edea7
```

Before:

```text
lazy graph build never started/completed for the valid project after a prior non-project root
test result: FAILED. 0 passed; 1 failed
finished in 8.05s
```

After:

```text
test non_project_root_does_not_consume_lazy_build_trigger ... ok
test result: ok. 1 passed; 0 failed
```

10 consecutive post-fix runs passed.

## Contributor License Agreement

CLA already signed on the contributor account.
