### PR TITLE
fix(guard): stop both pre-push guards going blind on a new branch

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -70,14 +70,16 @@ while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     fi
 
     if [[ "$REMOTE_SHA" == "0000000000000000000000000000000000000000" ]]; then
-        # New branch — check all commits
-        RANGE="$LOCAL_SHA"
+        # New branch on the remote: nothing exists there yet, so every file in
+        # the pushed tree becomes newly published. `git diff --name-only <sha>`
+        # compares the WORKING TREE against that commit — on a clean tree it
+        # prints nothing and exits 0, so the fallback below never fired and this
+        # guard passed by construction for the first push of a branch.
+        FILES=$(git ls-tree -r --name-only "$LOCAL_SHA" 2>/dev/null || true)
     else
-        RANGE="$REMOTE_SHA..$LOCAL_SHA"
+        # Existing branch: only what this push adds or modifies is newly exposed.
+        FILES=$(git diff --diff-filter=ACMR --name-only "$REMOTE_SHA..$LOCAL_SHA" 2>/dev/null || true)
     fi
-
-    # Get files ADDED or MODIFIED in the push range (not deletions)
-    FILES=$(git diff --diff-filter=ACMR --name-only "$RANGE" 2>/dev/null || git diff-tree --no-commit-id --diff-filter=ACMR --name-only -r "$LOCAL_SHA" 2>/dev/null || true)
 
     for file in $FILES; do
         for pattern in "${BLOCKED[@]}"; do

--- a/.github/hooks/pre-push-proprietary-guard.sh
+++ b/.github/hooks/pre-push-proprietary-guard.sh
@@ -31,7 +31,14 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     continue
   fi
   
-  FILES=$(git diff --name-only "$REMOTE_SHA..$LOCAL_SHA" 2>/dev/null || git diff --name-only HEAD)
+  if [ "$REMOTE_SHA" = "0000000000000000000000000000000000000000" ]; then
+    # New branch on the remote: every file in the pushed tree is newly
+    # published. The previous fallback compared the working tree against HEAD,
+    # which is empty on a clean checkout — the guard passed by construction.
+    FILES=$(git ls-tree -r --name-only "$LOCAL_SHA" 2>/dev/null || true)
+  else
+    FILES=$(git diff --name-only "$REMOTE_SHA..$LOCAL_SHA" 2>/dev/null || true)
+  fi
   
   for pattern in "${PROPRIETARY_PATTERNS[@]}"; do
     MATCHES=$(echo "$FILES" | grep "$pattern" || true)


### PR DESCRIPTION
## Summary

Both local pre-push guards are blind on the **first** push of a branch — the one
case where the most content becomes newly public at once.

`.githooks/pre-push`:

```bash
if [[ "$REMOTE_SHA" == "000...0" ]]; then
    RANGE="$LOCAL_SHA"          # new branch
...
FILES=$(git diff --diff-filter=ACMR --name-only "$RANGE" ... || git diff-tree ...)
```

With `RANGE` set to a bare SHA, `git diff --name-only <sha>` compares the
**working tree** against that commit — on a clean tree it prints nothing and
exits 0, so the `||` fallback never fires. The loop then iterates over an empty
file list and the guard passes by construction.

`.github/hooks/pre-push-proprietary-guard.sh` has the same shape:

```bash
FILES=$(git diff --name-only "$REMOTE_SHA..$LOCAL_SHA" 2>/dev/null || git diff --name-only HEAD)
```

For a new branch `$REMOTE_SHA` is all zeros, the range is invalid, and the
fallback compares the working tree against `HEAD` — empty again.

Both now enumerate the pushed tree instead:

```bash
FILES=$(git ls-tree -r --name-only "$LOCAL_SHA")
```

and the existing-branch path keeps its explicit `"$REMOTE_SHA..$LOCAL_SHA"`
diff, so only what the push adds is examined there.

## Scope — what this does and does not fix

This hardens **layer 2** of `docs/contracts/oss-plane-separation-v1.md`. It is
not the only defence and this PR does not claim it was wide open:

- The CI *Proprietary code guardrail* and *Commercial-plane guard* in
  `security-check.yml` test `[ -e "$path" ]` against the checked-out tree, so
  they catch a listed path regardless of this bug.
- But CI runs **after** the push has landed on GitHub. For a leak, "detected
  after publication" is not the same as "prevented".
- And the CI lists are hardcoded, while the hooks read `.github-ignore`. For any
  path that lives only in that file, the local hook is the only layer that can
  ever act.

## Test plan

- [x] `bash -n .githooks/pre-push` and `bash -n .github/hooks/pre-push-proprietary-guard.sh`
- [x] Measured on this branch's own commit, clean tree:
      `git ls-tree -r --name-only HEAD` → **3845 files**,
      `git diff --name-only HEAD` → **0 files**. On a new-branch push the old
      code iterated the second list, so the guard examined nothing while 3845
      files were becoming public.
- [x] Existing-branch pushes unchanged: still `"$REMOTE_SHA..$LOCAL_SHA"`.
- [ ] No Rust/cookbook/package code touched.

## Notes for reviewers

- Risk areas: the new-branch path now examines the **whole tree**, so a first
  push of a long-lived branch reports every blocked path it contains, not just
  what that branch added. That is the intended reading — on a branch the remote
  has never seen, every file in it is newly published.
- Backwards compatibility: no behaviour change for existing branches, which is
  the common case.
- Docs: `oss-plane-separation-v1.md` already describes layers 2 and 3 reading
  the same `.github-ignore`; that statement stays true, so no doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
