### PR TITLE
feat(dashboard): the invitation popup asks how people use LeanCTX

### DIFF
--- a/rust/src/dashboard/static/components/cockpit-partner-promo.js
+++ b/rust/src/dashboard/static/components/cockpit-partner-promo.js
@@ -1,11 +1,25 @@
 /**
- * One-time design-partner and SDK invitation for the local dashboard.
- * The campaign key is versioned so future invitations can be shown once.
+ * One-time invitation shown once per campaign in the local dashboard.
+ *
+ * Campaign v2 asks how people actually use LeanCTX and keeps the SDK pointer.
+ * The design-partner solicitation from v1 is gone: a cold "email us to roll
+ * this out" in a local tool asks the reader for a commitment before we have
+ * asked them anything, and it competed with the one question that is worth a
+ * modal — what they use it for and what is missing.
+ *
+ * The storage key is versioned exactly so a new campaign reaches people who
+ * dismissed the previous one; bumping it here is what makes v2 appear.
+ *
+ * Sending is deliberate and one-way: nothing leaves the machine until the
+ * button is pressed, and the notice above it says where the answers go before
+ * they go there. The same form lives permanently in Settings
+ * (`cockpit-feedback`) for anyone who dismisses this and wants it later.
  */
 (function () {
   'use strict';
 
-  var STORAGE_KEY = 'leanctx_partner_sdk_promo_v1';
+  var STORAGE_KEY = 'leanctx_feedback_survey_v2';
+  var MAX_ANSWER = 2000;
   var OVERLAY_ID = 'leanctxPartnerPromo';
   var previousFocus = null;
   var backgroundState = [];
@@ -129,6 +143,47 @@
     if (focusable.length) focusable[0].focus();
   }
 
+  /* Three of the four are free text on purpose: a fixed list of features can
+     only return the answers it already contains, and the point is to learn
+     which use cases exist. Frequency is the one multiple choice, and it is what
+     makes the free text groupable — "what is missing" from a daily user and
+     from someone who installed it yesterday are different wishes. */
+  var QUESTIONS = [
+    { id: 'use_case', label: 'What do you use LeanCTX for?', rows: 2 },
+    { id: 'likes_most', label: 'What do you like most about it?', rows: 2 },
+    { id: 'wishes', label: 'What is missing?', rows: 2 }
+  ];
+
+  var FREQUENCIES = [
+    { id: 'daily', label: 'Daily' },
+    { id: 'weekly', label: 'Weekly' },
+    { id: 'occasionally', label: 'Occasionally' },
+    { id: 'new', label: 'Just started' }
+  ];
+
+  function escapeHtml(value) {
+    return String(value == null ? '' : value).replace(/[&<>"']/g, function (ch) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+    });
+  }
+
+  function questionFields() {
+    return QUESTIONS.map(function (q) {
+      return '<label class="promo-field">' +
+        '<span class="promo-field-label">' + escapeHtml(q.label) + '</span>' +
+        '<textarea id="promoFb-' + q.id + '" rows="' + q.rows + '" ' +
+          'maxlength="' + MAX_ANSWER + '"></textarea>' +
+        '</label>';
+    }).join('');
+  }
+
+  function frequencyChips() {
+    return FREQUENCIES.map(function (f) {
+      return '<button type="button" class="promo-chip" data-freq="' + escapeHtml(f.id) + '" ' +
+        'aria-pressed="false">' + escapeHtml(f.label) + '</button>';
+    }).join('');
+  }
+
   function createOverlay() {
     var overlay = document.createElement('div');
     overlay.id = OVERLAY_ID;
@@ -136,33 +191,110 @@
     overlay.innerHTML =
       '<section class="partner-promo" role="dialog" aria-modal="true" ' +
         'aria-labelledby="partnerPromoTitle" aria-describedby="partnerPromoDescription">' +
-        '<button type="button" class="partner-promo-close" aria-label="Dismiss invitation">&times;</button>' +
-        '<div class="partner-promo-kicker">BUILD WITH LEANCTX</div>' +
-        '<h2 id="partnerPromoTitle">Take LeanCTX further</h2>' +
+        '<button type="button" class="partner-promo-close" aria-label="Dismiss">&times;</button>' +
+        '<div class="partner-promo-kicker">HELP SHAPE LEANCTX</div>' +
+        '<h2 id="partnerPromoTitle">How do you use LeanCTX?</h2>' +
         '<p id="partnerPromoDescription" class="partner-promo-intro">' +
-          'We are looking for design partners and engineering teams ready to deploy LeanCTX in real workflows.' +
+          'Four questions, all optional. What you write here decides what gets built next.' +
         '</p>' +
-        '<div class="partner-promo-options">' +
-          '<article class="partner-promo-option">' +
-            '<span class="partner-promo-index" aria-hidden="true">01</span>' +
-            '<h3>Roll out LeanCTX</h3>' +
-            '<p>Work with us on integrations, governance, rollout and measurable context efficiency for your organization.</p>' +
-            '<a class="partner-promo-cta partner-promo-cta-primary" ' +
-              'href="mailto:yves@thinkery.ch?subject=LeanCTX%20design%20partner%20inquiry">' +
-              'Email yves@thinkery.ch <span aria-hidden="true">&rarr;</span></a>' +
-          '</article>' +
-          '<article class="partner-promo-option">' +
-            '<span class="partner-promo-index" aria-hidden="true">02</span>' +
-            '<h3>Build your own agent</h3>' +
-            '<p>Use the Python SDK with the local LeanCTX Engine to build custom, token-efficient agent workflows.</p>' +
-            '<a class="partner-promo-cta" href="https://github.com/Thinkery-AG/leanctx-sdk#readme" ' +
-              'target="_blank" rel="noopener noreferrer">Explore the SDK <span aria-hidden="true">&rarr;</span>' +
-              '<span class="partner-promo-sr-only"> (opens in a new tab)</span></a>' +
-          '</article>' +
+        '<div class="promo-form">' +
+          questionFields() +
+          '<div class="promo-field">' +
+            '<span class="promo-field-label">How often do you use it?</span>' +
+            '<div class="promo-chips">' + frequencyChips() + '</div>' +
+          '</div>' +
         '</div>' +
-        '<button type="button" class="partner-promo-later">Dismiss</button>' +
+        /* Said before the button, not after: pressing send is the moment
+           something leaves this machine. */
+        '<p class="promo-note">Sending transmits these answers, your LeanCTX version and the ' +
+          'anonymous installation id to leanctx.com. Nothing else, and nothing until you press it.</p>' +
+        '<div class="promo-actions">' +
+          '<button type="button" class="partner-promo-cta partner-promo-cta-primary" id="promoFbSend">' +
+            'Send feedback</button>' +
+          '<a class="partner-promo-cta" href="https://github.com/Thinkery-AG/leanctx-sdk#readme" ' +
+            'target="_blank" rel="noopener noreferrer">Explore the SDK <span aria-hidden="true">&rarr;</span>' +
+            '<span class="partner-promo-sr-only"> (opens in a new tab)</span></a>' +
+        '</div>' +
+        '<p class="promo-status" id="promoFbStatus" role="status" aria-live="polite"></p>' +
+        '<button type="button" class="partner-promo-later">Not now</button>' +
       '</section>';
     return overlay;
+  }
+
+  function collectAnswers(overlay) {
+    var body = {};
+    QUESTIONS.forEach(function (q) {
+      var el = overlay.querySelector('#promoFb-' + q.id);
+      body[q.id] = el ? el.value : '';
+    });
+    var active = overlay.querySelector('.promo-chip[aria-pressed="true"]');
+    body.frequency = active ? active.getAttribute('data-freq') : '';
+    return body;
+  }
+
+  function wireForm(overlay) {
+    overlay.querySelectorAll('.promo-chip').forEach(function (chip) {
+      chip.addEventListener('click', function () {
+        var on = chip.getAttribute('aria-pressed') === 'true';
+        overlay.querySelectorAll('.promo-chip').forEach(function (other) {
+          other.setAttribute('aria-pressed', 'false');
+        });
+        // Clicking the active choice clears it: the question is optional and
+        // there is otherwise no way back to "I would rather not say".
+        chip.setAttribute('aria-pressed', on ? 'false' : 'true');
+      });
+    });
+
+    var send = overlay.querySelector('#promoFbSend');
+    var status = overlay.querySelector('#promoFbStatus');
+    if (!send || !status) return;
+
+    send.addEventListener('click', async function () {
+      var body = collectAnswers(overlay);
+      var answered = ['use_case', 'likes_most', 'wishes'].some(function (id) {
+        return String(body[id] || '').trim() !== '';
+      });
+      if (!answered) {
+        status.textContent = 'Answer at least one question before sending.';
+        status.className = 'promo-status is-error';
+        return;
+      }
+
+      var apiFetch = window.LctxApi && window.LctxApi.apiFetch;
+      if (!apiFetch) {
+        status.textContent = 'Dashboard API unavailable — reload the page.';
+        status.className = 'promo-status is-error';
+        return;
+      }
+
+      send.disabled = true;
+      status.textContent = 'Sending…';
+      status.className = 'promo-status';
+      try {
+        var res = await apiFetch('/api/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        var data = null;
+        try { data = await res.json(); } catch (_) { data = null; }
+        if (res && res.ok) {
+          // Only a successful send counts as done — a failed one must not
+          // burn the campaign and lose what was typed.
+          status.textContent = 'Sent — thank you.';
+          status.className = 'promo-status is-ok';
+          setTimeout(function () { dismiss(); }, 1200);
+          return;
+        }
+        status.textContent = 'Not sent: ' + ((data && (data.error || data.message)) || 'the server refused it');
+        status.className = 'promo-status is-error';
+      } catch (e) {
+        status.textContent = 'Not sent: ' + (e && e.message ? e.message : 'network error');
+        status.className = 'promo-status is-error';
+      } finally {
+        send.disabled = false;
+      }
+    });
   }
 
   function show() {
@@ -175,9 +307,13 @@
 
     overlay.querySelector('.partner-promo-close').addEventListener('click', dismiss);
     overlay.querySelector('.partner-promo-later').addEventListener('click', dismiss);
-    overlay.querySelectorAll('.partner-promo-cta').forEach(function (link) {
+    // Only the outbound SDK link dismisses on click. The send button must not:
+    // it dismisses itself after a *successful* send, so a failed one keeps the
+    // dialog and the text the person just typed.
+    overlay.querySelectorAll('a.partner-promo-cta').forEach(function (link) {
       link.addEventListener('click', dismiss);
     });
+    wireForm(overlay);
     overlay.addEventListener('click', function (event) {
       if (event.target === overlay) dismiss();
     });

--- a/rust/src/dashboard/static/style.css
+++ b/rust/src/dashboard/static/style.css
@@ -1415,6 +1415,30 @@ tr:hover td{background:var(--surface-2)}
   color:var(--muted);font-size:11.5px;cursor:pointer;
 }
 .partner-promo-later:hover{color:var(--text-bright)}
+/* Survey fields inside the invitation dialog (campaign v2). Reuses the promo
+   tokens so the form is the same object visually, not a second style. */
+.promo-form{display:flex;flex-direction:column;gap:14px;margin-bottom:18px}
+.promo-field{display:flex;flex-direction:column;gap:6px}
+.promo-field-label{color:var(--text-bright);font-size:12.5px;font-weight:600}
+.promo-field textarea{
+  width:100%;background:var(--bg);color:inherit;border:1px solid var(--border);
+  border-radius:6px;padding:8px 10px;font:inherit;font-size:12.5px;resize:vertical;
+}
+.promo-field textarea:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+.promo-chips{display:flex;gap:6px;flex-wrap:wrap}
+.promo-chip{
+  border:1px solid var(--border);background:transparent;color:var(--muted);
+  border-radius:99px;padding:5px 12px;font:inherit;font-size:12px;cursor:pointer;
+}
+.promo-chip:hover{border-color:var(--border-light);color:var(--text-bright)}
+.promo-chip[aria-pressed="true"]{border-color:var(--accent);background:var(--accent-dim);color:var(--accent)}
+.promo-chip:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+.promo-note{margin:0 0 14px;color:var(--muted);font-size:11.5px;line-height:1.5}
+.promo-actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.promo-actions .partner-promo-cta{cursor:pointer}
+.promo-status{margin:10px 0 0;min-height:1em;font-size:12px;color:var(--muted)}
+.promo-status.is-ok{color:var(--green)}
+.promo-status.is-error{color:var(--red)}
 .partner-promo-sr-only{
   position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
   clip:rect(0,0,0,0);white-space:nowrap;border:0;

--- a/rust/src/dashboard/tests.rs
+++ b/rust/src/dashboard/tests.rs
@@ -677,7 +677,14 @@ fn partner_promo_is_accessible_versioned_and_served() {
     assert_eq!(status, "200 OK");
     assert_eq!(content_type, "application/javascript; charset=utf-8");
     assert!(COCKPIT_INDEX_HTML.contains("/static/components/cockpit-partner-promo.js"));
-    assert!(source.contains("leanctx_partner_sdk_promo_v1"));
+    // Campaign v2 (#feedback): the key is versioned so a new invitation reaches
+    // people who dismissed the previous one. Pinning the literal is deliberate —
+    // shipping a campaign without bumping it would silently reach nobody.
+    assert!(source.contains("leanctx_feedback_survey_v2"));
+    assert!(
+        !source.contains("leanctx_partner_sdk_promo_v1"),
+        "the previous campaign key must not linger — it would suppress v2"
+    );
     assert!(source.contains("aria-modal=\"true\""));
     assert!(source.contains("aria-labelledby=\"partnerPromoTitle\""));
     assert!(source.contains("event.key === 'Escape'"));
@@ -691,10 +698,38 @@ fn partner_promo_is_accessible_versioned_and_served() {
     assert!(source.contains("opens in a new tab"));
     assert!(source.contains("target=\"_blank\" rel=\"noopener noreferrer\""));
     assert!(source.contains("Thinkery-AG/leanctx-sdk#readme"));
+    // The design-partner solicitation is gone on purpose: it asked the reader
+    // for a commitment before asking them anything, and it occupied the one
+    // modal available. Asserting its absence keeps it from drifting back in.
     assert!(
-        source.contains("mailto:yves@thinkery.ch?subject=LeanCTX%20design%20partner%20inquiry")
+        !source.contains("mailto:"),
+        "campaign v2 asks a question; it does not solicit"
     );
-    assert!(source.contains("local LeanCTX Engine"));
+    assert!(
+        !source.to_lowercase().contains("design partner"),
+        "the v1 solicitation must stay out"
+    );
+
+    // What v2 does instead: three free-text questions plus one grouping choice.
+    for question in ["use_case", "likes_most", "wishes"] {
+        assert!(source.contains(question), "missing question: {question}");
+    }
+    for frequency in ["daily", "weekly", "occasionally"] {
+        assert!(source.contains(frequency), "missing frequency: {frequency}");
+    }
+    assert!(source.contains("/api/feedback"));
+
+    // The destination is named before the button that reaches it, not after.
+    let notice = source
+        .find("Sending transmits")
+        .expect("the transmission notice must be present");
+    let button = source
+        .find("Send feedback")
+        .expect("the send button must be present");
+    assert!(
+        notice < button,
+        "the notice must precede the button that sends"
+    );
 
     let rewritten = super::base_path::rewrite_asset_urls(COCKPIT_INDEX_HTML, "/dashboard");
     assert!(rewritten.contains("src=\"/dashboard/static/components/cockpit-partner-promo.js\""));


### PR DESCRIPTION
Campaign v1 of the one-time dashboard invitation opened with a design-partner
solicitation — *"We are looking for design partners…"* with a `mailto:`. That
asks the reader for a commitment before we have asked them anything, and it
occupied the one modal we get.

v2 asks instead: **what do you use LeanCTX for, what do you like most, what is
missing, and how often**. The SDK pointer stays, now beside the send button
rather than as a competing card.

## Why three of the four are free text

A fixed list of features can only ever return the answers it already contains,
and the point is to learn which use cases exist rather than confirm the ones we
guessed. Frequency is the single multiple choice, and it is what makes the free
text groupable afterwards: "what is missing" from a daily user and from someone
who installed it yesterday are usually different wishes.

## Three deliberate details

- **The storage key moves to `leanctx_feedback_survey_v2`.** The file documents
  the key as versioned precisely so a new campaign reaches people who dismissed
  the previous one. Without the bump, everyone who saw v1 would never see this.
- **Only the outbound SDK link dismisses on click.** Previously *every* CTA did
  — which would have destroyed what someone typed the moment a send failed. The
  dialog now closes itself only after a send actually succeeded.
- **The notice naming the destination sits above the button**, not below it and
  not in a changelog: pressing send is the moment something leaves the machine.

## Placement

The permanent form stays in Settings (`cockpit-feedback`) for anyone who
dismisses the popup and wants to answer later. Both post to the same
`/api/feedback` route, so one file still decides what leaves the machine.

## Verification

Checked against the **served** output of a rebuilt dashboard, not the source:
design-partner block and `mailto:` gone, SDK link kept, three free-text
questions and frequency chips present, transmission notice before the button,
campaign key v2 with the v1 key gone, and `POST /api/feedback` returning 200.

`PREFLIGHT_BASE=github/main scripts/preflight.sh`: **PASSED**, 7/7 gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)