### PR TITLE
fix(release): read Windows wheel payloads as binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed — release packaging
 
+- Windows Engine companion wheels now read `.exe` payloads in binary mode,
+  avoiding false truncation errors when binaries contain the DOS EOF byte
+  (`0x1A`).
 - Linux musl release builds now use the platform system allocator instead of
   compiling jemalloc, avoiding its C11-atomics incompatibility on supported
   musl runners. glibc Linux and macOS builds continue to use jemalloc.

--- a/scripts/build-python-engine-wheel.py
+++ b/scripts/build-python-engine-wheel.py
@@ -38,7 +38,12 @@ def _read_regular(path: Path, *, maximum: int, label: str) -> bytes:
         raise ValueError(f"{label} must be a regular non-symlink file")
     if initial.st_size <= 0 or initial.st_size > maximum:
         raise ValueError(f"{label} size is outside the release bounds")
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
     descriptor = os.open(path, flags)
     try:
         opened = os.fstat(descriptor)

--- a/tests/delivery/test_python_engine_wheel.py
+++ b/tests/delivery/test_python_engine_wheel.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import stat
 import tempfile
 import unittest
+from unittest import mock
 import zipfile
 
 
@@ -140,6 +141,33 @@ class PythonEngineWheelTests(unittest.TestCase):
         ):
             with self.subTest(expected=expected):
                 self.assertIn(expected, workflow)
+
+    def test_read_regular_requests_binary_mode(self):
+        payload = b"MZ\r\n\x1a\x00lean-ctx\r\n"
+        self.binary.write_bytes(payload)
+        self.assertEqual(
+            MODULE._read_regular(self.binary, maximum=1024, label="binary"),
+            payload,
+        )
+
+        original_open = MODULE.os.open
+        binary_flag = 1 << 29
+
+        def open_without_synthetic_flag(path, flags):
+            return original_open(path, flags & ~binary_flag)
+
+        with (
+            mock.patch.object(MODULE.os, "O_BINARY", binary_flag, create=True),
+            mock.patch.object(
+                MODULE.os, "open", side_effect=open_without_synthetic_flag
+            ) as mocked_open,
+        ):
+            self.assertEqual(
+                MODULE._read_regular(self.binary, maximum=1024, label="binary"),
+                self.binary.read_bytes(),
+            )
+
+        self.assertTrue(mocked_open.call_args.args[1] & binary_flag)
 
     def test_release_uses_system_allocator_on_musl(self):
         manifest = (ROOT / "rust" / "Cargo.toml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- open Engine payloads with the Windows CRT binary-mode flag
- preserve symlink, size, identity, truncation, growth, and final-stat checks
- add a byte-exact regression fixture containing the DOS EOF byte
- document the release packaging fix

## Root cause
Both Windows artifacts built successfully. Companion wheel creation then read the executable through CRT text mode, where byte 0x1A was interpreted as EOF and falsely reported as truncation.

## Verified
- 214 delivery and security tests
- wheel regression suite 8/8
- Ruff Pyflakes checks
- delivery evidence and diff checks
- independent reviewer confirmed minimal fix