### PR TITLE
fix(proxy): forward x-opencode-session so OpenCode keeps session affinity

### DIFF
--- a/rust/src/proxy/forward/headers.rs
+++ b/rust/src/proxy/forward/headers.rs
@@ -85,6 +85,11 @@ pub(crate) const ALLOWED_REQUEST_HEADERS: &[&str] = &[
     // every request. Passed through verbatim — lean-ctx neither renames nor
     // invents it.
     "x-claude-code-session-id",
+    // #1752: OpenCode (and OpenCode zen) carry their session on their own
+    // header. #1730 enumerated only the Claude Code spellings, so this sibling
+    // kept being stripped and every relayed request reached the upstream as a
+    // fresh session. Passed through verbatim, same as the header above.
+    "x-opencode-session",
 ];
 
 pub(crate) fn is_allowed_request_header(name: &str) -> bool {

--- a/rust/src/proxy/forward/tests.rs
+++ b/rust/src/proxy/forward/tests.rs
@@ -901,6 +901,55 @@ fn relay_test_state() -> ProxyState {
 }
 
 #[test]
+fn forwards_opencode_session_header() {
+    // #1752: OpenCode (and OpenCode zen) key session affinity off their own
+    // header. #1730 enumerated only the Claude Code spellings, so this sibling
+    // kept being stripped and every relayed request looked like a new session.
+    assert!(ALLOWED_REQUEST_HEADERS.contains(&"x-opencode-session"));
+    assert!(is_allowed_request_header("x-opencode-session"));
+    assert!(should_forward_request_header("x-opencode-session", false));
+}
+
+#[tokio::test]
+async fn opencode_session_reaches_the_upstream_verbatim() {
+    // #1752 end-to-end: assert what the upstream actually receives, including
+    // the mixed-case spelling OpenCode puts on the wire.
+    let (upstream, server) = upstream_capturing_headers().await;
+    let parts = Request::builder()
+        .method("POST")
+        .uri("/v1/messages")
+        .header("X-OpenCode-Session", "0f9c2b71-4d3a-4e58-9c11-7a6e5b2d8f40")
+        .header("X-Leanctx-Project", "internal-only")
+        .body(())
+        .unwrap()
+        .into_parts()
+        .0;
+
+    let response = transport::send_upstream(
+        &relay_test_state(),
+        &parts,
+        &upstream,
+        b"{}".to_vec(),
+        "Anthropic",
+        false,
+    )
+    .await
+    .unwrap();
+    assert!(response.status().is_success());
+
+    let seen = server.await.unwrap();
+    assert!(
+        seen.contains("x-opencode-session: 0f9c2b71-4d3a-4e58-9c11-7a6e5b2d8f40"),
+        "session header must reach the upstream verbatim, got: {seen}"
+    );
+    // Widening the allowlist for #1752 must not widen it for anything else.
+    assert!(
+        !seen.contains("x-leanctx-project"),
+        "internal header must stay stripped, got: {seen}"
+    );
+}
+
+#[test]
 fn forwards_claude_code_session_id_header() {
     // #1730: Claude Code's per-conversation UUID must survive the relay so a
     // downstream proxy can key session affinity and prompt-cache reuse on it.


### PR DESCRIPTION
## Summary

Routing `opencode` (including OpenCode zen) through the lean-ctx proxy dropped
the `x-opencode-session` request header, so the upstream saw a fresh session on
every request and session affinity / prompt-cache reuse were lost.

Same class as #1730 (`x-claude-code-session-id`), which PR #1742 fixed by
enumerating only the Claude Code spellings. OpenCode uses the same pattern with
a different header name, so it kept being stripped.

Forwarded verbatim — lean-ctx neither renames nor invents it.

Fixes #1752

## Test plan

- [x] `cargo test --lib opencode_session` — 2 passed, 0 failed
- [x] `cargo fmt --check` (also enforced by the pre-commit hook on this branch)
- [x] `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines`
      (the gate CI runs for this crate, ci.yml:243) — 0 errors
- [x] `cargo test --lib -- --test-threads=1` — 10813 passed, 0 failed
      (run on a tree that also carried the other three issue fixes)
- [ ] cookbook/packages untouched

## Notes for reviewers

- Risk areas / edge cases: widening a request allowlist is the risk. The
  end-to-end test asserts both directions — `x-opencode-session` reaches the
  upstream verbatim (mixed-case on the wire), and the internal
  `x-leanctx-project` tag stays stripped (enterprise#11). So this widens the
  allowlist for exactly one header.
- Backwards compatibility: additive; no existing header changes behaviour.
- Docs updated: none needed — the allowlist is not a generated artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
