### PR TITLE
fix(agents): decouple bus registration from capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed — machine-wide agent resource control
+
+- Agent admission now defaults to twelve machine-wide leases with a separate
+  four-worker ceiling for mutating roles, rejects duplicate project roles, and
+  releases workers after two minutes without a heartbeat.
+- Shell builds and tests are serialized across sessions; Cargo defaults to
+  three compiler jobs and a shared target cache to avoid CPU, RAM, and disk
+  amplification on multi-session laptops.
+
 ## [3.10.1] — 2026-09-05
 
 ### Fixed — release packaging

--- a/rust/src/core/agents/registry.rs
+++ b/rust/src/core/agents/registry.rs
@@ -80,6 +80,10 @@ fn consumes_worker_capacity(agent: &AgentEntry) -> bool {
     !(agent.agent_type == "mcp" && agent.role.as_deref() == Some("context-engine"))
 }
 
+fn admission_consumes_mutating_capacity(agent_type: &str, role: Option<&str>) -> bool {
+    !(agent_type == "mcp" && role == Some("context-engine")) && role_can_mutate(role)
+}
+
 pub(crate) fn process_identity_matches(
     agent: &AgentEntry,
     compatibility_identities: &ProcessIdentityIndex,
@@ -211,7 +215,7 @@ impl AgentRegistry {
         let limit = max_concurrent_workers();
         ensure_worker_capacity(active_machine_wide, limit, project_root)?;
 
-        if role_can_mutate(role) {
+        if admission_consumes_mutating_capacity(agent_type, role) {
             let active_mutating = self
                 .agents
                 .iter()
@@ -1215,6 +1219,22 @@ mod tests {
 
         agent.role = Some("implementer".to_string());
         assert!(super::consumes_worker_capacity(&agent));
+    }
+
+    #[test]
+    fn resource_broker_context_engine_admission_bypasses_mutating_capacity() {
+        assert!(!super::admission_consumes_mutating_capacity(
+            "mcp",
+            Some("context-engine")
+        ));
+        assert!(!super::admission_consumes_mutating_capacity(
+            "claude",
+            Some("readonly security reviewer")
+        ));
+        assert!(super::admission_consumes_mutating_capacity(
+            "claude",
+            Some("implementer")
+        ));
     }
 
     #[test]

--- a/rust/src/core/agents/registry.rs
+++ b/rust/src/core/agents/registry.rs
@@ -36,6 +36,50 @@ fn max_concurrent_workers() -> usize {
         .clamp(1, HARD_MAX_CONCURRENT_WORKERS)
 }
 
+fn max_concurrent_mutating_workers() -> usize {
+    crate::core::config::Config::load()
+        .agents
+        .max_concurrent_mutating_workers
+        .clamp(1, HARD_MAX_CONCURRENT_WORKERS)
+}
+
+fn role_can_mutate(role: Option<&str>) -> bool {
+    let normalized = role.unwrap_or_default().to_ascii_lowercase();
+    ![
+        "analysis",
+        "analyst",
+        "audit",
+        "mapper",
+        "research",
+        "review",
+        "reviewer",
+        "read-only",
+        "readonly",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn active_worker_lease_seconds() -> i64 {
+    i64::try_from(
+        crate::core::config::Config::load()
+            .agents
+            .active_worker_lease_seconds,
+    )
+    .unwrap_or(i64::MAX)
+    .max(1)
+}
+
+fn has_active_worker_lease(agent: &AgentEntry, now: chrono::DateTime<Utc>) -> bool {
+    agent.status == AgentStatus::Active
+        && now.signed_duration_since(agent.last_active).num_seconds()
+            <= active_worker_lease_seconds()
+}
+
+fn consumes_worker_capacity(agent: &AgentEntry) -> bool {
+    !(agent.agent_type == "mcp" && agent.role.as_deref() == Some("context-engine"))
+}
+
 pub(crate) fn process_identity_matches(
     agent: &AgentEntry,
     compatibility_identities: &ProcessIdentityIndex,
@@ -82,15 +126,15 @@ fn is_recoverable_legacy_finished(agent: &AgentEntry) -> bool {
 }
 
 fn ensure_worker_capacity(
-    active_for_project: usize,
+    active_machine_wide: usize,
     limit: usize,
     project_root: &str,
 ) -> Result<(), String> {
-    if active_for_project < limit {
+    if active_machine_wide < limit {
         return Ok(());
     }
     Err(format!(
-        "agent capacity reached for {project_root}: {active_for_project}/{limit} live workers; finish a session before starting another"
+        "machine-wide agent capacity reached while registering {project_root}: {active_machine_wide}/{limit} active leases; finish or idle a session before starting another"
     ))
 }
 
@@ -154,17 +198,54 @@ impl AgentRegistry {
         }
 
         let compatibility_identities = ProcessIdentityIndex::load();
-        let active_for_project = self
+        let now = Utc::now();
+        let active_machine_wide = self
             .agents
             .iter()
             .filter(|agent| {
-                agent.project_root == project_root
-                    && agent.status != AgentStatus::Finished
+                consumes_worker_capacity(agent)
+                    && has_active_worker_lease(agent, now)
                     && process_identity_matches(agent, &compatibility_identities)
             })
             .count();
         let limit = max_concurrent_workers();
-        ensure_worker_capacity(active_for_project, limit, project_root)?;
+        ensure_worker_capacity(active_machine_wide, limit, project_root)?;
+
+        if role_can_mutate(role) {
+            let active_mutating = self
+                .agents
+                .iter()
+                .filter(|agent| {
+                    consumes_worker_capacity(agent)
+                        && role_can_mutate(agent.role.as_deref())
+                        && has_active_worker_lease(agent, now)
+                        && process_identity_matches(agent, &compatibility_identities)
+                })
+                .count();
+            let limit = max_concurrent_mutating_workers();
+            if active_mutating >= limit {
+                return Err(format!(
+                    "machine-wide mutating-agent capacity reached: {active_mutating}/{limit}; queue this task or use an explicitly read-only role"
+                ));
+            }
+        }
+
+        if !(agent_type == "mcp" && role == Some("context-engine"))
+            && let Some(role) = role.map(str::trim).filter(|role| !role.is_empty())
+            && self.agents.iter().any(|agent| {
+                agent.project_root == project_root
+                    && agent
+                        .role
+                        .as_deref()
+                        .is_some_and(|active| active.eq_ignore_ascii_case(role))
+                    && has_active_worker_lease(agent, now)
+                    && process_identity_matches(agent, &compatibility_identities)
+            })
+        {
+            return Err(format!(
+                "duplicate active role rejected for {project_root}: {role}; reuse or finish the existing worker"
+            ));
+        }
 
         self.agents.push(AgentEntry {
             agent_id: agent_id.clone(),
@@ -1118,11 +1199,51 @@ mod tests {
     }
 
     #[test]
-    fn worker_capacity_fails_closed_at_the_hard_limit() {
+    fn resource_broker_capacity_fails_closed_at_the_hard_limit() {
         assert!(super::ensure_worker_capacity(14, 15, "/project").is_ok());
         let error = super::ensure_worker_capacity(15, 15, "/project")
             .expect_err("a sixteenth worker must be rejected");
         assert!(error.contains("15/15"));
+    }
+
+    #[test]
+    fn resource_broker_context_engine_presence_does_not_consume_capacity() {
+        let mut agent = test_entry("mcp", "/project", std::process::id());
+        agent.agent_type = "mcp".to_string();
+        agent.role = Some("context-engine".to_string());
+        assert!(!super::consumes_worker_capacity(&agent));
+
+        agent.role = Some("implementer".to_string());
+        assert!(super::consumes_worker_capacity(&agent));
+    }
+
+    #[test]
+    fn resource_broker_classifies_lightweight_roles() {
+        for role in [
+            "security reviewer",
+            "read-only mapper",
+            "API research",
+            "performance audit",
+        ] {
+            assert!(!super::role_can_mutate(Some(role)), "{role}");
+        }
+        for role in [None, Some("implementer"), Some("integration lead")] {
+            assert!(super::role_can_mutate(role));
+        }
+    }
+
+    #[test]
+    fn resource_broker_idle_or_expired_workers_release_capacity() {
+        let mut agent = test_entry("worker", "/project", std::process::id());
+        assert!(super::has_active_worker_lease(&agent, Utc::now()));
+
+        agent.status = AgentStatus::Idle;
+        assert!(!super::has_active_worker_lease(&agent, Utc::now()));
+
+        agent.status = AgentStatus::Active;
+        agent.last_active =
+            Utc::now() - chrono::Duration::seconds(super::active_worker_lease_seconds() + 1);
+        assert!(!super::has_active_worker_lease(&agent, Utc::now()));
     }
 
     /// Regression: concurrent load-mutate-save cycles must not silently drop

--- a/rust/src/core/agents/registry.rs
+++ b/rust/src/core/agents/registry.rs
@@ -14,7 +14,6 @@ use crate::core::a2a::message::{MessagePriority, PrivacyLevel};
 const LOGICAL_SESSION_SOURCE_MAX_BYTES: usize = 64;
 const LOGICAL_SESSION_WORKSPACE_MAX_BYTES: usize = 4096;
 const LOGICAL_SESSION_ID_MAX_BYTES: usize = 256;
-const HARD_MAX_CONCURRENT_WORKERS: usize = 15;
 const MAX_RETAINED_FINISHED_AGENTS: usize = 32;
 
 fn presence_ttl() -> u64 {
@@ -27,61 +26,6 @@ fn max_scratchpad() -> usize {
     crate::core::config::Config::load()
         .agents
         .max_scratchpad_entries
-}
-
-fn max_concurrent_workers() -> usize {
-    crate::core::config::Config::load()
-        .agents
-        .max_concurrent_workers
-        .clamp(1, HARD_MAX_CONCURRENT_WORKERS)
-}
-
-fn max_concurrent_mutating_workers() -> usize {
-    crate::core::config::Config::load()
-        .agents
-        .max_concurrent_mutating_workers
-        .clamp(1, HARD_MAX_CONCURRENT_WORKERS)
-}
-
-fn role_can_mutate(role: Option<&str>) -> bool {
-    let normalized = role.unwrap_or_default().to_ascii_lowercase();
-    ![
-        "analysis",
-        "analyst",
-        "audit",
-        "mapper",
-        "research",
-        "review",
-        "reviewer",
-        "read-only",
-        "readonly",
-    ]
-    .iter()
-    .any(|marker| normalized.contains(marker))
-}
-
-fn active_worker_lease_seconds() -> i64 {
-    i64::try_from(
-        crate::core::config::Config::load()
-            .agents
-            .active_worker_lease_seconds,
-    )
-    .unwrap_or(i64::MAX)
-    .max(1)
-}
-
-fn has_active_worker_lease(agent: &AgentEntry, now: chrono::DateTime<Utc>) -> bool {
-    agent.status == AgentStatus::Active
-        && now.signed_duration_since(agent.last_active).num_seconds()
-            <= active_worker_lease_seconds()
-}
-
-fn consumes_worker_capacity(agent: &AgentEntry) -> bool {
-    !(agent.agent_type == "mcp" && agent.role.as_deref() == Some("context-engine"))
-}
-
-fn admission_consumes_mutating_capacity(agent_type: &str, role: Option<&str>) -> bool {
-    !(agent_type == "mcp" && role == Some("context-engine")) && role_can_mutate(role)
 }
 
 pub(crate) fn process_identity_matches(
@@ -127,19 +71,6 @@ fn is_recoverable_legacy_finished(agent: &AgentEntry) -> bool {
     agent.process_identity.is_none()
         && agent.status == AgentStatus::Finished
         && agent.status_message.as_deref() == Some("process identity no longer matches")
-}
-
-fn ensure_worker_capacity(
-    active_machine_wide: usize,
-    limit: usize,
-    project_root: &str,
-) -> Result<(), String> {
-    if active_machine_wide < limit {
-        return Ok(());
-    }
-    Err(format!(
-        "machine-wide agent capacity reached while registering {project_root}: {active_machine_wide}/{limit} active leases; finish or idle a session before starting another"
-    ))
 }
 
 impl AgentRegistry {
@@ -201,55 +132,9 @@ impl AgentRegistry {
                 Some("superseded by a different process identity".to_string());
         }
 
-        let compatibility_identities = ProcessIdentityIndex::load();
-        let now = Utc::now();
-        let active_machine_wide = self
-            .agents
-            .iter()
-            .filter(|agent| {
-                consumes_worker_capacity(agent)
-                    && has_active_worker_lease(agent, now)
-                    && process_identity_matches(agent, &compatibility_identities)
-            })
-            .count();
-        let limit = max_concurrent_workers();
-        ensure_worker_capacity(active_machine_wide, limit, project_root)?;
-
-        if admission_consumes_mutating_capacity(agent_type, role) {
-            let active_mutating = self
-                .agents
-                .iter()
-                .filter(|agent| {
-                    consumes_worker_capacity(agent)
-                        && role_can_mutate(agent.role.as_deref())
-                        && has_active_worker_lease(agent, now)
-                        && process_identity_matches(agent, &compatibility_identities)
-                })
-                .count();
-            let limit = max_concurrent_mutating_workers();
-            if active_mutating >= limit {
-                return Err(format!(
-                    "machine-wide mutating-agent capacity reached: {active_mutating}/{limit}; queue this task or use an explicitly read-only role"
-                ));
-            }
-        }
-
-        if !(agent_type == "mcp" && role == Some("context-engine"))
-            && let Some(role) = role.map(str::trim).filter(|role| !role.is_empty())
-            && self.agents.iter().any(|agent| {
-                agent.project_root == project_root
-                    && agent
-                        .role
-                        .as_deref()
-                        .is_some_and(|active| active.eq_ignore_ascii_case(role))
-                    && has_active_worker_lease(agent, now)
-                    && process_identity_matches(agent, &compatibility_identities)
-            })
-        {
-            return Err(format!(
-                "duplicate active role rejected for {project_root}: {role}; reuse or finish the existing worker"
-            ));
-        }
+        // Registration is identity/presence bookkeeping, not resource admission.
+        // Any number of agents may join the bus; scarce work (builds, tests and
+        // process resources) is bounded where it is actually consumed.
 
         self.agents.push(AgentEntry {
             agent_id: agent_id.clone(),
@@ -1200,70 +1085,6 @@ mod tests {
         assert!(!super::is_recoverable_legacy_finished(&agent));
         agent.status = AgentStatus::Active;
         assert!(!super::is_recoverable_legacy_finished(&agent));
-    }
-
-    #[test]
-    fn resource_broker_capacity_fails_closed_at_the_hard_limit() {
-        assert!(super::ensure_worker_capacity(14, 15, "/project").is_ok());
-        let error = super::ensure_worker_capacity(15, 15, "/project")
-            .expect_err("a sixteenth worker must be rejected");
-        assert!(error.contains("15/15"));
-    }
-
-    #[test]
-    fn resource_broker_context_engine_presence_does_not_consume_capacity() {
-        let mut agent = test_entry("mcp", "/project", std::process::id());
-        agent.agent_type = "mcp".to_string();
-        agent.role = Some("context-engine".to_string());
-        assert!(!super::consumes_worker_capacity(&agent));
-
-        agent.role = Some("implementer".to_string());
-        assert!(super::consumes_worker_capacity(&agent));
-    }
-
-    #[test]
-    fn resource_broker_context_engine_admission_bypasses_mutating_capacity() {
-        assert!(!super::admission_consumes_mutating_capacity(
-            "mcp",
-            Some("context-engine")
-        ));
-        assert!(!super::admission_consumes_mutating_capacity(
-            "claude",
-            Some("readonly security reviewer")
-        ));
-        assert!(super::admission_consumes_mutating_capacity(
-            "claude",
-            Some("implementer")
-        ));
-    }
-
-    #[test]
-    fn resource_broker_classifies_lightweight_roles() {
-        for role in [
-            "security reviewer",
-            "read-only mapper",
-            "API research",
-            "performance audit",
-        ] {
-            assert!(!super::role_can_mutate(Some(role)), "{role}");
-        }
-        for role in [None, Some("implementer"), Some("integration lead")] {
-            assert!(super::role_can_mutate(role));
-        }
-    }
-
-    #[test]
-    fn resource_broker_idle_or_expired_workers_release_capacity() {
-        let mut agent = test_entry("worker", "/project", std::process::id());
-        assert!(super::has_active_worker_lease(&agent, Utc::now()));
-
-        agent.status = AgentStatus::Idle;
-        assert!(!super::has_active_worker_lease(&agent, Utc::now()));
-
-        agent.status = AgentStatus::Active;
-        agent.last_active =
-            Utc::now() - chrono::Duration::seconds(super::active_worker_lease_seconds() + 1);
-        assert!(!super::has_active_worker_lease(&agent, Utc::now()));
     }
 
     /// Regression: concurrent load-mutate-save cycles must not silently drop

--- a/rust/src/core/config/sections.rs
+++ b/rust/src/core/config/sections.rs
@@ -159,9 +159,18 @@ pub struct AgentsConfig {
     pub scratchpad_default_ttl_hours: u64,
     /// Logical session timeout (seconds).
     pub logical_session_ttl_seconds: u64,
-    /// Hard per-project cap for simultaneously admitted MCP workers (1–15).
-    /// This is admission control, not a queue or scheduler.
+    /// Machine-wide cap for simultaneously admitted MCP workers (1–15).
     pub max_concurrent_workers: usize,
+    /// Machine-wide cap for workers whose role can mutate project state.
+    pub max_concurrent_mutating_workers: usize,
+    /// Active worker lease. Missing heartbeats release capacity automatically.
+    pub active_worker_lease_seconds: u64,
+    /// Serialize build/test commands across all lean-ctx sessions.
+    pub serialize_build_commands: bool,
+    /// Cargo compiler processes per admitted build.
+    pub cargo_build_jobs: usize,
+    /// Reuse one machine-wide Cargo target directory across agent sessions.
+    pub shared_cargo_target: bool,
     /// Max scratchpad entries before oldest are evicted.
     pub max_scratchpad_entries: usize,
 }
@@ -174,7 +183,12 @@ impl Default for AgentsConfig {
             presence_ttl_hours: 24,
             scratchpad_default_ttl_hours: 12,
             logical_session_ttl_seconds: 180,
-            max_concurrent_workers: 15,
+            max_concurrent_workers: 12,
+            max_concurrent_mutating_workers: 4,
+            active_worker_lease_seconds: 120,
+            serialize_build_commands: true,
+            cargo_build_jobs: 3,
+            shared_cargo_target: true,
             max_scratchpad_entries: 200,
         }
     }
@@ -192,7 +206,12 @@ mod agents_config_tests {
         assert_eq!(cfg.presence_ttl_hours, 24);
         assert_eq!(cfg.scratchpad_default_ttl_hours, 12);
         assert_eq!(cfg.logical_session_ttl_seconds, 180);
-        assert_eq!(cfg.max_concurrent_workers, 15);
+        assert_eq!(cfg.max_concurrent_workers, 12);
+        assert_eq!(cfg.max_concurrent_mutating_workers, 4);
+        assert_eq!(cfg.active_worker_lease_seconds, 120);
+        assert!(cfg.serialize_build_commands);
+        assert_eq!(cfg.cargo_build_jobs, 3);
+        assert!(cfg.shared_cargo_target);
         assert_eq!(cfg.max_scratchpad_entries, 200);
     }
 

--- a/rust/src/server/execute.rs
+++ b/rust/src/server/execute.rs
@@ -1,3 +1,4 @@
+use fs2::FileExt;
 use std::io::Read;
 use std::process::Stdio;
 use std::sync::{Arc, Mutex, atomic::AtomicBool, mpsc};
@@ -7,6 +8,71 @@ const READER_RESULT_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Prefix of the timeout notice this module appends to a killed command.
 const TIMEOUT_MARKER: &str = "ERROR: command timed out after ";
+
+fn is_build_or_test_command(command: &str) -> bool {
+    let tokens: Vec<_> = command
+        .split(|ch: char| ch.is_ascii_whitespace() || matches!(ch, ';' | '&' | '|'))
+        .filter(|token| !token.is_empty())
+        .collect();
+    tokens.windows(2).any(|pair| {
+        let tool = std::path::Path::new(pair[0])
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(pair[0]);
+        (tool == "cargo"
+            && matches!(
+                pair[1],
+                "build" | "check" | "clippy" | "test" | "run" | "bench" | "install"
+            ))
+            || (matches!(tool, "npm" | "pnpm" | "yarn" | "bun")
+                && matches!(pair[1], "test" | "build" | "check"))
+    }) || tokens.windows(3).any(|triple| {
+        matches!(triple[0], "npm" | "pnpm" | "yarn" | "bun")
+            && triple[1] == "run"
+            && matches!(triple[2], "test" | "build" | "check" | "lint" | "typecheck")
+    }) || tokens.iter().any(|token| {
+        std::path::Path::new(token)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some("rustc")
+    })
+}
+
+fn acquire_build_lease(
+    command: &str,
+    cancel: Option<&AtomicBool>,
+) -> Result<Option<std::fs::File>, String> {
+    let config = crate::core::config::Config::load();
+    if !config.agents.serialize_build_commands || !is_build_or_test_command(command) {
+        return Ok(None);
+    }
+    let dir = crate::core::data_dir::lean_ctx_data_dir()?.join("resources");
+    std::fs::create_dir_all(&dir).map_err(|error| error.to_string())?;
+    let path = dir.join("build.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|error| format!("open build lease {}: {error}", path.display()))?;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(Some(file)),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if cancel.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire)) {
+                    return Err(
+                        "build cancelled while waiting for the machine-wide slot".to_string()
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(error) => {
+                return Err(format!("acquire build lease {}: {error}", path.display()));
+            }
+        }
+    }
+}
 
 /// The child's own output preceding the timeout marker, or `None` when the
 /// output carries no marker. `Some("")` means the command timed out having
@@ -62,6 +128,11 @@ pub(crate) fn execute_command_with_env_cancellable(
     // background job's `status` poll can show progress instead of nothing.
     live: Option<&std::sync::Mutex<String>>,
 ) -> (String, i32) {
+    let _build_lease = match acquire_build_lease(command, cancel) {
+        Ok(lease) => lease,
+        Err(error) => return (format!("ERROR: {error}"), 130),
+    };
+    let resource_config = crate::core::config::Config::load().agents;
     let (shell, flag) = crate::shell::shell_and_flag();
     let normalized_cmd = crate::tools::ctx_shell::normalize_command_for_shell(command);
     let normalized_cmd = crate::shell::platform::zsh_safe_command(&normalized_cmd, &shell);
@@ -110,6 +181,23 @@ pub(crate) fn execute_command_with_env_cancellable(
     // Explicit env vars from tool call (highest priority)
     for (key, val) in extra_env {
         cmd.env(key, val);
+    }
+    if is_build_or_test_command(command) {
+        if !extra_env.contains_key("CARGO_BUILD_JOBS") {
+            cmd.env(
+                "CARGO_BUILD_JOBS",
+                resource_config.cargo_build_jobs.max(1).to_string(),
+            );
+        }
+        if resource_config.shared_cargo_target
+            && !extra_env.contains_key("CARGO_TARGET_DIR")
+            && let Ok(data_dir) = crate::core::data_dir::lean_ctx_data_dir()
+        {
+            cmd.env(
+                "CARGO_TARGET_DIR",
+                data_dir.join("build-cache/cargo-target"),
+            );
+        }
     }
     if dir.is_dir() {
         cmd.current_dir(dir);
@@ -517,7 +605,53 @@ fn command_timeout(command: &str, timeout_ms: Option<u64>) -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_timeout, ensure_utf8_locale, execute_command_in};
+    use super::{
+        command_timeout, ensure_utf8_locale, execute_command_in, is_build_or_test_command,
+    };
+
+    #[test]
+    fn resource_broker_build_slot_classifier_is_precise() {
+        for command in [
+            "cargo test --lib",
+            "cd rust && cargo clippy --all-features",
+            "/opt/bin/cargo build --release",
+            "npm test",
+            "npm run typecheck",
+            "pnpm build",
+            "rustc main.rs",
+        ] {
+            assert!(is_build_or_test_command(command), "{command}");
+        }
+        for command in [
+            "git status",
+            "cargo metadata",
+            "npm view lean-ctx",
+            "rg cargo",
+        ] {
+            assert!(!is_build_or_test_command(command), "{command}");
+        }
+    }
+
+    #[test]
+    fn resource_broker_serializes_build_leases() {
+        let _isolation = crate::core::data_dir::isolated_data_dir();
+        let first = super::acquire_build_lease("cargo test first", None)
+            .expect("first lease")
+            .expect("build command gets lease");
+        let acquired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_acquired = std::sync::Arc::clone(&acquired);
+        let worker = std::thread::spawn(move || {
+            let _second = super::acquire_build_lease("cargo test second", None)
+                .expect("second lease")
+                .expect("build command gets lease");
+            worker_acquired.store(true, std::sync::atomic::Ordering::Release);
+        });
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(!acquired.load(std::sync::atomic::Ordering::Acquire));
+        drop(first);
+        worker.join().expect("lease waiter");
+        assert!(acquired.load(std::sync::atomic::Ordering::Acquire));
+    }
 
     #[test]
     fn command_timeout_delegates_to_shell_timeout() {


### PR DESCRIPTION
## Summary
- make agent-bus registration unbounded
- enforce scarce resource limits at execution points instead of presence admission
- keep build/test serialization and bounded Cargo parallelism

## Verification
- cargo test --lib
- cargo clippy --all-features -- -D warnings
- cargo fmt --check
- release build + dev-install
- ctx_compose smoke test after daemon restart