### PR TITLE
fix(bm25): stop minified bundles from exploding the index (#1739)

### DIFF
--- a/packages/lean-ctx-bin/postinstall.test.cjs
+++ b/packages/lean-ctx-bin/postinstall.test.cjs
@@ -76,6 +76,16 @@ child.unref();
       }
     }
     try { runner.kill(); } catch {}
-    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 50, retryDelay: 100 });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 50, retryDelay: 100 });
+    } catch (error) {
+      // Windows keeps a directory handle alive for a while after
+      // TerminateProcess, so the descendant killed just above can still hold
+      // `dir` past the retry budget and rmSync throws EBUSY. Every assertion
+      // has already run by this point — failing the suite on temp-directory
+      // hygiene turns a runner quirk into a red pipeline (it took down
+      // #1741, #1742, #1732 and #1749), and the runner is discarded anyway.
+      console.warn(`cleanup: could not remove ${dir}: ${error.message}`);
+    }
   }
 })().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/rust/crates/lean-ctx-embed/tests/engine_read.rs
+++ b/rust/crates/lean-ctx-embed/tests/engine_read.rs
@@ -7,6 +7,23 @@ use std::path::PathBuf;
 
 use lean_ctx_embed::{Engine, ReadMode};
 
+/// The embedded tools resolve paths against process-global state: engine init
+/// sets `LEAN_CTX_*` once per process (`configure_process_env`), and the tool
+/// dispatch resolves relative paths against a shared session root. Two engines
+/// rooted at different temp projects therefore cannot be live at the same time.
+///
+/// libtest runs the tests in this binary in parallel, so they were racing:
+/// `read_then_reread_is_cheaper` intermittently resolved `src/main.rs` against
+/// another test's root and failed with "file not found" (CI on #1749).
+/// Serialising here is better than relying on `--test-threads=1` being passed.
+static ENGINE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn engine_guard() -> std::sync::MutexGuard<'static, ()> {
+    ENGINE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Create a unique temp project dir with a couple of source files.
 fn temp_project() -> PathBuf {
     let unique = format!(
@@ -34,6 +51,7 @@ fn temp_project() -> PathBuf {
 
 #[test]
 fn read_then_reread_is_cheaper() {
+    let _guard = engine_guard();
     let dir = temp_project();
     let engine = Engine::builder(&dir).build().expect("engine builds");
 
@@ -57,6 +75,7 @@ fn read_then_reread_is_cheaper() {
 
 #[test]
 fn pathjail_rejects_escape() {
+    let _guard = engine_guard();
     let dir = temp_project();
     let engine = Engine::builder(&dir).build().expect("engine builds");
 
@@ -73,6 +92,7 @@ fn pathjail_rejects_escape() {
 
 #[test]
 fn search_finds_symbol() {
+    let _guard = engine_guard();
     let dir = temp_project();
     let engine = Engine::builder(&dir).build().expect("engine builds");
 
@@ -87,6 +107,7 @@ fn search_finds_symbol() {
 
 #[test]
 fn exec_tool_requires_optin() {
+    let _guard = engine_guard();
     let dir = temp_project();
     let engine = Engine::builder(&dir).build().expect("engine builds");
 
@@ -108,6 +129,7 @@ fn exec_tool_requires_optin() {
 
 #[test]
 fn unknown_tool_errors() {
+    let _guard = engine_guard();
     let dir = temp_project();
     let engine = Engine::builder(&dir).build().expect("engine builds");
 

--- a/rust/src/core/bm25_index/build.rs
+++ b/rust/src/core/bm25_index/build.rs
@@ -173,6 +173,14 @@ fn prepare_file(
         return None;
     }
 
+    // #1739: bundled/minified payloads explode the chunker (one chunk per
+    // nested scope, each carrying its full subtree text). Applied at the same
+    // point in all three build paths so parallel stays identical to sequential.
+    if looks_minified(&content) {
+        tracing::debug!("[bm25: skipping minified payload {rel}]");
+        return None;
+    }
+
     let mut chunks = extract_chunks(rel, &content);
     chunks.sort_by(|a, b| {
         a.start_line
@@ -403,6 +411,12 @@ impl BM25Index {
                     Err(_) => continue,
                 }
             };
+
+            // #1739: see `prepare_file` — same predicate, same position.
+            if looks_minified(&content) {
+                tracing::debug!("[bm25: skipping minified payload {rel}]");
+                continue;
+            }
 
             let mut chunks = extract_chunks(rel, &content);
             chunks.sort_by(|a, b| {

--- a/rust/src/core/bm25_index/chunking.rs
+++ b/rust/src/core/bm25_index/chunking.rs
@@ -53,6 +53,45 @@ pub(crate) fn split_camel_case_tokens(tokens: &[String]) -> Vec<String> {
     result
 }
 
+/// Whether `content` is a bundled/minified payload rather than human-authored
+/// source — a whole program packed onto a handful of enormous lines.
+///
+/// These are the chunker's pathological input, not merely wasted index space.
+/// Tree-sitter emits one chunk per nested scope and each chunk carries its full
+/// subtree text, so a bundle with thousands of nested closures gets tokenized
+/// once per enclosing scope. #1739 measured 15 MB of committed vendor bundles
+/// producing a >10 GB in-memory index, while the surrounding 150 MB of real
+/// source produced 1.4 MB.
+///
+/// Glob lists cannot carry this alone: the bundles in #1739 were named
+/// `swagger-ui-bundle.js` and `redoc.standalone.js`, which no `*.min.js`
+/// pattern matches. The shape of the content is the reliable signal, so all
+/// three conditions must hold together — big enough to matter, dominated by
+/// huge lines, and huge on average — which prose and generated-but-readable
+/// code do not satisfy.
+pub(crate) fn looks_minified(content: &str) -> bool {
+    /// Below this a pathological file cannot move the index materially.
+    const MIN_BYTES: usize = 64 * 1024;
+    /// No hand-written line comes close; minified bundles run to megabytes.
+    const MIN_LONGEST_LINE_BYTES: usize = 5_000;
+    /// Real source averages well under this, unwrapped prose included.
+    const MIN_AVERAGE_LINE_BYTES: usize = 500;
+
+    if content.len() < MIN_BYTES {
+        return false;
+    }
+    let mut lines = 0_usize;
+    let mut longest = 0_usize;
+    for line in content.lines() {
+        lines += 1;
+        longest = longest.max(line.len());
+    }
+    if longest < MIN_LONGEST_LINE_BYTES {
+        return false;
+    }
+    content.len() / lines.max(1) >= MIN_AVERAGE_LINE_BYTES
+}
+
 pub(crate) fn extract_chunks(file_path: &str, content: &str) -> Vec<CodeChunk> {
     #[cfg(feature = "tree-sitter")]
     {
@@ -319,4 +358,44 @@ pub(crate) fn enrich_for_bm25(chunk: &CodeChunk) -> String {
     }
 
     format!("{} {} {} {}", chunk.content, stem, stem, dir)
+}
+
+#[cfg(test)]
+mod chunking_shape_tests {
+    use super::looks_minified;
+
+    #[test]
+    fn minified_bundles_are_recognised_without_a_glob() {
+        // #1739: the offending files were `swagger-ui-bundle.js` and
+        // `redoc.standalone.js` — no `*.min.js` pattern matches either.
+        let bundle = format!("!function(){{{}}}();", "var aB=1;".repeat(20_000));
+        assert!(bundle.len() > 64 * 1024);
+        assert!(looks_minified(&bundle));
+    }
+
+    #[test]
+    fn ordinary_source_and_prose_are_not_minified() {
+        // Real source: big file, ordinary lines.
+        let source = "pub fn compute(value: i32) -> i32 {\n    value * 2\n}\n".repeat(3_000);
+        assert!(source.len() > 64 * 1024);
+        assert!(!looks_minified(&source));
+
+        // Unwrapped prose: long lines, but nowhere near a minified bundle.
+        let prose = format!("{}\n", "lorem ipsum dolor sit amet ".repeat(60)).repeat(60);
+        assert!(prose.len() > 64 * 1024);
+        assert!(!looks_minified(&prose));
+
+        // A small file is never worth skipping, however it is shaped.
+        let tiny = format!("var a={};", "0".repeat(6_000));
+        assert!(!looks_minified(&tiny));
+
+        // One long line inside an otherwise normal large file (an embedded
+        // data URI, say) must not disqualify the file.
+        let mostly_normal = format!(
+            "{}\nconst DATA = \"{}\";\n",
+            "let x = 1;\n".repeat(20_000),
+            "A".repeat(9_000)
+        );
+        assert!(!looks_minified(&mostly_normal));
+    }
 }

--- a/rust/src/core/bm25_index/mod.rs
+++ b/rust/src/core/bm25_index/mod.rs
@@ -482,6 +482,11 @@ impl BM25Index {
             if content.is_empty() {
                 continue;
             }
+            // #1739: see `build::prepare_file` — same predicate, same position.
+            if looks_minified(&content) {
+                tracing::debug!("[bm25: skipping minified payload {rel}]");
+                continue;
+            }
             let mut chunks = extract_chunks(rel, &content);
             chunks.sort_by(|a, b| {
                 a.start_line
@@ -694,7 +699,7 @@ impl BM25Index {
                 return None;
             }
             let compressed = std::fs::read(&zst_path).ok()?;
-            let max_decompressed = max_bytes * 20; // allow 20x expansion ratio
+            let max_decompressed = max_decompressed_bytes(meta.len());
             let data = bounded_zstd_decode(&compressed, max_decompressed)?;
             let idx: Self = postcard::from_bytes(&data).ok()?;
             return Some(idx);
@@ -1007,6 +1012,13 @@ fn dir_states(root: &Path, files: &[String]) -> HashMap<String, u64> {
         .collect()
 }
 
+/// Streams the persisted index out, refusing anything past `max_bytes`.
+///
+/// The buffer never grows beyond `max_bytes`, so the ceiling passed in *is* the
+/// worst-case allocation — which is why #1739 hinged on that ceiling being a
+/// sane number rather than on this loop. Our own writer streams postcard into
+/// the encoder (#790) and so never records a frame content size, which rules
+/// out a cheap header pre-check.
 fn bounded_zstd_decode(compressed: &[u8], max_bytes: u64) -> Option<Vec<u8>> {
     use std::io::Read;
     let mut decoder = zstd::Decoder::new(compressed).ok()?;
@@ -1030,6 +1042,31 @@ fn bounded_zstd_decode(compressed: &[u8], max_bytes: u64) -> Option<Vec<u8>> {
         buf.extend_from_slice(&chunk[..n]);
     }
     Some(buf)
+}
+
+/// Worst-case RAM this process will spend decompressing a persisted index.
+///
+/// #1739: this was `max_bm25_cache_bytes() * 20` — twenty times a **disk**
+/// budget, with no reference to the file at hand or to the machine's memory. On
+/// the default 512 MB disk budget that authorised a 10 GB allocation for any
+/// index, however small the file; because `ctx_search` reloads on demand,
+/// repeated calls stacked to 20 GB RSS and froze the host.
+///
+/// The index is decompressed into RAM, so RAM is what has to bound it, and a
+/// given file cannot plausibly expand past a fixed ratio of its own size.
+fn max_decompressed_bytes(compressed_bytes: u64) -> u64 {
+    /// postcard + zstd on an index this shape expands well under this.
+    const MAX_EXPANSION_RATIO: u64 = 20;
+    /// Keeps small indices loadable on hosts that report little or no RAM.
+    const FLOOR: u64 = 64 * 1024 * 1024;
+
+    let file_derived = compressed_bytes
+        .saturating_mul(MAX_EXPANSION_RATIO)
+        .max(FLOOR);
+    match crate::core::memory_guard::rss_limit_bytes() {
+        Some(limit) => file_derived.min(limit.max(FLOOR)),
+        None => file_derived,
+    }
 }
 
 fn index_dir(root: &Path) -> PathBuf {

--- a/rust/src/core/bm25_index/tests.rs
+++ b/rust/src/core/bm25_index/tests.rs
@@ -1193,3 +1193,69 @@ fn index_without_directory_snapshot_is_refreshed_once() {
         "and the next call takes the cheap path again"
     );
 }
+
+#[test]
+fn decompression_ceiling_follows_the_file_and_the_host_not_a_disk_budget() {
+    // #1739: the ceiling was `max_bm25_cache_bytes() * 20` — on the default
+    // 512 MB disk budget that authorised a 10 GB allocation for *any* index.
+    let tiny = max_decompressed_bytes(1024);
+    let ram = crate::core::memory_guard::rss_limit_bytes();
+
+    assert!(
+        tiny <= 64 * 1024 * 1024 || Some(tiny) == ram.map(|r| r.max(64 * 1024 * 1024)),
+        "a 1 KB index must not authorise more than the floor, got {tiny}"
+    );
+    assert!(
+        max_decompressed_bytes(10 * 1024 * 1024) >= max_decompressed_bytes(1024),
+        "the ceiling must not shrink as the file grows"
+    );
+    if let Some(limit) = ram {
+        assert!(
+            max_decompressed_bytes(u64::MAX / 32) <= limit.max(64 * 1024 * 1024),
+            "the host's RSS limit must cap the ceiling"
+        );
+    }
+
+    // The streaming guard still refuses payloads past whatever ceiling applies.
+    let payload = vec![b'x'; 4 * 1024 * 1024];
+    let compressed = zstd::encode_all(payload.as_slice(), 3).expect("compress");
+    assert!(bounded_zstd_decode(&compressed, 1024 * 1024).is_none());
+    assert_eq!(
+        bounded_zstd_decode(&compressed, 8 * 1024 * 1024).map(|out| out.len()),
+        Some(payload.len())
+    );
+}
+
+#[test]
+fn minified_payloads_stay_out_of_the_index() {
+    // #1739 end-to-end: a committed vendor bundle next to real source must not
+    // reach the chunker, while the source next to it indexes normally.
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(
+        root.join("app.rs"),
+        "pub fn distinctive_helper_name() -> i32 {\n    41 + 1\n}\n",
+    )
+    .expect("write source");
+    std::fs::write(
+        root.join("swagger-ui-bundle.js"),
+        format!(
+            "!function(){{{}}}();",
+            "var distinctiveBundleToken=1;".repeat(20_000)
+        ),
+    )
+    .expect("write bundle");
+
+    let index = BM25Index::build_from_directory(root);
+
+    assert!(
+        index.files.contains_key("app.rs"),
+        "real source must still be indexed, got {:?}",
+        index.files.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !index.files.contains_key("swagger-ui-bundle.js"),
+        "the minified bundle must be skipped, got {:?}",
+        index.files.keys().collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Fixes #1739.

Thanks for the bisection table — it made this a two-line diagnosis instead of a fishing trip.

There are two independent defects here, one on each side, and the report identified both.

## Build side — the bundles never should have been chunked

The chunker emits one chunk per nested scope, and each chunk carries its **full subtree text**. On hand-written source that is cheap: few scopes, shallow nesting. On a bundle with thousands of nested closures the same bytes get tokenized once per enclosing scope, which is where 15 MB turns into gigabytes.

`DEFAULT_BM25_IGNORES` already carried `*.min.js`, `*.min.css`, `*.bundle.js`. It could not catch your case for exactly the reason you gave: `swagger-ui-bundle.js` matches none of them (`*.bundle.js` is not `*-bundle.js`), `redoc.standalone.js` matches nothing at all, and `.gitignore` is irrelevant for files that are committed. A glob list is the wrong instrument — the shape of the content is the reliable signal.

`looks_minified` now requires **all three** of:

- at least 64 KiB (below that a pathological file cannot move the index),
- a line of at least 5 000 bytes,
- an average line of at least 500 bytes.

Unwrapped prose, generated-but-readable code, and a large file containing one long embedded data URI each fail at least one condition, so none of them get dropped. Tests cover all three negatives explicitly.

The predicate runs at the same point in all three build paths — `prepare_file`, the sequential full build, and `rebuild_incremental_sequential` — so the parallel/sequential determinism contract (#498) still holds.

## Load side — your point 2, arrived at from the other end

I tried the `ZSTD_getFrameContentSize` check you suggested and had to drop it: `save` streams postcard directly into the encoder (#790, to avoid holding the serialized buffer in memory), so our frames never record a content size. The header check compiled, passed review, and could never fire. Worth writing down so nobody tries it again.

The real defect was one line above it:

```rust
let max_decompressed = max_bytes * 20; // allow 20x expansion ratio
```

`max_bytes` there is `max_bm25_cache_bytes()` — a **disk** budget. Twenty times the default 512 MB is exactly the `10240 MB` in your log, and it applied to *any* index regardless of the file's real size or the host's RAM. Since `ctx_search` reloads on demand, that is also why repeated calls stacked rather than settling: each one was independently authorised to allocate 10 GB.

The index is decompressed into RAM, so RAM is what bounds it now. `max_decompressed_bytes` takes the lower of 20x **this file's own** compressed size and the guardian's `rss_limit_bytes()` (your configured `max_ram_percent`), with a 64 MB floor so small indices stay loadable on hosts that report no RAM. On your 62 MB index that is ~1.24 GB instead of 10 GB, and capped further by your RAM setting.

## Your point 3

Not addressed here. `prepare_file` already checks `memory_guard::abort_requested()` per file, but you are right that the guard cannot interrupt a decompress or a `postcard::from_bytes` once it is under way. With the ceiling fixed those allocations are now bounded before they start, which removes the case you hit — but a general "guard can abort an in-flight load" is a separate piece of work and should get its own issue rather than being quietly folded in here.

## Verification

`cargo test --lib`: 10 800 passed, 0 failed. Both pre-commit clippy gates clean.

Your workaround (`[index] exclude` + rebuild) stays valid and is still the faster route on an already-poisoned index — the build-side fix prevents a *new* one from forming, it does not retroactively shrink the file on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
