### PR TITLE
fix(release): keep Windows launcher attached to engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Windows Engine companion wheels now read `.exe` payloads in binary mode,
   avoiding false truncation errors when binaries contain the DOS EOF byte
   (`0x1A`).
+- Installed Windows launchers now stay attached until the bundled Engine exits,
+  preserving SDK process monitoring and deterministic temporary-file cleanup.
 - Linux musl release builds now use the platform system allocator instead of
   compiling jemalloc, avoiding its C11-atomics incompatibility on supported
   musl runners. glibc Linux and macOS builds continue to use jemalloc.

--- a/scripts/build-python-engine-wheel.py
+++ b/scripts/build-python-engine-wheel.py
@@ -83,6 +83,7 @@ import hashlib
 from importlib.resources import files
 import os
 import stat
+import subprocess
 import sys
 
 EXPECTED_SHA256 = "{expected_sha256}"
@@ -102,6 +103,8 @@ def main() -> None:
         raise RuntimeError("bundled LeanCTX Engine failed integrity verification")
     if os.name != "nt" and not os.access(path, os.X_OK):
         raise RuntimeError("bundled LeanCTX Engine is not executable")
+    if os.name == "nt":
+        raise SystemExit(subprocess.call([path, *sys.argv[1:]], shell=False))
     os.execv(path, [path, *sys.argv[1:]])
 '''
     return source.encode("utf-8")

--- a/tests/delivery/test_python_engine_wheel.py
+++ b/tests/delivery/test_python_engine_wheel.py
@@ -169,6 +169,23 @@ class PythonEngineWheelTests(unittest.TestCase):
 
         self.assertTrue(mocked_open.call_args.args[1] & binary_flag)
 
+    def test_windows_launcher_waits_for_native_engine(self):
+        wheel = self.build()
+        with zipfile.ZipFile(wheel) as archive:
+            launcher = archive.read(
+                "thinkery_leanctx_engine/launcher.py"
+            ).decode("utf-8")
+
+        windows_wait = (
+            'if os.name == "nt":\n'
+            '        raise SystemExit('
+            'subprocess.call([path, *sys.argv[1:]], shell=False))'
+        )
+        self.assertIn("import subprocess", launcher)
+        self.assertIn(windows_wait, launcher)
+        self.assertIn("os.execv(path, [path, *sys.argv[1:]])", launcher)
+        self.assertLess(launcher.index(windows_wait), launcher.index("os.execv("))
+
     def test_release_uses_system_allocator_on_musl(self):
         manifest = (ROOT / "rust" / "Cargo.toml").read_text(encoding="utf-8")
         self.assertIn(


### PR DESCRIPTION
## Summary
- keep the installed Windows Python console launcher alive while the bundled Engine runs
- propagate the native Engine exit code and preserve Unix exec replacement
- document the packaging fix and add a generated-launcher regression test

## Root cause
The generated Windows console wrapper used os.execv. On Windows the wrapper could exit while the native Engine continued, so the SDK observed a dead tracked process after hello, failed on tree, and cleanup hit a locked temporary directory.

## Verification
- focused wheel tests: 9 passed
- delivery and security tests: 215 passed
- Ruff Pyflakes, py_compile, delivery evidence, and diff check passed
- independent release-workflow review: approved