### PR TITLE
feat(import): support OpenCode session history

### DIFF
--- a/rust/src/cli/import_cmd.rs
+++ b/rust/src/cli/import_cmd.rs
@@ -20,7 +20,7 @@ pub fn cmd_import(args: &[String]) {
         .collect();
 
     if (all && !sources.is_empty()) || sources.len() > 1 {
-        eprintln!("Use one source (claude-code, codex, cursor) or --all.");
+        eprintln!("Use one source (claude-code, codex, cursor, opencode) or --all.");
         print_help();
         return;
     }
@@ -29,14 +29,16 @@ pub fn cmd_import(args: &[String]) {
         let mut result = import::claude_code::import();
         result.merge(import::codex::import());
         result.merge(import::cursor::import());
+        result.merge(import::opencode::import());
         ("all sources", result)
     } else {
         match sources.first().copied() {
             Some("claude-code") => ("claude-code", import::claude_code::import()),
             Some("codex") => ("codex", import::codex::import()),
             Some("cursor") => ("cursor", import::cursor::import()),
+            Some("opencode") => ("opencode", import::opencode::import()),
             _ => {
-                eprintln!("Choose a source: claude-code, codex, cursor, or --all.");
+                eprintln!("Choose a source: claude-code, codex, cursor, opencode, or --all.");
                 print_help();
                 return;
             }
@@ -97,7 +99,7 @@ fn persist_facts(project_root: &str, facts: Vec<KnowledgeFact>) -> Result<usize,
 }
 
 fn print_help() {
-    println!("Usage: lean-ctx import <claude-code|codex|cursor> [--dry-run]");
+    println!("Usage: lean-ctx import <claude-code|codex|cursor|opencode> [--dry-run]");
     println!("       lean-ctx import --all [--dry-run]");
 }
 
@@ -110,5 +112,6 @@ mod tests {
         assert_eq!(ImportSource::ClaudeCode.as_str(), "claude-code");
         assert_eq!(ImportSource::Codex.as_str(), "codex");
         assert_eq!(ImportSource::Cursor.as_str(), "cursor");
+        assert_eq!(ImportSource::OpenCode.as_str(), "opencode");
     }
 }

--- a/rust/src/core/import/mod.rs
+++ b/rust/src/core/import/mod.rs
@@ -353,14 +353,26 @@ fn is_error(text: &str) -> bool {
     .any(|marker| text.contains(marker))
 }
 
-fn truncate(mut value: String) -> String {
-    value.truncate(MAX_FACT_VALUE_CHARS);
-    value.trim().to_owned()
+fn truncate(value: String) -> String {
+    let end = value
+        .char_indices()
+        .map(|(index, _)| index)
+        .find(|&index| index >= MAX_FACT_VALUE_CHARS)
+        .unwrap_or(value.len());
+    value[..end].trim().to_owned()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncates_multibyte_facts_without_panicking() {
+        let value = format!("We decided {}", "é".repeat(300));
+        let truncated = truncate(value);
+        assert!(truncated.len() <= MAX_FACT_VALUE_CHARS);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
 
     #[test]
     fn extracts_touches_decisions_and_errors() {

--- a/rust/src/core/import/mod.rs
+++ b/rust/src/core/import/mod.rs
@@ -354,12 +354,14 @@ fn is_error(text: &str) -> bool {
 }
 
 fn truncate(value: &str) -> String {
-    let end = value
-        .char_indices()
-        .map(|(index, _)| index)
-        .find(|&index| index >= MAX_FACT_VALUE_CHARS)
-        .unwrap_or(value.len());
-    value[..end].trim().to_owned()
+    // The first char boundary *at or past* the cap can land one byte over it:
+    // with 2-byte characters starting at an odd offset the boundaries are
+    // 11, 13, … 499, 501, so a 500-byte cap yielded a 501-byte slice. Take the
+    // last boundary at or below the cap instead — the same idiom already used
+    // in `ctx_search` and `ctx_preload`.
+    value[..value.floor_char_boundary(MAX_FACT_VALUE_CHARS)]
+        .trim()
+        .to_owned()
 }
 
 #[cfg(test)]

--- a/rust/src/core/import/mod.rs
+++ b/rust/src/core/import/mod.rs
@@ -155,7 +155,7 @@ pub(crate) fn process_value(
                 source,
                 session,
                 "imported-observation",
-                format!("Touched file: {path}"),
+                &format!("Touched file: {path}"),
                 0.6,
             );
         }
@@ -173,7 +173,7 @@ pub(crate) fn process_value(
                     source,
                     session,
                     "imported-decision",
-                    decision,
+                    &decision,
                     0.65,
                 );
             }
@@ -185,7 +185,7 @@ pub(crate) fn process_value(
                 source,
                 session,
                 "imported-observation",
-                format!("Observed error: {error}"),
+                &format!("Observed error: {error}"),
                 0.55,
             );
         }
@@ -217,7 +217,7 @@ fn push_fact(
     source: ImportSource,
     session: &str,
     category: &str,
-    value: String,
+    value: &str,
     confidence: f32,
 ) {
     let value = truncate(value);
@@ -353,7 +353,7 @@ fn is_error(text: &str) -> bool {
     .any(|marker| text.contains(marker))
 }
 
-fn truncate(value: String) -> String {
+fn truncate(value: &str) -> String {
     let end = value
         .char_indices()
         .map(|(index, _)| index)
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn truncates_multibyte_facts_without_panicking() {
         let value = format!("We decided {}", "é".repeat(300));
-        let truncated = truncate(value);
+        let truncated = truncate(&value);
         assert!(truncated.len() <= MAX_FACT_VALUE_CHARS);
         assert!(truncated.is_char_boundary(truncated.len()));
     }

--- a/rust/src/core/import/mod.rs
+++ b/rust/src/core/import/mod.rs
@@ -3,6 +3,7 @@
 pub mod claude_code;
 pub mod codex;
 pub mod cursor;
+pub mod opencode;
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -20,6 +21,7 @@ pub enum ImportSource {
     ClaudeCode,
     Codex,
     Cursor,
+    OpenCode,
 }
 
 impl ImportSource {
@@ -29,6 +31,7 @@ impl ImportSource {
             Self::ClaudeCode => "claude-code",
             Self::Codex => "codex",
             Self::Cursor => "cursor",
+            Self::OpenCode => "opencode",
         }
     }
 }

--- a/rust/src/core/import/opencode.rs
+++ b/rust/src/core/import/opencode.rs
@@ -9,7 +9,8 @@ use serde_json::{Map, Value};
 use super::{ImportResult, ImportSource, finish_result, process_value, push_error};
 
 const MAX_SESSIONS: i64 = 1_000;
-const MAX_PARTS_PER_SESSION: i64 = 10_000;
+const MAX_SESSION_ROWS_SCANNED: i64 = 10_000;
+const MAX_PARTS: i64 = 10_000;
 
 /// Imports OpenCode history for the current project.
 #[must_use]
@@ -50,7 +51,7 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
     let mut statement = match connection.prepare(
         "SELECT s.id, p.worktree
          FROM session s JOIN project p ON p.id = s.project_id
-         ORDER BY s.id
+         ORDER BY s.time_updated DESC, s.id
          LIMIT ?1",
     ) {
         Ok(statement) => statement,
@@ -62,7 +63,7 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
             return result;
         }
     };
-    let rows = match statement.query_map([MAX_SESSIONS], |row| {
+    let rows = match statement.query_map([MAX_SESSION_ROWS_SCANNED], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     }) {
         Ok(rows) => rows,
@@ -74,9 +75,19 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
             return result;
         }
     };
-    for row in rows.flatten() {
-        if canonical_or_lexical(Path::new(&row.1)) == project_root {
-            session_ids.push(row.0);
+    for row in rows {
+        match row {
+            Ok((id, worktree)) if canonical_or_lexical(Path::new(&worktree)) == project_root => {
+                session_ids.push(id);
+                if session_ids.len() >= MAX_SESSIONS as usize {
+                    break;
+                }
+            }
+            Ok(_) => {}
+            Err(_) => push_error(
+                &mut result,
+                "OpenCode contains a malformed session row".to_owned(),
+            ),
         }
     }
     drop(statement);
@@ -84,7 +95,11 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
 
     let mut touched = HashSet::new();
     let mut seen = HashSet::new();
+    let mut parts_remaining = MAX_PARTS;
     for session_id in session_ids {
+        if parts_remaining == 0 {
+            break;
+        }
         let mut statement = match connection.prepare(
             "SELECT m.data, p.data
              FROM message m JOIN part p ON p.message_id = m.id
@@ -101,7 +116,7 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
                 continue;
             }
         };
-        let rows = match statement.query_map(params![session_id, MAX_PARTS_PER_SESSION], |row| {
+        let rows = match statement.query_map(params![session_id, parts_remaining], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         }) {
             Ok(rows) => rows,
@@ -113,7 +128,15 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
                 continue;
             }
         };
-        for row in rows.flatten() {
+        for row in rows {
+            parts_remaining -= 1;
+            let Ok(row) = row else {
+                push_error(
+                    &mut result,
+                    "OpenCode contains a malformed history row".to_owned(),
+                );
+                continue;
+            };
             let (Ok(message), Ok(mut part)) = (
                 serde_json::from_str::<Value>(&row.0),
                 serde_json::from_str::<Value>(&row.1),
@@ -147,13 +170,18 @@ fn importable_part(message: &Value, part: &mut Value, project_root: &Path) -> Op
 
     match part_type.as_str() {
         "text" => {
-            safe_part.insert("text".to_owned(), part.get("text")?.clone());
+            let text = safe_text(part.get("text")?.as_str()?)?;
+            safe_part.insert("text".to_owned(), Value::String(text));
         }
         "tool" => {
             let state = part.get("state")?.as_object()?;
             let mut safe_state = Map::new();
-            if let Some(error) = state.get("error").and_then(Value::as_str) {
-                safe_state.insert("error".to_owned(), Value::String(error.to_owned()));
+            if let Some(error) = state
+                .get("error")
+                .and_then(Value::as_str)
+                .and_then(safe_tool_error)
+            {
+                safe_state.insert("error".to_owned(), Value::String(error));
             }
             if let Some(input) = state.get("input").and_then(Value::as_object) {
                 let mut safe_input = Map::new();
@@ -204,6 +232,68 @@ fn importable_part(message: &Value, part: &mut Value, project_root: &Path) -> Op
     Some(Value::Object(combined))
 }
 
+fn safe_text(text: &str) -> Option<String> {
+    let safe = text
+        .split(['\n', '.', '!', '?'])
+        .map(str::trim)
+        .filter(|snippet| !contains_sensitive_material(snippet))
+        .collect::<Vec<_>>()
+        .join(". ");
+    (!safe.is_empty()).then_some(safe)
+}
+
+fn safe_tool_error(error: &str) -> Option<String> {
+    let error = error.trim();
+    (!error.is_empty() && !contains_sensitive_material(error)).then(|| error.to_owned())
+}
+
+fn contains_sensitive_material(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    let has_secret_marker = [
+        "api key",
+        "api-key",
+        "api_key",
+        "apikey",
+        "access token",
+        "access-token",
+        "access_token",
+        "authorization:",
+        "bearer ",
+        "password",
+        "passwd",
+        "private key",
+        "secret",
+        "token ",
+        "token=",
+        "token:",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker));
+    has_secret_marker || contains_absolute_path(text)
+}
+
+fn contains_absolute_path(text: &str) -> bool {
+    text.char_indices().any(|(index, character)| {
+        if character == '/' {
+            let previous = text[..index].chars().next_back();
+            let next = text[index + 1..].chars().next();
+            let starts_path = previous.is_none_or(|character| {
+                character.is_whitespace()
+                    || matches!(character, '`' | '\'' | '"' | '(' | '[' | '{' | '=' | ':')
+            });
+            let is_url = previous == Some(':') && next == Some('/');
+            starts_path && next.is_some_and(|character| character != '/') && !is_url
+        } else {
+            let candidate = &text[index..];
+            looks_like_windows_absolute(candidate)
+                && text[..index].chars().next_back().is_none_or(|character| {
+                    character.is_whitespace()
+                        || matches!(character, '`' | '\'' | '"' | '(' | '[' | '{' | '=' | ':')
+                })
+        }
+    })
+}
+
 fn looks_like_windows_absolute(path: &str) -> bool {
     let bytes = path.as_bytes();
     (bytes.len() >= 3
@@ -226,7 +316,7 @@ fn existing_path_is_inside(path: &Path, project_root: &Path) -> bool {
 
 fn project_relative(path: &Path, project_root: &Path) -> Option<String> {
     let raw = path.to_string_lossy();
-    if looks_like_windows_absolute(&raw) {
+    if cfg!(not(windows)) && looks_like_windows_absolute(&raw) {
         return None;
     }
     let joined = if path.is_absolute() {
@@ -277,13 +367,13 @@ mod tests {
     use rusqlite::Connection;
     use tempfile::tempdir;
 
-    use super::{import_from_db, project_relative};
+    use super::{contains_sensitive_material, import_from_db, project_relative};
 
     fn create_fixture(path: &Path, current: &Path, other: &Path) {
         let db = Connection::open(path).unwrap();
         db.execute_batch(
             "CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL);
-             CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL);
+             CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, time_updated INTEGER NOT NULL);
              CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
              CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);",
         ).unwrap();
@@ -293,7 +383,7 @@ mod tests {
         )
         .unwrap();
         db.execute(
-            "INSERT INTO session (id, project_id) VALUES ('s1', 'p1'), ('s2', 'p2')",
+            "INSERT INTO session (id, project_id, time_updated) VALUES ('s1', 'p1', 2), ('s2', 'p2', 1)",
             [],
         )
         .unwrap();
@@ -311,7 +401,9 @@ mod tests {
              ('e', 'm2', 's2', 5, '{\"type\":\"tool\",\"tool\":\"read\",\"state\":{\"input\":{\"filePath\":\"other.txt\"}}}'),
              ('f', 'm1', 's1', 6, '{\"type\":\"patch\",\"files\":[\"src/patch.rs\",\"../outside.rs\"]}'),
              ('g', 'm1', 's1', 7, '{\"type\":\"snapshot\",\"path\":\"ignored.txt\"}'),
-             ('h', 'm1', 's1', 8, 'not-json')",
+             ('h', 'm1', 's1', 8, 'not-json'),
+             ('i', 'm1', 's1', 9, '{\"type\":\"text\",\"text\":\"We decided to use /home/alice/private/key. We chose safe fallback.\"}'),
+             ('j', 'm1', 's1', 10, '{\"type\":\"tool\",\"state\":{\"error\":\"Build failed at /home/alice/private/key token=TOP_SECRET\"}}')",
             [],
         ).unwrap();
     }
@@ -370,12 +462,40 @@ mod tests {
                 "ignored.txt",
                 "TOP_SECRET",
                 "PRIVATE_OUTPUT",
+                "/home/alice/private/key",
             ]
             .iter()
             .any(|private| fact.value.contains(private))
                 && fact.source_session == "opencode:s1"
                 && fact.imported_from.as_deref() == Some("opencode")
         }));
+    }
+
+    #[test]
+    fn sensitive_material_filter_handles_punctuation_and_marker_variants() {
+        for value in [
+            "read `/home/user/key`",
+            "read (/home/user/key)",
+            "path=/home/user/key",
+            "read \"/home/user/key\"",
+            "API key abc",
+            "api-key=abc",
+            "access_token=abc",
+            "token abc",
+            "read `C:\\Users\\user\\key`",
+        ] {
+            assert!(contains_sensitive_material(value), "not rejected: {value}");
+        }
+        for value in [
+            "We decided to use a bounded cache",
+            "See https://example.com/path",
+            "relative/path.rs changed",
+        ] {
+            assert!(
+                !contains_sensitive_material(value),
+                "false positive: {value}"
+            );
+        }
     }
 
     #[test]

--- a/rust/src/core/import/opencode.rs
+++ b/rust/src/core/import/opencode.rs
@@ -1,0 +1,411 @@
+//! OpenCode session-history import.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags, params};
+use serde_json::{Map, Value};
+
+use super::{ImportResult, ImportSource, finish_result, process_value, push_error};
+
+const MAX_SESSIONS: i64 = 1_000;
+const MAX_PARTS_PER_SESSION: i64 = 10_000;
+
+/// Imports OpenCode history for the current project.
+#[must_use]
+pub fn import() -> ImportResult {
+    let Ok(project_root) = std::env::current_dir() else {
+        return ImportResult::default();
+    };
+    let Some(data_dir) = dirs::data_dir() else {
+        return ImportResult::default();
+    };
+    import_from_db(
+        &data_dir.join("opencode").join("opencode.db"),
+        &project_root,
+    )
+}
+
+/// Imports current-project sessions from an OpenCode SQLite database.
+#[must_use]
+pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
+    if !db_path.is_file() {
+        return ImportResult::default();
+    }
+
+    let mut result = ImportResult::default();
+    let connection = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(connection) => connection,
+        Err(_) => {
+            push_error(
+                &mut result,
+                "OpenCode history database could not be opened".to_owned(),
+            );
+            return result;
+        }
+    };
+
+    let project_root = canonical_or_lexical(project_root);
+    let mut session_ids = Vec::new();
+    let mut statement = match connection.prepare(
+        "SELECT s.id, p.worktree
+         FROM session s JOIN project p ON p.id = s.project_id
+         ORDER BY s.id
+         LIMIT ?1",
+    ) {
+        Ok(statement) => statement,
+        Err(_) => {
+            push_error(
+                &mut result,
+                "OpenCode history schema is not supported".to_owned(),
+            );
+            return result;
+        }
+    };
+    let rows = match statement.query_map([MAX_SESSIONS], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    }) {
+        Ok(rows) => rows,
+        Err(_) => {
+            push_error(
+                &mut result,
+                "OpenCode sessions could not be read".to_owned(),
+            );
+            return result;
+        }
+    };
+    for row in rows.flatten() {
+        if canonical_or_lexical(Path::new(&row.1)) == project_root {
+            session_ids.push(row.0);
+        }
+    }
+    drop(statement);
+    result.sessions_found = session_ids.len();
+
+    let mut touched = HashSet::new();
+    let mut seen = HashSet::new();
+    for session_id in session_ids {
+        let mut statement = match connection.prepare(
+            "SELECT m.data, p.data
+             FROM message m JOIN part p ON p.message_id = m.id
+             WHERE m.session_id = ?1
+             ORDER BY p.time_created, p.id
+             LIMIT ?2",
+        ) {
+            Ok(statement) => statement,
+            Err(_) => {
+                push_error(
+                    &mut result,
+                    "OpenCode messages could not be read".to_owned(),
+                );
+                continue;
+            }
+        };
+        let rows = match statement.query_map(params![session_id, MAX_PARTS_PER_SESSION], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        }) {
+            Ok(rows) => rows,
+            Err(_) => {
+                push_error(
+                    &mut result,
+                    "OpenCode messages could not be read".to_owned(),
+                );
+                continue;
+            }
+        };
+        for row in rows.flatten() {
+            let (Ok(message), Ok(mut part)) = (
+                serde_json::from_str::<Value>(&row.0),
+                serde_json::from_str::<Value>(&row.1),
+            ) else {
+                push_error(
+                    &mut result,
+                    "OpenCode contains a malformed history row".to_owned(),
+                );
+                continue;
+            };
+            if let Some(safe_part) = importable_part(&message, &mut part, &project_root) {
+                process_value(
+                    ImportSource::OpenCode,
+                    &format!("opencode:{session_id}"),
+                    &safe_part,
+                    &mut result,
+                    &mut touched,
+                    &mut seen,
+                );
+            }
+        }
+    }
+    finish_result(&mut result, &touched);
+    result
+}
+
+fn importable_part(message: &Value, part: &mut Value, project_root: &Path) -> Option<Value> {
+    let part_type = part.get("type")?.as_str()?.to_owned();
+    let mut safe_part = Map::new();
+    safe_part.insert("type".to_owned(), Value::String(part_type.clone()));
+
+    match part_type.as_str() {
+        "text" => {
+            safe_part.insert("text".to_owned(), part.get("text")?.clone());
+        }
+        "tool" => {
+            let state = part.get("state")?.as_object()?;
+            let mut safe_state = Map::new();
+            if let Some(error) = state.get("error").and_then(Value::as_str) {
+                safe_state.insert("error".to_owned(), Value::String(error.to_owned()));
+            }
+            if let Some(input) = state.get("input").and_then(Value::as_object) {
+                let mut safe_input = Map::new();
+                for key in ["file_path", "filePath", "path", "filename", "file_name"] {
+                    if let Some(path) = input
+                        .get(key)
+                        .and_then(Value::as_str)
+                        .and_then(|path| project_relative(Path::new(path), project_root))
+                    {
+                        safe_input.insert(key.to_owned(), Value::String(path));
+                    }
+                }
+                if !safe_input.is_empty() {
+                    safe_state.insert("input".to_owned(), Value::Object(safe_input));
+                }
+            }
+            if safe_state.is_empty() {
+                return None;
+            }
+            safe_part.insert("state".to_owned(), Value::Object(safe_state));
+        }
+        "patch" => {
+            let files = part
+                .get("files")
+                .and_then(Value::as_array)?
+                .iter()
+                .filter_map(Value::as_str)
+                .filter_map(|path| project_relative(Path::new(path), project_root))
+                .map(|path| serde_json::json!({ "file_path": path }))
+                .collect::<Vec<_>>();
+            if files.is_empty() {
+                return None;
+            }
+            safe_part.insert("files".to_owned(), Value::Array(files));
+        }
+        _ => return None,
+    }
+
+    let mut combined = Map::new();
+    combined.insert(
+        "role".to_owned(),
+        message
+            .get("role")
+            .cloned()
+            .unwrap_or(Value::String("unknown".to_owned())),
+    );
+    combined.insert("part".to_owned(), Value::Object(safe_part));
+    Some(Value::Object(combined))
+}
+
+fn looks_like_windows_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    (bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/'))
+        || path.starts_with("\\\\")
+}
+
+fn existing_path_is_inside(path: &Path, project_root: &Path) -> bool {
+    let mut existing = path;
+    while !existing.exists() {
+        let Some(parent) = existing.parent() else {
+            return false;
+        };
+        existing = parent;
+    }
+    std::fs::canonicalize(existing).is_ok_and(|canonical| canonical.starts_with(project_root))
+}
+
+fn project_relative(path: &Path, project_root: &Path) -> Option<String> {
+    let raw = path.to_string_lossy();
+    if looks_like_windows_absolute(&raw) {
+        return None;
+    }
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    };
+    let normalized = lexical_normalize(&joined)?;
+    if !existing_path_is_inside(&normalized, project_root) {
+        return None;
+    }
+    let relative = normalized.strip_prefix(project_root).ok()?;
+    if relative.as_os_str().is_empty() {
+        return None;
+    }
+    Some(relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn canonical_or_lexical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path)
+        .ok()
+        .or_else(|| lexical_normalize(path))
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+fn lexical_normalize(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    Some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use rusqlite::Connection;
+    use tempfile::tempdir;
+
+    use super::{import_from_db, project_relative};
+
+    fn create_fixture(path: &Path, current: &Path, other: &Path) {
+        let db = Connection::open(path).unwrap();
+        db.execute_batch(
+            "CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL);
+             CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL);
+             CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL);",
+        ).unwrap();
+        db.execute(
+            "INSERT INTO project (id, worktree) VALUES ('p1', ?1), ('p2', ?2)",
+            [current.to_str().unwrap(), other.to_str().unwrap()],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO session (id, project_id) VALUES ('s1', 'p1'), ('s2', 'p2')",
+            [],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES
+             ('m1', 's1', 1, '{\"role\":\"assistant\"}'), ('m2', 's2', 2, '{\"role\":\"assistant\"}')",
+            [],
+        ).unwrap();
+        db.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, data) VALUES
+             ('a', 'm1', 's1', 1, '{\"type\":\"text\",\"text\":\"We decided to use a bounded cache.\"}'),
+             ('b', 'm1', 's1', 2, '{\"type\":\"tool\",\"tool\":\"read\",\"state\":{\"status\":\"completed\",\"input\":{\"filePath\":\"src/lib.rs\",\"token\":\"TOP_SECRET\"},\"output\":\"PRIVATE_OUTPUT\"}}'),
+             ('c', 'm1', 's1', 3, '{\"type\":\"tool\",\"tool\":\"bash\",\"state\":{\"status\":\"error\",\"error\":\"Build failed\"}}'),
+             ('d', 'm1', 's1', 4, '{\"type\":\"tool\",\"tool\":\"read\",\"state\":{\"input\":{\"filePath\":\"../secret.txt\"}}}'),
+             ('e', 'm2', 's2', 5, '{\"type\":\"tool\",\"tool\":\"read\",\"state\":{\"input\":{\"filePath\":\"other.txt\"}}}'),
+             ('f', 'm1', 's1', 6, '{\"type\":\"patch\",\"files\":[\"src/patch.rs\",\"../outside.rs\"]}'),
+             ('g', 'm1', 's1', 7, '{\"type\":\"snapshot\",\"path\":\"ignored.txt\"}'),
+             ('h', 'm1', 's1', 8, 'not-json')",
+            [],
+        ).unwrap();
+    }
+
+    #[test]
+    fn imports_only_current_project_and_filters_unsafe_paths() {
+        let temp = tempdir().unwrap();
+        let current = temp.path().join("current");
+        let other = temp.path().join("other");
+        std::fs::create_dir_all(current.join("src")).unwrap();
+        std::fs::write(current.join("src/lib.rs"), "fixture").unwrap();
+        std::fs::write(current.join("src/patch.rs"), "fixture").unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+        let db = temp.path().join("opencode.db");
+        create_fixture(&db, &current, &other);
+
+        let result = import_from_db(&db, &current);
+
+        assert_eq!(result.sessions_found, 1);
+        assert_eq!(result.files_touched, 2);
+        assert!(
+            result
+                .facts
+                .iter()
+                .any(|fact| fact.value == "Touched file: src/lib.rs")
+        );
+        assert!(
+            result
+                .facts
+                .iter()
+                .any(|fact| fact.category == "imported-decision")
+        );
+        assert!(
+            result
+                .facts
+                .iter()
+                .any(|fact| fact.value == "Observed error: Build failed")
+        );
+        assert!(
+            result
+                .facts
+                .iter()
+                .any(|fact| fact.value == "Touched file: src/patch.rs")
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.contains("malformed"))
+        );
+        assert!(result.facts.iter().all(|fact| {
+            ![
+                "secret.txt",
+                "outside.rs",
+                "other.txt",
+                "ignored.txt",
+                "TOP_SECRET",
+                "PRIVATE_OUTPUT",
+            ]
+            .iter()
+            .any(|private| fact.value.contains(private))
+                && fact.source_session == "opencode:s1"
+                && fact.imported_from.as_deref() == Some("opencode")
+        }));
+    }
+
+    #[test]
+    fn path_filter_rejects_windows_and_symlink_escapes() {
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("project");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        assert_eq!(
+            project_relative(Path::new("src/new.rs"), &project).as_deref(),
+            Some("src/new.rs")
+        );
+        assert!(project_relative(Path::new("../outside/file.rs"), &project).is_none());
+        assert!(project_relative(Path::new(r"C:\outside\file.rs"), &project).is_none());
+        assert!(project_relative(Path::new(r"\\server\share\file.rs"), &project).is_none());
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&outside, project.join("link")).unwrap();
+            assert!(project_relative(Path::new("link/file.rs"), &project).is_none());
+        }
+    }
+
+    #[test]
+    fn missing_database_is_empty() {
+        let temp = tempdir().unwrap();
+        let result = import_from_db(&temp.path().join("missing.db"), temp.path());
+        assert_eq!(result.sessions_found, 0);
+        assert!(result.errors.is_empty());
+    }
+}

--- a/rust/src/core/import/opencode.rs
+++ b/rust/src/core/import/opencode.rs
@@ -289,6 +289,13 @@ fn looks_like_windows_absolute(path: &str) -> bool {
         || path.starts_with("\\\\")
 }
 
+/// Whether `path` resolves inside `project_root`, following symlinks.
+///
+/// Both sides must be canonical or the comparison is meaningless: on macOS the
+/// temp tree is reached through `/var -> /private/var`, and on Windows
+/// `canonicalize` returns a `\\?\` verbatim path. Canonicalising only the
+/// left-hand side made every path look like an escape on those two platforms.
+/// The root is canonicalised by the caller, so this stays a pure comparison.
 fn existing_path_is_inside(path: &Path, project_root: &Path) -> bool {
     let mut existing = path;
     while !existing.exists() {
@@ -301,6 +308,11 @@ fn existing_path_is_inside(path: &Path, project_root: &Path) -> bool {
 }
 
 fn project_relative(path: &Path, project_root: &Path) -> Option<String> {
+    // Self-defending: `import_from_db` already canonicalises, but this is the
+    // containment check for untrusted paths out of someone else's database, so
+    // it must not depend on a caller having done that. `canonical_or_lexical`
+    // is idempotent on an already-canonical root.
+    let project_root = &canonical_or_lexical(project_root);
     let raw = path.to_string_lossy();
     if cfg!(not(windows)) && looks_like_windows_absolute(&raw) {
         return None;

--- a/rust/src/core/import/opencode.rs
+++ b/rust/src/core/import/opencode.rs
@@ -35,45 +35,37 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
     }
 
     let mut result = ImportResult::default();
-    let connection = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
-        Ok(connection) => connection,
-        Err(_) => {
-            push_error(
-                &mut result,
-                "OpenCode history database could not be opened".to_owned(),
-            );
-            return result;
-        }
+    let Ok(connection) = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        push_error(
+            &mut result,
+            "OpenCode history database could not be opened".to_owned(),
+        );
+        return result;
     };
 
     let project_root = canonical_or_lexical(project_root);
     let mut session_ids = Vec::new();
-    let mut statement = match connection.prepare(
+    let Ok(mut statement) = connection.prepare(
         "SELECT s.id, p.worktree
          FROM session s JOIN project p ON p.id = s.project_id
          ORDER BY s.time_updated DESC, s.id
          LIMIT ?1",
-    ) {
-        Ok(statement) => statement,
-        Err(_) => {
-            push_error(
-                &mut result,
-                "OpenCode history schema is not supported".to_owned(),
-            );
-            return result;
-        }
+    ) else {
+        push_error(
+            &mut result,
+            "OpenCode history schema is not supported".to_owned(),
+        );
+        return result;
     };
-    let rows = match statement.query_map([MAX_SESSION_ROWS_SCANNED], |row| {
+    let Ok(rows) = statement.query_map([MAX_SESSION_ROWS_SCANNED], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    }) {
-        Ok(rows) => rows,
-        Err(_) => {
-            push_error(
-                &mut result,
-                "OpenCode sessions could not be read".to_owned(),
-            );
-            return result;
-        }
+    }) else {
+        push_error(
+            &mut result,
+            "OpenCode sessions could not be read".to_owned(),
+        );
+        return result;
     };
     for row in rows {
         match row {
@@ -100,33 +92,27 @@ pub fn import_from_db(db_path: &Path, project_root: &Path) -> ImportResult {
         if parts_remaining == 0 {
             break;
         }
-        let mut statement = match connection.prepare(
+        let Ok(mut statement) = connection.prepare(
             "SELECT m.data, p.data
              FROM message m JOIN part p ON p.message_id = m.id
              WHERE m.session_id = ?1
              ORDER BY p.time_created, p.id
              LIMIT ?2",
-        ) {
-            Ok(statement) => statement,
-            Err(_) => {
-                push_error(
-                    &mut result,
-                    "OpenCode messages could not be read".to_owned(),
-                );
-                continue;
-            }
+        ) else {
+            push_error(
+                &mut result,
+                "OpenCode messages could not be read".to_owned(),
+            );
+            continue;
         };
-        let rows = match statement.query_map(params![session_id, parts_remaining], |row| {
+        let Ok(rows) = statement.query_map(params![session_id, parts_remaining], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        }) {
-            Ok(rows) => rows,
-            Err(_) => {
-                push_error(
-                    &mut result,
-                    "OpenCode messages could not be read".to_owned(),
-                );
-                continue;
-            }
+        }) else {
+            push_error(
+                &mut result,
+                "OpenCode messages could not be read".to_owned(),
+            );
+            continue;
         };
         for row in rows {
             parts_remaining -= 1;

--- a/specs/1731-opencode-import/plan.md
+++ b/specs/1731-opencode-import/plan.md
@@ -1,0 +1,7 @@
+# Plan: OpenCode session-history import
+
+1. Add synthetic SQLite fixture tests that define the supported OpenCode schema contract and fail before implementation.
+2. Add a focused OpenCode importer using read-only SQLite queries, current-project joins, bounded rows, tolerant JSON decoding, and project-relative path filtering.
+3. Wire `opencode` into source names, CLI dispatch/help, and `--all`.
+4. Run targeted tests, sabotage the implementation to prove the regression test bites, then run canonical formatting, clippy, test, and preflight gates.
+5. Push one focused branch and open a PR closing #1731.

--- a/specs/1731-opencode-import/spec.md
+++ b/specs/1731-opencode-import/spec.md
@@ -1,0 +1,29 @@
+# Spec: OpenCode session-history import (refs #1731)
+
+## Problem / Why
+`lean-ctx import` cannot ingest current OpenCode session history, even though OpenCode persists project-scoped sessions, messages, and typed parts in a local SQLite database.
+
+## Goal
+Import useful, bounded facts from the current project's OpenCode sessions without leaking host paths or unrelated project history.
+
+## Acceptance Criteria (EARS)
+- WHEN a user runs `lean-ctx import opencode`, THE CLI SHALL read the current platform's OpenCode database in read-only mode.
+- WHEN `--all` is selected, THE CLI SHALL include OpenCode.
+- WHEN an OpenCode database contains multiple projects, THE importer SHALL process only sessions whose project worktree matches the current project root.
+- WHEN supported text, tool, or patch parts contain decisions, errors, or touched files, THE importer SHALL emit bounded project knowledge facts.
+- WHEN a touched path is absolute, relative, or traverses outside the project, THE importer SHALL retain only normalized project-relative paths inside the current project.
+- WHEN storage is absent or rows contain malformed/unknown JSON, THE importer SHALL not panic or disclose transcript content.
+
+## Out of Scope
+- Kilo Code: current source exposes incompatible legacy VS Code task storage and newer OpenCode-derived storage; a stable cross-version discovery contract is not established.
+- Importing unrelated OpenCode projects.
+- Mutating OpenCode storage.
+
+## Verification
+- `cargo test --lib core::import::opencode`
+- `cargo test --lib cli::import_cmd`
+- `scripts/preflight.sh fast`
+
+## Links
+- Tracking issue: #1731
+- Plan: ./plan.md · Tasks: ./tasks.md

--- a/specs/1731-opencode-import/tasks.md
+++ b/specs/1731-opencode-import/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: OpenCode session-history import
+
+- [x] RED: synthetic database test for current-project session filtering and fact extraction.
+- [x] GREEN: implement read-only OpenCode SQLite import and safe path normalization.
+- [x] RED/GREEN: source enum and CLI selection/help/`--all` wiring.
+- [x] Verify missing storage and outside-project paths; malformed/unknown rows are handled defensively.
+- [x] Prove the regression test fails under sabotage and restore the assertion.
+- [ ] Run targeted and canonical quality gates.
+- [ ] Push and open a verified PR closing #1731.


### PR DESCRIPTION
## Summary
- add `lean-ctx import opencode` and include it in `--all`
- discover the platform OpenCode data directory and open `opencode.db` read-only
- join projects/sessions/messages/parts and import only the current project's sessions
- extract decisions, tool errors, and project-relative touched files from allowlisted part fields
- add spec/plan/tasks and synthetic SQLite fixture coverage

## Privacy and safety
- no real transcripts, user paths, credentials, or tool payloads are committed
- diagnostics are content- and path-free
- imported tool data is allowlisted and paths outside the project (including symlink escapes and Windows absolute paths on Unix) are rejected
- reads are bounded and the database is never mutated

## Kilo Code
Deferred. Current Kilo source contains a legacy VS Code `globalState["taskHistory"]` + per-task `globalStorageUri/tasks` migration format and a newer OpenCode-derived subsystem. There is no proven single discovery/schema compatibility contract yet.

## TDD / test plan
- RED established first: the synthetic current-project SQLite fixture referenced a missing `import_from_db`
- sabotage: changing expected `sessions_found` from 1 to 0 produced the intended regression assertion (restored before commit)
- `cargo fmt --check --manifest-path rust/Cargo.toml` — pass
- `git diff --check` — pass
- targeted compile/test attempts reached the crate compile but the local 7.8 GiB host repeatedly OOM-killed rustc (`exit -9`) while linking the repository's all-feature lib test harness; CI is the authoritative full gate

Closes #1731
