### PR TITLE
ci: lint the 20 Python files this repo ships (#1676)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,17 @@ jobs:
         run: python3 scripts/check-no-internal-artifacts.py
       - name: Enforce the single SDK surface
         run: python3 scripts/check-sdk-surface.py
+      # GH #1676: 20 Python files ship in this repo, several of them the CI
+      # gates in the steps above, and none of them were linted. A gate that
+      # breaks only when someone needs it is the worst kind. Scoped to
+      # pyflakes (`F`): undefined names and unused imports — real defects, at
+      # near-zero cost. Style and typing are separate, larger decisions, and
+      # the default rule set flags 210 findings that would be pure churn
+      # across those 20 files.
+      - name: Lint Python (pyflakes rules)
+        run: |
+          python3 -m pip install --quiet --disable-pip-version-check ruff
+          python3 -m ruff check --select F scripts/ skills/
 
   package-assets:
     name: Published crate assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added — Python is linted (#1676)
+
+- The repo ships 20 Python files under `scripts/` and `skills/`, several of them
+  CI gates (`check-narrative-governance.py`, `check-release-tag.py`,
+  `verify-ocla-contract-suite.py`, …). None of them were linted: no `ruff`,
+  `flake8`, `black` or `mypy` anywhere, and the pre-commit hooks are
+  `types: [rust]`.
+- The exposure was never the gates that run on every push — those fail loudly.
+  It was the scripts that run rarely, where a typo'd name surfaces at the moment
+  someone needs them, which is usually the worst moment.
+- CI now runs `ruff check --select F`, scoped to pyflakes: undefined names and
+  unused imports. That is the ticket's own recommendation, and it is deliberate
+  — the default rule set flags 210 findings across those files, which would be
+  style churn rather than defect removal. Formatting and typing stay separate
+  decisions.
+- Two real findings, both fixed: an unused `sys` import in
+  `verify-release-integrity.py` (a release gate) and an f-string with no
+  placeholders in `scan_session.py`. Verified beyond the linter — every one of
+  the 20 files still compiles and `scan_session.py --selftest` still passes.
+
+
 ### Fixed — `wrap claude` could break a Pro/Max login (#1705)
 
 - `lean-ctx wrap claude` wrote `ANTHROPIC_BASE_URL=http://127.0.0.1:4444` into

--- a/scripts/verify-release-integrity.py
+++ b/scripts/verify-release-integrity.py
@@ -5,7 +5,6 @@ import argparse
 import hashlib
 import json
 import re
-import sys
 import urllib.parse
 import urllib.request
 from pathlib import Path

--- a/skills/lean-ctx-review/scripts/scan_session.py
+++ b/skills/lean-ctx-review/scripts/scan_session.py
@@ -171,7 +171,7 @@ def main():
         for r in errors:
             show(r)
 
-    print(f"\nall calls (-d N for full output):")
+    print("\nall calls (-d N for full output):")
     for r in rows:
         print(one_line(r))
 


### PR DESCRIPTION
Several of them are the CI gates themselves — `check-narrative-governance.py`,
`check-release-tag.py`, `verify-ocla-contract-suite.py`. None were linted: no
`ruff`, `flake8`, `black` or `mypy` anywhere, and the pre-commit hooks are
`types: [rust]`.

The exposure was never the gates that run on every push; those fail loudly. It
is the scripts that run **rarely** — a release helper, a one-off migration —
where a typo'd name surfaces at the moment someone needs them, which is usually
the worst moment.

## Scope, deliberately narrow

`ruff check --select F` — pyflakes only: undefined names and unused imports.

That is the issue's own recommendation, and the limit is the point: ruff's
**default** rule set flags **210** findings across these files. Fixing those
would be style churn across 20 files rather than defect removal, and it would
make the gate's first appearance a wall of noise. Formatting and typing stay
separate decisions.

## Two real findings, both fixed

| File | Finding |
|---|---|
| `scripts/verify-release-integrity.py` | `sys` imported but unused — in a *release gate* |
| `skills/lean-ctx-review/scripts/scan_session.py` | f-string with no placeholders |

Verified beyond the linter's word: `sys` is genuinely unreferenced (`grep sys\.`
is empty), **all 20 files still compile**, and `scan_session.py --selftest`
still passes.

## Credit

Raised by @andig in #1673 as a reason to hesitate about adding a Python script
to a Rust repo. The premise that the repo had no Python tooling turned out to be
wrong — 19 such files were already here — but the observation that none of it
was linted was correct, and it now applies to 20.

Fixes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)