### PR TITLE
fix(session): avoid global latest-session scans

### DIFF
--- a/docs/reference/14-performance-tuning.md
+++ b/docs/reference/14-performance-tuning.md
@@ -132,7 +132,33 @@ equivalent). At sustained pressure, reduce `memory_profile`, disable
 
 ---
 
-## 5. Finding what's slow — `slow-log`
+## 5. Reproducing session-store startup latency
+
+Session lookup for a safe project root reads its bounded `project-index` first.
+An absent, malformed, or stale index is repaired once by scanning the store;
+the normal command path never scans unrelated session JSON.
+
+Build the release binary, then run the isolated benchmark. It creates a temporary
+Git project and data directory, seeds one indexed session plus 10,000 unrelated
+JSON sessions, warms the command, and reports p50 without touching user data:
+
+```bash
+cd rust && cargo build --release
+cd .. && scripts/benchmark/session-store.sh 10000
+```
+
+On the 2026-09-04 development Mac, assess `p50_ms` after warm-up against the
+MES-2189 target of 200 ms or less. Set `LEAN_CTX_BIN`, `RUNS`, or `WARMUP` to
+measure another built binary or sampling regime.
+
+Session retention is separate from archive retention: `session_retention_days`
+(or `LEAN_CTX_SESSION_RETENTION_DAYS`) supplies the default for explicit
+`lean-ctx sessions cleanup` and `ctx_session cleanup`. Cleanup preserves the
+newest session for every project root.
+
+---
+
+## 6. Finding what's slow — `slow-log`
 
 lean-ctx records commands that exceed `slow_command_threshold_ms` (default
 `5000`) so you can see where wall-clock time goes:
@@ -152,7 +178,7 @@ turn "it feels slow" into a concrete list.
 
 ---
 
-## 6. Keeping caches lean
+## 7. Keeping caches lean
 
 ```bash
 lean-ctx cache stats              # size + hit rate
@@ -166,7 +192,7 @@ in-budget entries.
 
 ---
 
-## 7. Workload fit — where lean-ctx nets out (and where it doesn't)
+## 8. Workload fit — where lean-ctx nets out (and where it doesn't)
 
 lean-ctx saves tokens two ways: **cold-read compression** (a single read sent
 smaller) and **cached re-reads** (an unchanged file re-read collapses to a

--- a/docs/reference/generated/config-keys.md
+++ b/docs/reference/generated/config-keys.md
@@ -77,6 +77,7 @@ Top-level configuration keys
 - `rules_scope` (enum: both | global | project, default `both`) — Where agent rule files are installed. Override via LEAN_CTX_RULES_SCOPE
 - `sandbox_level` (u8, default `0` — env `LEAN_CTX_SANDBOX_LEVEL`) — Sandbox strictness level (0=default, 1=strict, 2=paranoid)
 - `savings_footer` (enum: auto | always | never, default `always` — env `LEAN_CTX_SAVINGS_FOOTER`) — Controls visibility of token savings footers: always (default, show on every response), never, auto (context-dependent). Also: LEAN_CTX_SHOW_SAVINGS=1|0
+- `session_retention_days` (u32, default `7` — env `LEAN_CTX_SESSION_RETENTION_DAYS`) — Retention window for explicit session cleanup; independent from archive retention and preserves the newest session per project
 - `shadow_mode` (bool, default `true` — env `LEAN_CTX_SHADOW_MODE`) — Default on: denies native tools at the permission level, forcing agents to use ctx_* MCP tools for maximum compression. Disable with shadow_mode = false if you prefer native tools.
 - `shell_activation` (enum: always | agents-only | off, default `agents-only` — env `LEAN_CTX_SHELL_ACTIVATION`) — Controls when the shell hook auto-activates aliases (agents-only since #699: transparent in plain human terminals)
 - `shell_allow_writes` (bool, default `false` — env `LEAN_CTX_SHELL_ALLOW_WRITES`) — Allow ctx_shell file-write redirects (>, >>, tee, heredoc-to-file, curl -o, wget default mode). Default false — prefer the native Write/Edit tool. The real command gating (allowlist, dangerous-pattern, interpreter-eval) still applies

--- a/rust/src/cli/call_cmd.rs
+++ b/rust/src/cli/call_cmd.rs
@@ -129,10 +129,10 @@ fn parse_args(args: &[String]) -> Result<CallArgs, CallError> {
 
 /// Load the project's most recent session for a one-shot `lean-ctx call`.
 ///
-/// Index-based, never a full scan: `load_latest_for_project_root` parses
-/// every file in the session store (measured: 160 files / 14.2 MB on one
-/// developer machine) before filtering on project root, and `lean-ctx call`
-/// is a short-lived subprocess that consumers spawn in loops.
+/// Index-based with bounded reads: `load_recent_for_project_root` resolves the
+/// canonical root, reads its project index, then loads only the indexed session.
+/// One-shot CLI calls are short-lived subprocesses that consumers spawn in loops,
+/// so their startup cost stays independent of unrelated session-store cardinality.
 ///
 /// This function only READS — it never writes the session back, and there is
 /// no implicit post-dispatch save (that belongs to the MCP server,

--- a/rust/src/cli/config_cmd.rs
+++ b/rust/src/cli/config_cmd.rs
@@ -1235,6 +1235,11 @@ max_ram_percent = 5
 # Flows into archive.max_age_hours.
 # max_staleness_days = 30
 
+# Session retention for `lean-ctx sessions cleanup` and `ctx_session cleanup`.
+# This is independent from archive retention and preserves the newest session
+# for every project root.
+# session_retention_days = 7
+
 # Explicit project paths to scan/index (default: auto-detect).
 # [ide_paths]
 # cursor = ["/home/user/projects/app1"]
@@ -1276,6 +1281,14 @@ fn cmd_show_effective() {
         " max_ram_percent     = {:10}  {}",
         cfg.max_ram_percent,
         source_hint("LEAN_CTX_MAX_RAM_PERCENT", cfg.max_ram_percent != 5)
+    ));
+    box_row(&format!(
+        " session_retention_days = {:8}  {}",
+        cfg.session_retention_days_effective(),
+        source_hint(
+            "LEAN_CTX_SESSION_RETENTION_DAYS",
+            cfg.session_retention_days != 7
+        )
     ));
     box_row(&format!(
         " max_staleness_days  = {:10}  {}",

--- a/rust/src/cli/session_cmd.rs
+++ b/rust/src/cli/session_cmd.rs
@@ -343,7 +343,14 @@ pub fn cmd_sessions(args: &[String]) {
             }
         }
         "cleanup" => {
-            let days = args.get(1).and_then(|s| s.parse::<i64>().ok()).unwrap_or(7);
+            let days = args
+                .get(1)
+                .and_then(|value| value.parse::<i64>().ok())
+                .unwrap_or_else(|| {
+                    i64::from(
+                        crate::core::config::Config::load().session_retention_days_effective(),
+                    )
+                });
             let removed = SessionState::cleanup_old_sessions(days);
             let (wf_removed, wf_freed) = crate::core::workflow::cleanup_expired();
             println!("Cleaned up {removed} session(s) older than {days} days.");

--- a/rust/src/core/config/defaults.rs
+++ b/rust/src/core/config/defaults.rs
@@ -160,6 +160,7 @@ impl Default for Config {
             max_ram_percent: serde_defaults::default_max_ram_percent(),
             max_disk_mb: 0,
             max_staleness_days: 0,
+            session_retention_days: serde_defaults::default_session_retention_days(),
             max_index_threads: 0,
             savings_footer: SavingsFooter::default(),
             compression_annotation: CompressionAnnotation::default(),

--- a/rust/src/core/config/logic.rs
+++ b/rust/src/core/config/logic.rs
@@ -481,6 +481,15 @@ impl Config {
             .unwrap_or(self.max_staleness_days)
     }
 
+    /// Effective retention window for explicit session cleanup, independent of
+    /// the archive staleness policy.
+    pub fn session_retention_days_effective(&self) -> u32 {
+        std::env::var("LEAN_CTX_SESSION_RETENTION_DAYS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(self.session_retention_days)
+    }
+
     /// Effective fixed-context budget (tokens) from env or config (#964). `0`
     /// (env or config) disables the warning; otherwise the per-session footprint
     /// is checked against this in `doctor overhead` and `gain`.

--- a/rust/src/core/config/model.rs
+++ b/rust/src/core/config/model.rs
@@ -545,6 +545,11 @@ pub struct Config {
     /// Flows into archive.max_age_hours and lifecycle idle TTL.
     #[serde(default)]
     pub max_staleness_days: u32,
+    /// Retention window for explicit session cleanup. This is independent from
+    /// archive retention and always preserves the newest session per project.
+    /// Override via LEAN_CTX_SESSION_RETENTION_DAYS.
+    #[serde(default = "serde_defaults::default_session_retention_days")]
+    pub session_retention_days: u32,
     /// Cap on the rayon worker threads used by the CPU-heavy index build
     /// (call graph etc.). 0 = rayon default (all cores). Set >0 to bound
     /// per-instance CPU so a fleet of concurrent sessions can't saturate the

--- a/rust/src/core/config/schema/sections_core.rs
+++ b/rust/src/core/config/schema/sections_core.rs
@@ -620,6 +620,15 @@ pub(super) fn build(sections: &mut BTreeMap<String, SectionSchema>) {
         ),
     );
     root.insert(
+        "session_retention_days".into(),
+        key_with_env(
+            "u32",
+            serde_json::json!(cfg.session_retention_days),
+            "Retention window for explicit session cleanup; independent from archive retention and preserves the newest session per project",
+            "LEAN_CTX_SESSION_RETENTION_DAYS",
+        ),
+    );
+    root.insert(
         "project_root".into(),
         key_with_env(
             "string?",

--- a/rust/src/core/config/serde_defaults.rs
+++ b/rust/src/core/config/serde_defaults.rs
@@ -53,6 +53,10 @@ pub(super) fn default_max_ram_percent() -> u8 {
     5
 }
 
+pub(super) fn default_session_retention_days() -> u32 {
+    7
+}
+
 pub(super) fn default_cognition_loop_interval() -> u64 {
     3600
 }

--- a/rust/src/core/config/tests_parsing.rs
+++ b/rust/src/core/config/tests_parsing.rs
@@ -275,6 +275,17 @@ mod simplified_config_tests {
     }
 
     #[test]
+    fn session_retention_days_is_independent_from_archive_staleness() {
+        let cfg = Config {
+            max_staleness_days: 30,
+            session_retention_days: 14,
+            ..Default::default()
+        };
+
+        assert_eq!(cfg.session_retention_days_effective(), 14);
+    }
+
+    #[test]
     fn staleness_explicit_archive_age_overrides() {
         let cfg = Config {
             max_staleness_days: 30,

--- a/rust/src/core/session/persistence.rs
+++ b/rust/src/core/session/persistence.rs
@@ -36,10 +36,29 @@ fn project_index_path(dir: &std::path::Path, project_root: &str) -> std::path::P
     dir.join("project-index").join(format!("{key}.json"))
 }
 
-/// Update one project's bounded warm-history index under a short, local lock.
-/// The index is strictly an acceleration structure: a failure never invalidates
-/// the already-committed session save.
-fn update_project_index(dir: &std::path::Path, project_root: &str, id: &str) -> Result<(), String> {
+fn read_project_index(dir: &std::path::Path, project_root: &str) -> Option<ProjectSessionIndex> {
+    std::fs::read_to_string(project_index_path(dir, project_root))
+        .ok()
+        .and_then(|json| serde_json::from_str::<ProjectSessionIndex>(&json).ok())
+        .filter(|index| index.version == 1 && index.project_root == project_root)
+}
+
+fn write_project_index(
+    index_path: &std::path::Path,
+    index: &ProjectSessionIndex,
+) -> Result<(), String> {
+    let json = serde_json::to_string(index).map_err(|e| format!("serialize project index: {e}"))?;
+    let tmp = index_path.with_extension(format!("{}.tmp", std::process::id()));
+    std::fs::write(&tmp, json).map_err(|e| format!("write project index: {e}"))?;
+    restrict_file_permissions(&tmp);
+    std::fs::rename(tmp, index_path).map_err(|e| format!("commit project index: {e}"))
+}
+
+fn with_project_index_lock<T>(
+    dir: &std::path::Path,
+    project_root: &str,
+    operation: impl FnOnce(&std::path::Path) -> Result<T, String>,
+) -> Result<T, String> {
     use fs2::FileExt;
     use std::time::{Duration, Instant};
 
@@ -49,13 +68,11 @@ fn update_project_index(dir: &std::path::Path, project_root: &str, id: &str) -> 
     let index_path = project_index_path(dir, project_root);
     let index_dir = index_path.parent().ok_or("project index has no parent")?;
     std::fs::create_dir_all(index_dir).map_err(|e| format!("create project index: {e}"))?;
-
-    let lock_path = index_path.with_extension("lock");
     let lock = std::fs::OpenOptions::new()
         .create(true)
         .truncate(false)
         .write(true)
-        .open(lock_path)
+        .open(index_path.with_extension("lock"))
         .map_err(|e| format!("project index lock: {e}"))?;
     let deadline = Instant::now() + LOCK_TIMEOUT;
     loop {
@@ -72,18 +89,22 @@ fn update_project_index(dir: &std::path::Path, project_root: &str, id: &str) -> 
             Err(error) => return Err(format!("project index lock: {error}")),
         }
     }
+    let result = operation(&index_path);
+    let _ = FileExt::unlock(&lock);
+    result
+}
 
-    let result = (|| {
-        let mut index = std::fs::read_to_string(&index_path)
-            .ok()
-            .and_then(|json| serde_json::from_str::<ProjectSessionIndex>(&json).ok())
-            .filter(|index| index.version == 1 && index.project_root == project_root)
-            .unwrap_or_else(|| ProjectSessionIndex {
+/// Update one project's bounded warm-history index under a short, local lock.
+/// The index is strictly an acceleration structure: a failure never invalidates
+/// the already-committed session save.
+fn update_project_index(dir: &std::path::Path, project_root: &str, id: &str) -> Result<(), String> {
+    with_project_index_lock(dir, project_root, |index_path| {
+        let mut index =
+            read_project_index(dir, project_root).unwrap_or_else(|| ProjectSessionIndex {
                 version: 1,
                 project_root: project_root.to_string(),
                 session_ids: Vec::new(),
             });
-
         index.session_ids.retain(|existing| existing != id);
         index.session_ids.push(id.to_string());
         let excess = index
@@ -93,16 +114,50 @@ fn update_project_index(dir: &std::path::Path, project_root: &str, id: &str) -> 
         if excess > 0 {
             index.session_ids.drain(..excess);
         }
+        write_project_index(index_path, &index)
+    })
+}
 
-        let json =
-            serde_json::to_string(&index).map_err(|e| format!("serialize project index: {e}"))?;
-        let tmp = index_path.with_extension(format!("{}.tmp", std::process::id()));
-        std::fs::write(&tmp, json).map_err(|e| format!("write project index: {e}"))?;
-        restrict_file_permissions(&tmp);
-        std::fs::rename(tmp, index_path).map_err(|e| format!("commit project index: {e}"))
-    })();
-    let _ = FileExt::unlock(&lock);
-    result
+fn repair_project_index(dir: &std::path::Path, project_root: &str) -> Option<SessionState> {
+    let mut matches = Vec::new();
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        if id == "latest" || id.starts_with('.') {
+            continue;
+        }
+        let Some(session) = SessionState::load_by_id(id) else {
+            continue;
+        };
+        if session_matches_project_root(&session, std::path::Path::new(project_root)) {
+            matches.push(session);
+        }
+    }
+    matches.sort_by_key(|session| session.updated_at);
+    let latest = matches.last().cloned();
+    let first_retained = matches.len().saturating_sub(PROJECT_HISTORY_LIMIT);
+    let session_ids = matches[first_retained..]
+        .iter()
+        .map(|session| session.id.clone())
+        .collect();
+    if let Err(error) = with_project_index_lock(dir, project_root, |index_path| {
+        write_project_index(
+            index_path,
+            &ProjectSessionIndex {
+                version: 1,
+                project_root: project_root.to_string(),
+                session_ids,
+            },
+        )
+    }) {
+        tracing::debug!("lean-ctx: session project index repair skipped: {error}");
+    }
+    latest
 }
 
 #[cfg(unix)]
@@ -346,51 +401,23 @@ impl SessionState {
     }
 
     /// Loads the most recent session matching a specific project root.
+    ///
+    /// A valid per-project index is the only nominal path: one index read and
+    /// one session read, independent of the global session-store cardinality.
+    /// A missing, corrupt, or stale index is repaired by one exceptional scan.
     pub fn load_latest_for_project_root(project_root: &str) -> Option<Self> {
-        // Broad roots ("/", HOME, agent sandboxes) never own a session. Bail out
-        // BEFORE scanning: the daemon boots with cwd "/" and previously walked
-        // every stored session here, stat-ing each session's project_root /
-        // shell_cwd. For roots under ~/Documents that probe popped the macOS
-        // TCC prompt in lean-ctx's name on every launchd (re)start (#356) —
-        // and `shell_cwd.starts_with("/")` could even leak an arbitrary
-        // project's session into the broad-root context.
-        if crate::core::pathutil::is_broad_or_unsafe_root(std::path::Path::new(project_root)) {
-            return None;
-        }
+        let target_root = normalized_safe_project_root(project_root)?;
         let dir = sessions_dir()?;
-        let target_root =
-            crate::core::pathutil::safe_canonicalize_or_self(std::path::Path::new(project_root));
-        let mut latest_match: Option<Self> = None;
 
-        for entry in std::fs::read_dir(&dir).ok()?.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                continue;
-            }
-            if path.file_name().and_then(|n| n.to_str()) == Some("latest.json") {
-                continue;
-            }
-
-            let Some(id) = path.file_stem().and_then(|n| n.to_str()) else {
-                continue;
-            };
-            let Some(session) = Self::load_by_id(id) else {
-                continue;
-            };
-
-            if !session_matches_project_root(&session, &target_root) {
-                continue;
-            }
-
-            if latest_match
-                .as_ref()
-                .is_none_or(|existing| session.updated_at > existing.updated_at)
-            {
-                latest_match = Some(session);
-            }
+        if let Some(index) = read_project_index(&dir, &target_root)
+            && let Some(id) = index.session_ids.last()
+            && let Some(session) = Self::load_by_id(id)
+            && session_matches_project_root(&session, std::path::Path::new(&target_root))
+        {
+            return Some(session);
         }
 
-        latest_match
+        repair_project_index(&dir, &target_root)
     }
 
     /// Loads a specific session from disk by its unique ID.
@@ -541,48 +568,84 @@ impl SessionState {
         (found, quarantined)
     }
 
-    /// Deletes sessions older than `max_age_days`, preserving the latest. Returns count removed.
+    /// Deletes sessions older than `max_age_days`, preserving the most recent
+    /// session for every project root. Returns the count removed.
+    ///
+    /// This is an explicit retention operation, so its single store scan stays
+    /// off the command hot path.
     pub fn cleanup_old_sessions(max_age_days: i64) -> u32 {
         let Some(dir) = sessions_dir() else { return 0 };
-
         let cutoff = Utc::now() - chrono::Duration::days(max_age_days);
-        let latest = Self::load_latest().map(|s| s.id);
-        let mut removed = 0u32;
+        let global_latest = Self::load_global_latest_pointer().map(|session| session.id);
+        let mut sessions = Vec::new();
 
         if let Ok(entries) = std::fs::read_dir(&dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
                     continue;
                 }
-                let filename = path.file_stem().and_then(|n| n.to_str()).unwrap_or("");
-                if filename == "latest" || filename.starts_with('.') {
+                let Some(id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                    continue;
+                };
+                if id == "latest" || id.starts_with('.') {
                     continue;
                 }
-                if latest.as_deref() == Some(filename) {
-                    continue;
-                }
-                if let Ok(json) = std::fs::read_to_string(&path)
-                    && let Ok(session) = serde_json::from_str::<SessionState>(&json)
-                    && session.updated_at < cutoff
-                    && std::fs::read_to_string(&path)
-                        .ok()
-                        .and_then(|content| serde_json::from_str::<Self>(&content).ok())
-                        .is_none_or(|session| persist_session_facts(&session).is_ok())
-                    && std::fs::remove_file(&path).is_ok()
-                {
-                    removed += 1;
+                if let Some(session) = Self::load_by_id(id) {
+                    sessions.push((path, session));
                 }
             }
         }
 
-        removed
+        let mut newest_by_project = std::collections::HashMap::new();
+        for (_, session) in &sessions {
+            let Some(project_root) = session
+                .project_root
+                .as_deref()
+                .filter(|root| !root.trim().is_empty())
+            else {
+                continue;
+            };
+            newest_by_project
+                .entry(project_root)
+                .and_modify(|current: &mut &SessionState| {
+                    if session.updated_at > current.updated_at {
+                        *current = session;
+                    }
+                })
+                .or_insert(session);
+        }
+
+        let mut retained_ids: std::collections::HashSet<String> = newest_by_project
+            .values()
+            .map(|session| session.id.clone())
+            .collect();
+        if let Some(id) = global_latest {
+            retained_ids.insert(id);
+        }
+
+        sessions
+            .into_iter()
+            .filter(|(_, session)| {
+                session.updated_at < cutoff && !retained_ids.contains(&session.id)
+            })
+            .filter(|(_, session)| persist_session_facts(session).is_ok())
+            .filter(|(path, _)| std::fs::remove_file(path).is_ok())
+            .map(|(path, session)| {
+                let snapshot = path.with_file_name(format!("{}_snapshot.txt", session.id));
+                let _ = std::fs::remove_file(snapshot);
+            })
+            .count() as u32
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SessionState;
+    use super::{
+        ProjectSessionIndex, SessionState, normalized_safe_project_root, project_index_path,
+        write_project_index,
+    };
+    use chrono::{Duration, Utc};
 
     #[test]
     fn recent_project_sessions_use_bounded_index_without_scanning_legacy_store() {
@@ -633,6 +696,193 @@ mod tests {
                 .read_dir()
                 .map_or(true, |mut entries| entries.next().is_none())
         );
+    }
+
+    #[test]
+    fn latest_project_session_uses_valid_index_without_scanning_unindexed_sessions() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let project = tempfile::tempdir().expect("project tempdir");
+        let root = project.path().to_string_lossy().to_string();
+
+        let mut indexed = SessionState::new();
+        indexed.id = "indexed".to_string();
+        indexed.project_root = Some(root.clone());
+        indexed.updated_at = Utc::now() - Duration::hours(1);
+        indexed.save().expect("save indexed session");
+
+        // This valid but unindexed legacy file is newer. The nominal path must
+        // trust the index and never deserialize unrelated root-level sessions.
+        let mut unindexed = SessionState::new();
+        unindexed.id = "unindexed".to_string();
+        unindexed.project_root = Some(root.clone());
+        unindexed.updated_at = Utc::now();
+        let sessions = crate::core::session::paths::sessions_dir().expect("sessions dir");
+        std::fs::write(
+            sessions.join("unindexed.json"),
+            serde_json::to_string(&unindexed).expect("serialize legacy session"),
+        )
+        .expect("write unindexed session");
+
+        assert_eq!(
+            SessionState::load_latest_for_project_root(&root)
+                .expect("load indexed session")
+                .id,
+            "indexed"
+        );
+    }
+
+    #[test]
+    fn latest_project_session_repairs_a_missing_index() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let project = tempfile::tempdir().expect("project tempdir");
+        let root = project.path().to_string_lossy().to_string();
+        let mut session = SessionState::new();
+        session.id = "repair-missing".to_string();
+        session.project_root = Some(root.clone());
+        session.save().expect("save indexed session");
+
+        let sessions = crate::core::session::paths::sessions_dir().expect("sessions dir");
+        let canonical_root = normalized_safe_project_root(&root).expect("safe root");
+        let index_path = project_index_path(&sessions, &canonical_root);
+        std::fs::remove_file(&index_path).expect("remove project index");
+
+        assert_eq!(
+            SessionState::load_latest_for_project_root(&root)
+                .expect("repair and load session")
+                .id,
+            "repair-missing"
+        );
+        let repaired: ProjectSessionIndex =
+            serde_json::from_str(&std::fs::read_to_string(index_path).expect("repaired index"))
+                .expect("valid repaired index");
+        assert_eq!(repaired.session_ids, ["repair-missing"]);
+    }
+
+    #[test]
+    fn latest_project_session_repairs_an_empty_index() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let project = tempfile::tempdir().expect("project tempdir");
+        let root = project.path().to_string_lossy().to_string();
+        let mut session = SessionState::new();
+        session.id = "repair-empty".to_string();
+        session.project_root = Some(root.clone());
+        session.save().expect("save indexed session");
+
+        let sessions = crate::core::session::paths::sessions_dir().expect("sessions dir");
+        let canonical_root = normalized_safe_project_root(&root).expect("safe root");
+        let index_path = project_index_path(&sessions, &canonical_root);
+        write_project_index(
+            &index_path,
+            &ProjectSessionIndex {
+                version: 1,
+                project_root: canonical_root,
+                session_ids: Vec::new(),
+            },
+        )
+        .expect("empty project index");
+
+        assert_eq!(
+            SessionState::load_latest_for_project_root(&root)
+                .expect("repair and load session")
+                .id,
+            "repair-empty"
+        );
+        let repaired: ProjectSessionIndex =
+            serde_json::from_str(&std::fs::read_to_string(index_path).expect("repaired index"))
+                .expect("valid repaired index");
+        assert_eq!(repaired.session_ids, ["repair-empty"]);
+    }
+
+    #[test]
+    fn latest_project_session_repairs_a_corrupt_index() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let project = tempfile::tempdir().expect("project tempdir");
+        let root = project.path().to_string_lossy().to_string();
+        let mut session = SessionState::new();
+        session.id = "repair-corrupt".to_string();
+        session.project_root = Some(root.clone());
+        session.save().expect("save indexed session");
+
+        let sessions = crate::core::session::paths::sessions_dir().expect("sessions dir");
+        let canonical_root = normalized_safe_project_root(&root).expect("safe root");
+        let index_path = project_index_path(&sessions, &canonical_root);
+        std::fs::write(&index_path, "not json").expect("corrupt project index");
+
+        assert_eq!(
+            SessionState::load_latest_for_project_root(&root)
+                .expect("repair and load session")
+                .id,
+            "repair-corrupt"
+        );
+        let repaired: ProjectSessionIndex =
+            serde_json::from_str(&std::fs::read_to_string(index_path).expect("repaired index"))
+                .expect("valid repaired index");
+        assert_eq!(repaired.session_ids, ["repair-corrupt"]);
+    }
+
+    #[test]
+    fn latest_project_session_repairs_an_index_with_a_missing_session() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let project = tempfile::tempdir().expect("project tempdir");
+        let root = project.path().to_string_lossy().to_string();
+
+        let mut older = SessionState::new();
+        older.id = "repair-older".to_string();
+        older.project_root = Some(root.clone());
+        older.updated_at = Utc::now() - Duration::hours(1);
+        older.save().expect("save older session");
+
+        let mut missing = SessionState::new();
+        missing.id = "repair-missing-file".to_string();
+        missing.project_root = Some(root.clone());
+        missing.save().expect("save missing session");
+        let sessions = crate::core::session::paths::sessions_dir().expect("sessions dir");
+        std::fs::remove_file(sessions.join("repair-missing-file.json"))
+            .expect("remove indexed session");
+
+        assert_eq!(
+            SessionState::load_latest_for_project_root(&root)
+                .expect("repair and load fallback")
+                .id,
+            "repair-older"
+        );
+        let repaired: ProjectSessionIndex = serde_json::from_str(
+            &std::fs::read_to_string(project_index_path(
+                &sessions,
+                &normalized_safe_project_root(&root).expect("safe root"),
+            ))
+            .expect("repaired index"),
+        )
+        .expect("valid repaired index");
+        assert_eq!(repaired.session_ids, ["repair-older"]);
+    }
+
+    #[test]
+    fn cleanup_old_sessions_preserves_the_latest_session_for_each_project() {
+        let _data = crate::core::data_dir::isolated_data_dir();
+        let project_a = tempfile::tempdir().expect("project A");
+        let project_b = tempfile::tempdir().expect("project B");
+        let root_a = project_a.path().to_string_lossy().to_string();
+        let root_b = project_b.path().to_string_lossy().to_string();
+
+        for (id, root, age_days) in [
+            ("a-old", root_a.as_str(), 10),
+            ("a-latest", root_a.as_str(), 8),
+            ("b-old", root_b.as_str(), 10),
+            ("b-latest", root_b.as_str(), 8),
+        ] {
+            let mut session = SessionState::new();
+            session.id = id.to_string();
+            session.project_root = Some(root.to_string());
+            session.updated_at = Utc::now() - Duration::days(age_days);
+            session.save().expect("save session");
+        }
+
+        assert_eq!(SessionState::cleanup_old_sessions(7), 2);
+        assert!(SessionState::load_by_id("a-latest").is_some());
+        assert!(SessionState::load_by_id("b-latest").is_some());
+        assert!(SessionState::load_by_id("a-old").is_none());
+        assert!(SessionState::load_by_id("b-old").is_none());
     }
 
     #[test]

--- a/rust/src/tools/ctx_session.rs
+++ b/rust/src/tools/ctx_session.rs
@@ -464,10 +464,9 @@ fn handle_list() -> String {
 }
 
 fn handle_cleanup() -> String {
-    {
-        let removed = SessionState::cleanup_old_sessions(7);
-        format!("Cleaned up {removed} old session(s) (>7 days).")
-    }
+    let days = crate::core::config::Config::load().session_retention_days_effective();
+    let removed = SessionState::cleanup_old_sessions(i64::from(days));
+    format!("Cleaned up {removed} old session(s) (>{days} days).")
 }
 
 fn handle_configure(session: &mut SessionState, opts: SessionToolOptions<'_>) -> String {

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -23,3 +23,17 @@ divided by four (`chars / 4`, integer-truncated). This measures emitted input
 size, not model-specific tokenizer output. Reduction is calculated from the
 per-task token estimates; the report's final row is the arithmetic mean across
 the ten tasks.
+
+## Session-store lookup benchmark
+
+From the repository root, build the release binary and create a temporary store with
+one indexed project session plus 10,000 unrelated sessions:
+
+```bash
+cd rust && cargo build --release
+cd .. && scripts/benchmark/session-store.sh 10000
+```
+
+The script measures warmed `lean-ctx -c /usr/bin/true` invocations and prints p50 in
+milliseconds. It uses temporary directories only and removes them on exit. Set
+`LEAN_CTX_BIN`, `RUNS`, or `WARMUP` to select a binary or adjust sampling.

--- a/scripts/benchmark/session-store.sh
+++ b/scripts/benchmark/session-store.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="${LEAN_CTX_BIN:-$ROOT/rust/target/release/lean-ctx}"
+if [[ ! -x "$BIN" ]]; then
+  BIN="$(command -v lean-ctx)"
+fi
+[[ -x "$BIN" ]] || { echo "Build rust/target/release/lean-ctx or set LEAN_CTX_BIN." >&2; exit 1; }
+
+COUNT="${1:-10000}"
+RUNS="${RUNS:-15}"
+WARMUP="${WARMUP:-5}"
+DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lean-ctx-session-store.XXXXXX")"
+PROJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lean-ctx-session-project.XXXXXX")"
+cleanup() { rm -rf "$DATA_DIR" "$PROJECT_DIR"; }
+trap cleanup EXIT
+
+git -C "$PROJECT_DIR" init -q
+export LEAN_CTX_DATA_DIR="$DATA_DIR"
+"$BIN" call ctx_session --project-root "$PROJECT_DIR" --json '{"action":"save"}' >/dev/null
+SEED="$(find "$DATA_DIR/sessions" -maxdepth 1 -type f -name '*.json' ! -name latest.json -print -quit)"
+[[ -n "$SEED" ]] || { echo "Could not create a seed session." >&2; exit 1; }
+
+python3 - "$SEED" "$DATA_DIR/sessions" "$COUNT" "$BIN" "$PROJECT_DIR" "$RUNS" "$WARMUP" <<'PY'
+import copy
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+seed_path, sessions_dir, count, binary, project_dir, runs, warmup = sys.argv[1:]
+count, runs, warmup = map(int, (count, runs, warmup))
+with open(seed_path, encoding="utf-8") as handle:
+    seed = json.load(handle)
+
+for number in range(count):
+    session = copy.deepcopy(seed)
+    session["id"] = f"nonrelevant-{number:05d}"
+    session["project_root"] = f"/tmp/lean-ctx-nonrelevant-project-{number:05d}"
+    session["shell_cwd"] = session["project_root"]
+    with open(
+        os.path.join(sessions_dir, f"{session['id']}.json"),
+        "w",
+        encoding="utf-8",
+    ) as handle:
+        json.dump(session, handle)
+
+command = [binary, "-c", "/usr/bin/true"]
+for _ in range(warmup):
+    subprocess.run(command, cwd=project_dir, check=True, stdout=subprocess.DEVNULL)
+
+samples = []
+for _ in range(runs):
+    started = time.perf_counter_ns()
+    subprocess.run(command, cwd=project_dir, check=True, stdout=subprocess.DEVNULL)
+    samples.append((time.perf_counter_ns() - started) / 1_000_000)
+
+print(f"sessions={count} runs={runs} warmup={warmup}")
+print(f"p50_ms={statistics.median(samples):.1f}")
+print("samples_ms=" + ",".join(f"{sample:.1f}" for sample in samples))
+PY


### PR DESCRIPTION
## Summary
- Use project-index as the bounded nominal latest-session lookup and repair missing, corrupt, stale, or empty indexes safely.
- Add configurable session retention that preserves the most recent session for each project root.
- Add a reproducible 10,000-session benchmark in scripts/benchmark/session-store.sh.

## Reproduction
Run scripts/benchmark/session-store.sh after building the release binary. It seeds one indexed project session, creates 10,000 unrelated sessions, warms up, then measures lean-ctx -c /usr/bin/true.

## Validation
- cargo fmt --check
- cargo clippy --all-features -- -D warnings
- cargo test --lib core::session::persistence::tests
- pre-push fast CI-parity gate: whitespace, format, clippy, rustdoc, generated-docs, registry snapshot, Windows cross-compile
- benchmark: p50 10.1 ms with 10,000 sessions

Note: cargo test --lib still has three host-root failures unrelated to this change.

Refs: MES-2189