### PR TITLE
fix(index): preserve exact tree-sitter chunk content

### DIFF
--- a/rust/src/core/chunks_ts.rs
+++ b/rust/src/core/chunks_ts.rs
@@ -187,18 +187,16 @@ pub(crate) fn extract_chunks_ts(
     content: &str,
     file_ext: &str,
 ) -> Option<Vec<CodeChunk>> {
-    let lines: Vec<&str> = content.lines().collect();
     let mut chunks = Vec::new();
 
     for_each_chunk_node(
         content,
         file_ext,
         |node, name_text, kind, start_line, end_line| {
-            let start_row0 = node.start_position().row;
-            let end_row0 = node.end_position().row;
-            let block: String = lines[start_row0..=end_row0.min(lines.len().saturating_sub(1))]
-                .to_vec()
-                .join("\n");
+            let block = match node.utf8_text(content.as_bytes()) {
+                Ok(text) => text.to_owned(),
+                Err(_) => return,
+            };
             let token_count = super::bm25_index::tokenize_for_index(&block).len();
 
             chunks.push(CodeChunk {
@@ -436,6 +434,18 @@ pub fn complex(x: i32, y: i32) -> Result<String, Error> {
     #[test]
     fn empty_file_returns_none() {
         assert!(extract_chunks_ts("empty.rs", "", "rs").is_none());
+    }
+
+    #[test]
+    fn javascript_same_line_functions_use_exact_node_content() {
+        let src = "function alpha(){return 1;}function beta(){return 2;}";
+        let chunks = extract_chunks_ts("min.js", src, "js").unwrap();
+
+        let alpha = chunks.iter().find(|c| c.symbol_name == "alpha").unwrap();
+        let beta = chunks.iter().find(|c| c.symbol_name == "beta").unwrap();
+
+        assert_eq!(alpha.content, "function alpha(){return 1;}");
+        assert_eq!(beta.content, "function beta(){return 2;}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1733

I ended up looking at this while investigating very high memory usage on Windows. In a few large coding sessions I had seen a `lean-ctx` process grow past 40 GB, so I started breaking the indexing path into smaller tests instead of assuming there was one single cause.

One reproducible case involved generated or minified source where many functions live on the same physical line. In that case, several tree-sitter nodes could end up using the whole line as chunk content, so the same large piece of source could be repeated many times before indexing.

This patch changes that behavior so each chunk keeps the exact byte range reported by tree-sitter instead of rebuilding its content from the whole physical line. I also added a small regression test with multiple JavaScript functions on one line.

On my Windows setup the targeted tests pass. With the synthetic reproduction attached to #1733, the unpatched build went above 2 GB before I stopped it, while the patched build stayed around 90 MB and completed normally. I also tried a later full-index run with a one-line file containing thousands of small functions and did not see the same abnormal memory growth.

I have only tested this on my own Windows environment, so I would really appreciate broader testing on other machines, platforms and source shapes before considering this fully validated.

Happy to adjust the implementation if there is a cleaner or more project-idiomatic way to solve the same problem.