### PR TITLE
fix(proxy): relay Claude Code's session id (#1730)

### DIFF
--- a/rust/src/proxy/forward/headers.rs
+++ b/rust/src/proxy/forward/headers.rs
@@ -79,6 +79,12 @@ pub(crate) const ALLOWED_REQUEST_HEADERS: &[&str] = &[
     "x-system-prompt-breakdown",
     "x-cmd-zdr",
     "x-session-id",
+    // #1730: Claude Code stamps every request with a stable per-conversation
+    // UUID. Relays behind this proxy key session affinity and prompt-cache
+    // reuse off it, so stripping it silently hands them a fresh session on
+    // every request. Passed through verbatim — lean-ctx neither renames nor
+    // invents it.
+    "x-claude-code-session-id",
 ];
 
 pub(crate) fn is_allowed_request_header(name: &str) -> bool {

--- a/rust/src/proxy/forward/tests.rs
+++ b/rust/src/proxy/forward/tests.rs
@@ -843,6 +843,118 @@ fn cache_prompt_hash_is_content_sensitive() {
     assert_ne!(hash(b"one"), hash(b"two"));
 }
 
+/// Loopback upstream that answers exactly one request and hands back its raw,
+/// lowercased request header block. Lets a test assert what actually leaves the
+/// proxy, not only what the allowlist constant claims.
+async fn upstream_capturing_headers() -> (String, tokio::task::JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut buffer).await.unwrap();
+            if read == 0 {
+                break request.len();
+            }
+            request.extend_from_slice(&buffer[..read]);
+            if let Some(end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break end + 4;
+            }
+        };
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\n{}")
+            .await
+            .unwrap();
+        String::from_utf8_lossy(&request[..header_end]).to_lowercase()
+    });
+    (format!("http://{address}"), server)
+}
+
+/// Minimal state for the transport layer. `send_upstream` reads only
+/// `state.client`; the watch receiver keeps serving its last value after the
+/// sender drops, so no keep-alive is needed.
+fn relay_test_state() -> ProxyState {
+    let (_upstreams, state_upstreams) =
+        tokio::sync::watch::channel(Arc::new(crate::core::config::Upstreams {
+            anthropic: "https://api.anthropic.com".into(),
+            openai: "https://api.openai.com".into(),
+            chatgpt: "https://chatgpt.com".into(),
+            gemini: "https://generativelanguage.googleapis.com".into(),
+            providers: Vec::new(),
+        }));
+    ProxyState {
+        client: reqwest::Client::new(),
+        port: 0,
+        stats: Arc::new(crate::proxy::ProxyStats::default()),
+        break_even: Arc::new(crate::proxy::break_even::BreakEvenCalculator::new(1500)),
+        introspect: Arc::new(crate::proxy::introspect::IntrospectState::default()),
+        ocla_cache: None,
+        upstreams: state_upstreams,
+        chatgpt_cookies: crate::proxy::chatgpt_cookies::shared_chatgpt_cloudflare_cookie_store(),
+        mcp_servers: Arc::new(Vec::new()),
+        web_app_tracker: Arc::new(std::sync::Mutex::new(
+            crate::proxy::web_app::conversation_tracker::ConversationTracker::default(),
+        )),
+    }
+}
+
+#[test]
+fn forwards_claude_code_session_id_header() {
+    // #1730: Claude Code's per-conversation UUID must survive the relay so a
+    // downstream proxy can key session affinity and prompt-cache reuse on it.
+    assert!(ALLOWED_REQUEST_HEADERS.contains(&"x-claude-code-session-id"));
+    assert!(is_allowed_request_header("x-claude-code-session-id"));
+    assert!(should_forward_request_header(
+        "x-claude-code-session-id",
+        false
+    ));
+}
+
+#[tokio::test]
+async fn claude_code_session_id_reaches_the_upstream_verbatim() {
+    // #1730 end-to-end: assert what the upstream actually receives, including
+    // the mixed-case spelling Claude Code puts on the wire.
+    let (upstream, server) = upstream_capturing_headers().await;
+    let parts = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header(
+            "X-Claude-Code-Session-Id",
+            "11111111-2222-3333-4444-555555555555",
+        )
+        .header("X-Leanctx-Project", "internal-only")
+        .body(())
+        .unwrap()
+        .into_parts()
+        .0;
+
+    let response = transport::send_upstream(
+        &relay_test_state(),
+        &parts,
+        &upstream,
+        b"{}".to_vec(),
+        "Anthropic",
+        false,
+    )
+    .await
+    .unwrap();
+    assert!(response.status().is_success());
+
+    let seen = server.await.unwrap();
+    assert!(
+        seen.contains("x-claude-code-session-id: 11111111-2222-3333-4444-555555555555"),
+        "session id must reach the upstream verbatim, got: {seen}"
+    );
+    // Widening the allowlist for #1730 must not widen it for anything else:
+    // the internal gateway tag stays stripped (enterprise#11).
+    assert!(
+        !seen.contains("x-leanctx-project"),
+        "internal header must stay stripped, got: {seen}"
+    );
+}
+
 #[test]
 fn forwards_commandcode_cli_headers() {
     // Command Code (`cmd`) gates agent calls on `x-command-code-version`.


### PR DESCRIPTION
Fixes #1730.

## Summary

`x-claude-code-session-id` is now on the proxy's request allowlist, so Claude
Code's per-conversation UUID reaches the upstream instead of being stripped at
the loopback boundary.

The header is passed through **verbatim**. lean-ctx does not rename it, does not
map it onto any downstream vocabulary, and does not invent one when the client
omits it — that mapping belongs in whatever relay actually needs it.

## Why the one-liner and not `extra_allowed_request_headers`

The reporter offered both. The allowlist entry is the right shape here:

- It is a plain correlation id, the same class as `x-session-id`,
  `x-grok-session-id`, `x-client-request-id` and `mcp-session-id`, all of which
  are already forwarded unconditionally.
- #1638/#1639 established that client-side correlation headers get relayed,
  because silently dropping them breaks whatever sits downstream.
- Claude Code is the Anthropic client this relay exists for. Forwarding every
  other client's session header and not Claude Code's is not defensible.

A configurable list is a larger change (config plumbing, validation, Workspace
Trust scoping, and the question of whether the response-side `FORWARDED_HEADERS`
needs the same treatment). It stays open as an option; it is not needed for this.

## Tests

Two, both new:

- `forwards_claude_code_session_id_header` — allowlist membership, matching the
  shape of the existing per-client header tests.
- `claude_code_session_id_reaches_the_upstream_verbatim` — end-to-end through
  `send_upstream` against a loopback listener that hands back the raw request
  header block. It asserts the value arrives intact from the mixed-case
  `X-Claude-Code-Session-Id` spelling Claude Code puts on the wire, **and** that
  `x-leanctx-project` is still stripped in the same request — widening the
  allowlist for #1730 must not widen it for anything else.

The second test exercises the real relay path rather than re-asserting the
constant, so a future refactor of the header filter cannot pass it by accident.


🤖 Generated with [Claude Code](https://claude.com/claude-code)