### PR TITLE
fix(npm): prevent onboarding descendants from holding install streams open

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
       - uses: actions/checkout@v4 # v4
         with:
           persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Test npm postinstall stdio isolation
+        run: node packages/lean-ctx-bin/postinstall.test.cjs
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Ensure toolchain is active
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,24 @@ jobs:
         working-directory: rust
         run: cargo fmt --check
 
+  npm-postinstall:
+    name: npm postinstall (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Test stdio isolation
+        run: node packages/lean-ctx-bin/postinstall.test.cjs
+
   cookbook:
     name: Cookbook (Node)
     runs-on: ubuntu-latest
@@ -322,8 +340,6 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: packages/pi-lean-ctx/package-lock.json
-      - name: Test npm postinstall stdio isolation
-        run: node packages/lean-ctx-bin/postinstall.test.cjs
       - name: Install
         working-directory: packages/pi-lean-ctx
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,6 @@ jobs:
       - uses: actions/checkout@v4 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - name: Test npm postinstall stdio isolation
-        run: node packages/lean-ctx-bin/postinstall.test.cjs
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Ensure toolchain is active
         shell: bash
@@ -327,6 +322,8 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: packages/pi-lean-ctx/package-lock.json
+      - name: Test npm postinstall stdio isolation
+        run: node packages/lean-ctx-bin/postinstall.test.cjs
       - name: Install
         working-directory: packages/pi-lean-ctx
         run: npm ci

--- a/packages/lean-ctx-bin/postinstall.js
+++ b/packages/lean-ctx-bin/postinstall.js
@@ -293,7 +293,7 @@ function runOnboard(binaryPath) {
   try {
     console.log("");
     console.log("Running onboard (connecting your AI tools)...");
-    execSync(`"${binaryPath}" onboard`, { stdio: "inherit", timeout: 30000 });
+    execSync(`"${binaryPath}" onboard`, { stdio: "ignore", timeout: 30000 });
   } catch {
     // Non-fatal: onboard may fail in restricted envs
   }

--- a/packages/lean-ctx-bin/postinstall.test.cjs
+++ b/packages/lean-ctx-bin/postinstall.test.cjs
@@ -8,6 +8,7 @@ const vm = require("node:vm");
 const assert = require("node:assert/strict");
 const { execSync, spawn } = require("node:child_process");
 const { once } = require("node:events");
+const { setTimeout: delay } = require("node:timers/promises");
 
 const postinstall = path.join(__dirname, "postinstall.js");
 
@@ -61,7 +62,19 @@ child.unref();
   } finally {
     clearTimeout(timer);
     fs.writeFileSync(release, "");
-    try { process.kill(Number(fs.readFileSync(pidFile, "utf8"))); } catch {}
+    if (fs.existsSync(pidFile)) {
+      const pid = Number(fs.readFileSync(pidFile, "utf8"));
+      try { process.kill(pid); } catch {}
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        try {
+          process.kill(pid, 0);
+          await delay(50);
+        } catch {
+          break;
+        }
+      }
+    }
     try { runner.kill(); } catch {}
     fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
   }

--- a/packages/lean-ctx-bin/postinstall.test.cjs
+++ b/packages/lean-ctx-bin/postinstall.test.cjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vm = require("node:vm");
+const assert = require("node:assert/strict");
+const { execSync, spawn } = require("node:child_process");
+const { once } = require("node:events");
+
+const postinstall = path.join(__dirname, "postinstall.js");
+
+function loadRunOnboard(env) {
+  const source = fs.readFileSync(postinstall, "utf8");
+  const start = source.indexOf("function runOnboard");
+  const end = source.indexOf("\nfunction printSuccess", start);
+  assert(start >= 0 && end > start, "runOnboard was not found");
+  return vm.runInNewContext(`(${source.slice(start, end)})`, {
+    console, execSync, process: { env },
+  });
+}
+
+if (process.argv[2] === "--runner") {
+  const env = { ...process.env };
+  delete env.CI;
+  delete env.LEAN_CTX_NO_ONBOARD;
+  loadRunOnboard(env)(process.execPath);
+  fs.writeFileSync(env.LEAN1721_RETURNED, "");
+} else (async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lean1721-"));
+  const release = path.join(dir, "release");
+  const returned = path.join(dir, "returned");
+  const pidFile = path.join(dir, "fixture.pid");
+  fs.writeFileSync(path.join(dir, "onboard"), `
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const code = "const fs=require('node:fs'); setInterval(() => { if (fs.existsSync(process.env.LEAN1721_RELEASE)) process.exit(0); }, 10); setTimeout(() => process.exit(1), 60000);";
+const child = spawn(process.execPath, ["-e", code], { detached: true, stdio: ["ignore", "ignore", "inherit"] });
+fs.writeFileSync(process.env.LEAN1721_PID, String(child.pid));
+child.unref();
+`);
+  const env = { ...process.env, LEAN1721_RELEASE: release, LEAN1721_RETURNED: returned, LEAN1721_PID: pidFile };
+  delete env.CI;
+  delete env.LEAN_CTX_NO_ONBOARD;
+  const runner = spawn(process.execPath, [__filename, "--runner"], { cwd: dir, env, stdio: ["ignore", "pipe", "pipe"] });
+  runner.stdout.resume();
+  runner.stderr.resume();
+  let timer;
+  try {
+    // The descendant stays alive until cleanup: installer pipes must close first.
+    const [code] = await Promise.race([
+      once(runner, "close"),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error("runOnboard kept inherited stdio open")), 5000);
+      }),
+    ]);
+    assert.equal(code, 0);
+    assert(fs.existsSync(returned), "runner exited before runOnboard returned");
+    assert(fs.existsSync(pidFile), "onboard did not launch the descendant");
+  } finally {
+    clearTimeout(timer);
+    fs.writeFileSync(release, "");
+    try { process.kill(Number(fs.readFileSync(pidFile, "utf8"))); } catch {}
+    try { runner.kill(); } catch {}
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/rust/src/daemon.rs
+++ b/rust/src/daemon.rs
@@ -128,7 +128,13 @@ pub fn start_daemon(args: &[String]) -> Result<()> {
         .open(&stderr_log);
     let stderr_cfg = match stderr_file {
         Ok(f) => std::process::Stdio::from(f),
-        Err(_) => std::process::Stdio::inherit(),
+        Err(error) => {
+            eprintln!(
+                "Cannot open {}: {error}; daemon stderr disabled.",
+                stderr_log.display()
+            );
+            std::process::Stdio::null()
+        }
     };
 
     let mut cmd = Command::new(&exe);


### PR DESCRIPTION
## Summary

Fixes #1721. Disconnect npm postinstall onboarding from npm's stdio so background descendants cannot keep the installer waiting for open streams. Keep synchronous, best-effort onboarding and the existing 30-second timeout.

The Rust daemon already redirects stdout and normally logs stderr to a file. If that file cannot open, warn in the parent and give the daemon a null stream instead of inherited stderr. Existing successful log-file behavior is unchanged.

## Test plan

- [x] `node packages/lean-ctx-bin/postinstall.test.cjs` — Linux regression using the actual onboarding function and real child/grandchild processes.
- [x] An isolated copy with the original onboarding stdio setting fails the regression test.
- [x] JavaScript syntax checks, `cd rust && cargo fmt --check`, and `git diff --check`.
- [x] Add a lightweight npm postinstall CI job with an explicit `ubuntu-latest` / `windows-latest` Node 22 matrix, running the regression directly without dependency installation or Rust compilation; verified locally on Linux with `CI=true`.
- [ ] Full Rust validation: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, and `cargo test --release`.
- [ ] `scripts/preflight.sh fast` and Windows verification.

Local `cargo test --lib` and `cargo clippy --all-features -- -D warnings` attempts exceeded this environment's available memory, including with one build job and debug information disabled. Heavy Rust validation is deferred to the existing CI tests, Clippy, and formatting jobs; no local Rust test or Windows pass is claimed.

## Notes for reviewers

Onboarding output is intentionally suppressed during npm installation. Daemon stderr is discarded only when its log cannot open, with a warning emitted before spawning. The separate tar-extraction diagnostic change is outside this patch. No public command, flag, schema, or dependency changes.
