### PR TITLE
docs(tools): say that mode=diff diffs the cache, not git

### DIFF
--- a/docs/reference/generated/mcp-tools.md
+++ b/docs/reference/generated/mcp-tools.md
@@ -168,7 +168,7 @@ Incremental diff since last read — shows only changed lines after you edit.
 WORKFLOW: ctx_read(mode=full) -> edit -> ctx_delta (no re-read needed).
 Use INSTEAD of re-reading the whole file after modifications — it returns only changed
 lines and avoids resending unchanged content. Path must have a prior ctx_read in this session's cache.
-For the full git diff against HEAD, use ctx_read(path, mode=diff) instead.
+ctx_read(mode=diff) diffs this same cache, not git; for HEAD use git diff.
 
 Parameters: `path`*
 

--- a/rust/src/tools/registered/ctx_delta.rs
+++ b/rust/src/tools/registered/ctx_delta.rs
@@ -19,7 +19,7 @@ impl McpTool for CtxDeltaTool {
              WORKFLOW: ctx_read(mode=full) -> edit -> ctx_delta (no re-read needed).\n\
              Use INSTEAD of re-reading the whole file after modifications — it returns only changed\n\
              lines and avoids resending unchanged content. Path must have a prior ctx_read in this session\'s cache.\n\
-             For the full git diff against HEAD, use ctx_read(path, mode=diff) instead.",
+             ctx_read(mode=diff) diffs this same cache, not git; for HEAD use git diff.",
             json!({
                 "type": "object",
                 "properties": {

--- a/rust/src/tools/registered/ctx_read.rs
+++ b/rust/src/tools/registered/ctx_read.rs
@@ -46,7 +46,7 @@ impl McpTool for CtxReadTool {
                     "paths": { "type": "array", "items": { "type": "string" }, "description": "Batch read" },
                     "mode": {
                         "type": "string",
-                        "description": "Recommended (defaults to auto). full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=git-delta lines:N-M=window (comma multi-selects: lines:5,10-20) reference=quotes task=focus"
+                        "description": "Recommended (defaults to auto). full=verbatim(edit-ready) anchored=full+N:hh|anchors(edit via ctx_patch) raw=exact-bytes signatures=API map=structure auto=smart diff=cache-delta lines:N-M=window (comma multi-selects: lines:5,10-20) reference=quotes task=focus"
                     },
                     "raw": { "type": "boolean", "description": "Verbatim (= mode=raw + fresh)" },
                     "start_line": { "type": "integer", "description": "1-based" },


### PR DESCRIPTION
## Summary

`ctx_delta`'s description promised *"For the full git diff against HEAD, use
ctx_read(path, mode=diff) instead"*, and `ctx_read` advertised the mode as
`diff=git-delta`. Both are wrong. `mode=diff` renders against the **session
cache**, which `render.rs` already states internally:

> `mode=diff` renders against the session cache and cannot be produced here.

The reporter committed a change, confirmed `git diff HEAD` was empty, and still
got the committed delta back from `mode=diff` — behaving exactly as designed,
while the exposed guidance said otherwise.

The cache-relative behaviour is intentional (it is what makes delta re-reads
cheap), so this corrects the promise rather than the semantics, and points at
`git diff` for a HEAD-relative answer.

Fixes #1753

## Test plan

- [x] `cargo run --example gen_docs --features dev-tools` — regenerated
      `docs/reference/generated/mcp-tools.md` (included in this PR)
- [x] `cargo test --lib minimal_arm_per_turn_prefix` — passed
- [x] `cargo fmt --check` (also enforced by the pre-commit hook on this branch)
- [x] `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines`
      (the gate CI runs for this crate, ci.yml:243) — 0 errors
- [x] `cargo test --lib -- --test-threads=1` — 10813 passed, 0 failed
      (run on a tree that also carried the other three issue fixes)

## Notes for reviewers

- **Token budget:** these strings ship in every turn's tool schema. My first
  wording was longer and pushed the minimal-arm prefix to 1974 tokens against a
  budget of 1965 — `minimal_arm_per_turn_prefix_stays_within_budget` caught it.
  The wording here is deliberately terse so the correction costs no per-turn
  budget. Please keep any rewording within that constraint.
- Risk areas / edge cases: description-only change; no code path is touched.
- Backwards compatibility: unchanged behaviour by design — this PR exists
  precisely because the behaviour is correct and the documentation was not.
- Docs updated: `docs/reference/generated/mcp-tools.md`, regenerated rather
  than hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
