### PR TITLE
fix(sandbox): preserve SystemDrive on Windows

### DIFF
--- a/rust/src/core/sandbox.rs
+++ b/rust/src/core/sandbox.rs
@@ -423,6 +423,7 @@ const SANDBOX_ENV_ALLOWLIST: &[&str] = &[
     "TEMP",
     "SYSTEMROOT",
     "WINDIR",
+    "SystemDrive",
 ];
 
 fn apply_sandbox_env(cmd: &mut Command, runtime: &RuntimeConfig) {
@@ -810,6 +811,34 @@ pub mod tests {
         let result = execute("python", &huge, None);
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("exceeds the"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sandbox_env_preserves_system_drive() {
+        let expected =
+            std::env::var_os("SystemDrive").expect("SystemDrive must be defined on Windows");
+
+        let runtime = RuntimeConfig {
+            command: "cmd".to_string(),
+            args: Vec::new(),
+            needs_temp_file: false,
+            file_extension: "bat".to_string(),
+            env: HashMap::new(),
+        };
+
+        let mut cmd = Command::new("cmd");
+        apply_sandbox_env(&mut cmd, &runtime);
+
+        let preserved = cmd.get_envs().any(|(key, value)| {
+            key.to_string_lossy().eq_ignore_ascii_case("SystemDrive")
+                && value == Some(expected.as_os_str())
+        });
+
+        assert!(
+            preserved,
+            "Windows sandbox child environment must preserve SystemDrive"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Preserve Windows `SystemDrive` in sandbox child environments.

Fixes #1696

## Root cause

Sandbox execution clears the inherited environment and restores only `SANDBOX_ENV_ALLOWLIST`.

On Windows the allowlist preserved `SYSTEMROOT` and `WINDIR` but not `SystemDrive`. A sandboxed Python invocation could therefore cause Windows components to materialize a literal:

```text
%SystemDrive%\ProgramData\Microsoft\Windows\Caches
```

under the LeanCTX working directory.

## Fix

Add `SystemDrive` to `SANDBOX_ENV_ALLOWLIST`.

## Regression coverage

Adds a Windows-only unit test that verifies `apply_sandbox_env` preserves the current `SystemDrive` value.

Before the production fix, the focused regression test fails deterministically with:

```text
Windows sandbox child environment must preserve SystemDrive
```

After the fix:

- focused regression test: PASS
- `core::sandbox::tests::execute_python_error`: PASS
- literal `rust\%SystemDrive%` artifact: not created
- all `core::sandbox` tests: 10/10 PASS
- `cargo fmt --check`: PASS
- `git diff --check`: PASS

