### PR TITLE
fix(gain): never gate the takedown path behind publication (#1726)

### DIFF
--- a/rust/src/cli/dispatch/analytics/gain.rs
+++ b/rust/src/cli/dispatch/analytics/gain.rs
@@ -7,6 +7,18 @@ fn publication_research_enabled() -> bool {
     std::env::var("LEAN_CTX_EXPERIMENTAL_PUBLICATION").as_deref() == Ok("1")
 }
 
+/// Whether this invocation asks for a research-gated *publication* action.
+/// `--unpublish` is deliberately absent: removal stays available even when
+/// publishing is not (#1726).
+fn publication_requested(rest: &[String]) -> bool {
+    rest.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "--publish" | "--leaderboard" | "--link" | "--rejoin"
+        ) || arg.starts_with("--rejoin=")
+    }) || link_request(rest).is_some()
+}
+
 fn print_publication_unavailable() {
     eprintln!(
         "Hosted publication and public rankings are Research and unavailable in the public LeanCTX Runtime. \\
@@ -71,24 +83,22 @@ pub(in crate::cli::dispatch) fn cmd_gain(rest: &[String]) {
         core::context_overhead::set_no_cache_adjust(true);
     }
 
-    let publication_requested = rest.iter().any(|arg| {
-        matches!(
-            arg.as_str(),
-            "--publish" | "--leaderboard" | "--link" | "--rejoin"
-        ) || arg.starts_with("--rejoin=")
-    }) || unpublish_request(rest).is_some()
-        || link_request(rest).is_some();
-    if publication_requested && !publication_research_enabled() {
-        print_publication_unavailable();
+    // #1726: taking a published card down is never gated. Turning publication
+    // off (or shipping a runtime where it was never on) must not strand a page
+    // that is already public — the exit door has to outlive the entrance.
+    if let Some(req) = unpublish_request(rest) {
+        use crate::cli::wrapped_publish::UnpublishTarget;
+        let target = match &req {
+            UnpublishReq::All => UnpublishTarget::All,
+            UnpublishReq::Target(s) => UnpublishTarget::One(s.as_str()),
+            UnpublishReq::Latest => UnpublishTarget::Latest,
+        };
+        crate::cli::wrapped_publish::unpublish(target);
         return;
     }
 
-    if let Some(req) = unpublish_request(rest) {
-        let id = match &req {
-            UnpublishReq::Id(s) => Some(s.as_str()),
-            UnpublishReq::Latest => None,
-        };
-        crate::cli::wrapped_publish::unpublish(id);
+    if publication_requested(rest) && !publication_research_enabled() {
+        print_publication_unavailable();
         return;
     }
     if rest.iter().any(|a| a == "--rejoin") {
@@ -505,17 +515,23 @@ fn print_support_hint() {
 /// Resolves the output path for the shareable SVG Wrapped card, or `None` when no
 /// card was requested. Accepts `--svg`, `--svg=<path>`, `--card`, `--card=<path>`;
 /// a bare flag falls back to `lean-ctx-wrapped.svg` in the current directory.
-/// A requested `--unpublish`: either an explicit card id, or the most recent published card.
+/// A requested `--unpublish`: the most recent card, every card, or one named
+/// by id or by its published permalink.
 enum UnpublishReq {
     Latest,
-    Id(String),
+    All,
+    Target(String),
 }
 
-/// Parses `--unpublish[=<id>]`. `None` means it was not requested at all.
+/// Parses `--unpublish[=<id|url|all>]`. `None` means it was not requested.
 fn unpublish_request(rest: &[String]) -> Option<UnpublishReq> {
     for a in rest {
         if let Some(v) = a.strip_prefix("--unpublish=") {
-            return Some(UnpublishReq::Id(v.to_string()));
+            return Some(if v.eq_ignore_ascii_case("all") {
+                UnpublishReq::All
+            } else {
+                UnpublishReq::Target(v.to_string())
+            });
         }
         if a == "--unpublish" {
             return Some(UnpublishReq::Latest);
@@ -878,7 +894,10 @@ fn cmd_stats_raw(rest: &[String]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{base_url_arg, share_target, svg_target};
+    use super::{
+        UnpublishReq, base_url_arg, publication_requested, share_target, svg_target,
+        unpublish_request,
+    };
 
     fn args(xs: &[&str]) -> Vec<String> {
         xs.iter().map(|s| (*s).to_string()).collect()
@@ -954,5 +973,47 @@ mod tests {
             Some("https://me.dev")
         );
         assert_eq!(base_url_arg(&args(&["--share"])), None);
+    }
+
+    #[test]
+    fn unpublish_accepts_id_permalink_and_all() {
+        assert!(matches!(
+            unpublish_request(&args(&["--unpublish"])),
+            Some(UnpublishReq::Latest)
+        ));
+        assert!(matches!(
+            unpublish_request(&args(&["--unpublish=all"])),
+            Some(UnpublishReq::All)
+        ));
+        assert!(matches!(
+            unpublish_request(&args(&["--unpublish=ALL"])),
+            Some(UnpublishReq::All)
+        ));
+        match unpublish_request(&args(&[
+            "--unpublish=https://leanctx.com/w/196127aaad436a2cd42164cbbbbcd3cb",
+        ])) {
+            Some(UnpublishReq::Target(target)) => {
+                assert!(target.ends_with("196127aaad436a2cd42164cbbbbcd3cb"));
+            }
+            other => panic!(
+                "permalink must parse as a target, got {:?}",
+                other.is_some()
+            ),
+        }
+        assert!(unpublish_request(&args(&["--publish"])).is_none());
+    }
+
+    #[test]
+    fn unpublish_is_not_a_research_gated_publication_action() {
+        // #1726: removal must stay reachable when publishing is unavailable,
+        // otherwise an already-published page can never be taken down.
+        assert!(!publication_requested(&args(&["--unpublish"])));
+        assert!(!publication_requested(&args(&["--unpublish=all"])));
+        for gated in ["--publish", "--leaderboard", "--link", "--rejoin"] {
+            assert!(
+                publication_requested(&args(&[gated])),
+                "`{gated}` must stay behind the research gate"
+            );
+        }
     }
 }

--- a/rust/src/cli/dispatch/help.rs
+++ b/rust/src/cli/dispatch/help.rs
@@ -155,7 +155,7 @@ COMMANDS:
     gain --publish [--name=<n>]    Development-only local export (hosted publication is Research)
     gain --publish --leaderboard   Unavailable: public rankings are Research
     gain --link [CODE]             Development-only local pairing experiment
-    gain --unpublish[=<id>]        Remove a local development export
+    gain --unpublish[=<id|url|all>]  Take a published card down (works even when publishing is off)
     config set gain.auto_publish true  Development-only local export setting (off by default)
     savings [--period day|week|month|all] [--format table|json|markdown] Local representation-change report; not comparable proof
     learning [status|export|import]  Local adaptive-learning state: inspect, export, import

--- a/rust/src/cli/wrapped_publish.rs
+++ b/rust/src/cli/wrapped_publish.rs
@@ -748,33 +748,117 @@ fn auto_publish_due(last: Option<&str>, interval_hours: u64) -> bool {
     elapsed.num_hours() >= interval
 }
 
-/// `lean-ctx gain --unpublish[=<id>]` — delete a published card via its stored `edit_token`.
-/// With no id, removes the most recently published card.
-pub(crate) fn unpublish(id: Option<&str>) {
-    let mut store = PublishedStore::load();
-    let entry = match id {
-        Some(id) => store.cards.iter().find(|c| c.id == id).cloned(),
-        None => store.cards.last().cloned(),
-    };
+/// What `lean-ctx gain --unpublish` was asked to take down.
+#[derive(Clone, Copy)]
+pub(crate) enum UnpublishTarget<'a> {
+    /// `--unpublish` — the most recently published card.
+    Latest,
+    /// `--unpublish=all` — every card this machine published.
+    All,
+    /// `--unpublish=<id|url>` — one specific card.
+    One(&'a str),
+}
 
-    let Some(entry) = entry else {
-        match id {
-            Some(id) => println!("No published card with id {id} found locally."),
-            None => println!("No published cards found. Publish one with: lean-ctx gain --publish"),
+/// Extracts a card id from either a bare id or a published permalink.
+///
+/// The takedown request in #1726 arrived as a URL, because that is the only
+/// form a user ever sees — the id is never printed on its own. Accepts
+/// `https://leanctx.com/w/<id>`, `leanctx.com/w/<id>`, and the bare `<id>`;
+/// query strings and fragments are dropped.
+fn card_id_from_target(target: &str) -> &str {
+    let target = target.trim();
+    let target = target.split(['?', '#']).next().unwrap_or(target);
+    target
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(target)
+}
+
+/// Explains why a card the user can see is not takeable-down from here, instead
+/// of leaving them with a bare "not found". The `edit_token` is minted once, at
+/// publish time, and stored only on the publishing machine — so a card
+/// published from another machine (or from a since-cleared data directory)
+/// cannot be deleted from this one.
+fn print_unknown_card(target: &str, store: &PublishedStore) {
+    println!("No published card matching `{target}` is known on this machine.");
+    println!();
+    if store.cards.is_empty() {
+        println!("  This machine has no publication records at all.");
+    } else {
+        println!("  Cards published from this machine:");
+        for card in &store.cards {
+            println!("    {}  {}", card.id, card.url);
         }
-        return;
-    };
+        println!();
+        println!("  Remove one with: lean-ctx gain --unpublish=<id|url>");
+        println!("  Remove all with: lean-ctx gain --unpublish=all");
+    }
+    println!();
+    println!("  A card is deleted with the edit token minted when it was");
+    println!("  published, and that token is kept only on the machine that");
+    println!("  published it. If that machine or its data directory is gone,");
+    println!("  request takedown at https://leanctx.com/support");
+}
 
+/// Deletes one card via its stored `edit_token`. Returns `false` on a server
+/// error, having already reported it.
+fn unpublish_entry(store: &mut PublishedStore, entry: &PublishedEntry) -> bool {
     match cloud_client::unpublish_wrapped(&entry.id, &entry.edit_token) {
         Ok(()) => {
             store.cards.retain(|c| c.id != entry.id);
             let _ = store.save();
             println!("Unpublished {} ({})", entry.id, entry.url);
+            true
         }
         Err(e) => {
-            eprintln!("Unpublish failed: {e}");
-            std::process::exit(1);
+            eprintln!("Unpublish failed for {}: {e}", entry.id);
+            false
         }
+    }
+}
+
+/// `lean-ctx gain --unpublish[=<id|url|all>]` — take a published card down.
+///
+/// Deliberately not gated behind `LEAN_CTX_EXPERIMENTAL_PUBLICATION`: turning
+/// publishing off must never strand a page that is already public (#1726).
+pub(crate) fn unpublish(target: UnpublishTarget<'_>) {
+    let mut store = PublishedStore::load();
+
+    let entries = match target {
+        UnpublishTarget::All => store.cards.clone(),
+        UnpublishTarget::Latest => store.cards.last().cloned().into_iter().collect(),
+        UnpublishTarget::One(target) => {
+            let id = card_id_from_target(target);
+            store
+                .cards
+                .iter()
+                .find(|c| c.id == id)
+                .cloned()
+                .into_iter()
+                .collect()
+        }
+    };
+
+    if entries.is_empty() {
+        match target {
+            UnpublishTarget::One(target) => print_unknown_card(target, &store),
+            _ => println!("No published cards found on this machine."),
+        }
+        return;
+    }
+
+    let mut failed = 0_usize;
+    for entry in &entries {
+        if !unpublish_entry(&mut store, entry) {
+            failed += 1;
+        }
+    }
+    if failed > 0 {
+        eprintln!(
+            "{failed} of {} card(s) could not be removed.",
+            entries.len()
+        );
+        std::process::exit(1);
     }
 }
 
@@ -962,5 +1046,22 @@ mod tests {
         let loaded = PublishedStore::load();
         assert_eq!(loaded.cards.len(), 1);
         assert_eq!(loaded.cards[0].edit_token, "secret-token");
+    }
+
+    #[test]
+    fn card_id_is_extracted_from_a_published_permalink() {
+        // #1726: the id is never shown on its own, so a takedown request
+        // arrives as the URL the user can actually see.
+        let id = "196127aaad436a2cd42164cbbbbcd3cb";
+        for target in [
+            id,
+            &format!("https://leanctx.com/w/{id}"),
+            &format!("leanctx.com/w/{id}"),
+            &format!("https://leanctx.com/w/{id}/"),
+            &format!("https://leanctx.com/w/{id}?utm_source=x"),
+            &format!("  https://leanctx.com/w/{id}#top  "),
+        ] {
+            assert_eq!(card_id_from_target(target), id, "target: {target}");
+        }
     }
 }

--- a/rust/src/cloud_client.rs
+++ b/rust/src/cloud_client.rs
@@ -530,14 +530,19 @@ pub fn recover_wrapped_edit_token(
 }
 
 /// Delete a previously published card using its one-time `edit_token` (sent as `X-Edit-Token`).
+///
+/// Idempotent: a card the server no longer has (404/410) counts as removed.
+/// The caller's goal is "this page is not public any more", and failing a
+/// takedown because it already succeeded would strand the local record with no
+/// way to clear it (#1726).
 pub fn unpublish_wrapped(id: &str, edit_token: &str) -> Result<(), String> {
     let url = format!("{}/api/wrapped/{id}", api_url());
 
-    ureq::delete(&url)
-        .header("X-Edit-Token", edit_token)
-        .call()
-        .map_err(|e| format!("Unpublish failed: {e}"))?;
-    Ok(())
+    match ureq::delete(&url).header("X-Edit-Token", edit_token).call() {
+        // Removed now, or already gone (404/410) — either way it is not public.
+        Ok(_) | Err(ureq::Error::StatusCode(404 | 410)) => Ok(()),
+        Err(e) => Err(format!("Unpublish failed: {e}")),
+    }
 }
 
 /// Bind a published card to the logged-in account so the leaderboard stacks all of the


### PR DESCRIPTION
Fixes #1726.

## The actual defect

`--unpublish` existed, but it was unreachable in the runtime the reporter is on.

`cmd_gain` grouped it with `--publish`, `--leaderboard`, `--link` and `--rejoin`
into one `publication_requested` set, gated behind
`LEAN_CTX_EXPERIMENTAL_PUBLICATION=1`. In the public runtime that variable is
unset, so `lean-ctx gain --unpublish` printed *"Hosted publication and public
rankings are Research and unavailable"* and exited.

That is the reported situation exactly: `gain.auto_publish` published a page
while publishing was enabled, publishing was then turned off, and the takedown
path went off with it. The page stays up and the CLI refuses to remove it.

**The exit door must outlive the entrance.** `--unpublish` is now handled before
the research gate and is never gated by it. Nothing else moves out from behind
the gate — a test pins `--publish` / `--leaderboard` / `--link` / `--rejoin` in
place.

## The rest of the gap

Four smaller things stood between a user and a takedown:

- **Only a bare card id was accepted.** The id is never printed on its own; the
  only form a user ever sees is the permalink. `--unpublish` now takes
  `https://leanctx.com/w/<id>`, `leanctx.com/w/<id>` or the bare id, and drops a
  trailing slash, query string or fragment.
- **No way to clear everything.** `--unpublish=all` removes every card this
  machine published.
- **A card already gone server-side failed forever.** `unpublish_wrapped` now
  treats 404/410 as success and prunes the local record. The goal is "this page
  is not public any more"; failing a takedown because it already succeeded left
  the local record unclearable.
- **"No published card with id X found locally."** replaced with an explanation:
  the `edit_token` is minted at publish time and kept only on the publishing
  machine, so a card published elsewhere (or from a since-cleared data
  directory) cannot be removed from here. It lists the cards this machine can
  remove and points at the support takedown path for the ones it cannot.

Help text was `gain --unpublish[=<id>]  Remove a local development export`,
which hid that the command takes down a hosted page. It now reads
`Take a published card down (works even when publishing is off)`.

## Not addressed here

The reporter's second point — that opt-out-before-publish would be the safer
default for `gain.auto_publish` — is a product decision, not a bug fix, and is
left for #1726 to carry.

Recovering an `edit_token` for a card published from a machine you no longer
have would need a server endpoint that mints a recovery challenge outside the
publish response. Today `edit_token_challenge` only arrives on re-publish, so
that path cannot be built client-side.

## Tests

- `unpublish_accepts_id_permalink_and_all` — parser over id, permalink,
  `all`/`ALL`, and a negative case.
- `unpublish_is_not_a_research_gated_publication_action` — the regression that
  matters: `--unpublish` is outside `publication_requested`, every genuinely
  gated flag is still inside it.
- `card_id_is_extracted_from_a_published_permalink` — id, both URL forms,
  trailing slash, query string, fragment, surrounding whitespace.


🤖 Generated with [Claude Code](https://claude.com/claude-code)