### PR TITLE
fix(kernel): honor configured cache directory for feedback

### DIFF
--- a/rust/src/core/context_kernel/feedback.rs
+++ b/rust/src/core/context_kernel/feedback.rs
@@ -33,10 +33,13 @@ impl FeedbackCollector {
     }
 
     pub fn default_for_project(_project_root: &str) -> Self {
-        let cache_root = std::env::var_os("HOME")
-            .map_or_else(|| PathBuf::from("."), PathBuf::from)
-            .join(".cache")
-            .join("lean-ctx")
+        let cache_root = crate::core::paths::cache_dir()
+            .unwrap_or_else(|_| {
+                std::env::var_os("HOME")
+                    .map_or_else(|| PathBuf::from("."), PathBuf::from)
+                    .join(".cache")
+                    .join("lean-ctx")
+            })
             .join("kernel");
         Self::new(cache_root.join("feedback.jsonl"))
     }
@@ -170,6 +173,52 @@ pub mod tests {
             quality_signals: Vec::new(),
             feedback_attribution: HashMap::from([("files".to_owned(), 1.0)]),
         }
+    }
+
+    #[test]
+    fn default_for_project_honors_cache_dir_override() {
+        let _env_lock = crate::core::data_dir::test_env_lock();
+        let home = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+
+        let previous_home = std::env::var_os("HOME");
+        let previous_cache = std::env::var_os("LEAN_CTX_CACHE_DIR");
+
+        crate::test_env::set_var("HOME", home.path());
+        crate::test_env::set_var("LEAN_CTX_CACHE_DIR", cache.path());
+
+        let expected = cache.path().join("kernel").join("feedback.jsonl");
+        let legacy = home
+            .path()
+            .join(".cache")
+            .join("lean-ctx")
+            .join("kernel")
+            .join("feedback.jsonl");
+
+        let mut collector = FeedbackCollector::default_for_project("project");
+        collector.record_outcome(&receipt(ReceiptOutcome::Rejected));
+
+        let expected_exists = expected.exists();
+        let legacy_exists = legacy.exists();
+
+        match previous_home {
+            Some(value) => crate::test_env::set_var("HOME", value),
+            None => crate::test_env::remove_var("HOME"),
+        }
+
+        match previous_cache {
+            Some(value) => crate::test_env::set_var("LEAN_CTX_CACHE_DIR", value),
+            None => crate::test_env::remove_var("LEAN_CTX_CACHE_DIR"),
+        }
+
+        assert!(
+            expected_exists,
+            "Context Kernel feedback must honor LEAN_CTX_CACHE_DIR"
+        );
+        assert!(
+            !legacy_exists,
+            "Context Kernel feedback must not bypass the central cache resolver"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

* route Context Kernel feedback through the central `paths::cache_dir()` resolver
* honor `LEAN_CTX_CACHE_DIR`, XDG cache layout, compatibility behavior, and the test sandbox
* retain the previous HOME-based path only as a fallback if cache resolution fails
* add regression coverage proving the configured cache directory is used

Fixes #1693

## Root cause

`FeedbackCollector::default_for_project()` constructed `HOME/.cache/lean-ctx/kernel` directly, bypassing the central cache resolver.

On native Windows with `HOME` unset this could also create a relative `.cache/lean-ctx/kernel/feedback.jsonl` inside the current working directory.

## Validation

```text
focused regression before fix:   FAIL (expected RED)
focused regression after fix:    1/1 PASS
feedback tests:                  4/4 PASS
Context Kernel tests:          501/501 PASS
stray rust/.cache created:       no
cargo fmt --check:              PASS
git diff --check:               PASS
```
