### PR TITLE
test(hooks): make bash path assertion shell-aware

### DIFF
--- a/rust/src/hook_handlers/tests_parsing_platform.rs
+++ b/rust/src/hook_handlers/tests_parsing_platform.rs
@@ -167,9 +167,10 @@ fn wrap_command_preserves_bash_compatible_path() {
         !result.contains('\\'),
         "wrapped command must not contain backslashes, got: {result}"
     );
+    let executable = result.strip_prefix("& ").unwrap_or(&result);
     assert!(
-        result.contains(&binary),
-        "must preserve bash-compatible path, got: {result}"
+        executable.starts_with(&binary),
+        "must invoke the bash-compatible path as the executable, got: {result}"
     );
 }
 

--- a/rust/src/hook_handlers/tests_parsing_platform.rs
+++ b/rust/src/hook_handlers/tests_parsing_platform.rs
@@ -160,7 +160,7 @@ fn rewrite_preserves_native_windows_binary_path() {
 }
 
 #[test]
-fn wrap_command_with_bash_path() {
+fn wrap_command_preserves_bash_compatible_path() {
     let binary = crate::hooks::to_bash_compatible_path(r"E:\packages\lean-ctx.exe");
     let result = wrap_single_command("git status", &binary);
     assert!(
@@ -168,8 +168,8 @@ fn wrap_command_with_bash_path() {
         "wrapped command must not contain backslashes, got: {result}"
     );
     assert!(
-        result.starts_with("/e/packages/lean-ctx.exe"),
-        "must use bash-compatible path, got: {result}"
+        result.contains(&binary),
+        "must preserve bash-compatible path, got: {result}"
     );
 }
 


### PR DESCRIPTION
## Summary

Make the bash-compatible path regression assertion shell-aware.

Fixes #1700

## Root cause

`wrap_command_with_bash_path` asserted that the wrapped command must start with the MSYS-style executable path:

```rust
result.starts_with("/e/packages/lean-ctx.exe")
```

That assumption is only valid for POSIX-style command rendering.

On native Windows PowerShell, `wrap_single_command()` correctly renders:

```text
& /e/packages/lean-ctx.exe -c 'git status'
```

The leading `&` is the PowerShell call operator, so the test failed even though the bash-compatible path was preserved correctly.

Forcing Bash semantics made the original test pass, while the existing native Windows path regression tests remained green.

## Fix

Rename the test to describe the actual invariant and assert that the generated command contains the converted path:

```rust
result.contains(&binary)
```

The existing backslash assertion is kept.

No production code is changed.

## Validation

```text
default Windows shell:
1 passed, 0 failed

forced Bash:
1 passed, 0 failed

hook_handlers::tests::tests_parsing_platform:
30 passed, 0 failed
```

Also verified:

```text
cargo fmt --check  PASS
git diff --check   PASS
```

