### PR TITLE
fix(cli): recover from stale daemon project roots

### DIFF
--- a/rust/src/cli/read_cmd.rs
+++ b/rust/src/cli/read_cmd.rs
@@ -11,11 +11,13 @@ use crate::core::signatures;
 
 /// Detect daemon results that indicate a read failure — the CLI should fall
 /// through to standalone (which runs as the user's process, not sandboxed).
-/// Catches: `"file.rs 0L"` stubs and `"Cannot read file:"` handler errors.
+/// Catches: explicit tool errors, `"file.rs 0L"` stubs, and read-handler
+/// failures. A daemon is rooted at its startup project, so an absolute path from
+/// another CLI caller can be valid locally while the shared daemon rejects it.
 #[cfg(unix)]
 fn is_failed_daemon_result(output: &str) -> bool {
     let first_line = output.lines().next().unwrap_or("");
-    if first_line.starts_with("ERROR:TCC_RESTRICTED:") {
+    if first_line.starts_with("ERROR:") {
         return true;
     }
     if first_line.starts_with("Cannot read file:") || first_line.starts_with("File is empty:") {
@@ -721,8 +723,9 @@ pub fn cmd_ls(args: &[String]) {
                 })),
             )
         {
-            if !out.starts_with("ERROR:TCC_RESTRICTED:") {
-                println!("{}", super::common::filter_daemon_output(&out));
+            let filtered = super::common::filter_daemon_output(&out);
+            if !filtered.trim().is_empty() && !is_failed_daemon_result(&filtered) {
+                println!("{filtered}");
                 return;
             }
         }
@@ -731,6 +734,10 @@ pub fn cmd_ls(args: &[String]) {
 
     let (out, original) =
         crate::tools::ctx_tree::handle(path, depth, show_hidden, respect_gitignore);
+    if out.starts_with("ERROR:") {
+        eprintln!("{out}");
+        std::process::exit(1);
+    }
     println!("{out}");
     super::common::cli_track_tree(original, count_tokens(&out));
 }
@@ -793,6 +800,13 @@ fn main() {}
     fn detects_tcc_restricted_marker() {
         assert!(is_failed_daemon_result(
             "ERROR:TCC_RESTRICTED: daemon cannot access /Users/me/Documents/proj (sandboxed)"
+        ));
+    }
+
+    #[test]
+    fn detects_daemon_project_root_denial() {
+        assert!(is_failed_daemon_result(
+            "ERROR: path escapes project root: /work/current/scripts (root: /work/stale)"
         ));
     }
 }

--- a/rust/tests/suite/integration_tests.rs
+++ b/rust/tests/suite/integration_tests.rs
@@ -55,6 +55,31 @@ fn binary_read_file() {
 }
 
 #[test]
+fn binary_ls_missing_path_exits_nonzero() {
+    let root = tempfile::tempdir().expect("temp dir");
+    let missing = root.path().join("missing");
+    let output = lean_ctx_bin()
+        .arg("ls")
+        .arg(&missing)
+        .output()
+        .expect("failed to run lean-ctx ls");
+
+    assert!(
+        !output.status.success(),
+        "directory access failures must return a nonzero status"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not exist or is not a directory"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "directory access failures must not be printed as successful output"
+    );
+}
+
+#[test]
 fn binary_config_shows_defaults() {
     let output = lean_ctx_bin()
         .arg("config")


### PR DESCRIPTION
## Summary

- treat daemon tool errors as fallback signals for one-shot CLI reads and directory listings
- retry `lean-ctx ls` in the caller process when a shared daemon is rooted in another project
- return a nonzero exit status and stderr for genuine standalone directory errors
- add unit and CLI integration regressions

Fixes #1695

## Validation

- `cargo test --lib empty_daemon_tests`: 6 passed
- `cargo test --test main binary_ls_missing_path_exits_nonzero`: 1 passed
- `cargo test --lib`: 10,714 passed; 0 failed; 22 ignored
- `cargo clippy --all-features -- -D warnings`: passed
- `cargo fmt --check`: passed
- independent Luna review: PASS

No daemon trust boundary is widened: rejected paths fall back to the existing
caller-local path jail.
