### PR TITLE
perf(index): avoid duplicate property-graph mirror

### DIFF
--- a/rust/src/core/index_orchestrator.rs
+++ b/rust/src/core/index_orchestrator.rs
@@ -356,9 +356,9 @@ fn run_build_worker(root: &str) {
         guard.report(0, 0);
         let graph_result = std::panic::catch_unwind(|| {
             let (idx, _cache) = graph_index::scan_with_content_cache(&graph_root);
-            if let Err(e) = idx.save() {
-                tracing::warn!("[index_orchestrator: graph save failed: {e}]");
-            }
+            // scan_with_content_cache persists the freshly built ProjectIndex
+            // before returning it; mirroring the same unchanged index again here
+            // only repeats the property-graph mirror.
             crate::core::code_health::persist::refresh_if_stale(&graph_root, &idx);
         });
         drop(guard);


### PR DESCRIPTION
Fixes #1735

This came out of the same Windows investigation where I had seen `lean-ctx` use more than 40 GB of RAM during a few large coding sessions.

While following the indexing path, I noticed what looked like the property graph being saved twice during the same full-index operation.

I do not think this explains the large memory usage that originally started the investigation. This PR is only meant as a small performance cleanup.

The change removes the second save while leaving the existing graph persistence path in place.

On my Windows machine the relevant indexing and graph tests pass. I also repeated the same indexing workload several times with and without the change. On my setup, removing the extra save made the full indexing run roughly 16% faster overall, while memory usage stayed basically the same.

That result is obviously limited to one machine and one workload, so I would not expect everyone to see exactly the same improvement.

The main thing I would appreciate feedback on is whether the second save really is redundant, or whether it exists for a lifecycle or recovery case I may have missed.

Happy to rework or drop the change if the current behavior is intentional.