### PR TITLE
fix(wrap): honour the Pro/Max auth guard, and fail with a non-zero status (#1705, #1706, #1707)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed — `wrap claude` could break a Pro/Max login (#1705)
+
+- `lean-ctx wrap claude` wrote `ANTHROPIC_BASE_URL=http://127.0.0.1:4444` into
+  `~/.claude/settings.json` unconditionally. On a Claude Pro/Max subscription
+  that is exactly the configuration `proxy enable` refuses to create and
+  `lean-ctx doctor` immediately calls invalid: the proxy injects no credentials,
+  and Anthropic rejects OAuth behind a custom base URL — login loop or 401.
+- The failure surfaced on the *next* request, long after the one-command setup
+  path had reported success, which made it hard to connect to `wrap` at all.
+- `wrap` now uses the same predicate `proxy_setup` has guarded with since the
+  proxy shipped, and explains the skip at wrap time instead of leaving it to a
+  later failed request. With an API key present the proxy is configured as
+  before.
+- The guard applies to the **variable, not the agent**: an exported
+  `ANTHROPIC_BASE_URL` reaches every process started from that shell, so
+  wrapping Windsurf, Cline or Aider could break a Claude subscription login just
+  as effectively. The shell-profile writer filters on the same predicate.
+
+### Fixed — a failed `wrap` exited 0 (#1707)
+
+- `wrap` printed its error and returned, so an unreachable proxy, an unsupported
+  autostart platform (Windows in 3.10.0), a failed backup, endpoint write, MCP
+  registration or profile write all exited **0**. Scripts, installers and CI
+  could not tell a failed setup from a successful one.
+- `wrap` and `unwrap` now return a status and the dispatcher exits with it —
+  the same shape `status` next to them already used. Help still exits 0.
+
+### Documented — subscription users and the request proxy (#1706)
+
+- The quick start now says, next to `wrap claude`, that a Pro/Max subscription
+  cannot use wire-level request compression and why — the `ctx_*` tools and
+  shell-output compression are unaffected. The limitation was only in the
+  advanced docs, one section away from the command that trips it.
+
+
 ## [3.10.1] — 2026-09-04
 
 ### Fixed — Codex browser login was sent to the API-key endpoint (#1685)

--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ lean-ctx gain
 
 `lean-ctx wrap` installs shell hooks, registers the MCP server, sets up agent hooks, starts the daemon, and verifies the connection — all in one command. Undo anytime with `lean-ctx unwrap cursor`.
 
+> **On a Claude Pro/Max subscription?** The `ctx_*` tools and shell-output
+> compression work exactly the same. The **request proxy** does not: a
+> subscription authenticates by OAuth, and Anthropic rejects OAuth behind a
+> custom `ANTHROPIC_BASE_URL`, so wire-level request compression for Claude
+> needs an `ANTHROPIC_API_KEY`. `wrap claude` detects this, leaves Claude Code
+> talking to `api.anthropic.com`, and says so — it will not create a
+> configuration that breaks your login.
+
 <details>
 <summary><strong>Alternative: full control</strong></summary>
 

--- a/rust/src/cli/dispatch/mod.rs
+++ b/rust/src/cli/dispatch/mod.rs
@@ -330,11 +330,19 @@ pub fn run() {
                 return;
             }
             "wrap" => {
-                crate::cli::wrap_cmd::cmd_wrap(&rest);
+                // #1707: a failed setup stage must not exit 0 — scripts,
+                // installers and CI cannot tell it from success otherwise.
+                let code = crate::cli::wrap_cmd::cmd_wrap(&rest);
+                if code != 0 {
+                    std::process::exit(code);
+                }
                 return;
             }
             "unwrap" => {
-                crate::cli::wrap_cmd::cmd_unwrap(&rest);
+                let code = crate::cli::wrap_cmd::cmd_unwrap(&rest);
+                if code != 0 {
+                    std::process::exit(code);
+                }
                 return;
             }
             "status" => {

--- a/rust/src/cli/wrap_cmd.rs
+++ b/rust/src/cli/wrap_cmd.rs
@@ -163,11 +163,20 @@ struct BackupFile {
     backup: Option<PathBuf>,
 }
 
-/// Dispatch `lean-ctx wrap <agent> [--port N] [--unwrap]`.
-pub(crate) fn cmd_wrap(args: &[String]) {
+/// Exit status for a failed setup stage (#1707).
+///
+/// `wrap` used to print an error and return `()`, so a fatal failure — an
+/// unreachable proxy, an unsupported autostart platform, a config write that
+/// did not happen — exited 0 and was indistinguishable from success to a
+/// script, an installer, CI, or anyone checking `$?` / `$LASTEXITCODE`.
+const EXIT_FAILURE: i32 = 1;
+
+/// Dispatch `lean-ctx wrap <agent> [--port N] [--unwrap]`. Returns the process
+/// exit status: non-zero when a setup stage failed.
+pub(crate) fn cmd_wrap(args: &[String]) -> i32 {
     if wants_help(args) {
         print_help();
-        return;
+        return 0;
     }
 
     let parsed = match WrapArgs::parse(args, false) {
@@ -175,22 +184,22 @@ pub(crate) fn cmd_wrap(args: &[String]) {
         Err(error) => {
             eprintln!("wrap: {error}");
             print_usage();
-            return;
+            return EXIT_FAILURE;
         }
     };
 
     if parsed.unwrap {
-        unwrap_agent(parsed.agent);
+        unwrap_agent(parsed.agent)
     } else {
-        wrap_agent(&parsed);
+        wrap_agent(&parsed)
     }
 }
 
 /// Dispatch the backwards-compatible `lean-ctx unwrap <agent>` spelling.
-pub(crate) fn cmd_unwrap(args: &[String]) {
+pub(crate) fn cmd_unwrap(args: &[String]) -> i32 {
     if wants_help(args) {
         print_unwrap_help();
-        return;
+        return 0;
     }
 
     let parsed = match WrapArgs::parse(args, true) {
@@ -198,16 +207,16 @@ pub(crate) fn cmd_unwrap(args: &[String]) {
         Err(error) => {
             eprintln!("unwrap: {error}");
             print_unwrap_usage();
-            return;
+            return EXIT_FAILURE;
         }
     };
-    unwrap_agent(parsed.agent);
+    unwrap_agent(parsed.agent)
 }
 
-fn wrap_agent(args: &WrapArgs) {
+fn wrap_agent(args: &WrapArgs) -> i32 {
     let Some(home) = dirs::home_dir() else {
         eprintln!("wrap: cannot determine the home directory");
-        return;
+        return EXIT_FAILURE;
     };
 
     let mut files = agent_config_paths(args.agent, &home);
@@ -216,12 +225,12 @@ fn wrap_agent(args: &WrapArgs) {
 
     if let Err(error) = ensure_proxy_running(args.port) {
         eprintln!("wrap: {error}");
-        return;
+        return EXIT_FAILURE;
     }
 
     if let Err(error) = save_backup_manifest(args.agent, &files) {
         eprintln!("wrap: could not create backups: {error}");
-        return;
+        return EXIT_FAILURE;
     }
 
     if let Err(error) = configure_agent_endpoint(args.agent, args.port, &home) {
@@ -229,23 +238,24 @@ fn wrap_agent(args: &WrapArgs) {
             "wrap: could not configure {}: {error}",
             args.agent.display_name()
         );
-        return;
+        return EXIT_FAILURE;
     }
 
     if let Err(error) = register_mcp(args.agent, &home) {
         eprintln!("wrap: could not register MCP server: {error}");
-        return;
+        return EXIT_FAILURE;
     }
 
     if let Err(error) = install_shell_exports(args.agent, args.port, &home) {
         eprintln!("wrap: could not persist environment variables: {error}");
-        return;
+        return EXIT_FAILURE;
     }
 
     print_wrap_success(args.agent, args.port);
+    0
 }
 
-fn unwrap_agent(agent: WrapAgent) {
+fn unwrap_agent(agent: WrapAgent) -> i32 {
     match load_backup_manifest(agent) {
         Ok(Some(manifest)) => match restore_backup_manifest(&manifest) {
             Ok(()) => {
@@ -255,22 +265,30 @@ fn unwrap_agent(agent: WrapAgent) {
                     "  Restart {} to use its restored configuration.",
                     agent.display_name()
                 );
+                0
             }
-            Err(error) => eprintln!("unwrap: could not restore backups: {error}"),
+            Err(error) => {
+                eprintln!("unwrap: could not restore backups: {error}");
+                EXIT_FAILURE
+            }
         },
         Ok(None) => {
             // A manually removed manifest should not strand an integration.  This
             // fallback only removes entries that identify themselves as lean-ctx.
             if let Err(error) = remove_owned_integration(agent) {
                 eprintln!("unwrap: {error}");
-                return;
+                return EXIT_FAILURE;
             }
             println!(
                 "✓ Removed lean-ctx integration for {}.",
                 agent.display_name()
             );
+            0
         }
-        Err(error) => eprintln!("unwrap: could not read backups: {error}"),
+        Err(error) => {
+            eprintln!("unwrap: could not read backups: {error}");
+            EXIT_FAILURE
+        }
     }
 }
 
@@ -321,9 +339,38 @@ fn agent_config_paths(agent: WrapAgent, home: &Path) -> Vec<PathBuf> {
     paths
 }
 
+/// May `ANTHROPIC_BASE_URL` be pointed at the local proxy? (#1705)
+///
+/// The proxy never injects credentials, so redirecting Claude Code only works
+/// in API-key mode. A Claude Pro/Max subscription authenticates by OAuth, which
+/// Anthropic rejects behind a custom `ANTHROPIC_BASE_URL` — the user gets a
+/// login loop or a 401, on the *next* request, long after `wrap` reported
+/// success.
+///
+/// `proxy_setup::install_claude_env_inner` has guarded this since the proxy
+/// shipped; `wrap` grew its own endpoint writer and never picked it up, so the
+/// one-command setup path could produce a configuration that `lean-ctx doctor`
+/// immediately calls invalid. This is the same predicate, not a second opinion.
+fn anthropic_redirect_allowed(home: &Path) -> bool {
+    crate::proxy_setup::anthropic_api_key_available(home)
+}
+
+/// Printed once when the redirect is skipped, so the reason is visible at
+/// wrap time rather than at the next failed request.
+fn explain_subscription_skip() {
+    println!("  Claude Code is authenticated by subscription (no Anthropic API key found).");
+    println!("  Leaving it pointed at api.anthropic.com — OAuth cannot be routed");
+    println!("  through a custom ANTHROPIC_BASE_URL, so the request proxy stays off.");
+    println!("  The ctx_* tools and shell-output compression work unchanged.");
+}
+
 fn configure_agent_endpoint(agent: WrapAgent, port: u16, home: &Path) -> Result<(), String> {
     match agent {
         WrapAgent::Claude => {
+            if !anthropic_redirect_allowed(home) {
+                explain_subscription_skip();
+                return Ok(());
+            }
             let path = crate::core::editor_registry::claude_state_dir(home).join("settings.json");
             set_json_env(
                 &path,
@@ -443,7 +490,15 @@ fn existing_shell_profiles(home: &Path) -> Vec<PathBuf> {
 }
 
 fn install_shell_exports(agent: WrapAgent, port: u16, home: &Path) -> Result<(), String> {
-    let variables = agent.environment(port);
+    // #1705: the guard is about the *variable*, not the agent. An exported
+    // `ANTHROPIC_BASE_URL` reaches every process started from that shell —
+    // Claude Code included — so wrapping Windsurf or Aider could break a
+    // subscription login just as effectively as wrapping Claude.
+    // `proxy_setup::shell` filters on exactly this predicate.
+    let mut variables = agent.environment(port);
+    if !anthropic_redirect_allowed(home) {
+        variables.retain(|(name, _)| *name != "ANTHROPIC_BASE_URL");
+    }
     if variables.is_empty() {
         return Ok(());
     }
@@ -793,5 +848,147 @@ mod tests {
         assert!(rendered.contains("OPENAI_BASE_URL=\"http://127.0.0.1:9340/v1\""));
         assert!(rendered.contains("export LAST=1"));
         assert!(!rendered.contains("old"));
+    }
+}
+
+#[cfg(test)]
+mod gh1705_1707 {
+    use super::*;
+
+    /// A home directory with Claude Code settings but no API key anywhere:
+    /// the Pro/Max subscription shape.
+    fn subscription_home() -> tempfile::TempDir {
+        let home = tempfile::tempdir().expect("tempdir");
+        let dir = crate::core::editor_registry::claude_state_dir(home.path());
+        std::fs::create_dir_all(&dir).expect("claude state dir");
+        std::fs::write(dir.join("settings.json"), "{}\n").expect("settings");
+        home
+    }
+
+    fn settings_of(home: &std::path::Path) -> String {
+        let path = crate::core::editor_registry::claude_state_dir(home).join("settings.json");
+        std::fs::read_to_string(path).unwrap_or_default()
+    }
+
+    /// The reported bug: `wrap claude` wrote a local ANTHROPIC_BASE_URL even
+    /// when Claude Code authenticates by subscription OAuth — a configuration
+    /// `lean-ctx doctor` immediately calls invalid, and which fails on the next
+    /// request rather than at wrap time.
+    #[test]
+    fn wrap_claude_leaves_a_subscription_pointed_at_anthropic() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let previous: Vec<_> = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"]
+            .iter()
+            .map(|k| (*k, std::env::var(k).ok()))
+            .collect();
+        for (key, _) in &previous {
+            crate::test_env::remove_var(key);
+        }
+
+        let home = subscription_home();
+        let result = configure_agent_endpoint(WrapAgent::Claude, 4444, home.path());
+
+        for (key, value) in previous {
+            match value {
+                Some(v) => crate::test_env::set_var(key, v),
+                None => crate::test_env::remove_var(key),
+            }
+        }
+
+        assert!(result.is_ok(), "skipping is not an error: {result:?}");
+        assert!(
+            !settings_of(home.path()).contains("ANTHROPIC_BASE_URL"),
+            "no local redirect may be written for a subscription: {}",
+            settings_of(home.path())
+        );
+    }
+
+    /// With an API key present the proxy is the point of `wrap`, so it is
+    /// configured — the guard must not disable the feature outright.
+    #[test]
+    fn wrap_claude_configures_the_proxy_in_api_key_mode() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let previous = std::env::var("ANTHROPIC_API_KEY").ok();
+        crate::test_env::set_var("ANTHROPIC_API_KEY", "sk-ant-test");
+
+        let home = subscription_home();
+        let result = configure_agent_endpoint(WrapAgent::Claude, 4444, home.path());
+
+        match previous {
+            Some(v) => crate::test_env::set_var("ANTHROPIC_API_KEY", v),
+            None => crate::test_env::remove_var("ANTHROPIC_API_KEY"),
+        }
+
+        assert!(result.is_ok(), "{result:?}");
+        assert!(
+            settings_of(home.path()).contains("127.0.0.1:4444"),
+            "an API-key install still gets the proxy: {}",
+            settings_of(home.path())
+        );
+    }
+
+    /// The guard is about the variable, not the agent: an exported
+    /// ANTHROPIC_BASE_URL reaches every process started from that shell,
+    /// Claude Code included.
+    #[test]
+    fn no_agent_exports_anthropic_base_url_without_a_key() {
+        let _lock = crate::core::data_dir::test_env_lock();
+        let previous: Vec<_> = ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"]
+            .iter()
+            .map(|k| (*k, std::env::var(k).ok()))
+            .collect();
+        for (key, _) in &previous {
+            crate::test_env::remove_var(key);
+        }
+
+        let home = subscription_home();
+        let allowed = anthropic_redirect_allowed(home.path());
+
+        for (key, value) in previous {
+            match value {
+                Some(v) => crate::test_env::set_var(key, v),
+                None => crate::test_env::remove_var(key),
+            }
+        }
+
+        assert!(!allowed, "a subscription home has no API key");
+        // Every agent whose profile exports the variable is covered by the
+        // same filter in `install_shell_exports`.
+        for agent in [
+            WrapAgent::Claude,
+            WrapAgent::Windsurf,
+            WrapAgent::Cline,
+            WrapAgent::Aider,
+        ] {
+            assert!(
+                agent
+                    .environment(4444)
+                    .iter()
+                    .any(|(name, _)| *name == "ANTHROPIC_BASE_URL"),
+                "{agent:?} exports the variable, so the filter must apply to it"
+            );
+        }
+    }
+
+    /// #1707: a fatal setup stage must not exit 0. Argument parsing is the one
+    /// failure reachable without touching the filesystem or the network.
+    #[test]
+    fn a_failed_wrap_reports_a_non_zero_status() {
+        assert_eq!(cmd_wrap(&[]), EXIT_FAILURE, "no agent named");
+        assert_eq!(
+            cmd_wrap(&["definitely-not-an-agent".to_string()]),
+            EXIT_FAILURE
+        );
+        assert_eq!(
+            cmd_unwrap(&["definitely-not-an-agent".to_string()]),
+            EXIT_FAILURE
+        );
+    }
+
+    /// Help is not a failure.
+    #[test]
+    fn help_still_succeeds() {
+        assert_eq!(cmd_wrap(&["--help".to_string()]), 0);
+        assert_eq!(cmd_unwrap(&["--help".to_string()]), 0);
     }
 }

--- a/rust/tests/suite/mod.rs
+++ b/rust/tests/suite/mod.rs
@@ -102,3 +102,4 @@ mod unified_ledger_evidence_v2_gate;
 mod uninstall_help_safety_476;
 mod utf8_safety_scenarios;
 mod web_url_read_live;
+mod wrap_exit_status_1707;

--- a/rust/tests/suite/wrap_exit_status_1707.rs
+++ b/rust/tests/suite/wrap_exit_status_1707.rs
@@ -1,0 +1,60 @@
+//! GH #1707: a failed `wrap` must not exit 0.
+//!
+//! The unit tests in `cli::wrap_cmd` cover what `cmd_wrap` *returns*. They
+//! cannot cover the part that actually reaches a script: the dispatcher turning
+//! that value into a process exit status. Wiring it wrong would leave every one
+//! of those tests green while `$?` stayed 0 — which is the bug. So this drives
+//! the real binary and reads the exit code the shell would read.
+
+use std::process::{Command, Stdio};
+
+fn lean_ctx_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lean-ctx")
+}
+
+fn run(args: &[&str]) -> (i32, String) {
+    let out = Command::new(lean_ctx_bin())
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lean-ctx");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.code().unwrap_or(-1), text)
+}
+
+/// The reported failure: `wrap` printed an error, returned, and the process
+/// still exited 0 — indistinguishable from success to a script, an installer,
+/// CI, or anyone checking `$?` / `$LASTEXITCODE`.
+#[test]
+fn a_failed_wrap_exits_non_zero() {
+    let (code, output) = run(&["wrap", "definitely-not-an-agent"]);
+    assert_ne!(code, 0, "a failed wrap must not exit 0; output:\n{output}");
+
+    let (code, output) = run(&["wrap"]);
+    assert_ne!(
+        code, 0,
+        "wrap with no agent is a usage error; output:\n{output}"
+    );
+}
+
+#[test]
+fn a_failed_unwrap_exits_non_zero() {
+    let (code, output) = run(&["unwrap", "definitely-not-an-agent"]);
+    assert_ne!(code, 0, "output:\n{output}");
+}
+
+/// Help is not a failure — the fix must not turn every invocation red.
+#[test]
+fn wrap_help_still_exits_zero() {
+    let (code, output) = run(&["wrap", "--help"]);
+    assert_eq!(code, 0, "output:\n{output}");
+
+    let (code, output) = run(&["unwrap", "--help"]);
+    assert_eq!(code, 0, "output:\n{output}");
+}


### PR DESCRIPTION
Third attempt: #1709 and #1710 carried this identical commit and were both closed unmerged with their branches deleted, at the moment `gh pr merge` reported "Head branch is out of date". Same commit, rebased onto `main` at 3b6dc3d271.

**#1705** — `wrap claude` wrote `ANTHROPIC_BASE_URL` into `~/.claude/settings.json` unconditionally. On a Pro/Max subscription that is exactly the configuration `proxy enable` refuses to create and `doctor` calls invalid: the proxy injects no credentials and Anthropic rejects OAuth behind a custom base URL. `wrap` now uses the same predicate `proxy_setup` has guarded with since the proxy shipped, and says so at wrap time.

The guard belongs to the **variable, not the agent** — a point the report does not make. Windsurf, Cline and Aider export `ANTHROPIC_BASE_URL` into shell profiles too, and an exported variable reaches every process from that shell, Claude Code included.

**#1707** — every fatal stage printed an error and returned `()`, so an unreachable proxy, an unsupported autostart platform, a failed backup or config write all exited **0**. `wrap`/`unwrap` now return a status and the dispatcher exits with it. The unit tests cover the return value; they cannot cover that wiring, so an integration test drives the real binary — confirmed red with the wiring removed while the unit tests stayed green.

**#1706** — the README quick start now states, next to `wrap claude`, that a subscription cannot use wire-level compression and why; `ctx_*` and shell compression are unaffected.

Verification: `cargo test --lib` 10720 passed / 0 failed; `wrap_exit_status` 3 passed; preflight PASSED 7/7; the subscription guard confirmed red against unpatched code.

Fixes #1705
Fixes #1706
Fixes #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)