### PR TITLE
fix(server): silence the setup tip when the user declined rule steering

### DIFF
--- a/rust/src/core/config/logic.rs
+++ b/rust/src/core/config/logic.rs
@@ -59,6 +59,23 @@ impl Config {
         }
     }
 
+    /// #1754: has the user declined lean-ctx steering their agent?
+    ///
+    /// `rules_injection = off` is the #1599 rule — off means off, on every
+    /// channel, including text lean-ctx appends inside a tool result. Under
+    /// `Off` such a reminder is also unclearable: `inject_all_rules`
+    /// early-returns, and the `lean-ctx setup` it suggests removes the rules
+    /// block rather than writing it, so the reminder returns next session.
+    ///
+    /// An explicit `setup.auto_inject_rules = false` says the same thing in the
+    /// setup section. `None` (auto — rules simply not present yet) is not a
+    /// refusal and still gets the reminder.
+    #[must_use]
+    pub fn declines_rule_steering(&self) -> bool {
+        self.rules_injection_effective() == RulesInjection::Off
+            || self.setup.auto_inject_rules == Some(false)
+    }
+
     /// Provider prompt-cache hit rate for net-of-injection (#1104).
     /// Returns the configured value or None (caller picks the default).
     #[must_use]

--- a/rust/src/core/config/tests_rules_injection.rs
+++ b/rust/src/core/config/tests_rules_injection.rs
@@ -48,6 +48,54 @@ fn unknown_value_falls_back_to_shared() {
     assert_eq!(cfg.rules_injection_effective(), RulesInjection::Shared);
 }
 
+// --- #1754: which settings silence in-band steering ---
+
+#[test]
+fn off_declines_rule_steering() {
+    // #1599's rule reaches the in-band setup tip too: off means off, on every
+    // channel. Under `off` the tip is also unclearable — `lean-ctx setup`
+    // removes the rules block rather than writing it.
+    for raw in ["off", "none", "disabled"] {
+        let cfg = Config {
+            rules_injection: Some(raw.to_string()),
+            ..Default::default()
+        };
+        assert!(
+            cfg.declines_rule_steering(),
+            "{raw:?} must silence in-band steering"
+        );
+    }
+}
+
+#[test]
+fn explicit_auto_inject_false_declines_rule_steering() {
+    // "never inject" said in the setup section is the same refusal.
+    let cfg = Config {
+        setup: SetupConfig {
+            auto_inject_rules: Some(false),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    assert!(cfg.declines_rule_steering());
+}
+
+#[test]
+fn auto_and_explicit_true_still_accept_rule_steering() {
+    // `None` is auto, not a refusal: rules are simply not present yet, which is
+    // exactly the case the tip exists for. `Some(true)` wants them outright.
+    assert!(!Config::default().declines_rule_steering());
+
+    let explicit_on = Config {
+        setup: SetupConfig {
+            auto_inject_rules: Some(true),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    assert!(!explicit_on.declines_rule_steering());
+}
+
 #[test]
 fn deserialization_from_toml() {
     let cfg: Config = toml::from_str(r#"rules_injection = "dedicated""#).unwrap();

--- a/rust/src/server/call_tool/pipeline.rs
+++ b/rust/src/server/call_tool/pipeline.rs
@@ -643,7 +643,9 @@ pub(in crate::server) async fn dispatch_and_post_process(
             .swap(true, std::sync::atomic::Ordering::Relaxed)
         {
             let cfg = crate::core::config::Config::load();
-            if !cfg.setup.should_inject_rules() {
+            // #1754: this tip is lean-ctx steering delivered inside a tool
+            // result, so the settings that decline steering must silence it.
+            if !cfg.declines_rule_steering() && !cfg.setup.should_inject_rules() {
                 result_text = format!(
                     "{result_text}\n\n\
                          --- tip: run 'lean-ctx setup' to configure agent rules for optimal AI integration ---"


### PR DESCRIPTION
## Summary

The once-per-session tip appended to the first `ctx_*` result —

```
--- tip: run 'lean-ctx setup' to configure agent rules for optimal AI integration ---
```

— fired even under `rules_injection = "off"`, because it only checked
`setup.should_inject_rules()`.

Under `off` the tip was also **unsilenceable and self-defeating**:
`inject_all_rules()` early-returns, so `lean-ctx setup` can never make
`rules_already_present()` true, and running it actively removes the rules block
and the skill directory. The tip asked the user to run a command whose effect is
to delete the thing whose absence triggers the tip.

`Config::declines_rule_steering()` names the three states apart:

| setting | steering declined? | tip |
|---|---|---|
| `rules_injection = off` | yes | silent |
| `setup.auto_inject_rules = false` (explicit) | yes | silent |
| `setup.auto_inject_rules = null` (auto, rules absent) | no | shown |

That last row is the case the tip exists for, so it keeps it.

This extends #1599's rule — *"Off means off, on every channel"*, already applied
to the `initialize` instructions block — to the in-band tip.

Fixes #1754

## Test plan

- [x] `cargo test --lib rule_steering` — 3 passed, 0 failed
- [x] `cargo fmt --check` (also enforced by the pre-commit hook on this branch)
- [x] `cargo clippy --all-features -- -D warnings -A clippy::too_many_lines`
      (the gate CI runs for this crate, ci.yml:243) — 0 errors
- [x] `cargo test --lib -- --test-threads=1` — 10813 passed, 0 failed
      (run on a tree that also carried the other three issue fixes)
- [ ] cookbook/packages untouched

## Notes for reviewers

- The reporter called the secondary question (should an explicit
  `auto_inject_rules = false` also silence it?) the weaker case and was happy
  either way. I included it: "never inject during setup/update" reads as the
  same refusal said in a different section. The auto case is untouched, so the
  tip still reaches the users it was written for.
- The predicate lives on `Config` rather than inline at the call site so it is
  unit-testable and self-documenting; `pipeline.rs` now reads as intent.
- Risk areas / edge cases: users on `auto_inject_rules = false` who *wanted*
  the reminder lose it. That is the intended reading of an explicit `false`.
- Docs updated: none needed — no config key added or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
