### PR TITLE
test: remove two wall-clock/global-counter flakes from the lib suite

### DIFF
--- a/rust/src/core/agents/registry.rs
+++ b/rust/src/core/agents/registry.rs
@@ -1202,28 +1202,46 @@ mod tests {
         let handles: Vec<_> = (0..8)
             .map(|i| {
                 std::thread::spawn(move || {
-                    AgentRegistry::mutate_locked(|registry| {
-                        registry.agents.push(AgentEntry {
-                            agent_id: format!("agent-{i}"),
-                            agent_type: "test".to_string(),
-                            role: None,
-                            project_root: "/tmp/project".to_string(),
-                            started_at: Utc::now(),
-                            last_active: Utc::now(),
-                            pid: 10_000 + i,
-                            process_identity: None,
-                            status: AgentStatus::Active,
-                            status_message: None,
+                    // `mutate_locked` bounds its wait for the registry file lock
+                    // and reports exhaustion as a refusal: the lock was never
+                    // taken, nothing was written, and no other writer's change
+                    // was lost. Eight threads on a saturated CI runner can
+                    // exceed that budget, so a refusal is retried rather than
+                    // failed — the invariant under test is "no lost update",
+                    // not "the lock is never contended".
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+                    loop {
+                        let outcome = AgentRegistry::mutate_locked(|registry| {
+                            registry.agents.push(AgentEntry {
+                                agent_id: format!("agent-{i}"),
+                                agent_type: "test".to_string(),
+                                role: None,
+                                project_root: "/tmp/project".to_string(),
+                                started_at: Utc::now(),
+                                last_active: Utc::now(),
+                                pid: 10_000 + i,
+                                process_identity: None,
+                                status: AgentStatus::Active,
+                                status_message: None,
+                            });
                         });
-                    })
+                        match outcome {
+                            Ok(_) => return,
+                            Err(error)
+                                if error.contains("timed out")
+                                    && std::time::Instant::now() < deadline =>
+                            {
+                                std::thread::yield_now();
+                            }
+                            Err(error) => panic!("mutate_locked must succeed: {error}"),
+                        }
+                    }
                 })
             })
             .collect();
 
         for h in handles {
-            h.join()
-                .expect("writer thread must not panic")
-                .expect("mutate_locked must succeed");
+            h.join().expect("writer thread must not panic");
         }
 
         let registry = AgentRegistry::load_or_create();

--- a/rust/src/core/content_cache.rs
+++ b/rust/src/core/content_cache.rs
@@ -424,24 +424,30 @@ pub mod tests {
         let dir = tempfile::tempdir().unwrap();
         let p = write(dir.path(), "a.rs", "hello world\n");
 
-        let before = stats();
+        let state = FileState::from_path(&p).unwrap();
+        assert!(
+            get(&p, state).is_none(),
+            "a fresh cache must not already hold the file"
+        );
+
         let first = get_or_read(&p).unwrap();
         assert_eq!(&*first, "hello world\n");
-        let after_first = stats();
-        assert_eq!(
-            after_first.inserts,
-            before.inserts + 1,
-            "first read inserts"
+        assert!(
+            get(&p, state).is_some(),
+            "the first read must populate the cache for this path and state"
         );
 
         let second = get_or_read(&p).unwrap();
         assert_eq!(&*second, "hello world\n");
-        let after_second = stats();
-        assert_eq!(
-            after_second.inserts, after_first.inserts,
-            "second read must NOT re-insert (served from cache)"
+        // Allocation identity, not counter arithmetic: a cache hit clones the
+        // stored `Arc`, a re-read allocates a new one. `stats()` is
+        // process-wide, so bracketing a call with `stats()` deltas races every
+        // parallel test that touches the content cache — that is what made this
+        // test flake in CI (seen on #1736 / #1738).
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "the second read must serve the cached allocation, not re-read the file"
         );
-        assert!(after_second.hits > after_first.hits, "second read is a hit");
     }
 
     #[test]


### PR DESCRIPTION
Two `--lib` tests fail intermittently on `Test (ubuntu-latest)` for reasons
unrelated to the code under review. Both hit #1736 and #1738 on 2026-09-08, each
in a different test, each with the PR's own subject untouched:

- `core::agents::registry::tests::mutate_locked_survives_concurrent_writers`
  (run 34249643312)
- `core::content_cache::tests::get_or_read_populates_then_serves_from_cache`
  (run 34249127958)

Neither is fixed by rerunning-until-green. Both had a specific cause.

## `get_or_read_populates_then_serves_from_cache`

The test bracketed a single `get_or_read` with `stats()` and asserted
`after.inserts == before.inserts + 1`.

`stats()` is **process-wide**. `TEST_LOCK` and `#[serial(cache_telemetry)]`
serialise the content-cache tests against each other, but not against the rest
of a 10,783-test parallel run — and anything that indexes or reads a file goes
through `content_cache::get_or_read`. One insert from another thread landing
between the two `stats()` calls makes the delta 2, and the test fails on
`"first read inserts"`. That is exactly the observed failure.

Replaced with assertions on cache *behaviour* instead of counter arithmetic:

- the cache does not hold the file before the first read,
- it does after,
- `Arc::ptr_eq(&first, &second)` — the second call handed back the cached
  allocation rather than re-reading.

`get_or_read` inserts `Arc::clone(&arc)` and returns `arc`, so pointer identity
holds if and only if the second call was served from the cache. This is
**stronger** than the counter it replaces: a hit that returned equal-but-freshly
-read content used to pass and now does not.

## `mutate_locked_survives_concurrent_writers`

Eight threads race through `mutate_locked`, which takes an exclusive file lock
on `registry.lock`. `FileLock::acquire` waits **750 ms** total, retrying every
25 ms, and reports exhaustion as `Err("agent registry lock timed out after
750ms")`. The test called `.expect("mutate_locked must succeed")` on that.

On a saturated CI runner — the whole suite in parallel, this job takes ~10
minutes — eight serialised load/parse/write/fsync cycles plus scheduling jitter
can exceed 750 ms for the last thread. The panic column in the CI log points at
that `.expect`.

A timeout here is a **refusal, not a lost update**: the lock was never acquired,
nothing was written, and no other writer's change was dropped. The invariant the
test exists to protect is "no lost update", not "the lock is never contended".
So a timeout is now retried (bounded at 30 s), and any *other* error still fails
the test immediately with its message. The final `agents.len() == 8` assertion
is unchanged — retrying after a refusal cannot double-count, because the refused
attempt wrote nothing.

## Left open deliberately

The 750 ms budget is a **product** question, not a test question, and this PR
does not touch it. Under enough concurrent sessions a real user can see
`agent registry lock timed out after 750ms` from an agent registration. I have
not measured that it is too tight in production — only that it is too tight for
a CI runner under full parallel load — so changing a runtime timing constant on
that evidence would be guessing. Worth its own issue.


🤖 Generated with [Claude Code](https://claude.com/claude-code)