### PR TITLE
test(git): isolate fixture commits from signing

### DIFF
--- a/rust/src/core/git_signals.rs
+++ b/rust/src/core/git_signals.rs
@@ -214,6 +214,7 @@ mod tests {
 
     fn run(dir: &std::path::Path, args: &[&str]) {
         let out = std::process::Command::new("git")
+            .args(["-c", "commit.gpgsign=false"])
             .args(args)
             .current_dir(dir)
             .env("GIT_AUTHOR_NAME", "t")
@@ -229,6 +230,26 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         run(dir.path(), &["init", "-q"]);
         dir
+    }
+
+    #[test]
+    fn fixture_commits_ignore_git_signing_config() {
+        let repo = temp_repo();
+
+        run(repo.path(), &["config", "commit.gpgsign", "true"]);
+        run(repo.path(), &["config", "gpg.format", "ssh"]);
+        run(
+            repo.path(),
+            &[
+                "config",
+                "user.signingkey",
+                "lean-ctx-test-missing-signing-key",
+            ],
+        );
+
+        std::fs::write(repo.path().join("signed.rs"), "// fixture").unwrap();
+        run(repo.path(), &["add", "."]);
+        run(repo.path(), &["commit", "-qm", "fixture"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make the `git_signals` test fixture helper independent of Git commit-signing configuration.

Fixes #1703

## Root cause

The test helper sets author and committer identity but inherits Git configuration.

When `commit.gpgsign=true`, temporary fixture commits are signed as well. In non-interactive test execution this can fail when the configured signing key requires interaction.

## Fix

Run fixture Git commands with:

```text
-c commit.gpgsign=false
```

This is test-only and does not change production Git behavior or user configuration.

A deterministic regression configures the temporary repository with commit signing enabled and a deliberately missing SSH signing key.

## Validation

Before the fix:

```text
fixture_commits_ignore_git_signing_config: FAILED
Couldn't load public key lean-ctx-test-missing-signing-key
fatal: failed to write commit object
```

After the fix:

```text
fixture_commits_ignore_git_signing_config: 1 passed
churn_normalized_to_max: 1 passed
core::git_signals::tests: 6 passed, 0 failed
cargo fmt --check: PASS
git diff --check: PASS
```
