### PR TITLE
ci: don't let a third-party apt list fail the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,20 @@ jobs:
       - name: Install mold linker
         if: runner.os == 'Linux'
         shell: bash
-        run: sudo apt-get update && sudo apt-get install -y mold
+        run: |
+          # The runner image ships third-party apt lists (Google Chrome's
+          # among them) that this job never uses. When one of them serves a
+          # bad index — as dl.google.com did on 2026-09-09 with a Hash Sum
+          # mismatch — `apt-get update` exits 100 and takes the whole test
+          # matrix with it, over a package that only ever comes from
+          # Ubuntu's own archive. Drop those lists first, so the update
+          # stays fatal for the archives `mold` actually lives in.
+          # Matches both the .list and deb822 .sources spellings, whichever
+          # the current runner image happens to ship.
+          sudo rm -f /etc/apt/sources.list.d/*google* \
+                     /etc/apt/sources.list.d/*microsoft*
+          sudo apt-get update
+          sudo apt-get install -y mold
       - name: Run tests
         working-directory: rust
         shell: bash


### PR DESCRIPTION
The Linux test job installs mold with `sudo apt-get update && sudo apt-get install -y mold`.

GitHub's runner image ships third-party apt lists that this job never uses. On 2026-09-09 `dl.google.com` served a bad Chrome index and `apt-get update` exited 100 on a Hash Sum mismatch:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

Every `Test (ubuntu-latest)` run died about 90 seconds in. #1741, #1742, #1743 and #1732 all failed on it, and reruns kept failing for as long as the upstream index stayed broken — over a package that only ever comes from Ubuntu's own archive.

The Chrome and Microsoft lists are removed before the update rather than softening it with `|| true`, so the update stays fatal for the archives `mold` actually lives in. A genuinely broken Ubuntu mirror still fails the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
